### PR TITLE
Added picojson header only library.

### DIFF
--- a/Library/Formula/picojson.rb
+++ b/Library/Formula/picojson.rb
@@ -1,0 +1,11 @@
+require 'formula'
+
+class Picojson < Formula
+  homepage 'https://github.com/kazuho/picojson'
+  url 'https://github.com/kazuho/picojson/tarball/53411f2055ceb427041ce6609de0a5f8751198c1'
+  sha1 '673d864442b2de4d529a106739e1fe28af711271'
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+end


### PR DESCRIPTION
Given that the make install was recently merged into that project but no release has been done yet, this is currently using a commit hash specific tarball from out of picojson's master branch.
It should get updated as soon as there is a proper release of picojson that includes the make install.
