### PR TITLE
Update and modernise aqbanking

### DIFF
--- a/Library/Formula/aqbanking.rb
+++ b/Library/Formula/aqbanking.rb
@@ -3,25 +3,16 @@ require 'formula'
 class Aqbanking < Formula
   homepage 'http://www.aqbanking.de/'
   head 'http://devel.aqbanking.de/svn/aqbanking/trunk'
+  url 'http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz'
+  sha1 '4783890253acf04dddede6d34bf81b8f1c24480d'
 
-  stable do
-    url 'http://www2.aquamaniac.de/sites/download/download.php?package=03&release=95&file=01&dummy=aqbanking-5.0.25.tar.gz'
-    sha1 '80314a6f6114a0a3f0062161bb38effc0f1f4b62'
-    depends_on 'gwenhywfar' # see caveats
-  end
-
-  devel do
-    url 'http://www2.aquamaniac.de/sites/download/download.php?package=03&release=115&file=01&dummy=aqbanking-5.4.3beta.tar.gz'
-    sha1 'd3d4dac73794227041c8ec4a777f00ac17efd8ca'
-
-    depends_on 'pkg-config' => :build
-    depends_on 'libxmlsec1'
-    depends_on 'libxslt'
-    depends_on 'libxml2'
-  end
-
+  depends_on 'gwenhywfar'
+  depends_on 'libxmlsec1'
+  depends_on 'libxslt'
+  depends_on 'libxml2'
   depends_on 'gettext'
   depends_on 'gmp'
+  depends_on 'pkg-config' => :build
   depends_on 'ktoblzcheck' => :recommended
 
   def install
@@ -32,16 +23,5 @@ class Aqbanking < Formula
                           "--enable-cli",
                           "--with-gwen-dir=#{HOMEBREW_PREFIX}"
     system "make install"
-  end
-
-  def caveats; <<-EOS.undent
-    To build the devel version install all the dependencies first,
-    then install the devel version of gwenhywfar separately,
-    and install the devel version of aqbanking afterwards.
-
-    brew install aqbanking --devel --only-dependencies
-    brew install gwenhywfar --devel
-    brew install aqbanking --devel
-    EOS
   end
 end

--- a/Library/Formula/aqbanking.rb
+++ b/Library/Formula/aqbanking.rb
@@ -1,19 +1,17 @@
-require 'formula'
-
 class Aqbanking < Formula
-  homepage 'http://www.aqbanking.de/'
-  head 'http://devel.aqbanking.de/svn/aqbanking/trunk'
-  url 'http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz'
-  sha1 '4783890253acf04dddede6d34bf81b8f1c24480d'
+  homepage "http://www.aqbanking.de/"
+  head "http://devel.aqbanking.de/svn/aqbanking/trunk"
+  url "http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz"
+  sha1 "4783890253acf04dddede6d34bf81b8f1c24480d"
 
-  depends_on 'gwenhywfar'
-  depends_on 'libxmlsec1'
-  depends_on 'libxslt'
-  depends_on 'libxml2'
-  depends_on 'gettext'
-  depends_on 'gmp'
-  depends_on 'pkg-config' => :build
-  depends_on 'ktoblzcheck' => :recommended
+  depends_on "gwenhywfar"
+  depends_on "libxmlsec1"
+  depends_on "libxslt"
+  depends_on "libxml2"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "pkg-config" => :build
+  depends_on "ktoblzcheck" => :recommended
 
   def install
     ENV.j1
@@ -22,6 +20,58 @@ class Aqbanking < Formula
                           "--prefix=#{prefix}",
                           "--enable-cli",
                           "--with-gwen-dir=#{HOMEBREW_PREFIX}"
-    system "make install"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    ENV["TZ"] = "UTC"
+    context = "balance.ctx"
+    (testpath/context).write <<-EOS.undent
+    accountInfoList {
+      accountInfo {
+        char bankCode="110000000"
+        char bankName="STRIPE TEST BANK"
+        char accountNumber="000123456789"
+        char accountName="demand deposit"
+        char iban="US44110000000000123456789"
+        char bic="BYLADEM1001"
+        char owner="JOHN DOE"
+        char currency="USD"
+        int  accountType="0"
+        int  accountId="2"
+
+        statusList {
+          status {
+            int  time="1388664000"
+
+            notedBalance {
+              value {
+                char value="123456%2F100"
+                char currency="USD"
+              } #value
+
+              int  time="1388664000"
+            } #notedBalance
+          } #status
+
+          status {
+            int  time="1388750400"
+
+            notedBalance {
+              value {
+                char value="132436%2F100"
+                char currency="USD"
+              } #value
+
+              int  time="1388750400"
+            } #notedBalance
+          } #status
+        } #statusList
+
+      } # accountInfo
+    } # accountInfoList
+    EOS
+    assert_match /^Account\s+110000000\s+000123456789\s+STRIPE TEST BANK\s+03.01.2014\s+12:00\s+1324.36\s+USD\s+$/, shell_output("#{bin}/aqbanking-cli listbal -c #{context}")
   end
 end


### PR DESCRIPTION
Note that aqbanking 5.5.1 should come along with the updated version of gwenhywfar (see #35471).