### PR TITLE
Update MonetDB to Oct2014-SP1 release and add optional packages

### DIFF
--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -37,9 +37,7 @@ class Monetdb < Formula
   option "with-java", 'Build the JDBC dirver'
   option "with-r", 'Build the R integration module'
 
-  if build.with? "r"
-    depends_on RRequirement => :optional
-  end
+  depends_on RRequirement => :optional
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -19,7 +19,7 @@ class Monetdb < Formula
     depends_on "automake" => :build
     depends_on "autoconf" => :build
   end
-  
+
   option "with-java" # Build the JDBC dirver
   option "with-r" # Build the R integration module
 

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -20,8 +20,8 @@ class Monetdb < Formula
     depends_on "autoconf" => :build
   end
   
-  option "with-java"
-  option "with-r"
+  option "with-java" # Build the JDBC dirver
+  option "with-r" # Build the R integration module
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build
@@ -46,7 +46,7 @@ class Monetdb < Formula
             "--enable-optimize=yes",
             "--enable-testing=no",
             "--with-readline=#{Formula["readline"].opt_prefix}", # Use the correct readline
-            "--without-rubygem"]
+            "--without-rubygem"] # Installing the RubyGems requires root permissions
 
     args << "--with-java=no" if build.without? "java"
     args << "--disable-rintegration" if build.without? "r"

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Monetdb < Formula
   homepage "https://www.monetdb.org/"
-  url "https://dev.monetdb.org/downloads/sources/Oct2014/MonetDB-11.19.7.zip"
+  url "https://dev.monetdb.org/downloads/sources/Oct2014-SP1/MonetDB-11.19.7.zip"
   sha1 "af542dc85a8474eb4bcf32565eccae3ea5d22768"
 
   bottle do

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -21,24 +21,24 @@ class Monetdb < Formula
   end
 
   class RRequirement < Requirement
-      fatal true
+    fatal true
 
-      satisfy { which('r') }
+    satisfy { which('r') }
 
-      def message; <<-EOS.undent
-          R not found. The R integration module requires R.
-          Do one of the following:
-          - install R
-          - remove the --with-r option
-          EOS
-      end
+    def message; <<-EOS.undent
+      R not found. The R integration module requires R.
+      Do one of the following:
+      - install R
+      - remove the --with-r option
+      EOS
+    end
   end
 
   option "with-java", 'Build the JDBC dirver'
   option "with-r", 'Build the R integration module'
 
   if build.with? "r"
-      depends_on RRequirement
+    depends_on RRequirement => :optional
   end
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -15,7 +15,7 @@ class RRequirement < Requirement
   end
 end
 
-class RRequirement < Formula
+class Monetdb < Formula
   homepage "https://www.monetdb.org/"
   url "https://dev.monetdb.org/downloads/sources/Oct2014-SP1/MonetDB-11.19.7.zip"
   sha1 "af542dc85a8474eb4bcf32565eccae3ea5d22768"

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -23,10 +23,10 @@ class Monetdb < Formula
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build
+  depends_on "libatomic_ops" => [:build, :recommended]
   depends_on "pcre"
   depends_on "readline" # Compilation fails with libedit.
   depends_on "openssl"
-  depends_on "libatomic_ops" => :recommended
 
   depends_on "unixodbc" => :optional # Build the ODBC driver
   depends_on "geos" => :optional # Build the GEOM module

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -21,7 +21,7 @@ class Monetdb < Formula
   depends_on "libtool" => :build # Needed for bootstrapping (when building the HEAD)
   depends_on "gettext" => :build # Needed for bootstrapping (when building the HEAD)
   depends_on "pcre"
-  depends_on "readline" # Compilation fails with libedit.o
+  depends_on "readline" # Compilation fails with libedit.
   depends_on "openssl"
   depends_on "libatomic_ops" => :recommended
 

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -16,10 +16,12 @@ class Monetdb < Formula
 
     depends_on "libtool" => :build
     depends_on "gettext" => :build
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
   end
   
   option "with-java"
-  option "with-rintegration"
+  option "with-r"
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build
@@ -47,7 +49,7 @@ class Monetdb < Formula
             "--without-rubygem"]
 
     args << "--with-java=no" if build.without? "java"
-    args << "--disable-rintegration" if build.without? "rintegration"
+    args << "--disable-rintegration" if build.without? "r"
 
     system "./configure", *args
     system "make install"

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -1,6 +1,21 @@
 require "formula"
 
