### PR TITLE
unittest-cpp head

### DIFF
--- a/Library/Formula/unittest-cpp.rb
+++ b/Library/Formula/unittest-cpp.rb
@@ -2,20 +2,11 @@ require 'formula'
 
 class UnittestCpp < Formula
   homepage 'http://unittest-cpp.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/unittest-cpp/UnitTest++/1.4/unittest-cpp-1.4.zip'
-  sha1 'dad944159e2e135aea74039987490eaaee00f2ad'
+  head "https://github.com/unittest-cpp/unittest-cpp.git"
 
+  depends_on "cmake" => :build
   def install
-    system "make"
-
-    # Install the headers
-    include.install Dir['src/*.h']
-    include.install 'src/Posix'
-
-    # Install the compiled library
-    lib.install 'libUnitTest++.a'
-
-    # Install the documentation
-    doc.install 'docs/UnitTest++.html'
+      system "cmake", ".", *std_cmake_args
+      system "make", "install"
   end
 end


### PR DESCRIPTION
Unittest appears to have stopped hosting releases at sourceforge so I've replaced it with a head option. 

The v1.4 github [release](https://github.com/unittest-cpp/unittest-cpp/releases/tag/v1.4) did not build on my system and so I didn't use that either.