### PR TITLE
parse-cli (new formula)

### DIFF
--- a/Library/Formula/parse-cli.rb
+++ b/Library/Formula/parse-cli.rb
@@ -1,0 +1,17 @@
+class ParseCli < Formula
+  homepage "https://parse.com"
+  url "https://www.parse.com/downloads/cloud_code/parse",
+    :using  => :nounzip
+  sha1 "b59d6ebf45bff657cbd743bc76191098da17ce02"
+  version "1.4.1"
+
+  def install
+    chmod 0755, "parse"
+    bin.install "parse" => "parse"
+  end
+
+  test do
+    version_str = pipe_output("#{bin}/parse |grep Version")
+    assert_equal "Version #{version}", version_str
+  end
+end


### PR DESCRIPTION
Parse cli is a tool to deploy code to https://parse.com - a mobile app
development platform. The current formula downloads the parse binary
form the parse site. Thats all there is to it.