### PR TITLE
Fix RE2 install-name preventing dynamic libraries from loading libre2.dylib

### DIFF
--- a/Library/Formula/re2.rb
+++ b/Library/Formula/re2.rb
@@ -24,9 +24,13 @@ class Re2 < Formula
                 # operator<<(std::ostream&, re2::StringPiece const&)
                 '__ZlsRSoRKN3re211StringPieceE'
     end
+    # As of writing, RE2 Makefile produces so extension instead of dylib
+    # extension and a fix is pending code review upstream:
+    # https://code-review.googlesource.com/#/c/3120/
+    inreplace "Makefile", "-dynamiclib $(LDFLAGS)", "-dynamiclib $(LDFLAGS) -Wl,-install_name,@rpath/libre2.dylib"
+    inreplace "Makefile", "libre2.so.$(SONAME).0.0", "libre2.$(SONAME).0.0.dylib"
+    inreplace "Makefile", "libre2.so.$(SONAME)", "libre2.$(SONAME).dylib"
+    inreplace "Makefile", "libre2.so", "libre2.dylib"
     system "make", "install", "prefix=#{prefix}"
-    mv lib/"libre2.so.0.0.0", lib/"libre2.0.0.0.dylib"
-    lib.install_symlink "libre2.0.0.0.dylib" => "libre2.0.dylib"
-    lib.install_symlink "libre2.0.0.0.dylib" => "libre2.dylib"
   end
 end


### PR DESCRIPTION
Hi,

The default make for re2 doesn't correctly set the install_name, so the library generated cannot be used by other libraries. Use by other binaries works OK.

Specifically, I'm trying to compile Ruby re2 extension, and using this formula it fails due to the libre2.dylib file actually having "libre2.so" as its install_name, thus the compiled ruby extension points to the incorrect library location.

Fixed it by adding an in replace to add the install_name parameter. Hopefully this is acceptable as a patch to fix the existing version. This is only an issue due to the "mv" which renames from .so to .dylib, which breaks the install_name - so they come hand in hand.

I will raise with upstream at some point to have .dylib files generated instead of .so for Mac so none of this "mv" or install_name is required.

Jason