### PR TITLE
node: npm bump

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -3,6 +3,7 @@ class Node < Formula
   homepage "https://nodejs.org/"
   url "https://nodejs.org/dist/v0.10.35/node-v0.10.35.tar.gz"
   sha256 "0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03"
+  revision 1
 
   bottle do
     sha1 "ca78513c44fc13be68573508ecd7d232653d6e60" => :yosemite
@@ -35,8 +36,8 @@ class Node < Formula
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.1.14.tgz"
-    sha1 "02f7a15112adc859191c9be9b9a601e866931aea"
+    url "https://registry.npmjs.org/npm/-/npm-2.1.17.tgz"
+    sha1 "80fa7873188659037ec0ed8ebc95c2b2723c8ac4"
   end
 
   def install


### PR DESCRIPTION
An `npm` bump and general formula revision. The latest `npm` squashes a small bundle of race conditions around git dependencies, so it’d be good to push this into users’ hands more immediately than the next Node release, hence the revision.

This essentially follows the new Homebrew Node guidelines of update and revision big, ignore little, bump whatever is available when there’s a Node update out.

Also fixes a bug around manpages and weird names causing breakage, because there are still people out there who prefer to not follow manpage naming conventions. Whole bundle of other smaller, less consequential documentation updates.