### PR TITLE
New formula: fb-adb

### DIFF
--- a/Library/Formula/fb-adb.rb
+++ b/Library/Formula/fb-adb.rb
@@ -1,0 +1,33 @@
+class FbAdb < Formula
+  homepage "https://github.com/facebook/fb-adb"
+  url "https://github.com/facebook/fb-adb/archive/1.2.0.tar.gz"
+  sha1 "a86939f72c8c52c2fc7bc2ec756f179863076622"
+
+  depends_on "android-ndk" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "android-sdk"
+
+  def install
+    ENV["ANDROID_NDK"] = Formula["android-ndk"].opt_prefix
+
+    system "./autogen.sh"
+
+    mkdir "build" do
+      system "../configure", "--prefix=#{prefix}"
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  def post_install
+    system "echo", "Y", "|", "android", "update", "sdk", "--no-ui", "--filter", "platform-tools"
+  end
+
+  test do
+    system "#{bin}/fb-adb", "devices"
+    system "#{bin}/fb-adb", "kill-server"
+    system "#{bin}/fb-adb", "start-server"
+  end
+end


### PR DESCRIPTION
fb-adb is a tool for interacting with Android systems. It does much of what adb does, but with better remote shell support and, hopefully, fewer bugs.

I had submitted a pull request #31555. Because fb-adb didn't have any stable releases, It has been closed.

I had submitted this PR on homebrew-headonly.
https://github.com/Homebrew/homebrew-headonly/pull/58

Now fb-adb has a first tagged version, fb-adb 1.2.0. So I just made another pull request for this version of fb-adb.
https://github.com/facebook/fb-adb/issues/4