### PR TITLE
language/python: add --no-user-cfg to setuptools options

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -89,6 +89,7 @@ module Language
         --prefix=#{prefix}
         --single-version-externally-managed
         --record=installed.txt
+        --no-user-cfg
       ]
     end
   end


### PR DESCRIPTION
Will not fix but nonetheless inspired by #35674; makes sure that our vendored Python installs aren't susceptible to user distutils configuration files.