### PR TITLE
Adding links to Pebble SDK license agreement in the caveat

### DIFF
--- a/Library/Formula/pebble-sdk.rb
+++ b/Library/Formula/pebble-sdk.rb
@@ -106,6 +106,11 @@ class PebbleSdk < Formula
   end
 
   def caveats; <<-EOS.undent
+    To use the Pebble SDK, you must read and agree to the Pebble Terms of Use
+    and the Pebble Developer License at:
+      http://developer.getpebble.com/legal/terms-of-use/
+      http://developer.getpebble.com/legal/sdk-license/
+
     Documentation and examples can be found in
       #{doc}
     EOS


### PR DESCRIPTION
As discussed in #34426.

@sarfata has indicated that presenting the links in the caveat (which is displayed after every install) would be enough to satisfy the lawyers.