### PR TITLE
JDK added in `brew config`

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -109,6 +109,11 @@ module Homebrew
     s
   end
 
+  def java_version
+    java = `java -version 2>&1`.lines.first.chomp
+    java =~ /java version "(.+?)"/ ? $1 : java
+  end
+
   def dump_verbose_config(f=$stdout)
     f.puts "HOMEBREW_VERSION: #{HOMEBREW_VERSION}"
     f.puts "ORIGIN: #{origin}"
@@ -130,5 +135,6 @@ module Homebrew
     f.puts "Perl: #{describe_perl}"
     f.puts "Python: #{describe_python}"
     f.puts "Ruby: #{describe_ruby}"
+    f.puts "Java: #{java_version}"
   end
 end


### PR DESCRIPTION
~~I’m not sure this is the simplest way to find the JDK.~~

Sample output (updated):

```
$ brew config
HOMEBREW_VERSION: 0.9.5
ORIGIN: https://github.com/Homebrew/homebrew.git
HEAD: f764655649d58c9d59643591558894752cd85181
Last commit: 3 hours ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CELLAR: /usr/local/Cellar
CPU: quad-core 64-bit haswell
OS X: 10.10.1-x86_64
Xcode: 6.1.1
CLT: 6.1.1.0.1.1416017670
couldn't understand kern.osversion `14.0.0'
GCC-4.2: build 5666
Clang: 6.0 build 600
X11: 2.7.7 => /opt/X11
System Ruby: 2.0.0-p481
Perl: /usr/bin/perl
Python: /usr/local/bin/python => /usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/bin/python2.7
Ruby: /Users/baptiste/.rvm/rubies/ruby-2.1.0/bin/ruby
Java: java version "1.7.0_40"
```