### PR TITLE
Added harfbuzz optional to fix spacing issues

### DIFF
--- a/Library/Formula/libass.rb
+++ b/Library/Formula/libass.rb
@@ -18,6 +18,7 @@ class Libass < Formula
   depends_on 'freetype'
   depends_on 'fribidi'
   depends_on 'fontconfig'
+  depends_on 'harfbuzz' => :optional
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
Refer to this thread:
https://github.com/mpv-player/mpv/issues/1365
tldr: I had spacing issues with japanese characters in mpv and they were fixed by recompiling libass with harfbuzz