### PR TITLE
bonnie++ 1.97 (update)

### DIFF
--- a/Library/Formula/bonnie++.rb
+++ b/Library/Formula/bonnie++.rb
@@ -17,10 +17,25 @@ class Bonniexx < Formula
 end
 
 __END__
-diff --git a/bonnie++.cpp b/bonnie++.cpp
-index 8c5a43a..7fc86f7 100644
---- a/bonnie++.cpp
-+++ b/bonnie++.cpp
+diff --git i/Makefile w/Makefile
+index 4bb5103..8f7ed41 100644
+--- i/Makefile
++++ w/Makefile
+@@ -10,8 +10,8 @@ eprefix=${prefix}
+ #MORE_WARNINGS=-Weffc++
+ WFLAGS=-Wall -W -Wshadow -Wpointer-arith -Wwrite-strings -pedantic -ffor-scope -Wcast-align -Wsign-compare -Wpointer-arith -Wwrite-strings -Wformat-security -Wswitch-enum -Winit-self $(MORE_WARNINGS)
+ CFLAGS=-O2  -DNDEBUG $(WFLAGS) $(MORECFLAGS)
+-CXX=g++ $(CFLAGS)
+-LINK=g++
++CXX=clang++ $(CFLAGS)
++LINK=clang++
+ THREAD_LFLAGS=-lpthread
+ 
+ INSTALL=/usr/bin/install -c
+diff --git i/bonnie++.cpp w/bonnie++.cpp
+index 8c5a43a..8a4b3dc 100644
+--- i/bonnie++.cpp
++++ w/bonnie++.cpp
 @@ -73,7 +73,7 @@ public:
    void set_io_chunk_size(int size)
      { delete m_buf; pa_new(size, m_buf, m_buf_pa); m_io_chunk_size = size; }
@@ -39,10 +54,31 @@ index 8c5a43a..7fc86f7 100644
    SetName(".");
  }
  
-@@ -393,8 +393,8 @@ int main(int argc, char *argv[])
-     usage();
+@@ -294,11 +294,7 @@ int main(int argc, char *argv[])
+       {
+         char *sbuf = _strdup(optarg);
+         char *size = strtok(sbuf, ":");
+-#ifdef _LARGEFILE64_SOURCE
+         file_size = size_from_str(size, "gt");
+-#else
+-        file_size = size_from_str(size, "g");
+-#endif
+         size = strtok(NULL, "");
+         if(size)
+         {
+@@ -384,17 +380,8 @@ int main(int argc, char *argv[])
+     if(file_size % 1024 > 512)
+       file_size = file_size + 1024 - (file_size % 1024);
    }
- #endif
+-#ifndef _LARGEFILE64_SOURCE
+-  if(file_size == 2048)
+-    file_size = 2047;
+-  if(file_size > 2048)
+-  {
+-    fprintf(stderr, "Large File Support not present, can't do %dM.\n", file_size);
+-    usage();
+-  }
+-#endif
 -  globals.byte_io_size = __min(file_size, globals.byte_io_size);
 -  globals.byte_io_size = __max(0, globals.byte_io_size);
 +  globals.byte_io_size = min(file_size, globals.byte_io_size);
@@ -50,10 +86,25 @@ index 8c5a43a..7fc86f7 100644
  
    if(machine == NULL)
    {
-diff --git a/duration.cpp b/duration.cpp
+@@ -465,14 +452,6 @@ int main(int argc, char *argv[])
+      && (directory_max_size < directory_min_size || directory_max_size < 0
+      || directory_min_size < 0) )
+     usage();
+-#ifndef _LARGEFILE64_SOURCE
+-  if(file_size > (1 << (31 - 20 + globals.io_chunk_bits)) )
+-  {
+-    fprintf(stderr
+-   , "The small chunk size and large IO size make this test impossible in 32bit.\n");
+-    usage();
+-  }
+-#endif
+   if(file_size && globals.ram && (file_size * concurrency) < (globals.ram * 2) )
+   {
+     fprintf(stderr
+diff --git i/duration.cpp w/duration.cpp
 index efa3fd3..f943155 100644
---- a/duration.cpp
-+++ b/duration.cpp
+--- i/duration.cpp
++++ w/duration.cpp
 @@ -38,7 +38,7 @@ double Duration_Base::stop()
    getTime(&tv);
    double ret;
@@ -63,10 +114,10 @@ index efa3fd3..f943155 100644
    return ret;
  }
  
-diff --git a/port.h b/port.h
+diff --git i/port.h w/port.h
 index 8d53622..2e1f112 100644
---- a/port.h
-+++ b/port.h
+--- i/port.h
++++ w/port.h
 @@ -49,8 +49,6 @@ typedef struct timeval TIMEVAL_TYPE;
  #endif
  
@@ -76,25 +127,10 @@ index 8d53622..2e1f112 100644
  typedef unsigned int UINT;
  typedef unsigned long ULONG;
  typedef const char * PCCHAR;
-diff --git a/Makefile b/Makefile
-index 4bb5103..8f7ed41 100644
---- a/Makefile
-+++ b/Makefile
-@@ -10,8 +10,8 @@ eprefix=${prefix}
- #MORE_WARNINGS=-Weffc++
- WFLAGS=-Wall -W -Wshadow -Wpointer-arith -Wwrite-strings -pedantic -ffor-scope -Wcast-align -Wsign-compare -Wpointer-arith -Wwrite-strings -Wformat-security -Wswitch-enum -Winit-self $(MORE_WARNINGS)
- CFLAGS=-O2  -DNDEBUG $(WFLAGS) $(MORECFLAGS)
--CXX=g++ $(CFLAGS)
--LINK=g++
-+CXX=clang++ $(CFLAGS)
-+LINK=clang++
- THREAD_LFLAGS=-lpthread
- 
- INSTALL=/usr/bin/install -c
-diff --git a/port.h.in b/port.h.in
+diff --git i/port.h.in w/port.h.in
 index 69c8f24..8359d72 100644
---- a/port.h.in
-+++ b/port.h.in
+--- i/port.h.in
++++ w/port.h.in
 @@ -49,8 +49,6 @@ typedef struct timeval TIMEVAL_TYPE;
  #endif
  

--- a/Library/Formula/bonnie++.rb
+++ b/Library/Formula/bonnie++.rb
@@ -16,6 +16,16 @@ class Bonniexx < Formula
   end
 end
 
+# Changes included in this patchset:
+# 1) Explicitly use clang/clang++ in Makefile
+# 2) __min() and __max() macros break bon_csv2html.cpp: "redefinition of 'min' as different kind of symbol"
+#    Remove the construct in favor of macro targets min()/max() provided by the library
+#    Files affected: port.h.in port.h duration.cpp bonnie++.cpp
+# 3) Remove the #ifdef _LARGEFILE64_SOURCE macros which not only prohibits the intended functionality of
+#    splitting into 2 GB files for such filesystems but also incorrectly tests for it in the first place.
+#    The ideal fix would be to replace the AC_TRY_RUN() in configure.in if the fail code actually worked.
+#    Files affected: bonnie++.cp
+
 __END__
 diff --git i/Makefile w/Makefile
 index 4bb5103..8f7ed41 100644


### PR DESCRIPTION
Added Ports patch to (re)enable large file support. Source: http://lists.freebsd.org/pipermail/freebsd-ports-bugs/2003-August/011265.html
I had to repatch bonnie++.cpp from scratch, so the diff is a bit ugly. The only actual changes are to the bonnie++.cpp file per the port's patch.