### PR TITLE
autoconf-archive: handle gnome-common conflict

### DIFF
--- a/Library/Formula/autoconf-archive.rb
+++ b/Library/Formula/autoconf-archive.rb
@@ -1,13 +1,32 @@
-require "formula"
-
 class AutoconfArchive < Formula
-  homepage "http://savannah.gnu.org/projects/autoconf-archive/"
+  homepage "https://savannah.gnu.org/projects/autoconf-archive/"
   url "http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2014.10.15.tar.xz"
-  mirror "http://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2014.10.15.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2014.10.15.tar.xz"
   sha1 "7efcefd29a67da2a7243ea2b30e353027d70b460"
 
   def install
     system "./configure", "--prefix=#{prefix}"
-    system 'make install'
+    system "make", "install"
+
+    # gnome_common shares two files with autoconf-archive.
+    if Formula["gnome-common"].opt_prefix.exist?
+      rm share/"aclocal/ax_check_enable_debug.m4"
+      rm share/"aclocal/ax_code_coverage.m4"
+    end
+  end
+
+  def caveats
+    s = ""
+
+    if Formula["gnome-common"].opt_prefix.exist?
+      s += <<-EOS.undent
+      Due to conflict with gnome-common two files have been removed:
+        ax_check_enable_debug.m4 and ax_code_coverage.m4
+
+      Should you remove gnome-common later, you may wish to do:
+        `brew reinstall autoconf-archive`
+      EOS
+    end
+    s
   end
 end


### PR DESCRIPTION
Turns out there’s conflict between gnome-common and autoconf-archive.

Not sure if this is the prettiest way to handle it in the world, but the two formulae seemed popular/useful enough to merit keeping them both in the $PATH, and not conflicting with each other.