### PR TITLE
tiger-vnc: re-adding formula with x11 dep dropped

### DIFF
--- a/Library/Formula/tiger-vnc.rb
+++ b/Library/Formula/tiger-vnc.rb
@@ -1,7 +1,7 @@
 class TigerVnc < Formula
   homepage "http://tigervnc.org/"
-  url "https://github.com/TigerVNC/tigervnc/archive/v1.4.0.tar.gz"
-  sha1 "36252b10912bcbef44d43c5fa7977ae97988fff3"
+  url "https://github.com/TigerVNC/tigervnc/archive/v1.4.1.tar.gz"
+  sha1 "bdc5d6c5e55a275b645260e01c1e7aa71ba79984"
 
   depends_on "cmake" => :build
   depends_on "gnutls" => :recommended
@@ -21,6 +21,6 @@ class TigerVnc < Formula
   end
 
   test do
-    assert `#{bin}/vncviewer --help 2>&1` =~ /TigerVNC Viewer.*v1\.4\.0/
+    assert `#{bin}/vncviewer --help 2>&1` =~ /TigerVNC Viewer.*v1\.4\.1/
   end
 end

--- a/Library/Formula/tiger-vnc.rb
+++ b/Library/Formula/tiger-vnc.rb
@@ -1,0 +1,24 @@
+require 'formula'
+
+class TigerVnc < Formula
+  homepage 'http://tigervnc.org/'
+  url 'https://github.com/TigerVNC/tigervnc/archive/v1.4.0.tar.gz'
+  sha1 '36252b10912bcbef44d43c5fa7977ae97988fff3'
+
+  depends_on 'cmake' => :build
+  depends_on 'gnutls' => :recommended
+  depends_on 'jpeg-turbo'
+  depends_on 'gettext'
+  depends_on 'fltk'
+
+  def install
+    turbo = Formula['jpeg-turbo']
+    args = std_cmake_args + %W[
+      -DJPEG_INCLUDE_DIR=#{turbo.include}
+      -DJPEG_LIBRARY=#{turbo.lib}/libjpeg.dylib
+      .
+    ]
+    system 'cmake', *args
+    system 'make install'
+  end
+end

--- a/Library/Formula/tiger-vnc.rb
+++ b/Library/Formula/tiger-vnc.rb
@@ -1,24 +1,26 @@
-require 'formula'
-
 class TigerVnc < Formula
-  homepage 'http://tigervnc.org/'
-  url 'https://github.com/TigerVNC/tigervnc/archive/v1.4.0.tar.gz'
-  sha1 '36252b10912bcbef44d43c5fa7977ae97988fff3'
+  homepage "http://tigervnc.org/"
+  url "https://github.com/TigerVNC/tigervnc/archive/v1.4.0.tar.gz"
+  sha1 "36252b10912bcbef44d43c5fa7977ae97988fff3"
 
-  depends_on 'cmake' => :build
-  depends_on 'gnutls' => :recommended
-  depends_on 'jpeg-turbo'
-  depends_on 'gettext'
-  depends_on 'fltk'
+  depends_on "cmake" => :build
+  depends_on "gnutls" => :recommended
+  depends_on "jpeg-turbo"
+  depends_on "gettext"
+  depends_on "fltk"
 
   def install
-    turbo = Formula['jpeg-turbo']
+    turbo = Formula["jpeg-turbo"]
     args = std_cmake_args + %W[
       -DJPEG_INCLUDE_DIR=#{turbo.include}
       -DJPEG_LIBRARY=#{turbo.lib}/libjpeg.dylib
       .
     ]
-    system 'cmake', *args
-    system 'make install'
+    system "cmake", *args
+    system "make", "install"
+  end
+
+  test do
+    assert `#{bin}/vncviewer --help 2>&1` =~ /TigerVNC Viewer.*v1\.4\.0/
   end
 end

--- a/Library/Formula/tiger-vnc.rb
+++ b/Library/Formula/tiger-vnc.rb
@@ -21,6 +21,6 @@ class TigerVnc < Formula
   end
 
   test do
-    assert `#{bin}/vncviewer --help 2>&1` =~ /TigerVNC Viewer.*v1\.4\.1/
+    assert `#{bin}/vncviewer --help 2>&1`.include? "TigerVNC Viewer"
   end
 end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -138,7 +138,6 @@ TAP_MIGRATIONS = {
   "terminator" => "homebrew/x11",
   "tetgen" => "homebrew/science",
   "texmacs" => "homebrew/boneyard",
-  "tiger-vnc" => "homebrew/x11",
   "tmap" => "homebrew/boneyard",
   "transmission-remote-gtk" => "homebrew/x11",
   "ume" => "homebrew/games",


### PR DESCRIPTION
The formula builds only the client (vncviewer)
which doesn't depend on x11

cf. 
-   http://librelist.com/browser/homebrew/2014/12/31/tiger-vnc-vs-x11/
-   https://github.com/Homebrew/homebrew-x11/pull/12