### PR TITLE
Quagga routing suite

### DIFF
--- a/Library/Formula/quagga.rb
+++ b/Library/Formula/quagga.rb
@@ -9,9 +9,7 @@ class Quagga < Formula
   depends_on "gawk" => :build
 
   def install
-    ENV.deparallelize
-    # Quagga's autotools setup requires some help
-    # enable all protocols and management 
+    # enable all protocol daemons and remote management tools
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -29,9 +27,9 @@ class Quagga < Formula
                           "--enable-multipath=0",
                           "--enable-rtadv",
                           "--enable-watchquagga",
-                          "--enable-user=quagga",
-                          "--enable-group=quagga",
-                          "--enable-vty-group=quagga",
+                          "--enable-user=daemon",
+                          "--enable-group=daemon",
+                          "--enable-vty-group=daemon",
                           "--enable-configfile-mask=0640",
                           "--enable-logfile-mask=0640"                         
     system "make", "install"
@@ -47,6 +45,6 @@ class Quagga < Formula
     #
     # The installed folder is not in the path, so use the entire path to any
     # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "false"
+    system "make", "check"
   end
 end

--- a/Library/Formula/quagga.rb
+++ b/Library/Formula/quagga.rb
@@ -1,0 +1,52 @@
+# Quagga Routing Suite
+
+class Quagga < Formula
+  homepage "http://www.nongnu.org/quagga/"
+  url "http://download.savannah.gnu.org/releases/quagga/quagga-0.99.23.1.tar.gz"
+  sha1 "0501f527383cfa548a800de9816cf1423f6b2336"
+
+  depends_on "readline" => :build
+  depends_on "gawk" => :build
+
+  def install
+    ENV.deparallelize
+    # Quagga's autotools setup requires some help
+    # enable all protocols and management 
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--enable-ipv6",
+                          "--enable-isisd",
+                          "--enable-isis-topology",
+                          "--enable-ospf-te",
+                          "--enable-opaque-lsa",
+                          "--enable-ospfclient=yes",
+                          "--enable-ospfapi=yes",
+                          "--enable-tcp-zebra",
+                          "--enable-vtysh",
+                          "--enable-fpm",
+                          "--enable-multipath=0",
+                          "--enable-rtadv",
+                          "--enable-watchquagga",
+                          "--enable-user=quagga",
+                          "--enable-group=quagga",
+                          "--enable-vty-group=quagga",
+                          "--enable-configfile-mask=0640",
+                          "--enable-logfile-mask=0640"                         
+    system "make", "install"
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! It's enough to just replace
+    # "false" with the main program this formula installs, but it'd be nice if you
+    # were more thorough. Run the test with `brew test quagga`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end


### PR DESCRIPTION
Here's a formula for the current stable version of Quagga.

The long ``./configure`` enables all the daemons/protocols and especially the remote admin/CLI tool ``vtysh``, which is used to remotely administer these daemons and general routing on other routers (as well as maybe locally).

Thanks to mistym on IRC