### PR TITLE
update znc formula

### DIFF
--- a/Library/Formula/znc.rb
+++ b/Library/Formula/znc.rb
@@ -28,6 +28,7 @@ class Znc < Formula
     args = ["--prefix=#{prefix}"]
     args << "--enable-debug" if build.include? "enable-debug"
 
+    system "git submodule update --init --recursive" if build.head?
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make install"


### PR DESCRIPTION
ZNC recently moved Csocket as submodule so `git submodule update --init
--recursive` when building from git.

I hope this is done correctly, I just looked what the autogen line does.