### PR TITLE
using Mac OS alias in linkapps so spotlight can index them

### DIFF
--- a/Library/Homebrew/cmd/linkapps.rb
+++ b/Library/Homebrew/cmd/linkapps.rb
@@ -26,17 +26,33 @@ module Homebrew
       keg = keg.opt_record if keg.optlinked?
       Dir["#{keg}/*.app", "#{keg}/bin/*.app", "#{keg}/libexec/*.app"].each do |app|
         puts "Linking #{app}"
-        app_name = File.basename(app)
+        app_name = File.basename(app, ".app")
         target = "#{target_dir}/#{app_name}"
 
-        if File.exist?(target) && !File.symlink?(target)
+        if File.exist?(target)
           onoe "#{target} already exists, skipping."
           next
         end
-        system "ln", "-sf", app, target_dir
+
+        link_app app, target_dir
       end
     end
 
     puts "Finished linking. Find the links under #{target_dir}."
+  end
+
+  private
+
+  def link_app app, target_dir
+    # Link app by creating Mac OS alias, so spotlight can index it.
+    # http://apple.stackexchange.com/a/8103
+    args = <<-EOS.undent
+      tell application "Finder"
+        set macSrcPath to POSIX file "#{app}" as text
+        set macDestPath to POSIX file "#{target_dir}" as text
+        make new alias file to file macSrcPath at folder macDestPath
+      end tell
+    EOS
+    quiet_system "/usr/bin/osascript", "-e", args
   end
 end

--- a/Library/Homebrew/cmd/unlinkapps.rb
+++ b/Library/Homebrew/cmd/unlinkapps.rb
@@ -7,15 +7,21 @@ module Homebrew
 
     return unless File.exist? target_dir
 
-    cellar_apps = Dir[target_dir + "/*.app"].select do |app|
+    cellar_apps = Dir[target_dir + "/*"].select do |app|
       if File.symlink?(app)
         should_unlink? File.readlink(app)
+      elsif File.file?(app) && alias?(app)
+        should_unlink? readalias(app)
       end
     end
 
     cellar_apps.each do |app|
       puts "Unlinking #{app}"
-      system "unlink", app
+      if File.symlink?(app)
+        system "unlink", app
+      else
+        rm app
+      end
     end
 
     puts "Finished unlinking from #{target_dir}" if cellar_apps
@@ -29,5 +35,23 @@ module Homebrew
     else
       ARGV.kegs.any? { |keg| file.match(keg.to_s) || file.match(keg.opt_record.to_s) }
     end
+  end
+
+  def alias? file
+    # Determine if a file is the Mac OS alias by its magic head.
+    # http://en.wikipedia.org/wiki/Alias_(Mac_OS)#/File_structure
+    File.read(file, 16) == "book\x00\x00\x00\x00mark\x00\x00\x00\x00"
+  end
+
+  def readalias file
+    # Try to retrieve the target path of an alias.
+    # http://stackoverflow.com/a/1330366
+    args =<<-EOS.undent
+      tell application "Finder"
+        set theItem to POSIX file "#{file}" as alias
+        get the POSIX path of ((original item of theItem) as text)
+      end tell
+    EOS
+    Utils.popen_read("/usr/bin/osascript", "-e", args).strip
   end
 end


### PR DESCRIPTION
This PR extends the features of `brew linkapps` and `brew unlinkapps` as below:
1. Use [Mac OS Alias](http://en.wikipedia.org/wiki/Alias_(Mac_OS)) rather than symbol link to link the applications. Therefore, spotlight can index them which solves https://github.com/Homebrew/homebrew/issues/28798.
2. `brew unlinkapps` can unlink old symbol link as forward compatible.

**Update**: the PR now contains Mac OS alias feature only.