### PR TITLE
apr 1.5.1 (new formula)

### DIFF
--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -1,0 +1,31 @@
+class AprUtil < Formula
+  homepage "https://apr.apache.org/"
+  url "http://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
+  sha1 "b00038b5081472ed094ced28bcbf2b5bb56c589d"
+
+  keg_only :provided_by_osx, "Apple's CLT package contains apr."
+
+  depends_on "apr"
+  depends_on "openssl"
+  depends_on "postgresql" => :optional
+
+  def install
+    # Stick it in libexec otherwise it pollutes lib with a .exp file.
+    args = %W[
+      --prefix=#{libexec}
+      --with-apr=#{Formula["apr"].opt_prefix}
+      --with-openssl=#{Formula["openssl"].opt_prefix}
+    ]
+
+    args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system "#{bin}/apu-1-config", "--link-libtool", "--libs"
+  end
+end

--- a/Library/Formula/apr.rb
+++ b/Library/Formula/apr.rb
@@ -1,0 +1,29 @@
+class Apr < Formula
+  homepage "https://apr.apache.org/"
+  url "http://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.1.tar.bz2"
+  sha1 "f94e4e0b678282e0704e573b5b2fe6d48bd1c309"
+
+  keg_only :provided_by_osx, "Apple's CLT package contains apr."
+
+  def install
+    # Configure switch unconditionally adds the -no-cpp-precomp switch
+    # to CPPFLAGS, which is an obsolete Apple-only switch that breaks
+    # builds under non-Apple compilers and which may or may not do anything anymore.
+    # Reported upstream: https://issues.apache.org/bugzilla/show_bug.cgi?id=48483
+    # Upstream bug report still open and unresolved as of end of 2014
+    inreplace "configure", " -no-cpp-precomp", ""
+
+    # https://issues.apache.org/bugzilla/show_bug.cgi?id=57359
+    # The internal libtool throws an enormous strop if we don't do...
+    ENV.deparallelize
+
+    # Stick it in libexec otherwise it pollutes lib with a .exp file.
+    system "./configure", "--prefix=#{libexec}"
+    system "make", "install"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system "#{bin}/apr-1-config", "--link-libtool", "--libs"
+  end
+end

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,4 +1,5 @@
 require 'requirement'
+require 'requirements/apr_dependency'
 require 'requirements/fortran_dependency'
 require 'requirements/language_module_dependency'
 require 'requirements/minimum_macos_requirement'
@@ -134,29 +135,5 @@ class JavaDependency < Requirement
     s = "Java#{version_string} is required to install this formula."
     s += super
     s
-  end
-end
-
-class AprDependency < Requirement
-  fatal true
-
-  satisfy(:build_env => false) { MacOS::CLT.installed? }
-
-  def message
-    message = <<-EOS.undent
-      Due to packaging problems on Apple's part, software that compiles
-      against APR requires the standalone Command Line Tools.
-    EOS
-    if MacOS.version >= :mavericks
-      message += <<-EOS.undent
-        Run `xcode-select --install` to install them.
-      EOS
-    else
-      message += <<-EOS.undent
-        The standalone package can be obtained from
-        https://developer.apple.com/downloads/,
-        or it can be installed via Xcode's preferences.
-      EOS
-    end
   end
 end

--- a/Library/Homebrew/requirements/apr_dependency.rb
+++ b/Library/Homebrew/requirements/apr_dependency.rb
@@ -1,0 +1,39 @@
+require "requirement"
+
+class AprDependency < Requirement
+  fatal true
+  default_formula "apr"
+
+  satisfy { MacOS::CLT.installed? || Formula["apr"].installed? }
+
+  env do
+    unless MacOS::CLT.installed?
+      ENV.prepend_path "PATH", "#{Formula["apr-util"].opt_prefix}/bin"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_prefix}/libexec/lib/pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_prefix}/libexec/lib/pkgconfig"
+    end
+  end
+
+  def message
+    message = <<-EOS.undent
+      Due to packaging problems on Apple's part, software that compiles
+      against APR requires the standalone Command Line Tools.
+    EOS
+    if MacOS.version >= :mavericks
+      message += <<-EOS.undent
+        Either
+        `brew install apr-util`
+        or
+        `xcode-select --install`
+        to install APR.
+      EOS
+    else
+      message += <<-EOS.undent
+        The standalone package can be obtained from
+        https://developer.apple.com/downloads/,
+        or it can be installed via Xcode's preferences.
+        Or you can `brew install apr-util`.
+      EOS
+    end
+  end
+end


### PR DESCRIPTION
New formulae for apr, apr-util and a reworded/repurposed requirement to fit both. The existing syntax in-formulae of ` depends_on :apr ` doesn't need changing, It should and appears to work as is. *(Which is nice, usually when I expect something to work as is it doesn't).*