### PR TITLE
python, python3: trim PYTHONPATH more carefully

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -259,7 +259,7 @@ class Python < Formula
               sys.path = [ p for p in sys.path
                            if (not p.startswith('/System') and
                                not p.startswith('#{HOMEBREW_PREFIX}/lib/python') and
-                               not (p.startswith('#{rack}') and p.endswith('site-packages'))) ]
+                               not (p.startswith('#{rack}/') and p.endswith('site-packages'))) ]
 
               # LINKFORSHARED (and python-config --ldflags) return the
               # full path to the lib (yes, "Python" is actually the lib, not a

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -244,7 +244,7 @@ class Python3 < Formula
               sys.path = [ p for p in sys.path
                            if (not p.startswith('/System') and
                                not p.startswith('#{HOMEBREW_PREFIX}/lib/python') and
-                               not (p.startswith('#{rack}') and p.endswith('site-packages'))) ]
+                               not (p.startswith('#{rack}/') and p.endswith('site-packages'))) ]
 
               # LINKFORSHARED (and python-config --ldflags) return the
               # full path to the lib (yes, "Python" is actually the lib, not a


### PR DESCRIPTION
Don't remove paths like HOMEBREW_CELLAR/pythonpy/(...)/site-packages
from PYTHONPATH when excluding python's Cellar site-packages.

Should allow #35760 to work.