### PR TITLE
Load formula classes into private namespace

### DIFF
--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -1,4 +1,5 @@
 require "mutex_m"
+require "debrew/irb"
 
 module Debrew
   extend Mutex_m
@@ -120,21 +121,17 @@ module Debrew
           menu.choice(:ignore) { return :ignore } if Ignorable === e
           menu.choice(:backtrace) { puts e.backtrace }
 
-          unless ENV["HOMEBREW_NO_READLINE"]
-            require "debrew/irb"
+          menu.choice(:irb) do
+            puts "When you exit this IRB session, execution will continue."
+            set_trace_func proc { |event, _, _, id, binding, klass|
+              if klass == Raise && id == :raise && event == "return"
+                set_trace_func(nil)
+                synchronize { IRB.start_within(binding) }
+              end
+            }
 
-            menu.choice(:irb) do
-              puts "When you exit this IRB session, execution will continue."
-              set_trace_func proc { |event, _, _, id, binding, klass|
-                if klass == Raise && id == :raise && event == "return"
-                  set_trace_func(nil)
-                  synchronize { IRB.start_within(binding) }
-                end
-              }
-
-              return :ignore
-            end if Ignorable === e
-          end
+            return :ignore
+          end if Ignorable === e
 
           menu.choice(:shell) do
             puts "When you exit this shell, you will return to the menu."

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -436,7 +436,7 @@ class Formula
   end
 
   def inspect
-    "#<#{self.class.name}: #{path}>"
+    "#<#{self.class.name.split("::").last}: #{path}>"
   end
 
   # Standard parameters for CMake builds.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -190,14 +190,6 @@ class FormulaInstaller
     opoo "Nothing was installed to #{formula.prefix}" unless formula.installed?
   end
 
-  # HACK: If readline is present in the dependency tree, it will clash
-  # with the stdlib's Readline module when the debugger is loaded
-  def perform_readline_hack
-    if (formula.recursive_dependencies.any? { |d| d.name == "readline" } || formula.name == "readline") && debug?
-      ENV['HOMEBREW_NO_READLINE'] = '1'
-    end
-  end
-
   def check_conflicts
     return if ARGV.force?
 
@@ -210,8 +202,6 @@ class FormulaInstaller
   end
 
   def compute_and_install_dependencies
-    perform_readline_hack
-
     req_map, req_deps = expand_requirements
 
     check_requirements(req_map)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -2,22 +2,43 @@
 # It is not meant to be used directy from formulae.
 
 class Formulary
+  module Formulae
+    class << self
+      if instance_method(:const_defined?).arity == -1
+        def formula_const_defined?(name)
+          const_defined?(name, false)
+        end
+
+        def formula_const_get(name)
+          const_get(name, false)
+        end
+      else
+        def formula_const_defined?(name)
+          const_defined?(name)
+        end
+
+        def formula_const_get(name)
+          const_get(name)
+        end
+      end
+
+      def remove_formula_const(name)
+        remove_const(name)
+      end
+
+      def formula_const_set(name, value)
+        const_set(name, value)
+      end
+    end
+  end
 
   def self.unload_formula formula_name
-    Object.send(:remove_const, class_s(formula_name))
-  end
-
-  def self.formula_class_defined? class_name
-    Object.const_defined?(class_name)
-  end
-
-  def self.get_formula_class class_name
-    Object.const_get(class_name)
+    Formulae.remove_formula_const(class_s(formula_name))
   end
 
   def self.restore_formula formula_name, value
     old_verbose, $VERBOSE = $VERBOSE, nil
-    Object.const_set(class_s(formula_name), value)
+    Formulae.formula_const_set(class_s(formula_name), value)
   ensure
     $VERBOSE = old_verbose
   end
@@ -50,11 +71,9 @@ class Formulary
       klass.new(name, path, spec)
     end
 
-    # Return the Class for this formula, `require`-ing it if
-    # it has not been parsed before.
     def klass
       begin
-        have_klass = Formulary.formula_class_defined? class_name
+        have_klass = Formulae.formula_const_defined?(class_name)
       rescue NameError => e
         raise unless e.name.to_s == class_name
         raise FormulaUnavailableError, name, e.backtrace
@@ -62,11 +81,7 @@ class Formulary
 
       load_file unless have_klass
 
-      klass = Formulary.get_formula_class(class_name)
-      if klass == Formula || !(klass < Formula)
-        raise FormulaUnavailableError.new(name)
-      end
-      klass
+      Formulae.formula_const_get(class_name)
     end
 
     private
@@ -74,7 +89,7 @@ class Formulary
     def load_file
       STDERR.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
       raise FormulaUnavailableError.new(name) unless path.file?
-      require(path)
+      Formulae.module_eval(path.read, path)
     end
   end
 


### PR DESCRIPTION
Now that the formula file is no longer the executing script during builds, we can exert total control over the context in which formula classes are loaded, including the namespace in which they exist.

This is accomplished by reading the file and `class_eval`ing it inside a module: https://github.com/jacknagel/homebrew/blob/5ac60666afde1f87c50855b7998112647d3b9a06/Library/Homebrew/formulary.rb#L87

This means we will no longer conflict with standard library constants like `Readline` and `Zlib`. :tada: