### PR TITLE
jp2a: TERM env variable defined in test

### DIFF
--- a/Library/Formula/jp2a.rb
+++ b/Library/Formula/jp2a.rb
@@ -23,6 +23,8 @@ class Jp2a < Formula
   end
 
   test do
+    # the test fails if this is not set
+    ENV["TERM"] = "xterm-256color"
     system "#{bin}/jp2a", test_fixtures("test.jpg")
   end
 end


### PR DESCRIPTION
This fixes [the build](http://bot.brew.sh/job/Homebrew/11203/version=mountain_lion/testReport/junit/brew-test-bot/mountain_lion/test_jp2a/).