### PR TITLE
rEFInd 0.8.4 (new formula)

### DIFF
--- a/Library/Formula/refind.rb
+++ b/Library/Formula/refind.rb
@@ -1,0 +1,9 @@
+class Refind < Formula
+  homepage "http://www.rodsbooks.com/refind/"
+  url "https://downloads.sourceforge.net/project/refind/0.8.4/refind-bin-0.8.4.zip"
+  sha1 "f219383924ef60cb6d147267f9ee44810c1f473f"
+
+  def install
+    system "sudo", "bash", "install.sh"
+  end
+end


### PR DESCRIPTION
A boot manager.

This is the updated forked of rEFIt, which was has stopped being
updated (#24818).

I couldn't figure out any easy way of testing the installation. 

Also uninstall [is possible but looks messy](http://www.rodsbooks.com/refind/installing.html#uninstalling) on OS X, so I haven't included that either.