### PR TITLE
brew irb --help replaced with --examples

### DIFF
--- a/Library/Homebrew/cmd/irb.rb
+++ b/Library/Homebrew/cmd/irb.rb
@@ -15,14 +15,14 @@ end
 
 module Homebrew
   def irb
-    if ARGV.include? "--help"
+    if ARGV.include? "--examples"
       puts "'v8'.f # => instance of the v8 formula"
       puts ":hub.f.installed?"
       puts ":lua.f.methods - 1.methods"
       puts ":mpd.f.recursive_dependencies.reject(&:installed?)"
     else
       ohai "Interactive Homebrew Shell"
-      puts "Example commands available with: brew irb --help"
+      puts "Example commands available with: brew irb --examples"
       IRB.start
     end
   end


### PR DESCRIPTION
`brew irb` says we can have example commands with `brew irb --help` but the `--help` flag is intercepted by `brew.rb` and prints the global usage string. `Homebrew.irb` is never called when `brew irb --help` is executed.

```
$ brew irb
==> Interactive Homebrew Shell
Example commands available with: brew irb --help
>> ^D

$ brew irb --help
Example usage:
  brew [info | home | options ] [FORMULA...]
  brew install FORMULA...
  brew uninstall FORMULA...
  brew search [foo]
  brew list [FORMULA...]
  brew update
  brew upgrade [FORMULA...]
  brew pin/unpin [FORMULA...]

Troubleshooting:
  brew doctor
  brew install -vd FORMULA
  brew [--env | config]

Brewing:
  brew create [URL [--no-fetch]]
  brew edit [FORMULA...]
  open https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md

Further help:
  man brew
  brew home
```

This PR renames this flag as `--examples` and allows it to work as expected :)