### PR TITLE
version: fix fake versions not being correctly compared

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -53,6 +53,25 @@ class VersionComparisonTests < Homebrew::TestCase
     assert_operator version('1.1beta2'), :<, version('1.1rc1')
     assert_operator version('1.0.0beta7'), :<, version('1.0.0')
     assert_operator version('3.2.1'), :>, version('3.2beta4')
+    assert_operator version('1.1rc1'), :<, version('1.1')
+  end
+
+  def test_fake_alpha_beta
+    assert_operator version('1.9'), :<, version('1.9a')
+    assert_operator version('2.6'), :<, version('2.6b')
+    assert_operator version('3.5beta'), :<, version('3.5b')
+    assert_operator version('2.1.2alpha'), :<, version('2.1.2a')
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".each_char do |letter|
+      assert_operator version("1.2#{letter}"), :>, version('1.2')
+      assert_operator version("1.3#{letter}"), :>, version('1.3alpha')
+      assert_operator version("1.6#{letter}"), :>, version('1.6beta')
+      assert_operator version("1.7#{letter}"), :>, version('1.7rc')
+    end
+    assert_operator version('1.0rc'), :<, version('1.0a')
+    versions = %w{0.9 1.0alpha 1.0alpha1 1.0beta 1.0beta1 1.0beta2 1.0rc 1.0rc1
+                  1.0rc2 1.0 1.0a 1.0ab 1.0b 1.0c 1.0r}
+    assert_equal versions, versions.sort_by { |v| version(v) }
+
   end
 
   def test_comparing_unevenly_padded_versions

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -51,6 +51,8 @@ class Version
 
     def <=>(other)
       case other
+      when AlphaToken, BetaToken, RCToken
+        1
       when StringToken
         value <=> other.value
       when NumericToken, NullToken
@@ -85,12 +87,17 @@ class Version
   end
 
   class AlphaToken < CompositeToken
-    PATTERN = /a(?:lpha)?[0-9]*/i
+    PATTERN = Regexp.union(
+      /alpha[0-9]*/i,
+      /a[0-9]+/,
+    )
 
     def <=>(other)
       case other
       when AlphaToken
         rev <=> other.rev
+      when BetaToken, RCToken, PatchToken, StringToken
+        -1
       else
         super
       end
@@ -98,7 +105,10 @@ class Version
   end
 
   class BetaToken < CompositeToken
-    PATTERN = /b(?:eta)?[0-9]*/i
+    PATTERN = Regexp.union(
+      /beta[0-9]*/i,
+      /b[0-9]+/,
+    )
 
     def <=>(other)
       case other
@@ -106,7 +116,7 @@ class Version
         rev <=> other.rev
       when AlphaToken
         1
-      when RCToken, PatchToken
+      when RCToken, PatchToken, StringToken
         -1
       else
         super
@@ -123,7 +133,7 @@ class Version
         rev <=> other.rev
       when AlphaToken, BetaToken
         1
-      when PatchToken
+      when PatchToken, StringToken
         -1
       else
         super

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -89,7 +89,7 @@ class Version
   class AlphaToken < CompositeToken
     PATTERN = Regexp.union(
       /alpha[0-9]*/i,
-      /a[0-9]+/,
+      /a[0-9]+/
     )
 
     def <=>(other)
@@ -107,7 +107,7 @@ class Version
   class BetaToken < CompositeToken
     PATTERN = Regexp.union(
       /beta[0-9]*/i,
-      /b[0-9]+/,
+      /b[0-9]+/
     )
 
     def <=>(other)


### PR DESCRIPTION
This patch fixes _wrong_ comparisons like 1.9 > 1.9a, which occurs for example with `tmux`.
The problem was that literal tokens like 'a' or 'b' were treated like alpha and beta tokens, while it's not true generally.