### PR TITLE
test-bot: unlink conflict formulae during the test

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -447,6 +447,10 @@ module Homebrew
           unless dependent.installed?
             test "brew", "fetch", "--retry", dependent.name
             next if steps.last.failed?
+            conflicts = dependent.conflicts.map { |c| Formulary.factory(c.name) }.select { |f| f.installed? }
+            conflicts.each do |conflict|
+              test "brew", "unlink", conflict.name
+            end
             test "brew", "install", dependent.name
             next if steps.last.failed?
           end


### PR DESCRIPTION
Solve the problem occured in https://github.com/Homebrew/homebrew/pull/35695