### PR TITLE
`brew style`: run Rubocop on formulae (new command)

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -8,6 +8,13 @@ module Homebrew
     formula_count = 0
     problem_count = 0
 
+    strict = ARGV.include? "--strict"
+    if strict && ARGV.formulae.any?
+      require "cmd/style"
+      ohai "brew style #{ARGV.formulae.join " "}"
+      style
+    end
+
     ENV.activate_extensions!
     ENV.setup_build_environment
 
@@ -17,13 +24,19 @@ module Homebrew
       ARGV.formulae
     end
 
-    strict = ARGV.include? "--strict"
+    output_header = !strict
 
     ff.each do |f|
       fa = FormulaAuditor.new(f, :strict => strict)
       fa.audit
 
       unless fa.problems.empty?
+        unless output_header
+          puts
+          ohai "audit problems"
+          output_header = true
+        end
+
         formula_count += 1
         problem_count += fa.problems.size
         puts "#{f.name}:", fa.problems.map { |p| " * #{p}" }, ""

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -1,0 +1,14 @@
+module Homebrew
+  def style
+    target = if ARGV.named.empty?
+      [HOMEBREW_LIBRARY]
+    else
+      ARGV.formulae.map(&:path)
+    end
+
+    Homebrew.install_gem_setup_path! "rubocop"
+
+    system "rubocop", "--format", "simple", *target
+    Homebrew.failed = !$?.success?
+  end
+end

--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -6,7 +6,7 @@ module Homebrew
       quiet_system("bundle", "check") || \
         system("bundle", "install", "--path", "vendor/bundle")
       system "bundle", "exec", "rake", "test"
-      exit $?.exitstatus
+      Homebrew.failed = !$?.success?
     end
   end
 end

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -133,6 +133,7 @@ begin
 
   if internal_cmd
     Homebrew.send cmd.to_s.gsub('-', '_').downcase
+    exit 1 if Homebrew.failed?
   elsif which "brew-#{cmd}"
     %w[CACHE CELLAR LIBRARY_PATH PREFIX REPOSITORY].each do |e|
       ENV["HOMEBREW_#{e}"] = Object.const_get("HOMEBREW_#{e}").to_s


### PR DESCRIPTION
This adds the `brew style` command to run `rubocop` on formulae (or `HOMEBREW_LIBRARY` if given no arguments). This command is also called by `brew audit --strict` to better handle e.g. double-quotes.

CC @Homebrew/owners for review. I'll assume if there's no comments after a few days that this is OK to go in.