-class Monetdb < Formula
+class RRequirement < Requirement
+  fatal true
+
+  satisfy { which('r') }
+
+  def message; <<-EOS.undent
+    R not found. The R integration module requires R.
+    Do one of the following:
+    - install R
+    -- run brew install homebrew/science/r or brew install Caskroom/cask/r
+    - remove the --with-r option
+    EOS
+  end
+end
+
+class RRequirement < Formula
   homepage "https://www.monetdb.org/"
   url "https://dev.monetdb.org/downloads/sources/Oct2014-SP1/MonetDB-11.19.7.zip"
   sha1 "af542dc85a8474eb4bcf32565eccae3ea5d22768"
@@ -18,20 +33,6 @@ class Monetdb < Formula
     depends_on "gettext" => :build
     depends_on "automake" => :build
     depends_on "autoconf" => :build
-  end
-
-  class RRequirement < Requirement
-    fatal true
-
-    satisfy { which('r') }
-
-    def message; <<-EOS.undent
-      R not found. The R integration module requires R.
-      Do one of the following:
-      - install R
-      - remove the --with-r option
-      EOS
-    end
   end
 
   option "with-java", 'Build the JDBC dirver'

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -11,29 +11,31 @@ class Monetdb < Formula
     sha1 "484c94edf77b0acb72aa0e0cb7a8017c149be95c" => :mountain_lion
   end
 
-  head "http://dev.monetdb.org/hg/MonetDB", :using => :hg
+  head do
+    url "http://dev.monetdb.org/hg/MonetDB", :using => :hg
 
+    depends_on "libtool" => :build
+    depends_on "gettext" => :build
+  end
+  
   option "with-java"
   option "with-rintegration"
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build
-  depends_on "libtool" => :build # Needed for bootstrapping (when building the HEAD)
-  depends_on "gettext" => :build # Needed for bootstrapping (when building the HEAD)
   depends_on "pcre"
   depends_on "readline" # Compilation fails with libedit.
   depends_on "openssl"
   depends_on "libatomic_ops" => :recommended
 
-  depends_on "unixodbc" => :optional # Build ODBC driver
+  depends_on "unixodbc" => :optional # Build the ODBC driver
   depends_on "geos" => :optional # Build the GEOM module
   depends_on "gsl" => :optional
   depends_on "cfitsio" => :optional
   depends_on "homebrew/php/libsphinxclient" => :optional
 
   def install
-    ENV["PKG_CONFIG_PATH"] = "/usr/local/opt/zlib/lib/pkgconfig" if build.head?
-    ENV["M4DIRS"] = "/usr/local/opt/gettext/share/aclocal" if build.head?
+    ENV["M4DIRS"] = "#{Formula["gettext"].opt_share}/aclocal" if build.head?
     system "./bootstrap" if build.head?
 
     args = ["--prefix=#{prefix}",
@@ -41,7 +43,7 @@ class Monetdb < Formula
             "--enable-assert=no",
             "--enable-optimize=yes",
             "--enable-testing=no",
-            "--with-readline=/usr/local/opt/readline", # Use the correct readline
+            "--with-readline=#{Formula["readline"].opt_prefix}", # Use the correct readline
             "--without-rubygem"]
 
     args << "--with-java=no" if build.without? "java"

--- a/Library/Formula/monetdb.rb
+++ b/Library/Formula/monetdb.rb
@@ -20,8 +20,26 @@ class Monetdb < Formula
     depends_on "autoconf" => :build
   end
 
-  option "with-java" # Build the JDBC dirver
-  option "with-r" # Build the R integration module
+  class RRequirement < Requirement
+      fatal true
+
+      satisfy { which('r') }
+
+      def message; <<-EOS.undent
+          R not found. The R integration module requires R.
+          Do one of the following:
+          - install R
+          - remove the --with-r option
+          EOS
+      end
+  end
+
+  option "with-java", 'Build the JDBC dirver'
+  option "with-r", 'Build the R integration module'
+
+  if build.with? "r"
+      depends_on RRequirement
+  end
 
   depends_on "pkg-config" => :build
   depends_on :ant => :build


### PR DESCRIPTION
Update MonetDB to Oct2014-SP1
Set the correct readline when building.
Add instructions to install GEOS, UnixODBC, GSL, FITS and Sphinx.
Add libatomic_ops as a recommended dependency.
Also add option to enable the R-integration.
Add gettext and libtool for as building dependencies - they are needed for bootstrapping when building the head.
Remove the JAQL reference, removed in MonetDB Oct2014.