### PR TITLE
source-highlight: use mirror from different domain

### DIFF
--- a/Library/Formula/source-highlight.rb
+++ b/Library/Formula/source-highlight.rb
@@ -1,9 +1,10 @@
 require 'formula'
 
 class SourceHighlight < Formula
-  homepage 'http://www.gnu.org/software/src-highlite/'
-  url 'http://ftpmirror.gnu.org/src-highlite/source-highlight-3.1.7.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/src-highlite/source-highlight-3.1.7.tar.gz'
+  homepage 'https://www.gnu.org/software/src-highlite/'
+  url 'https://ftpmirror.gnu.org/src-highlite/source-highlight-3.1.7.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/src-highlite/source-highlight-3.1.7.tar.gz'
+  mirror 'http://mirror.anl.gov/pub/gnu/src-highlite/source-highlight-3.1.7.tar.gz'
   sha1 '71c637548be71afc3f895b0d8ada1a72a8dab4a0'
 
   depends_on 'boost'


### PR DESCRIPTION
- Changes `url` and `mirror` to use different domains
  - The current `url` and `mirror` were both down for upwards of 2 hours last night (2015-1-6)
  - Argonne (the new mirror) was still up
- Changes homepage to use `https`