### PR TITLE
openssl: removing sslv3

### DIFF
--- a/Library/Formula/activemq-cpp.rb
+++ b/Library/Formula/activemq-cpp.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class ActivemqCpp < Formula
   homepage "https://activemq.apache.org/cms/index.html"
   url "http://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.8.3/activemq-cpp-library-3.8.3-src.tar.bz2"
   sha1 "ea67d8b86a524ff57f2a2e0e2451deafacfd6d4b"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,6 +12,7 @@ class ActivemqCpp < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on :apr => :build
   depends_on "openssl"
 
   def install

--- a/Library/Formula/aircrack-ng.rb
+++ b/Library/Formula/aircrack-ng.rb
@@ -1,12 +1,14 @@
-require "formula"
-
 class AircrackNg < Formula
   homepage "http://aircrack-ng.org/"
   # We can't update this due to linux-only dependencies in >1.1.
   # See https://github.com/Homebrew/homebrew/issues/29450
+  # 1.2RC1 is actually more portable, libnl detection has been fixed.
+  # If you inreplace the <endian.h> in src/osdep/radiotap/platform.h with
+  # </usr/include/sys/_endian.h> it almost compiles, with only arch errors.
+  # Monitor this going forwards.
   url "http://download.aircrack-ng.org/aircrack-ng-1.1.tar.gz"
   sha1 "16eed1a8cf06eb8274ae382150b56589b23adf77"
-  revision 1
+  revision 2
 
   depends_on "pkg-config" => :build
   depends_on "sqlite"

--- a/Library/Formula/alpine.rb
+++ b/Library/Formula/alpine.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Alpine < Formula
   homepage "http://patches.freeiz.com/alpine/"
   url "http://patches.freeiz.com/alpine/release/src/alpine-2.11.tar.xz"
   sha1 "656556f5d2e5ec7e3680d1760cd02aa3a0072c46"
+  revision 1
 
   bottle do
     sha1 "51fb44fd30777e0a64924689978e4f2d795176a5" => :yosemite

--- a/Library/Formula/freeradius-server.rb
+++ b/Library/Formula/freeradius-server.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class FreeradiusServer < Formula
   homepage "http://freeradius.org/"
   url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-2.2.6.tar.gz"
   sha1 "25b0a057b1fffad5a030946e8af0c6170e5cdf46"
+  revision 1
 
   devel do
     url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.5.tar.bz2"

--- a/Library/Formula/libtorrent-rasterbar.rb
+++ b/Library/Formula/libtorrent-rasterbar.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class LibtorrentRasterbar < Formula
   homepage "http://sourceforge.net/projects/libtorrent/"
   url "https://downloads.sourceforge.net/project/libtorrent/libtorrent/libtorrent-rasterbar-1.0.3.tar.gz"
   sha1 "ccdd8bdba178b300921b15b18dfe8c0705f7eb07"
+  revision 1
 
   head do
     url "https://libtorrent.googlecode.com/svn/trunk"

--- a/Library/Formula/libtorrent.rb
+++ b/Library/Formula/libtorrent.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Libtorrent < Formula
   homepage "http://libtorrent.rakshasa.no/"
   url "http://libtorrent.rakshasa.no/downloads/libtorrent-0.13.4.tar.gz"
   sha1 "3a3ca87054d020bc376abe2c1ea15bbbaef31131"
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
@@ -25,6 +24,6 @@ class Libtorrent < Formula
                           "--with-kqueue",
                           "--enable-ipv6"
     system "make"
-    system "make install"
+    system "make", "install"
   end
 end

--- a/Library/Formula/links.rb
+++ b/Library/Formula/links.rb
@@ -1,11 +1,9 @@
-require "formula"
-
 class Links < Formula
   homepage "http://links.twibright.com/"
   url "http://links.twibright.com/download/links-2.8.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/l/links2/links2_2.8.orig.tar.bz2"
   sha1 "a808d80d910b7d3ad86f4c5089e64f35113b69f2"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/lynx.rb
+++ b/Library/Formula/lynx.rb
@@ -1,11 +1,9 @@
-require "formula"
-
 class Lynx < Formula
   homepage "http://lynx.isc.org/release/"
   url "http://lynx.isc.org/current/lynx2.8.8rel.2.tar.bz2"
   version "2.8.8rel.2"
   sha1 "65bbf95627c88723bbb5880155e5fe01c2753d0c"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/ncrack.rb
+++ b/Library/Formula/ncrack.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Ncrack < Formula
   homepage "http://nmap.org/ncrack/"
   url "http://nmap.org/ncrack/dist/ncrack-0.4ALPHA.tar.gz"
   sha256 "f8bd7e0ef68559490064ec0a5f139b2b9c49aeaf9f6323e080db9ff344c87603"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Nginx < Formula
   homepage "http://nginx.org/"
   url "http://nginx.org/download/nginx-1.6.2.tar.gz"
   sha1 "1a5458bc15acf90eea16353a1dd17285cf97ec35"
+  revision 1
 
   devel do
     url "http://nginx.org/download/nginx-1.7.7.tar.gz"
