### PR TITLE
Update u-boot-tools

### DIFF
--- a/Library/Formula/u-boot-tools.rb
+++ b/Library/Formula/u-boot-tools.rb
@@ -1,13 +1,20 @@
-require 'formula'
+require "formula"
 
 class UBootTools < Formula
-  homepage 'http://www.denx.de/wiki/U-Boot/'
-  url 'ftp://ftp.denx.de/pub/u-boot/u-boot-2012.10.tar.bz2'
-  sha1 '80bc5f6d3e518803c9320d480e693fe1cb76a494'
+  homepage "http://www.denx.de/wiki/U-Boot/"
+  url "ftp://ftp.denx.de/pub/u-boot/u-boot-2015.01.tar.bz2"
+  sha1 "8d22ab0d9f3902122f160280facacc468bad0da9"
+
+  depends_on "openssl"
 
   def install
-    system 'make tools'
-    bin.install 'tools/mkimage'
-    man1.install 'doc/mkimage.1'
+    system "make sandbox_defconfig"
+    system "make tools"
+    bin.install "tools/mkimage"
+    man1.install "doc/mkimage.1"
+  end
+
+  test do
+    system bin/"mkimage", "-V"
   end
 end


### PR DESCRIPTION
The latest stable build (2014.10) does not compile on OSX, but the latest RC for the next build (2015.01-rc3) does.