### PR TITLE
mitmproxy build failures on OS X 10.10 (Yosemite)

### DIFF
--- a/Library/Formula/mitmproxy.rb
+++ b/Library/Formula/mitmproxy.rb
@@ -20,6 +20,7 @@ class Mitmproxy < Formula
   depends_on 'protobuf' => :optional
   depends_on :x11
   depends_on 'libffi'
+  depends_on 'openssl'
 
   resource 'pyopenssl' do
     url 'https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.14.tar.gz'

--- a/Library/Formula/mitmproxy.rb
+++ b/Library/Formula/mitmproxy.rb
@@ -18,6 +18,8 @@ class Mitmproxy < Formula
   depends_on 'freetype'
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on 'protobuf' => :optional
+  depends_on :x11
+  depends_on 'libffi'
 
   resource 'pyopenssl' do
     url 'https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.14.tar.gz'
@@ -65,6 +67,9 @@ class Mitmproxy < Formula
   end
 
   def install
+    libffi = Formula["libffi"]
+    ENV.append_to_cflags "-I#{libffi.lib}/libffi-#{libffi.version}/include"
+
     ENV["PYTHONPATH"] = lib+"python2.7/site-packages"
     ENV.prepend_create_path 'PYTHONPATH', libexec+'lib/python2.7/site-packages'
     install_args = [ "setup.py", "install", "--prefix=#{libexec}" ]


### PR DESCRIPTION
By default, it fails building Pillow because it's picking up an Xlib dependency via Tk but /opt/X11/include is apparently not in the include path:

https://gist.github.com/anonymous/6ee660d0cb79de2976f8

Adding `depends_on :x11` to mitmproxy.rb allows Pillow to build but it will fail on the cryptography module, which depends on libffi:

https://gist.github.com/b6763e148f04a51fcb69
