### PR TITLE
Changed ode formula to support ode 0.13.1

### DIFF
--- a/Library/Formula/ode.rb
+++ b/Library/Formula/ode.rb
@@ -2,11 +2,11 @@ require 'formula'
 
 class Ode < Formula
   homepage 'http://www.ode.org/'
-  url 'https://downloads.sourceforge.net/project/opende/ODE/0.13/ode-0.13.tar.bz2'
-  sha1 '0279d58cc390ff5cc048f2baf96cff23887f3838'
+  url 'https://bitbucket.org/odedevs/ode/downloads/ode-0.13.1.tar.gz'
+  sha1 '2fea08792e8f0fe606e929097fbec78ba926bcab'
 
   head do
-    url 'http://opende.svn.sourceforge.net/svnroot/opende/trunk'
+    url 'http://bitbucket.org/odedevs/ode/', :using => :hg
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -14,6 +14,7 @@ class Ode < Formula
   end
 
   option 'enable-double-precision', 'Compile ODE with double precision'
+  option 'enable-shared', 'Compile ODE with shared library support'
   option 'enable-libccd', 'enable all libccd colliders (except box-cylinder)'
 
   depends_on 'pkg-config' => :build
@@ -22,12 +23,13 @@ class Ode < Formula
     args = ["--prefix=#{prefix}",
             "--disable-demos"]
     args << "--enable-double-precision" if build.include? 'enable-double-precision'
+    args << "--enable-shared" if build.include? 'enable-shared'
     args << "--enable-libccd" if build.include? "enable-libccd"
 
     if build.head?
       ENV['LIBTOOLIZE'] = 'glibtoolize'
-      inreplace 'autogen.sh', 'libtoolize', '$LIBTOOLIZE'
-      system "./autogen.sh"
+      inreplace 'bootstrap', 'libtoolize', '$LIBTOOLIZE'
+      system "./bootstrap"
     end
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- Fixed head url to new repository.
- Fixed build to use the included bootstrap script.
- Added support for enable-shared.