### PR TITLE
wireshark 1.12.3 & 1.99.1

### DIFF
--- a/Library/Formula/wireshark.rb
+++ b/Library/Formula/wireshark.rb
@@ -1,20 +1,19 @@
-require "formula"
-
 class Wireshark < Formula
   homepage "https://www.wireshark.org"
 
   stable do
-    url "https://www.wireshark.org/download/src/all-versions/wireshark-1.12.2.tar.bz2"
-    mirror "https://1.eu.dl.wireshark.org/src/wireshark-1.12.2.tar.bz2"
-    sha1 "0598fe285725f97045d7d08e6bde04686044b335"
+    url "https://www.wireshark.org/download/src/all-versions/wireshark-1.12.3.tar.bz2"
+    mirror "https://1.eu.dl.wireshark.org/src/wireshark-1.12.3.tar.bz2"
+    sha1 "44ad77b6e80f41ba34ac0eaf477b81cb1345ceed"
 
     # Removes SDK checks that prevent the build from working on CLT-only systems
     # Reported upstream: https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=9290
     patch :DATA
+
+    depends_on "homebrew/dupes/libpcap" => :optional
   end
 
   bottle do
-    revision 2
     sha1 "6f7662eeef5a2827e65717725dcfc6f035104d27" => :yosemite
     sha1 "4132e4ced51696ff52513ec55d5be79754f58d95" => :mavericks
     sha1 "d9dee8926b364e76420aef082c17370fd65f72ac" => :mountain_lion
@@ -29,14 +28,17 @@ class Wireshark < Formula
   end
 
   devel do
-    url "https://www.wireshark.org/download/src/all-versions/wireshark-1.99.0.tar.bz2"
-    mirror "https://1.eu.dl.wireshark.org/src/wireshark-1.99.0.tar.bz2"
-    sha1 "2e5cf3209104b98251350b3a5e52401866916aec"
+    url "https://www.wireshark.org/download/src/all-versions/wireshark-1.99.1.tar.bz2"
+    mirror "https://1.eu.dl.wireshark.org/src/wireshark-1.99.1.tar.bz2"
+    sha1 "5ea32f83709a90fd5fdf5d331992e46a42ec27aa"
+
+    depends_on "homebrew/dupes/libpcap" if MacOS.version == :mavericks
   end
 
   option "with-gtk+3", "Build the wireshark command with gtk+3"
   option "with-gtk+", "Build the wireshark command with gtk+"
   option "with-qt", "Build the wireshark-qt command (can be used with or without either GTK option)"
+  option "with-qt5", "Build the wireshark-qt command with qt5 (can be used with or without either GTK option)"
   option "with-headers", "Install Wireshark library headers for plug-in development"
 
   depends_on "pkg-config" => :build
@@ -52,10 +54,10 @@ class Wireshark < Formula
   depends_on "libsmi" => :optional
   depends_on "lua" => :optional
   depends_on "portaudio" => :optional
+  depends_on "qt5" => :optional
   depends_on "qt" => :optional
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
-  depends_on "homebrew/dupes/libpcap" => :optional
   depends_on "gnome-icon-theme" if build.with? "gtk+3"
 
   def install
@@ -64,9 +66,9 @@ class Wireshark < Formula
             "--prefix=#{prefix}",
             "--with-gnutls"]
 
-    args << "--disable-wireshark" if build.without?("gtk+3") && build.without?("qt") && build.without?("gtk+")
+    args << "--disable-wireshark" if build.without?("gtk+3") && build.without?("qt") && build.without?("gtk+") && build.without?("qt5")
     args << "--disable-gtktest" if build.without?("gtk+3") && build.without?("gtk+")
-    args << "--with-qt" if build.with? "qt"
+    args << "--with-qt" if build.with? "qt" or build.with? "qt5"
     args << "--with-gtk3" if build.with? "gtk+3"
     args << "--with-gtk2" if build.with? "gtk+"
     args << "--with-libcap=#{Formula["libpcap"].opt_prefix}" if build.with? "libpcap"


### PR DESCRIPTION
A double bump, and a new Qt5 option.

Qt5 actually seems to be preferred by Wireshark-qt; If you leave both Qt5 and Qt in the $PATH, as soon as it finds Qt5 it stops looking for Qt - The other way around, it keeps checking for Qt5.