### PR TITLE
src 0.7

### DIFF
--- a/Library/Formula/src.rb
+++ b/Library/Formula/src.rb
@@ -1,0 +1,22 @@
+class Src < Formula
+  homepage "http://www.catb.org/~esr/src/"
+  url "http://www.catb.org/~esr/src/src-0.18.tar.gz"
+  sha1 "d4234bb6c56073204836ab23d18f36c1a732dd2c"
+
+  # test is failing on Mountain Lion
+  depends_on :macos => :mavericks
+
+  def install
+    # OSX doesn't provide a /usr/bin/python2. Upstream has been notified but
+    # cannot fix the issue. See:
+    #   https://github.com/Homebrew/homebrew/pull/34165#discussion_r22342214
+    inreplace "src", "#!/usr/bin/env python2", "#!/usr/bin/env python"
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    (testpath/"test.txt").write "foo"
+    system "#{bin}/src", "commit", "-m", "hello", "test.txt"
+    system "#{bin}/src", "status", "test.txt"
+  end
+end


### PR DESCRIPTION
[src](http://www.catb.org/~esr/src/) is a simple revision control system “with a modern UI for single-file solo projects kept possibly more than one to a directory”. This is a new RCS-like by Eric S. Raymond, still in its early stage (first release less than a week ago).

It has been on [HN](https://news.ycombinator.com/item?id=8601727)’s homepage for a couple hours now.