### PR TITLE
Adds JSON output to `outdated` command

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -395,7 +395,7 @@ _brew_outdated ()
     local cur="${COMP_WORDS[COMP_CWORD]}"
     case "$cur" in
     --*)
-        __brewcomp "--quiet"
+        __brewcomp "--quiet --json=v1"
         return
         ;;
     esac

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -3,14 +3,10 @@ require 'keg'
 
 module Homebrew
   def outdated
-    formulae = ARGV.resolved_formulae.any? ? ARGV.resolved_formulae : Formula.installed
-
-    outdated = outdated_brews(formulae) do |f, versions|
-      if ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
-        puts "#{f.full_name} (#{versions*', '} < #{f.pkg_version})"
-      else
-        puts f.full_name
-      end
+    if ARGV.json == "v1"
+      outdated = print_outdated_json
+    else
+      outdated = print_outdated
     end
     Homebrew.failed = ARGV.resolved_formulae.any? && outdated.any?
   end
@@ -36,5 +32,31 @@ module Homebrew
         f
       end
     end.compact
+  end
+
+  def formulae_to_check
+    ARGV.resolved_formulae.any? ? ARGV.resolved_formulae : Formula.installed
+  end
+
+  def print_outdated
+    outdated_brews(formulae_to_check) do |f, versions|
+      if ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
+        puts "#{f.full_name} (#{versions*', '} < #{f.pkg_version})"
+      else
+        puts f.full_name
+      end
+    end
+  end
+
+  def print_outdated_json
+    json = []
+    outdated = outdated_brews(formulae_to_check) do |f, versions|
+      json << {:name => f.name,
+               :installed_versions => versions.collect(&:to_s),
+               :current_version => f.pkg_version.to_s}
+    end
+    puts Utils::JSON.dump(json)
+    
+    outdated
   end
 end

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -295,7 +295,7 @@ Note that these flags should only appear after a command.
 
     If `--installed` is passed, show options for all installed formulae.
 
-  * `outdated [--quiet|--verbose]`:
+  * `outdated [--quiet | --verbose | --json=v1 ]`:
     Show formulae that have an updated version available.
 
     By default, version information is displayed in interactive shells, and
@@ -305,6 +305,9 @@ Note that these flags should only appear after a command.
     precedence over `--verbose`).
 
     If `--verbose` is passed, display detailed version information.
+
+    If `--json=<version>` is passed, the output will be in JSON format. The only
+    valid version is `v1`.
 
   * `pin` <formulae>:
     Pin the specified <formulae>, preventing them from being upgraded when

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -290,7 +290,7 @@ If \fB\-\-all\fR is passed, show options for all formulae\.
 If \fB\-\-installed\fR is passed, show options for all installed formulae\.
 .
 .IP "\(bu" 4
-\fBoutdated [\-\-quiet|\-\-verbose]\fR: Show formulae that have an updated version available\.
+\fBoutdated [\-\-quiet | \-\-verbose | \-\-json=v1 ]\fR: Show formulae that have an updated version available\.
 .
 .IP
 By default, version information is displayed in interactive shells, and suppressed otherwise\.
@@ -300,6 +300,9 @@ If \fB\-\-quiet\fR is passed, list only the names of outdated brews (takes prece
 .
 .IP
 If \fB\-\-verbose\fR is passed, display detailed version information\.
+.
+.IP
+If \fB\-\-json=<version>\fR is passed, the output will be in JSON format\. The only valid version is \fBv1\fR\.
 .
 .IP "\(bu" 4
 \fBpin\fR \fIformulae\fR: Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade \-\-all\fR command\. See also \fBunpin\fR\.


### PR DESCRIPTION
After some musing on brunophilipe/Cakebrew#71, I thought it would be useful to let Cakebrew and other tools grab the outdated formulae version information using a method more elegant than regex.

I poked around quickly for a pattern for how other commands are tested, but couldn't find it in the time I have available. I'll happily add a test if you can point out where!

I'm not entirely set on the keys in the JSON output. I went with the internal terminology, but think that `name`, `installed`, and `available` would be more expressive.

I'm pretty sure I got all the other things, too, like completions and man page.