### PR TITLE
LICENSE: bump to 2015

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2009-2014 Homebrew contributors.
+Copyright 2009-2015 Homebrew contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
It's that most glorious time of the year: When everyone on Github bumps their license dates to cover yet another year ahead.