### PR TITLE
smpeg2 2.0.0 (new formula)

### DIFF
--- a/Library/Formula/smpeg.rb
+++ b/Library/Formula/smpeg.rb
@@ -1,0 +1,43 @@
+class Smpeg < Formula
+  desc "SDL MPEG Player Library"
+  homepage "http://icculus.org/smpeg/"
+  url "svn://svn.icculus.org/smpeg/tags/release_0_4_5/", :revision => "399"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "sdl"
+  depends_on "gtk+" => :optional
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --with-sdl-prefix=#{Formula["sdl"].opt_prefix}
+      --disable-dependency-tracking
+      --disable-debug
+      --disable-sdltest
+    ]
+
+    if build.without? "gtk"
+      args << "--disable-gtk-player"
+      args << "--disable-gtktest"
+    end
+
+    # Skip glmovie to avoid OpenGL error
+    args << "--disable-opengl-player"
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make"
+    # Install script is not +x by default for some reason
+    chmod 0755, "./install-sh"
+    system "make", "install"
+
+    rm_f "#{man1}/gtv.1" if build.without? "gtk"
+  end
+
+  test do
+    system "#{bin}/plaympeg", "--version"
+  end
+end

--- a/Library/Formula/smpeg2.rb
+++ b/Library/Formula/smpeg2.rb
@@ -1,0 +1,31 @@
+class Smpeg2 < Formula
+  desc "SDL MPEG Player Library"
+  homepage "http://icculus.org/smpeg/"
+  url "svn://svn.icculus.org/smpeg/tags/release_2_0_0/", :revision => "408"
+  head "svn://svn.icculus.org/smpeg/trunk"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "sdl2"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-sdl-prefix=#{Formula["sdl2"].opt_prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-debug",
+                          "--disable-sdltest"
+    system "make"
+    system "make", "install"
+
+    # To avoid a possible conflict with smpeg 0.x
+    mv "#{bin}/plaympeg", "#{bin}/plaympeg2"
+    mv "#{man1}/plaympeg.1", "#{man1}/plaympeg2.1"
+  end
+
+  test do
+    system "#{bin}/plaympeg2", "--version"
+  end
+end


### PR DESCRIPTION
Introduce a separate formula of `smpeg2` for the latest version (2.0.0) dependent on `sdl2`.

An update for the old `smpeg`, which temporarily moved out to `homebrew-headonly`, is also posted (Homebrew/homebrew-headonly#79). 0.x version should remain as is because many applications still assume smpeg with SDL 1.2.

Summary of difference:

1. Uses `sdl2` instead of `sdl`.
2. Only `smpeg2` has `head`.
3. No `gtk+` dependency. Looks like it's been dropped in the upstream.
4. `--with-plaympeg` added to make plaympeg building optional. Otherwise it could have conflicted with plaympeg from old smpeg.
5. chmod trick removed. It seems working fine without permission fix.