### PR TITLE
Regroup ffmpeg dependencies options

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -13,11 +13,11 @@ class Ffmpeg < Formula
 
   option "without-x264", "Disable H.264 encoder"
   option "without-lame", "Disable MP3 encoder"
+  option "without-libvo-aacenc", "Disable VisualOn AAC encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
   option "without-qtkit", "Disable deprecated QuickTime framework"
 
   option "with-rtmpdump", "Enable RTMP protocol"
-  option "without-libvo-aacenc", "Enable VisualOn AAC encoder"
   option "with-libass", "Enable ASS/SSA subtitle format"
   option "with-opencore-amr", "Enable Opencore AMR NR/WB audio format"
   option "with-openjpeg", "Enable JPEG 2000 image format"
@@ -79,8 +79,8 @@ class Ffmpeg < Formula
            ]
 
     args << "--enable-libx264" if build.with? "x264"
-    args << "--enable-libfaac" if build.with? "faac"
     args << "--enable-libmp3lame" if build.with? "lame"
+    args << "--enable-libvo-aacenc" if build.with? "libvo-aacenc"
     args << "--enable-libxvid" if build.with? "xvid"
 
     args << "--enable-libfontconfig" if build.with? "fontconfig"
@@ -90,7 +90,7 @@ class Ffmpeg < Formula
     args << "--enable-libvpx" if build.with? "libvpx"
     args << "--enable-librtmp" if build.with? "rtmpdump"
     args << "--enable-libopencore-amrnb" << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
-    args << "--enable-libvo-aacenc" if build.with? "libvo-aacenc"
+    args << "--enable-libfaac" if build.with? "faac"
     args << "--enable-libass" if build.with? "libass"
     args << "--enable-ffplay" if build.with? "ffplay"
     args << "--enable-libspeex" if build.with? "speex"

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -159,7 +159,7 @@ class Ffmpeg < Formula
       To install with libfaac, you can:
         brew reinstall ffmpeg --with-faac
 
-      You can also use the libvo-acenc or experimental FFmpeg encoder to
+      You can also use the libvo-aacenc or experimental FFmpeg encoder to
       encode AAC audio:
         -c:a libvo_aacenc
       Or:


### PR DESCRIPTION
After `faac` has been moved to the optional dependencies group - in favor of `libvo-aacenc` - the list of build options and arguments got displaced, no longer reflecting the current grouping of recommended/optional dependencies.