### PR TITLE
cabal-install 1.22.0.0

### DIFF
--- a/Library/Formula/cabal-install.rb
+++ b/Library/Formula/cabal-install.rb
@@ -2,9 +2,8 @@ require "formula"
 
 class CabalInstall < Formula
   homepage "http://www.haskell.org/haskellwiki/Cabal-Install"
-  url "http://hackage.haskell.org/package/cabal-install-1.20.0.3/cabal-install-1.20.0.3.tar.gz"
-  sha1 "444448b0f704420e329e8fc1989b6743c1c8546d"
-  revision 1
+  url "https://www.haskell.org/cabal/release/cabal-install-1.22.0.0/cabal-install-1.22.0.0.tar.gz"
+  sha1 "a4b31edecc80e244231ebc4dc04c109776505ce2"
 
   bottle do
     cellar :any
@@ -19,20 +18,8 @@ class CabalInstall < Formula
   fails_with :clang if MacOS.version < :mavericks # Same as ghc.rb
 
   def install
-    # use a temporary package database instead of ~/.cabal or ~/.ghc
-    pkg_db = "#{Dir.pwd}/package.conf.d"
-    system "ghc-pkg", "init", pkg_db
-    ENV["EXTRA_CONFIGURE_OPTS"] = "--package-db=#{pkg_db}"
-    ENV["PREFIX"] = Dir.pwd
-    inreplace "bootstrap.sh", "list --global",
-      "list --global --no-user-package-db"
-
-    # Avoid a nasty bug in Cabal by forcing the bootstrap script to pull a later version.
-    # (q.v. https://github.com/haskell/cabal/issues/1740)
-    inreplace "bootstrap.sh", 'CABAL_VER="1.20.0.0";', 'CABAL_VER="1.20.0.2";'
-
-    system "sh", "bootstrap.sh"
-    bin.install "bin/cabal"
+    system "sh", "bootstrap.sh", "--sandbox"
+    bin.install ".cabal-sandbox/bin/cabal"
     bash_completion.install "bash-completion/cabal"
   end
 


### PR DESCRIPTION
I also took the opportunity to simplify a bunch of the code by _directly_ telling the bootstrap script to use a sandbox.