### PR TITLE
protobuf-c: add support universal support

### DIFF
--- a/Library/Formula/protobuf-c.rb
+++ b/Library/Formula/protobuf-c.rb
@@ -14,7 +14,11 @@ class ProtobufC < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf"
 
+  option :universal
+
   def install
+    ENV.universal_binary if build.universal?
+
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make install"
   end


### PR DESCRIPTION
Added the common --universal switch to allow compilation of the protobuf-c
libraries as a universal dylib