### PR TITLE
pandoc-citeproc 0.6: Remove require "formula"

### DIFF
--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -1,4 +1,3 @@
-require "formula"
 require "language/haskell"
 
 class PandocCiteproc < Formula


### PR DESCRIPTION
I'm primarily interested in a building a bottle for Yosemite.