### PR TITLE
cmake: remove gui option

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -34,7 +34,10 @@ class Cmake < Formula
   option "without-docs", "Don't build man pages"
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
   depends_on "xz" # For LZMA
-  depends_on "qt" => :optional
+
+  # The `with-qt` GUI option was removed due to circular dependencies if
+  # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
+  # For the GUI application please instead use brew install caskroom/cask/cmake.
 
   resource "sphinx" do
     url "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.2.3.tar.gz"
@@ -91,12 +94,9 @@ class Cmake < Formula
       args << "--sphinx-man" << "--sphinx-build=#{buildpath}/sphinx/bin/sphinx-build"
     end
 
-    args << "--qt-gui" if build.with? "qt"
-
     system "./bootstrap", *args
     system "make"
     system "make", "install"
-    bin.install_symlink Dir["#{prefix}/CMake.app/Contents/bin/*"] if build.with? "qt"
   end
 
   test do


### PR DESCRIPTION
The GUI option is potentially a cause of future headaches and bugs, see #35337.

Per Mike’s proposal, which I agree with, we could ditch it and move back to supporting the CLI tools only, and nudge people towards using the Cask for the app. 

The Cask very kindly merged my PR to create ` CMake.app ` this morning in https://github.com/caskroom/homebrew-cask/commit/3db9c980adc2be2a7d6b161a95cc8c24a6d82fca so ` brew cask install cmake ` will now result in that.