### PR TITLE
isl: add test

### DIFF
--- a/Library/Formula/isl.rb
+++ b/Library/Formula/isl.rb
@@ -1,7 +1,5 @@
-require 'formula'
-
 class Isl < Formula
-  homepage 'http://freecode.com/projects/isl'
+  homepage "http://freecode.com/projects/isl"
   # Note: Always use tarball instead of git tag for stable version.
   #
   # Currently isl detects its version using source code directory name
@@ -11,8 +9,8 @@ class Isl < Formula
   #
   # 0.13 is out, but we can't upgrade until a compatible version of cloog is
   # released.
-  url 'http://isl.gforge.inria.fr/isl-0.12.2.tar.bz2'
-  sha1 'ca98a91e35fb3ded10d080342065919764d6f928'
+  url "http://isl.gforge.inria.fr/isl-0.12.2.tar.bz2"
+  sha1 "ca98a91e35fb3ded10d080342065919764d6f928"
 
   bottle do
     cellar :any
@@ -23,14 +21,14 @@ class Isl < Formula
   end
 
   head do
-    url 'http://repo.or.cz/r/isl.git'
+    url "http://repo.or.cz/r/isl.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on 'gmp'
+  depends_on "gmp"
 
   def install
     system "./autogen.sh" if build.head?

--- a/Library/Formula/isl.rb
+++ b/Library/Formula/isl.rb
@@ -41,4 +41,19 @@ class Isl < Formula
     system "make", "install"
     (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
   end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-lisl", "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
isl has been released as version 0.14(current homebrew version is 0.12.1). The setback comes from cloog.
While the official release of cloog is 0.18.1 in website, the tag in cloog git repo has bumped to 0.18.3 
and 0.18.2 tarball can be downloaded. I will test the newer version and send another PR.