### PR TITLE
Add fetch --use-mirror support with optional arg value

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -73,6 +73,11 @@ class CurlDownloadStrategy < AbstractDownloadStrategy
     @mirrors ||= resource.mirrors.dup
   end
 
+  def use_mirror
+    return 1 if ARGV.include?("--use-mirror")
+    ARGV.value("use-mirror").to_i if ARGV.value("use-mirror")
+  end
+
   def tarball_path
     @tarball_path ||= Pathname.new("#{HOMEBREW_CACHE}/#{name}-#{resource.version}#{ext}")
   end
@@ -99,6 +104,10 @@ class CurlDownloadStrategy < AbstractDownloadStrategy
   end
 
   def fetch
+    if mirrors.any? && use_mirror
+      @url = mirrors.slice!(use_mirror-1) if use_mirror <= mirrors.size
+    end
+
     ohai "Downloading #{@url}"
     unless tarball_path.exist?
       had_incomplete_download = temporary_path.exist?


### PR DESCRIPTION
Pretty basic support for `brew fetch --use-mirror(=n)` as requested in #24424. Defaults to n=1 (first mirror) without an arg value. Ignored given some invalid n, or if there aren't any mirrors. Any suggestions appreciated.
