### PR TITLE
open-babel: Add HEAD and tests

### DIFF
--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -2,41 +2,68 @@ require 'formula'
 
 class OpenBabel < Formula
   homepage 'http://www.openbabel.org'
-  url 'https://downloads.sourceforge.net/project/openbabel/openbabel/2.3.2/openbabel-2.3.2.tar.gz'
-  sha1 'b8831a308617d1c78a790479523e43524f07d50d'
+
+  stable do
+    url 'https://downloads.sourceforge.net/project/openbabel/openbabel/2.3.2/openbabel-2.3.2.tar.gz'
+    sha1 'b8831a308617d1c78a790479523e43524f07d50d'
+
+    # Patch to support libc++ in OS X 10.9+, backport of upstream commit c3abbddae78e654df9322ad1020ff79dd6332946
+    patch do
+      url "https://gist.githubusercontent.com/erlendurj/40689d57bea3b0b0c767/raw/f8c87557bcdbd79fb796e06088cdd77123c9260a/ob-mavericks.patch"
+      sha1 "3ea95b20fdbe50f656f3073ef8916974495b569a"
+    end
+
+    # Patch to fix Molecule.draw() in pybel in accordance with upstream commit df59c4a630cf753723d1318c40479d48b7507e1c
+    patch do
+      url "https://gist.githubusercontent.com/fredrikw/5858168/raw/e4b5899e781d5707f5c386e436b5fc7810f2010d/ob-2-3-2-patch.diff"
+      sha1 "e304c308b39a465b632b397aa669c26f4b375da1"
+    end
+  end
+
+  head do
+    url 'https://github.com/openbabel/openbabel.git'
+  end
 
   option 'with-cairo',  'Support PNG depiction'
   option 'with-java',   'Compile Java language bindings'
+  option 'with-python', 'Compile Python language bindings'
+  option 'with-wxmac',  'Build with GUI'
 
   depends_on 'pkg-config' => :build
   depends_on 'cmake' => :build
   depends_on :python => :optional
   depends_on 'wxmac' => :optional
   depends_on 'cairo' => :optional
-  depends_on 'eigen' if build.with?('python') || build.with?('java')
-
-  # Patch to fix Molecule.draw() in pybel in accordance with upstream commit df59c4a630cf753723d1318c40479d48b7507e1c
-  patch do
-    url "https://gist.githubusercontent.com/fredrikw/5858168/raw/e4b5899e781d5707f5c386e436b5fc7810f2010d/ob-2-3-2-patch.diff"
-    sha1 "e304c308b39a465b632b397aa669c26f4b375da1"
-  end
-
-  # Patch to support Mavericks's libc++, a backport of upstream commit c3abbddae78e654df9322ad1020ff79dd6332946
-  patch do
-    url "https://gist.githubusercontent.com/erlendurj/40689d57bea3b0b0c767/raw/f8c87557bcdbd79fb796e06088cdd77123c9260a/ob-mavericks.patch"
-    sha1 "3ea95b20fdbe50f656f3073ef8916974495b569a"
-  end
+  depends_on 'eigen'
+  depends_on 'swig' if build.with? 'python' or build.with? 'java'
 
   def install
