### PR TITLE
john-jumbo 1.8.0-j1

### DIFF
--- a/Library/Formula/john-jumbo.rb
+++ b/Library/Formula/john-jumbo.rb
@@ -1,31 +1,25 @@
-require 'formula'
-
 class JohnJumbo < Formula
-  homepage 'http://www.openwall.com/john/'
-  url 'http://www.openwall.com/john/g/john-1.7.9.tar.bz2'
-  sha1 '8f77bdd42b7cf94ec176f55ea69c4da9b2b8fe3b'
-  revision 1
+  homepage "http://www.openwall.com/john/"
+  url "http://openwall.com/john/j/john-1.8.0-jumbo-1.tar.xz"
+  sha1 "38196f21d2c9c4b539529d0820eb242d5373241f"
+  version "1.8.0"
 
   bottle do
-    revision 1
     sha1 "a11eb01effa085f1f196353477111f76c39e6349" => :mavericks
     sha1 "acbdf6c2b4f59b2b4e756d7288f3d727ab630706" => :mountain_lion
     sha1 "eef8dcc88d9666c7c3c099bee4cc6d14f27a056b" => :lion
   end
 
-  conflicts_with 'john', :because => 'both install the same binaries'
+  conflicts_with "john", :because => "both install the same binaries"
 
+  option "without-completion", "bash/zsh completion will not be installed"
+
+  depends_on "pkg-config" => :build
   depends_on "openssl"
+  depends_on "gmp"
 
-  patch do
-    url "http://www.openwall.com/john/g/john-1.7.9-jumbo-7.diff.gz"
-    sha1 "22fd8294e997f45a301cfeb65a8aa7083f25a55d"
-  end
-
-  # First patch taken from MacPorts, tells john where to find runtime files
-  # Second patch protects against a redefinition of _mm_testz_si128 which
-  # tanked the build in clang;
-  # see https://github.com/Homebrew/homebrew/issues/26531
+  # Patch taken from MacPorts, tells john where to find runtime files.
+  # https://github.com/magnumripper/JohnTheRipper/issues/982
   patch :DATA
 
   fails_with :llvm do
@@ -33,37 +27,43 @@ class JohnJumbo < Formula
     cause "Don't remember, but adding this to whitelist 2336."
   end
 
+  # https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/doc/INSTALL#L133-L143
+  fails_with :gcc do
+    cause "Upstream have a hacky workaround for supporting gcc that we can't use."
+  end
+
   def install
-    ENV.deparallelize
-    arch = MacOS.prefer_64_bit? ? "64-opencl" : "sse2-opencl"
-    target = "macosx-x86-#{arch}"
-
-    args = %W[-C src clean CC=#{ENV.cc} #{target}]
-
-    if MacOS.version >= :snow_leopard
-      case ENV.compiler
-      when :clang
-        # no openmp support
-      when :gcc, :llvm
-        args << "OMPFLAGS=-fopenmp -msse2 -D_FORTIFY_SOURCE=0"
-      else
-        args << "OMPFLAGS=-fopenmp -msse2"
-      end
+    cd "src" do
+      system "./configure"
+      system "make", "clean"
+      system "make", "-s", "CC=#{ENV.cc}"
     end
 
-    system "make", *args
+    # Remove the symlink and install the real file
+    rm "README"
+    prefix.install "doc/README"
+    doc.install Dir["doc/*"]
 
-    # Remove the README symlink and install the real file
-    rm 'README'
-    prefix.install 'doc/README'
-    doc.install Dir['doc/*']
+    # Only symlink the main binary into bin
+    (share/"john").install Dir["run/*"]
+    bin.install_symlink share/"john/john"
 
-    # Only symlink the binary into bin
-    (share/'john').install Dir['run/*']
-    bin.install_symlink share/'john/john'
+    if build.with? "completion"
+      bash_completion.install share/"john/john.bash_completion" => "john.bash"
+      zsh_completion.install share/"john/john.zsh_completion" => "_john"
+    end
 
-    # Source code defaults to 'john.ini', so rename
-    mv share/'john/john.conf', share/'john/john.ini'
+    # Source code defaults to "john.ini", so rename
+    mv share/"john/john.conf", share/"john/john.ini"
+  end
+
+  test do
+    ENV["HOME"] = testpath
+    touch "john2.pot"
+    system "echo dave:`printf secret | openssl md5` > test"
+    output = shell_output("#{bin}/john --pot=#{testpath}/john2.pot --format=raw-md5 test")
+    assert output.include? "secret"
+    assert (testpath/"john2.pot").read.include?("secret")
   end
 end
 
@@ -90,17 +90,3 @@ __END__
  #endif
  #define JOHN_PRIVATE_HOME		"~/.john"
  #endif
-
-diff --git a/src/rawSHA1_ng_fmt.c b/src/rawSHA1_ng_fmt.c
-index 5f89cda..6cbd550 100644
---- a/src/rawSHA1_ng_fmt.c
-+++ b/src/rawSHA1_ng_fmt.c
-@@ -530,7 +530,7 @@ static void sha1_fmt_crypt_all(int count)
- 
- #if defined(__SSE4_1__)
- 
--# if !defined(__INTEL_COMPILER)
-+# if !defined(__INTEL_COMPILER) && !defined(__clang__)
- // This intrinsic is not always available in GCC, so define it here.
- static inline int _mm_testz_si128 (__m128i __M, __m128i __V)
- {


### PR DESCRIPTION
Version bump. Changed how we handle this, to reflect upstream’s new release priorities and move to autotools. Removed a redundant part of the patch.