### PR TITLE
Updated htop-osx to include patch to fix SIGSEGV fault when COLS > 178.

### DIFF
--- a/Library/Formula/htop-osx.rb
+++ b/Library/Formula/htop-osx.rb
@@ -1,7 +1,9 @@
+require "formula"
+
 class HtopOsx < Formula
   homepage "https://github.com/max-horvath/htop-osx"
-  url "https://github.com/max-horvath/htop-osx/archive/0.8.2.2.tar.gz"
-  sha1 "17c56fe5efe81cf6b0f4c13a958fa7e4d8591b23"
+  url "https://github.com/max-horvath/htop-osx/archive/0.8.2.3.tar.gz"
+  sha1 "43d63772dd610fb238e3b9a83c066658bd6218d9"
 
   bottle do
     revision 1

--- a/Library/Formula/htop-osx.rb
+++ b/Library/Formula/htop-osx.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class HtopOsx < Formula
   homepage "https://github.com/max-horvath/htop-osx"
   url "https://github.com/max-horvath/htop-osx/archive/0.8.2.3.tar.gz"


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew/pull/34684 ...