### PR TITLE
Fix brew test linking errors in several formula on 10.10

### DIFF
--- a/Library/Formula/assimp.rb
+++ b/Library/Formula/assimp.rb
@@ -35,7 +35,7 @@ class Assimp < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-lassimp", "-o", "test"
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lassimp", "-o", "test"
     system "./test"
 
     # Application test.

--- a/Library/Formula/gmp.rb
+++ b/Library/Formula/gmp.rb
@@ -48,7 +48,7 @@ class Gmp < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-lgmp", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lgmp", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/gmp.rb
+++ b/Library/Formula/gmp.rb
@@ -2,7 +2,7 @@ class Gmp < Formula
   homepage "http://gmplib.org/"
   url "http://ftpmirror.gnu.org/gmp/gmp-6.0.0a.tar.bz2"
   mirror "ftp://ftp.gmplib.org/pub/gmp/gmp-6.0.0a.tar.bz2"
-  mirror "http://ftp.gnu.org/gnu/gmp/gmp-6.0.0a.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.0.0a.tar.bz2"
   sha1 "360802e3541a3da08ab4b55268c80f799939fddc"
 
   bottle do

--- a/Library/Formula/libtiff.rb
+++ b/Library/Formula/libtiff.rb
@@ -42,7 +42,7 @@ class Libtiff < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-ltiff", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-ltiff", "-o", "test"
     system "./test", "test.tif"
     assert_match /ImageWidth.*10/, shell_output("#{bin}/tiffdump test.tif")
   end

--- a/Library/Formula/tinyxml.rb
+++ b/Library/Formula/tinyxml.rb
@@ -71,7 +71,7 @@ class Tinyxml < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-ltinyxml", "-o", "test"
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-ltinyxml", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/tinyxml2.rb
+++ b/Library/Formula/tinyxml2.rb
@@ -28,7 +28,7 @@ class Tinyxml2 < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-ltinyxml2", "-o", "test"
+    system ENV.cc, "test.cpp", "-L#{lib}", "-ltinyxml2", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/zeromq.rb
+++ b/Library/Formula/zeromq.rb
@@ -59,7 +59,7 @@ class Zeromq < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-lzmq", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lzmq", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
OS X 10.10 seems to require "-L{lib}" as a C/C++ compiler
argument in order to link properly. This is causing
several brew test failures.
~~~
brew test assimp
Testing assimp
==> /usr/bin/clang test.cpp -lassimp -o test
-o
test

ld: library not found for -lassimp
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: assimp: failed
...
~~~

This patch modifies several formula in a single commit
by adding "-L{lib}" to the brew test ENV.cc argument
lists. I manually verified that these specific tests
are failing with the change and passing with it on 10.10.

To identify other formulae that may be subject to this
issue, the following may be used:
~~~
grep -rnI 'ENV\.cc.*test\.c' Library/Formula \
  | grep -v '\-L#{lib}'
~~~

As an aside, does the brew test bot test any formulae outside of pull requests?