### PR TITLE
add formula for boot

### DIFF
--- a/Library/Formula/boot-clj.rb
+++ b/Library/Formula/boot-clj.rb
@@ -1,0 +1,14 @@
+class BootClj < Formula
+  homepage "http://boot-clj.com"
+  url "https://github.com/boot-clj/boot/releases/download/2.0.0/boot.sh",
+      :using => :nounzip
+  sha256 "2cb80c684a665f1979d5362f040144ab9891b2135b42ac2e1763b2f241b67f43"
+
+  def install
+    bin.install "boot.sh" => "boot"
+  end
+
+  test do
+    system "#{bin}/boot", "repl", "-e", "(System/exit 0)"
+  end
+end


### PR DESCRIPTION
This adds a formula for Boot, a build tool for Clojure: http://boot-clj.com

I'm uncertain if the main Homebrew Library is the right place but [denominator](https://github.com/Homebrew/homebrew/blob/3c6951ca3072c76af19d096e1332c31de07426c6/Library/Formula/denominator.rb) is similar in how it's packaged and was accepted so I thought I'd give it a try :)

Thanks 
