### PR TITLE
Csync updated to remove crashing iconv related bug and smbc_utime

### DIFF
--- a/Library/Formula/csync.rb
+++ b/Library/Formula/csync.rb
@@ -28,23 +28,68 @@ class Csync < Formula
 
   depends_on :macos => :lion
 
+  #
+  # Stable version requires inline patch
+  #
+  stable do
   patch :DATA
+  end
+
+  #
+  # Head version requires patch to fix smbc_utimes
+  #
+  head do
+  patch "--- a/modules/csync_smb.c
++++ b/modules/csync_smb.c
+@@ -414,7 +414,7 @@ static int _chown(const char *uri, uid_t owner, gid_t group) {
+ }
+
+ static int _utimes(const char *uri, const struct timeval *times) {
+-  return smbc_utimes(uri, (struct timeval *) times);
++  return smbc_utimes(uri, (void *) times);
+ }
+
+ static struct csync_vio_capabilities_s _smb_capabilities = {
+"
+  #
+  # Head version requires patch to ignore iconv ... this can't be right!
+  #
+    patch "--- a/src/std/c_string.c
++++ b/src/std/c_string.c
+@@ -87,6 +87,8 @@ enum iconv_direction { iconv_from_native, iconv_to_native };
+
+ static char *c_iconv(const char* str, enum iconv_direction dir)
+ {
++    return c_strdup(str);
++/*
+ #ifdef HAVE_ICONV_CONST
+     const char *in = str;
+ #else
+@@ -128,6 +130,7 @@ static char *c_iconv(const char* str, enum iconv_direction dir)
+   }
+
+   return out;
++ */
+ }
+ #endif /* defined(HAVE_ICONV) && defined(WITH_ICONV) */
+"
+  end
 
   def install
     mkdir 'build' unless build.head?
     cd 'build' do
-      system "cmake", "..", *std_cmake_args
-      # We need to run make csync first to make the "core",
-      # or the build system will freak out and try to link
-      # modules against core functions that aren't compiled
-      # yet. We also have to patch "link.txt" for all module
-      # targets. This should probably be reported upstream.
-      system "make csync"
-      inreplace Dir['modules/CMakeFiles/*/link.txt'] do |s|
-        s.gsub! '-o', "../src/libcsync.dylib ../src/std/libcstdlib.a -o"
-      end
-      # Now we can make and install.
-      system "make all"
+    system "cmake", "..", *std_cmake_args
+    # We need to run make csync first to make the "core",
+    # or the build system will freak out and try to link
+    # modules against core functions that aren't compiled
+    # yet. We also have to patch "link.txt" for all module
+    # targets. This should probably be reported upstream.
+    system "make csync"
+    inreplace Dir['modules/CMakeFiles/*/link.txt'] do |s|
+    s.gsub! '-o', "../src/libcsync.dylib ../src/std/libcstdlib.a -o"
+    end
+    # Now we can make and install.
+    system "make all"
       system "make install"
     end
   end


### PR DESCRIPTION
bugs on yosemite.   Only tested for HEAD