### PR TITLE
CGAL with --ipelets

### DIFF
--- a/Library/Formula/cgal.rb
+++ b/Library/Formula/cgal.rb
@@ -13,9 +13,12 @@ class Cgal < Formula
 
   option :cxx11
 
-  option 'imaging', "Build ImageIO and QT compoments of CGAL"
+  deprecated_option "imaging" => "with-imaging"
+
+  option 'with-imaging', "Build ImageIO and QT compoments of CGAL"
   option 'with-eigen3', "Build with Eigen3 support"
   option 'with-lapack', "Build with LAPACK support"
+  option 'with-ipelets', "Build Ipelet components of CGAL"
 
   depends_on 'cmake' => :build
   if build.cxx11?
@@ -27,8 +30,10 @@ class Cgal < Formula
   end
   depends_on 'mpfr'
 
-  depends_on 'qt' if build.include? 'imaging'
+  depends_on 'qt' if build.with? 'imaging'
   depends_on 'eigen' if build.with? "eigen3"
+
+  depends_on 'ipe' if build.with? 'ipelets'
 
   # Allows to compile with clang 425: http://goo.gl/y9Dg2y
   patch :DATA
@@ -39,7 +44,7 @@ class Cgal < Formula
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
             "-DCMAKE_INSTALL_NAME_DIR=#{HOMEBREW_PREFIX}/lib"]
-    unless build.include? 'imaging'
+    if build.without? 'imaging'
       args << "-DWITH_CGAL_Qt3=OFF" << "-DWITH_CGAL_Qt4=OFF" << "-DWITH_CGAL_ImageIO=OFF"
     end
     if build.with? "eigen3"
@@ -51,6 +56,16 @@ class Cgal < Formula
     args << '.'
     system "cmake", *args
     system "make install"
+
+    if build.with? "ipelets"
+      cd "demo/CGAL_ipelets"
+      system "cmake . -DCGAL_DIR=../.."
+      system "make"
+      system "make install DESTDIR=#{prefix}"
+
+      mv "#{prefix}/usr/local/lib/ipe", "#{lib}"
+      rmdir "-p #{prefix}/usr/local/lib"
+    end
   end
 end
 

--- a/Library/Formula/ipe.rb
+++ b/Library/Formula/ipe.rb
@@ -38,7 +38,7 @@ class Ipe < Formula
 
   def install
     cd 'src' do
-      system "make", "IPEPREFIX=#{prefix}"
+      system "make", "IPEPREFIX=#{HOMEBREW_PREFIX}"
       ENV.j1 # Parallel install fails
       system "make", "IPEPREFIX=#{prefix}", "install"
     end


### PR DESCRIPTION
Added `--ipelets` option to `cgal` formula + fix the `IPEPREFIX` path in `ipe` formula.