### PR TITLE
Source highlight/ftpmirror ssl

### DIFF
--- a/Library/Formula/source-highlight.rb
+++ b/Library/Formula/source-highlight.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class SourceHighlight < Formula
   homepage 'https://www.gnu.org/software/src-highlite/'
-  url 'https://ftpmirror.gnu.org/src-highlite/source-highlight-3.1.7.tar.gz'
+  url 'http://ftpmirror.gnu.org/src-highlite/source-highlight-3.1.7.tar.gz'
   mirror 'https://ftp.gnu.org/gnu/src-highlite/source-highlight-3.1.7.tar.gz'
   mirror 'http://mirror.anl.gov/pub/gnu/src-highlite/source-highlight-3.1.7.tar.gz'
   sha1 '71c637548be71afc3f895b0d8ada1a72a8dab4a0'


### PR DESCRIPTION
As per https://github.com/Homebrew/homebrew/commit/3ba9b284bc57a1a02c1e04b54c7f3b3283adac2b (@DomT4 FTFY), removes the ssl from ftpmirror as it does not have a valid certificate.

The new url returns a `302` and redirects to the correct tarball.