### PR TITLE
update libsass to 3.1 release

### DIFF
--- a/Library/Formula/libsass.rb
+++ b/Library/Formula/libsass.rb
@@ -1,7 +1,7 @@
 class Libsass < Formula
   homepage "https://github.com/sass/libsass"
-  url "https://github.com/sass/libsass/archive/3.0.2.tar.gz"
-  sha1 "415e4377ec73fcf0bd7af949d65f7ca730be1e5c"
+  url "https://github.com/sass/libsass/archive/3.1.0.tar.gz"
+  sha1 "858c41405f5ff8b4186c7111e08f29893f4e51a1"
   head "https://github.com/sass/libsass.git"
 
   bottle do
@@ -9,12 +9,6 @@ class Libsass < Formula
     sha1 "88f00899fb612aabe04a324cfc83bcf025aeb47e" => :yosemite
     sha1 "6e0616f8296f687f8efdcbf4ddc66527a9676a25" => :mavericks
     sha1 "d435e14e0a8a3886ba9dc301aed4db4baceb9fe6" => :mountain_lion
-  end
-
-  devel do
-    url "https://github.com/sass/libsass/archive/3.1.0-beta.tar.gz"
-    sha1 "478571d0ddf789a41c08587562c52b5b54c3e418"
-    version "3.1.0-beta"
   end
 
   depends_on "autoconf" => :build
@@ -25,7 +19,6 @@ class Libsass < Formula
   def install
     ENV.cxx11
     ENV["LIBSASS_VERSION"] = "HEAD" if build.head?
-    ENV["LIBSASS_VERSION"] = "3.1.0" if build.devel?
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"
@@ -39,24 +32,23 @@ class Libsass < Formula
   test do
     # This will need to be updated when devel = stable due to API changes.
     (testpath/"test.c").write <<-EOS.undent
-      #include <sass_interface.h>
+      #include <sass_context.h>
       #include <string.h>
 
       int main()
       {
-        struct sass_context* sass_ctx = sass_new_context();
-        struct sass_options options;
-        options.output_style = SASS_STYLE_NESTED;
-        options.source_comments = 0;
-        options.image_path = "images";
-        options.include_paths = "";
-        sass_ctx->source_string = "a { color:blue; &:hover { color:red; } }";
-        sass_ctx->options = options;
-        sass_compile(sass_ctx);
-        if(sass_ctx->error_status) {
+        char* source_string = "a { color:blue; &:hover { color:red; } }";
+        struct Sass_Data_Context* data_ctx = sass_make_data_context(source_string);
+        struct Sass_Options* options = sass_data_context_get_options(data_ctx);
+        sass_option_set_precision(options, SASS_STYLE_NESTED);
+        sass_option_set_source_comments(options, 0);
+        sass_compile_data_context(data_ctx);
+        struct Sass_Context* ctx = sass_data_context_get_context(data_ctx);
+        int err = sass_context_get_error_status(ctx);
+        if(err != 0) {
           return 1;
         } else {
-          return strcmp(sass_ctx->output_string, "a {\\n  color: blue; }\\n  a:hover {\\n    color: red; }\\n") != 0;
+          return strcmp(sass_context_get_output_string(ctx), "a {\\n  color: blue; }\\n  a:hover {\\n    color: red; }\\n") != 0;
         }
       }
     EOS


### PR DESCRIPTION
Minor version 3.1.0 of release has landed.  This updates the version and sha to the new release "Bulleit Bottle" https://github.com/sass/libsass/issues/697