### PR TITLE
brew-test-bot `brew uses` fixes

### DIFF
--- a/Library/Formula/fwknop.rb
+++ b/Library/Formula/fwknop.rb
@@ -25,7 +25,6 @@ class Fwknop < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
     touch testpath/".fwknoprc"
     chmod 0600, testpath/".fwknoprc"
     system "#{bin}/fwknop", "--version"

--- a/Library/Formula/john-jumbo.rb
+++ b/Library/Formula/john-jumbo.rb
@@ -59,7 +59,6 @@ class JohnJumbo < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
     touch "john2.pot"
     system "echo dave:`printf secret | openssl md5` > test"
     output = shell_output("#{bin}/john --pot=#{testpath}/john2.pot --format=raw-md5 test")

--- a/Library/Formula/sshrc.rb
+++ b/Library/Formula/sshrc.rb
@@ -10,7 +10,6 @@ class Sshrc < Formula
   end
 
   test do
-    ENV["HOME"] = testpath
     touch testpath/".sshrc"
     (testpath/"ssh").write <<-EOS.undent
       #!/bin/sh

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -362,6 +362,7 @@ module Homebrew
       changed_dependences = dependencies - unchanged_dependencies
 
       dependents = `brew uses #{formula_name}`.split("\n")
+      dependents -= @formulae
       dependents = dependents.map {|d| Formulary.factory(d)}
       testable_dependents = dependents.select {|d| d.test_defined? && d.stable.bottled? }
       uninstalled_testable_dependents = testable_dependents.reject {|d| d.installed? }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -605,13 +605,16 @@ class Formula
   end
 
   def run_test
+    @oldhome = ENV["HOME"]
     self.build = Tab.for_formula(self)
     mktemp do
       @testpath = Pathname.pwd
+      ENV["HOME"] = @testpath
       test
     end
   ensure
     @testpath = nil
+    ENV["HOME"] = @oldhome
   end
 
   def test_defined?


### PR DESCRIPTION
- better handle changed dependents so we don't try and install or test them if they're modified
- run `brew install/fetch/test` individually for each dependent to improve the output
- set (and unset) `ENV["HOME"]` when running `brew test`
- remove duplicate `ENV["HOME"]` declarations in formulae