### PR TITLE
install: fail on devel where devel doesn't exist

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -53,6 +53,11 @@ module Homebrew
           raise "No head is defined for #{f.name}"
         end
 
+        # Building stable-only with --devel is an error
+        if ARGV.build_devel? and f.devel.nil?
+          raise "No devel block is defined for #{f.name}"
+        end
+
         if f.installed?
           msg = "#{f.name}-#{f.installed_version} already installed"
           msg << ", it's just not linked" unless f.linked_keg.symlink? or f.keg_only?


### PR DESCRIPTION
Just equalises a little how we treat HEAD and devel. The former already fails if there isn’t a head defined, It seemed logical that devel should fail in the same way. At the moment where ` devel ` doesn't exist, it just goes ahead and installs stable, but this seems contrary to expectation if someone's deliberately specified ` devel `.