### PR TITLE
commonmark 0.15 (new formula)

### DIFF
--- a/Library/Formula/commonmark.rb
+++ b/Library/Formula/commonmark.rb
@@ -1,0 +1,25 @@
+class Commonmark < Formula
+  homepage "http://commonmark.org"
+  url "https://github.com/jgm/CommonMark/archive/0.15.tar.gz"
+  sha1 "877665a96fdc5fcc42ec2cd605d8535344a27b72"
+
+  depends_on "cmake" => :build
+  depends_on :python3 => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      ENV.deparallelize
+      system "make"
+      system "make", "test"
+      system "make", "install"
+    end
+  end
+
+  test do
+    test_input = "*hello, world*\n"
+    expected_output = "<p><em>hello, world</em></p>\n"
+    test_output = `/bin/echo -n "#{test_input}" | #{bin}/cmark`
+    assert_equal expected_output, test_output
+  end
+end


### PR DESCRIPTION
[CommonMark](http://commonmark.org) is "a strongly specified, highly compatible implementation of Markdown". In essence, an effort to standardize Markdown. The project has so far attracted 2,383 stars on [GitHub](https://github.com/jgm/CommonMark).

This formula installs [the reference C implementation](https://github.com/jgm/CommonMark), which is a [very fast](https://github.com/jgm/CommonMark/blob/master/benchmarks.md) and robust implementation. The installed executable is called `cmark` and hence doesn't interfere with other Markdown implementations.

The current version is 0.15. This is my first time contributing a new formula so I'm not so sure if this counts as a "stable version", but I did notice a lot of formulas below 1.0 around here. From my experience, I'd say this version is already very stable (at least I never had a problem).