### PR TITLE
audit: system check fixed for multiple arguments

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -552,7 +552,7 @@ class FormulaAuditor
     end
 
     if @strict
-      if line =~ /system (["'][^"' ]*\s[^"' ]*["'])/
+      if line =~ /system (["'][^"' ]*(?:\s[^"' ]*)+["'])/
         bad_system = $1
         good_system = bad_system.gsub(" ", "\", \"")
         problem "Use `system #{good_system}` instead of `system #{bad_system}` "


### PR DESCRIPTION
`brew audit --strict` warns about `system "make install"` but not `system "make some-option install"` (and other commands with more than two words). This PR fixes this.

Before:

```
brew audit --strict mp3val
mp3val:
 * A `test do` test block should be added
 * `require 'formula'` is now unnecessary

Error: 2 problems in 1 formulae
```

After:

```
$ b audit --strict mp3val
mp3val:
 * A `test do` test block should be added
 * `require 'formula'` is now unnecessary
 * Use `system "gnumake", "-f", "Makefile.gcc"` instead of `system "gnumake -f Makefile.gcc"`

Error: 3 problems in 1 formulae
```