### PR TITLE
samba 3.6.24, url: use https, modernizing

### DIFF
--- a/Library/Formula/samba.rb
+++ b/Library/Formula/samba.rb
@@ -1,14 +1,12 @@
-require 'formula'
-
 class Samba < Formula
-  homepage 'http://samba.org/'
-  url 'http://www.samba.org/samba/ftp/stable/samba-3.6.23.tar.gz'
-  sha1 '5ba2f8323ab17fa6c04bf87c11d20f10a4fcfe17'
+  homepage "https://samba.org/"
+  url "https://download.samba.org/pub/samba/stable/samba-3.6.24.tar.gz"
+  sha1 "6d48b55ab1e172b0c75035040f5aea65fbf0561e"
 
-  conflicts_with 'talloc', :because => 'both install `include/talloc.h`'
+  conflicts_with "talloc", :because => "both install `include/talloc.h`"
 
-  skip_clean 'private'
-  skip_clean 'var/locks'
+  skip_clean "private"
+  skip_clean "var/locks"
 
   # Fixes the Grouplimit of 16 users os OS X.
   # Bug has been raised upstream:
@@ -16,21 +14,21 @@ class Samba < Formula
   patch :DATA
 
   def install
-    cd 'source3' do
+    cd "source3" do
       system "./configure", "--disable-debug",
                             "--prefix=#{prefix}",
                             "--with-configdir=#{prefix}/etc",
                             "--without-ldap",
                             "--without-krb5"
-      system "make install"
-      (prefix/'etc').mkpath
-      touch prefix/'etc/smb.conf'
-      (prefix/'private').mkpath
-      (var/'locks').mkpath
+      system "make", "install"
+      (prefix/"etc").mkpath
+      touch prefix/"etc/smb.conf"
+      (prefix/"private").mkpath
+      (var/"locks").mkpath
     end
   end
 
-  plist_options :manual => 'smbd'
+  plist_options :manual => "smbd"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
samba 3.6.24, url: use https, modernizing

Replacing pull: https://github.com/Homebrew/homebrew/pull/35584

3.6.24 fixes: https://www.samba.org/samba/history/samba-3.6.24.html