### PR TITLE
expat: bump revision to help with keg-only move

### DIFF
--- a/Library/Formula/expat.rb
+++ b/Library/Formula/expat.rb
@@ -4,6 +4,7 @@ class Expat < Formula
   homepage 'http://expat.sourceforge.net/'
   url 'https://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz'
   sha1 'b08197d146930a5543a7b99e871cba3da614f6f0'
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
I have run into several support issues at the OSGeo4Mac tap whereby users still have an `expat` install with an incorrect install name that references `/usr/local/lib` instead of its [new keg-only location](https://github.com/Homebrew/homebrew/pull/31770). Bumping the revision will help clean up those installs, since a `brew reinstall expat` fixes the issue.

Apologies for not reporting sooner.

See:
https://github.com/OSGeo/homebrew-osgeo4mac/issues/70
https://github.com/OSGeo/homebrew-osgeo4mac/issues/63
https://github.com/OSGeo/homebrew-osgeo4mac/issues/52
https://github.com/OSGeo/homebrew-osgeo4mac/issues/45
