### PR TITLE
cdrdao fails with SHA1 mismatch

### DIFF
--- a/Library/Formula/cdrdao.rb
+++ b/Library/Formula/cdrdao.rb
@@ -17,9 +17,9 @@ class Cdrdao < Formula
   end
 
   # first patch fixes build problems under 10.6
-  # see http://sourceforge.net/tracker/index.php?func=detail&aid=2981804&group_id=2171&atid=302171
+  # see http://sourceforge.net/p/cdrdao/patches/23/
   patch do
-    url "http://sourceforge.net/tracker/download.php?group_id=2171&atid=302171&file_id=369387&aid=2981804"
+    url "http://sourceforge.net/p/cdrdao/patches/_discuss/thread/205354b0/141e/attachment/cdrdao-mac.patch"
     sha1 "1c0663d13d0f0b7ebbb281f69751eff0afed7c8c"
   end
 


### PR DESCRIPTION
```
==> Installing cdrdao
==> Downloading https://downloads.sourceforge.net/project/cdrdao/cdrdao/1.2.3/cdrdao-1.2.3.tar.bz2
######################################################################## 100.0%
==> Downloading http://sourceforge.net/tracker/download.php?group_id=2171&atid=302171&file_id=369387&aid=2981804
######################################################################## 100.0%
Error: SHA1 mismatch
Expected: 1c0663d13d0f0b7ebbb281f69751eff0afed7c8c
Actual: 7e9fb0ce882a9fffc3f5ba62e6e3c96d55891bbb
Archive: /Library/Caches/Homebrew/cdrdao--patch-1c0663d13d0f0b7ebbb281f69751eff0afed7c8c.php
To retry an incomplete download, remove the file above.
```

It appears that the SourceForge URL in the cdrdao recipe has changed.