### PR TITLE
Bump OpenSSL to 1.0.1k

### DIFF
--- a/Library/Formula/freeradius-server.rb
+++ b/Library/Formula/freeradius-server.rb
@@ -4,6 +4,7 @@ class FreeradiusServer < Formula
   homepage "http://freeradius.org/"
   url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-2.2.6.tar.gz"
   sha1 "25b0a057b1fffad5a030946e8af0c6170e5cdf46"
+  revision 1
 
   devel do
     url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.5.tar.bz2"

--- a/Library/Formula/lastpass-cli.rb
+++ b/Library/Formula/lastpass-cli.rb
@@ -5,6 +5,7 @@ class LastpassCli < Formula
   url "https://github.com/lastpass/lastpass-cli/archive/v0.4.0.tar.gz"
   sha1 "2c5766be2ad5bca398ed7615ddadde9c5bbf0ecd"
   head "https://github.com/lastpass/lastpass-cli.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -2,7 +2,6 @@ class Openssl < Formula
   homepage "https://openssl.org"
   url "https://www.openssl.org/source/openssl-1.0.1k.tar.gz"
   sha256 "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c"
-  revision 1
 
   bottle do
     sha1 "ffc47898c5c5599745b644c1889e473418a18d5a" => :yosemite

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,6 +1,7 @@
 class Openssl < Formula
   homepage "https://openssl.org"
   url "https://www.openssl.org/source/openssl-1.0.1k.tar.gz"
+  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.1k.tar.gz"
   sha256 "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c"
 
   bottle do

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,8 +1,7 @@
 class Openssl < Formula
   homepage "https://openssl.org"
-  url "https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.1j.tar.gz"
-  sha256 "1b60ca8789ba6f03e8ef20da2293b8dc131c39d83814e775069f02d26354edf3"
+  url "https://www.openssl.org/source/openssl-1.0.1k.tar.gz"
+  sha256 "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c"
   revision 1
 
   bottle do

--- a/Library/Formula/tor.rb
+++ b/Library/Formula/tor.rb
@@ -3,6 +3,7 @@ class Tor < Formula
   url "https://dist.torproject.org/tor-0.2.5.10.tar.gz"
   mirror "https://tor.eff.org/dist/tor-0.2.5.10.tar.gz"
   sha256 "b3dd02a5dcd2ffe14d9a37956f92779d4427edf7905c0bba9b1e3901b9c5a83b"
+  revision 1
 
   bottle do
     sha1 "0bf6ef6985285bac9e67fbc78cef7ebb78844de2" => :yosemite


### PR DESCRIPTION
Fixes https://www.openssl.org/news/secadv_20150108.txt