@@ -115,7 +114,7 @@ class Nginx < Formula
 
   def passenger_caveats; <<-EOS.undent
 
-    To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the 'http' context:
+    To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the "http" context:
       passenger_root #{Formula["passenger"].opt_libexec}/lib/phusion_passenger/locations.ini;
       passenger_ruby /usr/bin/ruby;
     EOS

--- a/Library/Formula/nmap.rb
+++ b/Library/Formula/nmap.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Nmap < Formula
   homepage "http://nmap.org/"
   head "https://guest:@svn.nmap.org/nmap/", :using => :svn
   url "http://nmap.org/dist/nmap-6.47.tar.bz2"
   sha1 "0c917453a91a5e85c2a217d27c3853b0f3e0e6ac"
+  revision 1
 
   bottle do
     revision 1
@@ -15,7 +14,7 @@ class Nmap < Formula
 
   depends_on "openssl"
 
-  conflicts_with 'ndiff', :because => 'both install `ndiff` binaries'
+  conflicts_with "ndiff", :because => "both install `ndiff` binaries"
 
   fails_with :llvm do
     build 2334
@@ -40,6 +39,6 @@ class Nmap < Formula
   end
 
   test do
-    system "#{bin}/nmap", '-p80,443', 'google.com'
+    system "#{bin}/nmap", "-p80,443", "google.com"
   end
 end

--- a/Library/Formula/osslsigncode.rb
+++ b/Library/Formula/osslsigncode.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Osslsigncode < Formula
   homepage "http://sourceforge.net/projects/osslsigncode/"
   url "https://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.6.tar.gz"
   sha1 "83c169638c8c1e0122127674cbb73d2e0e6b5bc2"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/peervpn.rb
+++ b/Library/Formula/peervpn.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Peervpn < Formula
   homepage "http://www.peervpn.net"
   url "http://www.peervpn.net/files/peervpn-0-041.tar.gz"
   version "0.041"
   sha1 "b05bb88bfe73976714f559c8aaf545d75b026768"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/phantomjs.rb
+++ b/Library/Formula/phantomjs.rb
@@ -1,7 +1,6 @@
-require "formula"
-
 class Phantomjs < Formula
   homepage "http://www.phantomjs.org/"
+  revision 1
 
   stable do
     url "https://github.com/ariya/phantomjs/archive/1.9.8.tar.gz"

--- a/Library/Formula/pypy.rb
+++ b/Library/Formula/pypy.rb
@@ -1,9 +1,9 @@
-require "formula"
-
 class Pypy < Formula
   homepage "http://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-src.tar.bz2"
   sha1 "e2e0bcf8457c0ae5a24f126a60aa921dabfe60fb"
+  revision 1
+
   bottle do
     cellar :any
     revision 4

--- a/Library/Formula/pypy3.rb
+++ b/Library/Formula/pypy3.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Pypy3 < Formula
   homepage "http://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2"
   sha1 "438572443ae6f54eb6122d807f104787c5247e01"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Python < Formula
   homepage "https://www.python.org"
   head "https://hg.python.org/cpython", :using => :hg, :branch => "2.7"
   url "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz"
   sha1 "7a191bcccb598ccbf2fa6a0edce24a97df3fc0ad"
+  revision 1
 
   bottle do
     revision 5

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Python3 < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz"
   sha1 "0727d8a8498733baabe6f51632b9bab0cbaa9ada"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/stunnel.rb
+++ b/Library/Formula/stunnel.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Stunnel < Formula
   homepage "https://www.stunnel.org/"
   url "https://www.stunnel.org/downloads/stunnel-5.08.tar.gz"
   mirror "http://www.usenix.org.uk/mirrors/stunnel/stunnel-5.08.tar.gz"
   sha256 "830b21d24cd237e96f4d7993be43553d4eba4d3cfa2660faa78dec8d41d314fc"
+  revision 1
 
   bottle do
     sha1 "aab0c4a1dcdfcdfdac9d9b9c06fda6b1933475af" => :yosemite

--- a/Library/Formula/tor.rb
+++ b/Library/Formula/tor.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Tor < Formula
   homepage "https://www.torproject.org/"
   url "https://dist.torproject.org/tor-0.2.5.10.tar.gz"
   sha256 "b3dd02a5dcd2ffe14d9a37956f92779d4427edf7905c0bba9b1e3901b9c5a83b"
+  revision 1
 
   bottle do
     sha1 "0bf6ef6985285bac9e67fbc78cef7ebb78844de2" => :yosemite


### PR DESCRIPTION
Removes SSLv3 and IDEA from OpenSSL, and revisions a decent chunk of things to deal with it. Most things are fine, and nothing is hugely hugely broken as far as my testing goes, but little minor things, certain obscure situations, etc, better handle those situations when built explicitly against the new OpenSSL.

This is a considerably smaller PR than when we killed SSLv2. Given the minimal impact of that change, there's a hope we can do without so many revisions this time.

This brings us on par with Debian Jessie, which is expected to be released as stable by February.

Closes #34634.