### PR TITLE
add yosemite support for neko

### DIFF
--- a/Library/Formula/neko.rb
+++ b/Library/Formula/neko.rb
@@ -12,7 +12,7 @@ class Neko < Formula
     version "2.0.0-6ab8f48"
 
     # Revisit with each stable release. Could be a while though.
-    depends_on MaximumMacOSRequirement => :mavericks
+    depends_on MaximumMacOSRequirement => :yosemite
   end
 
   bottle do


### PR DESCRIPTION
neko works fine in yosemite.   This formula works if I change the symbol reference.   Is this how we're supposed to signal that?