### PR TITLE
Add BSNES emulator to blacklist.

### DIFF
--- a/Library/Homebrew/blacklist.rb
+++ b/Library/Homebrew/blacklist.rb
@@ -55,5 +55,12 @@ def blacklisted? name
     To do it in one line, use this command:
       curl http://npmjs.org/install.sh | sh
     EOS
+  when 'bsnes' then <<-EOS.undent
+    BSNES requires a compiler that can utilize both C++0x and Cocoa, but
+    Apple's developer tools do not support this.
+
+    You can find a pre-compiled version of BSNES at:
+      http://www.bannister.org/software/bsnes.htm
+    EOS
   end
 end


### PR DESCRIPTION
I got excited about the BSNES emulator after reading this article:
http://arstechnica.com/gaming/news/2011/08/accuracy-takes-power-one-mans-3ghz-quest-to-build-a-perfect-snes-emulator.ars

But then I found out that it's not possible to build BSNES from source with Apple's developer tools. So I decided to add it to the blacklist to help people like me find out where to get a pre-compiled version.

See http://byuu.org/bsnes/compilation-guide for up-to-date information.
