### PR TITLE
brew-config: show realpath for pyenv and rbenv

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -74,11 +74,21 @@ module Homebrew
   end
 
   def describe_python
-    describe_path(which 'python')
+    python = which 'python'
+    if %r{/shims/python$} =~ python && which('pyenv')
+      "#{python} => #{Pathname.new(`pyenv which python`.strip).realpath}" rescue describe_path(python)
+    else
+      describe_path(python)
+    end
   end
 
   def describe_ruby
-    describe_path(which 'ruby')
+    ruby = which 'ruby'
+    if %r{/shims/ruby$} =~ ruby && which('rbenv')
+      "#{ruby} => #{Pathname.new(`rbenv which ruby`.strip).realpath}" rescue describe_path(ruby)
+    else
+      describe_path(ruby)
+    end
   end
 
   def hardware


### PR DESCRIPTION
Sample output: ( I don't use rbenv, but it should be same as pyenv.)

```
$ brew config
HOMEBREW_VERSION: 0.9.5
ORIGIN: git@github.com:xu-cheng/homebrew.git
HEAD: 332aefecb23de7f5715bf2647f02c0878e5b3c80
Last commit: 19 minutes ago
HOMEBREW_PREFIX: /Users/xucheng/Coding/Github/homebrew
HOMEBREW_CELLAR: /Users/xucheng/Coding/Github/homebrew/Cellar
CPU: 8-core 64-bit haswell
OS X: 10.10.1-x86_64
Xcode: 6.1.1
CLT: 6.1.1.0.1.1416017670
Clang: 6.0 build 600
X11: N/A
System Ruby: 2.0.0-p481
Perl: /usr/bin/perl
Python: /usr/local/var/pyenv/shims/python => /usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/bin/python2.7
Ruby: /usr/local/bin/ruby => /usr/local/Cellar/ruby/2.2.0/bin/ruby
```