### PR TITLE
avoid conflicts caused by setting install.prefix in distutils.cfg

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -48,6 +48,34 @@ class Python < Formula
     sha1 "9926640cb7c8e273e4b451469a2b13d4b9df5ba3"
   end
 
+  # Patch to avoid conflicts with install.prefix set in distutils.cfg
+  # allows --user installs with homebrew Python
+  patch :p0, <<-EOF
+--- ./Lib/distutils/dist_orig.py
++++ ./Lib/distutils/dist.py
+@@ -588,6 +588,20 @@
+         opt_dict = self.get_option_dict(command)
+         for (name, value) in vars(opts).items():
+             opt_dict[name] = ("command line", value)
++
++        # HOMEBREW PATCH: Avoid conflict with prefix set in distutils.cfg
++        # override, rather than fail
++        sys_dir = os.path.dirname(sys.modules['distutils'].__file__)
++        # Look for the system config file
++        sys_file = os.path.join(sys_dir, "distutils.cfg")
++
++        if command == 'install' and 'prefix' in opt_dict and opt_dict['prefix'][0] == sys_file:
++            for conflict in ('user', 'home', 'install_base', 'install_platbase'):
++                if conflict in opt_dict and opt_dict[conflict][0] != sys_file:
++                    # consider prefix unset if it's being overridden
++                    opt_dict.pop('prefix')
++                    continue
++        # END HOMEBREW PATCH
+
+         return args
+
+EOF
+
   # Patch to disable the search for Tk.framework, since Homebrew's Tk is
   # a plain unix build. Remove `-lX11`, too because our Tk is "AquaTk".
   patch :DATA if build.with? "brewed-tk"

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -31,6 +31,34 @@ class Python3 < Formula
   skip_clean "bin/pip3", "bin/pip-#{VER}"
   skip_clean "bin/easy_install3", "bin/easy_install-#{VER}"
 
+  # Patch to avoid conflicts with install.prefix set in distutils.cfg
+  # allows --user installs with homebrew Python
+  patch :p0, <<-EOF
+--- ./Lib/distutils/dist_orig.py
++++ ./Lib/distutils/dist.py
+@@ -591,6 +591,20 @@
+         opt_dict = self.get_option_dict(command)
+         for (name, value) in vars(opts).items():
+             opt_dict[name] = ("command line", value)
++
++        # HOMEBREW PATCH: Avoid conflict with prefix set in distutils.cfg
++        # override, rather than fail
++        sys_dir = os.path.dirname(sys.modules['distutils'].__file__)
++        # Look for the system config file
++        sys_file = os.path.join(sys_dir, "distutils.cfg")
++
++        if command == 'install' and 'prefix' in opt_dict and opt_dict['prefix'][0] == sys_file:
++            for conflict in ('user', 'home', 'install_base', 'install_platbase'):
++                if conflict in opt_dict and opt_dict[conflict][0] != sys_file:
++                    # consider prefix unset if it's being overridden
++                    opt_dict.pop('prefix')
++                    continue
++        # END HOMEBREW PATCH
+
+         return args
+
+EOF
+
   patch :DATA if build.with? 'brewed-tk'
 
   def site_packages_cellar


### PR DESCRIPTION
Setting `install.prefix` in `distutils.cfg` causes conflicts with other options set on the command-line, such as `--user`. This adds a check to distutils command-line parsing to unset `install.prefix` if such a conflict would be caused by settings from a higher priority source (e.g. command-line).

Supersedes #31803 by hopefully being less gross.

This addresses what I would consider a bug in Python distutils, and thus has the chance of evolving into an upstream patch: settings found in distutils.cfg are treated as if they were typed at the command-line in terms of conflict resolution, rather than as if they were defaults to be overridden. A generic patch for distutils to fix this logic would be more complex, but this simple patch handles the case that affects Homebrew Python as it is today.