### PR TITLE
pythonpy (0.3.6) new formula

### DIFF
--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -20,8 +20,8 @@ class Pythonpy < Formula
       # executables, if both versions are going to be installed
       version = version.to_s
       execs_to_wrap = [
-        "py#{version}", "py#{version[0]}",
-        "pycompleter#{version}", "pycompleter#{version[0]}"
+        "py#{version}", "py#{version[0..0]}",
+        "pycompleter#{version}", "pycompleter#{version[0..0]}"
       ]
       execs_to_wrap.each do |e|
         (bin/e).write_env_script(libexec/"bin"/e, :PYTHONPATH => ENV["PYTHONPATH"])
@@ -49,7 +49,7 @@ class Pythonpy < Formula
     end
 
     if build.with? "python3"
-      assert_equal "3", `#{bin}/py3 sys.version`[0]
+      assert_equal "3", `#{bin}/py3 sys.version`[0..0]
     end
   end
 end

--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -9,6 +9,10 @@ class Pythonpy < Formula
   depends_on :python3 => :optional
 
   def install
+    if build.without?("python") && build.without?("python3")
+      odie "You need to build against one python version."
+    end
+
     Language::Python.each_python(build) do |python, version|
       ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
       system python, *Language::Python.setup_install_args(libexec)

--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -1,0 +1,52 @@
+class Pythonpy < Formula
+  homepage "https://github.com/Russell91/pythonpy"
+  url "https://pypi.python.org/packages/source/p/pythonpy/pythonpy-0.3.6.tar.gz"
+  sha1 "180e4cd00f89cc00d8a657fc7a2d8af4da8b487c"
+  head "https://github.com/Russell91/pythonpy.git"
+
+  option "without-python", "Build without python 2 support"
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+  depends_on :python3 => :optional
+
+  def install
+    Language::Python.each_python(build) do |python, version|
+      ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+      system python, *Language::Python.setup_install_args(libexec)
+
+      # Cannot use bin.env_script_all_files since it would overwrite python2
+      # executables, if both versions are going to be installed
+      version = version.to_s
+      execs_to_wrap = [
+        "py#{version}", "py#{version[0]}",
+        "pycompleter#{version}", "pycompleter#{version[0]}"
+      ]
+      execs_to_wrap.each do |e|
+        (bin/e).write_env_script(libexec/"bin"/e, :PYTHONPATH => ENV["PYTHONPATH"])
+      end
+    end
+
+    # Prefer the python3 version of the "py" executable, if both are available
+    if build.with? "python3"
+      bin.install_symlink bin/"py3" => "py"
+      bin.install_symlink bin/"pycompleter3" => "pycompleter"
+    else
+      bin.install_symlink bin/"py2" => "py"
+      bin.install_symlink bin/"pycompleter2" => "pycompleter"
+    end
+
+    bash_completion.install libexec/"bash_completion.d/pycompletion.sh"
+  end
+
+  test do
+    assert_equal "13.5", `#{bin}/py 3*4.5`.strip
+
+    if build.with? "python"
+      assert_equal "2.7", `#{bin}/py2 sys.version`[0..2]
+      assert_equal "2.7", `#{bin}/py2.7 sys.version`[0..2]
+    end
+
+    if build.with? "python3"
+      assert_equal "3", `#{bin}/py3 sys.version`[0]
+    end
+  end
+end

--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -4,8 +4,7 @@ class Pythonpy < Formula
   sha1 "180e4cd00f89cc00d8a657fc7a2d8af4da8b487c"
   head "https://github.com/Russell91/pythonpy.git"
 
-  option "without-python", "Build without python 2 support"
-  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+  depends_on :python => :recommended
   depends_on :python3 => :optional
 
   def install

--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -17,11 +17,9 @@ class Pythonpy < Formula
       ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
       system python, *Language::Python.setup_install_args(libexec)
 
-      # Hack: direct string access for ruby 1.8 returns an integer
-      version = version.to_s.split(//)
-
       # Cannot use bin.env_script_all_files since it would overwrite python2
       # executables, if both versions are going to be installed
+      version = version.to_s
       execs_to_wrap = [
         "py#{version}", "py#{version[0]}",
         "pycompleter#{version}", "pycompleter#{version[0]}"
@@ -52,7 +50,7 @@ class Pythonpy < Formula
     end
 
     if build.with? "python3"
-      assert_equal "3", `#{bin}/py3 sys.version`[0..0]
+      assert_equal "3", `#{bin}/py3 sys.version`[0]
     end
   end
 end

--- a/Library/Formula/pythonpy.rb
+++ b/Library/Formula/pythonpy.rb
@@ -17,9 +17,11 @@ class Pythonpy < Formula
       ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
       system python, *Language::Python.setup_install_args(libexec)
 
+      # Hack: direct string access for ruby 1.8 returns an integer
+      version = version.to_s.split(//)
+
       # Cannot use bin.env_script_all_files since it would overwrite python2
       # executables, if both versions are going to be installed
-      version = version.to_s
       execs_to_wrap = [
         "py#{version}", "py#{version[0]}",
         "pycompleter#{version}", "pycompleter#{version[0]}"
@@ -50,7 +52,7 @@ class Pythonpy < Formula
     end
 
     if build.with? "python3"
-      assert_equal "3", `#{bin}/py3 sys.version`[0]
+      assert_equal "3", `#{bin}/py3 sys.version`[0..0]
     end
   end
 end


### PR DESCRIPTION
New formula for pythonpy. Using this formula one can have both versions of "py" installed, one for python 2.7 and one for python3.*. This useful for instance to test command for different versions of python.