### PR TITLE
Libraries for ODB : C++ Object-Relational Mapping (ORM)

### DIFF
--- a/Library/Formula/libodb-boost.rb
+++ b/Library/Formula/libodb-boost.rb
@@ -1,0 +1,18 @@
+require "formula"
+
+class LibodbBoost < Formula
+  homepage "http://www.codesynthesis.com/products.odb"
+  url "http://codesynthesis.com/download/odb/2.3/libodb-boost-2.3.0.tar.gz"
+  sha1 "38c8552db872cc32144fb653c19277cfec1df2ec"
+
+  depends_on "libodb" => :build
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+end

--- a/Library/Formula/libodb-sqlite.rb
+++ b/Library/Formula/libodb-sqlite.rb
@@ -1,0 +1,23 @@
+require "formula"
+
+class LibodbSqlite < Formula
+  homepage "http://www.codesynthesis.com/products.odb"
+  url "http://www.codesynthesis.com/download/odb/2.3/libodb-sqlite-2.3.0.tar.bz2"
+  sha1 "512a124e0b78ae36deee25d595e3e169bd24d216"
+
+  depends_on "libodb" => :build
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+        ODB is undel GPL v2 or NCUEL.
+        Please read http://codesynthesis.com/products/odb/license.xhtml before use.
+        EOS
+  end
+end

--- a/Library/Formula/libodb.rb
+++ b/Library/Formula/libodb.rb
@@ -1,0 +1,21 @@
+require "formula"
+
+class Libodb < Formula
+  homepage "http://www.codesynthesis.com/products/odb"
+  url "http://www.codesynthesis.com/download/odb/2.3/libodb-2.3.0.tar.bz2"
+  sha1 "eebc7fa706bc598a80439d1d6a798430fcfde23b"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+        ODB is undel GPL v2 or NCUEL.
+        Please read http://codesynthesis.com/products/odb/license.xhtml before use.
+        EOS
+  end
+end


### PR DESCRIPTION
The branch contains only two libraries: libodb and libodb-sqlite. 
Other libraries will be added soon.

ODB compiler will be submmited to homebrew-binary.