### PR TITLE
deisctl 1.1.0 (new formula)

### DIFF
--- a/Library/Formula/deisctl.rb
+++ b/Library/Formula/deisctl.rb
@@ -1,0 +1,47 @@
+require "formula"
+require "language/go"
+
+class Deisctl < Formula
+  homepage "http://deis.io/"
+  url "https://github.com/deis/deis/archive/v1.1.0.tar.gz"
+  sha1 "c57fb6073b374b95262c36959c6d2b6c508cda59"
+
+  depends_on :hg => :build
+  depends_on "go" => :build
+
+  go_resource "github.com/kr/godep" do
+    url "https://github.com/kr/godep.git", :revision => "07a96a1131ddff383e0f502d24c0f989ed0a8bb1"
+  end
+
+  go_resource "github.com/kr/fs" do
+    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+  end
+
+  go_resource "golang.org/x/tools" do
+    url "https://code.google.com/p/go.tools/", :revision => "140fcaadc586", :using => :hg
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["CGO_ENABLED"] = "0"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    mkdir_p "#{buildpath}/deisctl/Godeps/_workspace/src/github.com/deis"
+    ln_s buildpath, "#{buildpath}/deisctl/Godeps/_workspace/src/github.com/deis/deis"
+
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd "src/github.com/kr/godep" do
+      system "go", "install"
+    end
+
+    cd "deisctl" do
+      system "godep", "go", "build", "-a", "-ldflags", "-s", "-o", "dist/deisctl"
+      bin.install "dist/deisctl"
+    end
+  end
+
+  test do
+    system "#{bin}/deisctl", "help"
+  end
+end


### PR DESCRIPTION
This is a management utility for [Deis](http://deis.io/) clusters. It goes along with the recent Deis client added.