### PR TITLE
shadowsocks-libev 1.6.2

### DIFF
--- a/Library/Formula/shadowsocks-libev.rb
+++ b/Library/Formula/shadowsocks-libev.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class ShadowsocksLibev < Formula
-  homepage "https://github.com/madeye/shadowsocks-libev"
-  url "https://github.com/madeye/shadowsocks-libev/archive/v1.6.1.tar.gz"
-  sha1 "2cb88051e43c800dfe9ea55c8a2a3aee11d40ae2"
+  homepage "https://github.com/shadowsocks/shadowsocks-libev"
+  url "https://github.com/shadowsocks/shadowsocks-libev/archive/v1.6.2.tar.gz"
+  sha1 "f0b3be37192f3e19a4bba167673b39f073ae14fa"
 
   bottle do
     sha1 "dd210c18e372a9947df95c700fde51c6d45be436" => :yosemite
@@ -11,7 +11,7 @@ class ShadowsocksLibev < Formula
     sha1 "bc544dea1f6367143473093fb3433b8fe5ba9dd8" => :mountain_lion
   end
 
-  head "https://github.com/madeye/shadowsocks-libev.git"
+  head "https://github.com/shadowsocks/shadowsocks-libev.git"
 
   option "with-polarssl", "Use PolarSSL instead of OpenSSL"
 
@@ -32,6 +32,7 @@ class ShadowsocksLibev < Formula
     system "make"
 
     bin.install "src/ss-local"
+    bin.install "src/ss-tunnel"
 
     (buildpath/"shadowsocks-libev.json").write <<-EOS.undent
       {
@@ -45,6 +46,7 @@ class ShadowsocksLibev < Formula
     EOS
     etc.install "shadowsocks-libev.json"
 
+    inreplace "shadowsocks-libev.8", "/etc/shadowsocks-libev/config.json", "#{etc}/shadowsocks-libev.json"
     man8.install "shadowsocks-libev.8"
   end
 


### PR DESCRIPTION
Version 1.6.2: https://github.com/shadowsocks/shadowsocks-libev/releases/tag/v1.6.2 Minor bug fix.
Upstream URL changed to https://github.com/shadowsocks/shadowsocks-libev.

Happy new year!