### PR TITLE
Fix linking ffmpeg frameworks on 10.7. Fixes #34963

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -136,6 +136,9 @@ class Ffmpeg < Formula
 
     ENV["GIT_DIR"] = cached_download/".git" if build.head?
 
+    if MacOS.version < :mountain_lion
+      system "perl", *["-pi", "-e", "s/-framework CoreGraphics/-framework ApplicationServices/", "configure"]
+     
     system "./configure", *args
 
     if MacOS.prefer_64_bit?


### PR DESCRIPTION
FFmpeg changed the link frameworks in http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=a6555f88aaf0730e64240136fb19d8effb3a0738
(ApplicationServices -> CoreGraphics)
This reverts that change for Lion and below

--------

Apologies - I'm not sure on the convention of making patches to existing code. Is an inline edit using Perl acceptable?!

Fixes #34963