### PR TITLE
bwctl: include launchd plist and configuration files to run as daemon

### DIFF
--- a/Library/Formula/bwctl.rb
+++ b/Library/Formula/bwctl.rb
@@ -16,15 +16,99 @@ class Bwctl < Formula
   depends_on "iperf3" => :optional
   depends_on "thrulay" => :optional
 
+  # Patch to fix failure to start under launchd. Submitted upstream at
+  # https://code.google.com/p/perfsonar-ps/issues/detail?id=1043
+  patch :DATA
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
     system "make", "install"
+
+    (buildpath+"bwctld.conf").write <<-EOS.undent
+      allow_unsync
+      log_location
+      peer_port       6001-6200
+      facility        local5
+      test_port       5001-5900
+      iperf_port      5001-5300
+      nuttcp_port     5301-5600
+      owamp_port      5601-5900
+      user            nobody
+      group           nobody
+      EOS
+    (buildpath+"bwctld.keys").write ""
+    (etc+"bwctld").mkpath
+    (etc+"bwctld").install "bwctld.conf" => "bwctld.conf",
+                           "bwctld.keys" => "bwctld.keys",
+                           "conf/bwctld.conf" => "bwctld.conf.default",
+                           "conf/bwctld.limits" => "bwctld.limits"
+
+    (var+"log/bwctld").mkpath
+  end
+
+  plist_options :startup => true,
+      :manual => "bwctld -c #{HOMEBREW_PREFIX}/etc/bwctld -R #{HOMEBREW_PREFIX}/var/run"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/bwctld</string>
+        <string>-c</string>
+        <string>#{etc}/bwctld</string>
+        <string>-R</string>
+        <string>#{var}/run</string>
+        <string>-Z</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{var}/log/bwctld</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/bwctld/output.log</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/bwctld/output.log</string>
+      <key>HardResourceLimits</key>
+      <dict>
+        <key>NumberOfFiles</key>
+        <integer>1024</integer>
+      </dict>
+      <key>SoftResourceLimits</key>
+      <dict>
+        <key>NumberOfFiles</key>
+        <integer>1024</integer>
+      </dict>
+    </dict>
+    </plist>
+    EOS
   end
 
   test do
     system "#{bin}/bwctl", "-V"
   end
 end
+
+__END__
+diff --git a/bwctld/bwctld.c b/bwctld/bwctld.c
+index c155e31..3ec9f5f 100644
+--- a/bwctld/bwctld.c
++++ b/bwctld/bwctld.c
+@@ -2554,7 +2554,7 @@ main(int argc, char *argv[])
+          * kill call.) setsid handles this when daemonizing.
+          */
+         mypid = getpid();
+-        if(setpgid(0,mypid) != 0){
++        if(getsid(0) != mypid && setpgid(0,mypid) != 0){
+             I2ErrLog(errhand,"setpgid(): %M");
+             exit(1);
+         }


### PR DESCRIPTION
The bwctl package contains both comand-line client (bwctl) and daemon (bwctld). 

This patch enables the daemon functionality using plist/launchd files. It appears to work, but as this is my first attempt at using launchd I would be grateful if you would review. Notes:

* The -Z option makes bwctld run in the foreground, so I've added this to the launchd ProgramArguments but not to the options used to start it manually
* I had to add a patch for the -Z flag to work under launchd, due to the way it was calling setpgid() and failing because the process was already the session leader
* The daemon starts as root but I've made the default config switch to 'nobody'. (bwctld refuses to run as root unless you add the 'root_folly' flag to agree you're doing something stupid)
* The installed limits file is just [the sample one](https://code.google.com/p/perfsonar-ps/source/browse/conf/bwctld.limits?repo=bwctl) minus comments

If this is accepted, I'll do the same for owamp.