-    args = %W[ -DCMAKE_INSTALL_PREFIX=#{prefix} ]
+    args = std_cmake_parameters.split
+    args << "-DRUN_SWIG=ON" if build.with? 'python' or build.with? 'java'
     args << "-DJAVA_BINDINGS=ON" if build.with? 'java'
     args << "-DBUILD_GUI=ON" if build.with? 'wxmac'
-    # Looking for Cairo in HOMEBREW_PREFIX
-    # setting the arguments separately, joining them in one string fails with the 'system "cmake", *args' command
-    args << "-DCAIRO_INCLUDE_DIRS='#{HOMEBREW_PREFIX}/include/cairo'" if build.with? 'cairo'
-    args << "-DCAIRO_LIBRARIES='#{HOMEBREW_PREFIX}/lib/libcairo.dylib'" if build.with? 'cairo'
 
-    args << "-DPYTHON_BINDINGS=ON" if build.with? 'python'
+    # Look for Cairo in HOMEBREW_PREFIX (automatic detection with cmake is fixed in HEAD)
+    if build.with? 'cairo' and not build.head?
+      args << "-DCAIRO_INCLUDE_DIRS='#{HOMEBREW_PREFIX}/include/cairo'"
+      args << "-DCAIRO_LIBRARIES='#{HOMEBREW_PREFIX}/lib/libcairo.dylib'"
+    end
+
+    # Point cmake towards correct python
+    if build.with? 'python'
+      pyvers = "python" + `python -c 'import sys;print(sys.version[:3])'`.strip
+      pypref = `python -c 'import sys;print(sys.prefix)'`.strip
+      pyinc = `python -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.strip
+      args << "-DPYTHON_BINDINGS=ON"
+      args << "-DPYTHON_INCLUDE_DIR='#{pyinc}'"
+      if File.exist? "#{pypref}/Python"
+        args << "-DPYTHON_LIBRARY='#{pypref}/Python'"
+      elsif File.exists? "#{pypref}/lib/lib#{pyvers}.a"
+        args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.a'"
+      else
+        args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.dylib'"
+      end
+    end
 
     args << '..'
 
@@ -46,7 +73,8 @@ class OpenBabel < Formula
       system "make install"
     end
 
-    if build.with? 'python'
+    # Manually install the python files (fixed in HEAD)
+    if build.with? 'python' and not build.head?
       (lib+'python2.7/site-packages').install lib/'openbabel.py', lib/'pybel.py', lib/'_openbabel.so'
     end
   end
@@ -58,4 +86,10 @@ class OpenBabel < Formula
     EOS
   end
 
+  test do
+    system "obabel --help"
+    system "obabel -:'C1=CC=CC=C1Br' -ocan"
+    system "obabel -:'C1=CC=CC=C1Br' -omol"
+    system "obabel -:'C1=CC=CC=C1Br' -oinchi"
+  end
 end

--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -87,9 +87,6 @@ class OpenBabel < Formula
   end
 
   test do
-    system "obabel --help"
-    system "obabel -:'C1=CC=CC=C1Br' -ocan"
-    system "obabel -:'C1=CC=CC=C1Br' -omol"
-    system "obabel -:'C1=CC=CC=C1Br' -oinchi"
+    system "obabel", "-:'C1=CC=CC=C1Br'", "-omol"
   end
 end

--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -56,13 +56,7 @@ class OpenBabel < Formula
       pyinc = `python -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.strip
       args << "-DPYTHON_BINDINGS=ON"
       args << "-DPYTHON_INCLUDE_DIR='#{pyinc}'"
-      if File.exist? "#{pypref}/Python"
-        args << "-DPYTHON_LIBRARY='#{pypref}/Python'"
-      elsif File.exists? "#{pypref}/lib/lib#{pyvers}.a"
-        args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.a'"
-      else
-        args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.dylib'"
-      end
+      args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.dylib'"
     end
 
     args << '..'

--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -38,7 +38,7 @@ class OpenBabel < Formula
   depends_on 'swig' if build.with? 'python' or build.with? 'java'
 
   def install
-    args = std_cmake_parameters.split
+    args = std_cmake_args
     args << "-DRUN_SWIG=ON" if build.with? 'python' or build.with? 'java'
     args << "-DJAVA_BINDINGS=ON" if build.with? 'java'
     args << "-DBUILD_GUI=ON" if build.with? 'wxmac'

--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -51,12 +51,11 @@ class OpenBabel < Formula
 
     # Point cmake towards correct python
     if build.with? 'python'
-      pyvers = "python" + `python -c 'import sys;print(sys.version[:3])'`.strip
       pypref = `python -c 'import sys;print(sys.prefix)'`.strip
       pyinc = `python -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.strip
       args << "-DPYTHON_BINDINGS=ON"
       args << "-DPYTHON_INCLUDE_DIR='#{pyinc}'"
-      args << "-DPYTHON_LIBRARY='#{pypref}/lib/lib#{pyvers}.dylib'"
+      args << "-DPYTHON_LIBRARY='#{pypref}/lib/libpython2.7.dylib'"
     end
 
     args << '..'


### PR DESCRIPTION
Add HEAD option and exclude various patches and install hacks that have been fixed upstream. Also includes improved python detection and some simple tests.