### PR TITLE
tth 4.06

### DIFF
--- a/Library/Formula/tth.rb
+++ b/Library/Formula/tth.rb
@@ -1,14 +1,17 @@
-require 'formula'
-
 class Tth < Formula
-  homepage 'http://hutchinson.belmont.ma.us/tth/'
-  url 'http://hutchinson.belmont.ma.us/tth/tth-noncom/tth_C.tgz'
-  sha1 'bc571e5916b979c1dd8e3377249db66ceee28318'
-  version '4.05'
+  homepage "http://hutchinson.belmont.ma.us/tth/"
+  # upstream has been asked to provide versioned links (Jan 12, 2015)
+  url "http://hutchinson.belmont.ma.us/tth/tth-noncom/tth_C.tgz"
+  sha1 "27b44970d93f1e1964c92ffa0fa964e6045bae37"
+  version "4.06"
 
   def install
-    system "#{ENV.cc} -o tth tth.c"
-    bin.install %w(tth latex2gif ps2gif ps2png)
-    man1.install 'tth.1'
+    system ENV.cc, "-o", "tth", "tth.c"
+    bin.install %w[tth latex2gif ps2gif ps2png]
+    man1.install "tth.1"
+  end
+
+  test do
+    assert_match(/version #{version}/, pipe_output("#{bin}/tth", ""))
   end
 end


### PR DESCRIPTION
The author used the same URL but changed the .tar.gz, so installing TtH 4.05 fails because the SHA1 sum doesn’t match.