### PR TITLE
Update pstree source to point to a valid location

### DIFF
--- a/Library/Formula/pstree.rb
+++ b/Library/Formula/pstree.rb
@@ -4,8 +4,9 @@ require 'formula'
 # the /proc file system, which is not available on OS X.
 
 class Pstree < Formula
-  homepage 'http://freshmeat.net/projects/pstree/'
-  url 'ftp://ftp.thp.uni-duisburg.de/pub/source/pstree-2.36.tar.gz'
+  homepage 'http://www.thp.uni-duisburg.de/pstree/'
+  version '2.36'
+  url 'http://www.thp.uni-duisburg.de/pstree/pstree.tar.gz'
   sha1 '1ca2e08c62d33afd37d78a215095258e77654b3f'
 
   def install


### PR DESCRIPTION
Freecode is no longer being updated, and their FTP seems to be down so downloading the code doesn't work.

http://www.thp.uni-duisburg.de/pstree/ is a valid host for the code. I changed the homepage to point to http://www.thp.uni-duisburg.de/pstree/ because the freshmeat page just redirects to the freecode page (which is stale and contains invalid download links).