### PR TITLE
libgit2: use master branch for HEAD

### DIFF
--- a/Library/Formula/libgit2.rb
+++ b/Library/Formula/libgit2.rb
@@ -5,7 +5,7 @@ class Libgit2 < Formula
   url "https://github.com/libgit2/libgit2/archive/v0.21.3.tar.gz"
   sha1 "d116cb15f76edf2283c85da40389e4fecc8d5aeb"
 
-  head "https://github.com/libgit2/libgit2.git", :branch => "development"
+  head "https://github.com/libgit2/libgit2.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The libgit2 project switched back to `master` for development (libgit2/libgit2#2433).