### PR TITLE
update goocanvas Formula

### DIFF
--- a/Library/Formula/goocanvas.rb
+++ b/Library/Formula/goocanvas.rb
@@ -1,6 +1,6 @@
 require "formula"
 
-class Goocanvas2 < Formula
+class Goocanvas < Formula
   homepage "https://live.gnome.org/GooCanvas"
   url "http://ftp.gnome.org/pub/GNOME/sources/goocanvas/2.0/goocanvas-2.0.2.tar.xz"
   sha256 "f20e5fbef8d1a2633033edbd886dd13146a1b948d1813a9c353a80a29295d1d0"

--- a/Library/Formula/goocanvas.rb
+++ b/Library/Formula/goocanvas.rb
@@ -1,18 +1,26 @@
-require 'formula'
+require "formula"
 
-class Goocanvas < Formula
-  homepage 'https://live.gnome.org/GooCanvas'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/goocanvas/1.0/goocanvas-1.0.0.tar.bz2'
-  sha1 'b41d38726fa537258a5f00908eff2d6aad9a5e50'
+class Goocanvas2 < Formula
+  homepage "https://live.gnome.org/GooCanvas"
+  url "http://ftp.gnome.org/pub/GNOME/sources/goocanvas/2.0/goocanvas-2.0.2.tar.xz"
+  sha256 "f20e5fbef8d1a2633033edbd886dd13146a1b948d1813a9c353a80a29295d1d0"
 
   depends_on :x11
-  depends_on 'pkg-config' => :build
-  depends_on 'cairo'
-  depends_on 'glib'
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "glib"
+  depends_on "gtk+3"
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    args = %W[
+       --disable-dependency-tracking
+       --prefix=#{prefix}
+       --enable-introspection=yes
+       --disable-silent-rules
+       --disable-gtk-doc-html
+    ]
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
`goocanvas-2.0.2` depends `gtk+3` instead of `gtk+`.