### PR TITLE
geogig: replaces geogit due to renaming of project

### DIFF
--- a/Library/Aliases/geogig
+++ b/Library/Aliases/geogig
@@ -1,0 +1,1 @@
+../Formula/geogit.rb

--- a/Library/Formula/geogit.rb
+++ b/Library/Formula/geogit.rb
@@ -1,12 +1,26 @@
 require "formula"
 
 class Geogit < Formula
-  homepage "http://www.geogit.org"
-  url "https://downloads.sourceforge.net/project/geogit/geogit-0.10.0/geogit-cli-app-0.10.0.zip"
-  sha1 "290652c33995f9cba950b4e1e8514b724115a37d"
+  homepage "http://geogig.org/"
+  url "https://downloads.sourceforge.net/project/geogig/geogig-1.0-beta1/geogig-cli-app-1.0-beta1.zip"
+  sha1 "4d7b2594bed7f9c9a6816d69f6a9d68c85ed0605"
 
   def install
-    bin.install "bin/geogit", "bin/geogit-console"
+    bin.install "bin/geogig", "bin/geogig-console", "bin/geogig-gateway"
+    bin.env_script_all_files(libexec, :JAVA_HOME => "$(/usr/libexec/java_home)")
     prefix.install "repo"
+  end
+
+  def caveats; <<-EOS.undent
+    GeoGit project was renamed to GeoGig. All bin tools start with 'geogig'.
+
+    For all wrapper scripts in #{bin},
+    $JAVA_HOME is set to be the output of:
+      `/usr/libexec/java_home`
+  EOS
+  end
+
+  test do
+    system "#{bin}/geogig", "--version"
   end
 end


### PR DESCRIPTION
See: http://geogig.org/

Also, adds `JAVA_HOME` wrapper scripts and `geogig-gateway` server.