### PR TITLE
Linuxbrew: Add [-0-9] to BOTTLE_EXTNAME_RX

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -7,7 +7,7 @@ require 'metafiles'
 class Pathname
   include MachO
 
-  BOTTLE_EXTNAME_RX = /(\.[a-z_]+(32)?\.bottle\.(\d+\.)?tar\.gz)$/
+  BOTTLE_EXTNAME_RX = /(\.[-a-z0-9_]+\.bottle\.(\d+\.)?tar\.gz)$/
 
   def install *sources
     sources.each do |src|


### PR DESCRIPTION
This patch relaxes the bottle tag regex from `[a-z_]+(32)?` to `[-a-z0-9_]+`, that is, it additionally allows hyphens and digits. The Linuxbrew bottle tag is `x86_64-linux`.