### PR TITLE
go: style nits and future changes 

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -1,11 +1,13 @@
-require 'formula'
-
 class Go < Formula
-  homepage 'http://golang.org'
-  head 'https://go.googlesource.com/go', :using => :git
-  url 'https://storage.googleapis.com/golang/go1.4.src.tar.gz'
-  version '1.4'
-  sha1 '6a7d9bd90550ae1e164d7803b3e945dc8309252b'
+  homepage "https://golang.org"
+  # Version 1.5 is going to require version 1.4 present to bootstrap 1.4
+  # Perhaps we can use our previous bottles, ala the discussion around PyPy?
+  # https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28
+  url "https://storage.googleapis.com/golang/go1.4.src.tar.gz"
+  sha1 "6a7d9bd90550ae1e164d7803b3e945dc8309252b"
+  version "1.4"
+
+  head "https://go.googlesource.com/go", :using => :git
 
   bottle do
     sha1 "33aa691a93a3c9aa40334e3ce6daa49420696fe4" => :yosemite
@@ -13,54 +15,57 @@ class Go < Formula
     sha1 "359fe25e6755c2362d619c01363a7f80ec59efca" => :mountain_lion
   end
 
-  option 'cross-compile-all', "Build the cross-compilers and runtime support for all supported platforms"
-  option 'cross-compile-common', "Build the cross-compilers and runtime support for darwin, linux and windows"
-  option 'without-cgo', "Build without cgo"
+  option "with-cc-all", "Build with cross-compilers and runtime support for all supported platforms"
+  option "with-cc-common", "Build with cross-compilers and runtime support for darwin, linux and windows"
+  option "without-cgo", "Build without cgo"
+
+  deprecated_option "cross-compile-all" => "with-cc-all"
+  deprecated_option "cross-compile-common" => "with-cc-common"
 
   def install
     # host platform (darwin) must come last in the targets list
-    if build.include? 'cross-compile-all'
+    if build.with? "cc-all"
       targets = [
-        ['linux',   ['386', 'amd64', 'arm']],
-        ['freebsd', ['386', 'amd64', 'arm']],
-        ['netbsd',  ['386', 'amd64', 'arm']],
-        ['openbsd', ['386', 'amd64']],
-        ['windows', ['386', 'amd64']],
-        ['dragonfly', ['386', 'amd64']],
-        ['plan9',   ['386', 'amd64']],
-        ['solaris', ['amd64']],
-        ['darwin',  ['386', 'amd64']],
+        ["linux",   ["386", "amd64", "arm"]],
+        ["freebsd", ["386", "amd64", "arm"]],
+        ["netbsd",  ["386", "amd64", "arm"]],
+        ["openbsd", ["386", "amd64"]],
+        ["windows", ["386", "amd64"]],
+        ["dragonfly", ["386", "amd64"]],
+        ["plan9",   ["386", "amd64"]],
+        ["solaris", ["amd64"]],
+        ["darwin",  ["386", "amd64"]],
       ]
-    elsif build.include? 'cross-compile-common'
+    elsif build.with? "cc-common"
       targets = [
-        ['linux',   ['386', 'amd64', 'arm']],
-        ['windows', ['386', 'amd64']],
-        ['darwin',  ['386', 'amd64']],
+        ["linux",   ["386", "amd64", "arm"]],
+        ["windows", ["386", "amd64"]],
+        ["darwin",  ["386", "amd64"]],
       ]
     else
-      targets = [['darwin', ['']]]
+      targets = [["darwin", [""]]]
     end
 
     # The version check is due to:
     # http://codereview.appspot.com/5654068
-    (buildpath/'VERSION').write('default') if build.head?
+    (buildpath/"VERSION").write("default") if build.head?
 
-    cd 'src' do
+    cd "src" do
       targets.each do |os, archs|
-        cgo_enabled = os == 'darwin' && build.with?('cgo') ? "1" : "0"
+        cgo_enabled = os == "darwin" && build.with?("cgo") ? "1" : "0"
         archs.each do |arch|
-          ENV['GOROOT_FINAL'] = libexec
-          ENV['GOOS']         = os
-          ENV['GOARCH']       = arch
-          ENV['CGO_ENABLED']  = cgo_enabled
+          ENV["GOROOT_FINAL"] = libexec
+          ENV["GOOS"]         = os
+          ENV["GOARCH"]       = arch
+          ENV["CGO_ENABLED"]  = cgo_enabled
           system "./make.bash", "--no-clean"
         end
       end
     end
 
-    (buildpath/'pkg/obj').rmtree
+    (buildpath/"pkg/obj").rmtree
 
-    libexec.install Dir['*']
+    libexec.install Dir["*"]
     bin.install_symlink Dir["#{libexec}/bin/go*"]
   end
 
@@ -81,7 +86,7 @@ class Go < Formula
   end
 
   test do
-    (testpath/'hello.go').write <<-EOS.undent
+    (testpath/"hello.go").write <<-EOS.undent
     package main
 
     import "fmt"


### PR DESCRIPTION
Inserted a comment about the fun new situation we have upcoming where Go is going to be compiled with a prior version of Go. This is going to be a pretty similar discussion to the one we had about PyPy with potentially using our former bottles to bootstrap.

I’ve also depreciated a couple of the options in favour of shorter options that fit our ` —with- ` syntax. If you don’t like those, I’ll revert them.

Otherwise, just fixes the quotes up and makes the formula pass the strict audit. Uses the Homepage SSL/TLS link, rather than the plaintext one as well.