### PR TITLE
Sfml formula: sfml 2.1 -> 2.2

### DIFF
--- a/Library/Formula/csfml.rb
+++ b/Library/Formula/csfml.rb
@@ -2,8 +2,12 @@ require "formula"
 
 class Csfml < Formula
   homepage "http://www.sfml-dev.org/"
-  url "http://www.sfml-dev.org/download/csfml/CSFML-2.0-sources.zip"
-  sha1 "6d831634a558593580296209af278322523f1e43"
+  # CSFML 2.1 and SFML 2.2 are incompatible with each other
+  # Making CSFML 2.1 build requires multiple patches
+  # Until there is no newer relese, this formula uses fixed revision from master
+  # Also, see: https://github.com/LaurentGomila/CSFML/issues/50
+  url "https://github.com/LaurentGomila/CSFML.git", :revision => "848b4d3aaa7646c4742222489416ced48335274f"
+  version "2.1-848b4d3aaa7646c4742222489416ced48335274f"
 
   bottle do
     cellar :any
@@ -16,8 +20,7 @@ class Csfml < Formula
   depends_on "sfml"
 
   def install
-    cp_r "#{Formula["sfml"].share}/SFML/cmake/Modules/", "cmake"
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *std_cmake_args, "-DCMAKE_MODULE_PATH=#{Formula["sfml"].share}/SFML/cmake/Modules/"
     system "make", "install"
   end
 

--- a/Library/Formula/sfml.rb
+++ b/Library/Formula/sfml.rb
@@ -2,7 +2,6 @@ require "formula"
 
 class Sfml < Formula
   homepage "http://www.sfml-dev.org/"
-
   url "http://www.sfml-dev.org/download/sfml/2.2/SFML-2.2-sources.zip"
   sha1 "b21721a3dc221a790e4b81d6ba358c16cb1c1cd3"
 

--- a/Library/Formula/sfml.rb
+++ b/Library/Formula/sfml.rb
@@ -3,15 +3,8 @@ require "formula"
 class Sfml < Formula
   homepage "http://www.sfml-dev.org/"
 
-  stable do
-    url "http://www.sfml-dev.org/download/sfml/2.1/SFML-2.1-sources.zip"
-    sha1 "c27bdffdc4bedb5f6a20db03ceca715d42aa5752"
-
-    # Too many upstream differences to fix Yosemite compile.
-    # Big code changes upstream since previous release 15 months ago.
-    # Please remove this block with the next stable release.
-    depends_on MaximumMacOSRequirement => :mavericks
-  end
+  url "http://www.sfml-dev.org/download/sfml/2.2/SFML-2.2-sources.zip"
+  sha1 "b21721a3dc221a790e4b81d6ba358c16cb1c1cd3"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Resolves #35277 

Basically: unlike 2.1, sfml 2.2 builds just fine on yosemite, so I created this pull-request. Thanks to @DomT4 for the help with this pull-request!