### PR TITLE
Update libsvm to 3.19, add --with-tools option

### DIFF
--- a/Library/Formula/libsvm.rb
+++ b/Library/Formula/libsvm.rb
@@ -5,6 +5,9 @@ class Libsvm < Formula
   url 'http://www.csie.ntu.edu.tw/~cjlin/libsvm/oldfiles/libsvm-3.19.tar.gz'
   sha1 '0130bdfc66bce43d105c069f6a4c0767efd95c9f'
 
+  option "with-tools", "Add data-manipulation tools included in libsvm."
+  depends_on "gnuplot" if build.with? "tools"
+
   bottle do
     cellar :any
     revision 1
@@ -14,6 +17,15 @@ class Libsvm < Formula
   end
 
   def install
+    if build.with? "tools"
+      inreplace "tools/easy.py", /"..\/(svm-.+)"/, "\"#{bin}/\\1\""
+      inreplace "tools/grid.py", /'..\/svm-train'/, "'#{bin}/svm-train'"
+      inreplace "tools/grid.py", /'\/usr\/bin\/gnuplot'/, "'#{HOMEBREW_PREFIX}/opt/gnuplot/bin/gnuplot'"
+      bin.install "tools/checkdata.py" => "svm-checkdata"
+      bin.install "tools/easy.py" => "svm-easy"
+      bin.install "tools/grid.py" => "svm-grid"
+      bin.install "tools/subset.py" => "svm-subset"
+    end
     system "make", "CFLAGS=#{ENV.cflags}"
     system "make", "lib"
     bin.install "svm-scale", "svm-train", "svm-predict"

--- a/Library/Formula/libsvm.rb
+++ b/Library/Formula/libsvm.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Libsvm < Formula
   homepage 'http://www.csie.ntu.edu.tw/~cjlin/libsvm/'
-  url 'http://www.csie.ntu.edu.tw/~cjlin/libsvm/oldfiles/libsvm-3.18.tar.gz'
-  sha1 '20bd3e2d21d79c3714007043475b92dfeed29135'
+  url 'http://www.csie.ntu.edu.tw/~cjlin/libsvm/oldfiles/libsvm-3.19.tar.gz'
+  sha1 '0130bdfc66bce43d105c069f6a4c0767efd95c9f'
 
   bottle do
     cellar :any


### PR DESCRIPTION
There are two commits. The first just updates the package to the newest version, the other add a `--with-tools`-option. The new options adds the tools that are included in the libsvm package if the flag is set.