### PR TITLE
change linking of poco libraries

### DIFF
--- a/Library/Formula/poco.rb
+++ b/Library/Formula/poco.rb
@@ -22,9 +22,22 @@ class Poco < Formula
   depends_on "openssl"
 
   def install
+    #This modifies the install name of shared libraries so the path is the install directory instead of the build directory.
+    #https://github.com/pocoproject/poco/pull/670
+    files = ['build/config/Darwin-clang','build/config/Darwin-clang-libc++','build/config/Darwin-gcc']
+    inreplace files, '-dynamiclib', '-dynamiclib -Wl,-install_name,$(POCO_PREFIX)/lib/$(notdir \$@)'
+
     ENV.cxx11 if build.cxx11?
 
-    arch = Hardware.is_64_bit? ? 'Darwin64': 'Darwin32'
+    if ENV.compiler == :clang
+      if build.cxx11?
+        arch = Hardware.is_64_bit? ? 'Darwin64-clang-libc++': 'Darwin32-clang-libc++'
+      else
+        arch = Hardware.is_64_bit? ? 'Darwin64-clang': 'Darwin32-clang'
+      end
+    else # ENV.compiler == :gcc
+     arch = Hardware.is_64_bit? ? 'Darwin64-gcc': 'Darwin32-gcc'
+    end
     system "./configure", "--prefix=#{prefix}",
                           "--config=#{arch}",
                           "--omit=Data/MySQL,Data/ODBC",


### PR DESCRIPTION
from https://github.com/Homebrew/homebrew/issues/35702

Many of the poco libraries link against libraries in the directory #{build path}/lib, which is deleted after installation. For example,
```
$ otool -L libPocoNet.dylib 
libPocoNet.dylib:
    /usr/local/lib/libPocoNet.17.dylib (compatibility version 0.0.0, current version 0.0.0)
    /private/tmp/poco-I4ZjYj/poco-1.4.7p1-all/lib/Darwin/x86_64/libPocoFoundation.17.dylib (compatibility version 0.0.0, current version 0.0.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1197.1.1)
    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
```

This additional loop iterates over the shared libraries and changes the path to #{lib}