### PR TITLE
node: fix manpage linksage

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -98,7 +98,7 @@ class Node < Formula
     # And then a step to the right, with your hand on rm_f.
     ["man1", "man3", "man5", "man7"].each do |man|
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      Dir[share/"man/#{man}/npm*"].each {|f| ln_sf f, HOMEBREW_PREFIX/"share/man/#{man}" }
+      Dir[libexec/"npm/share/man/#{man}/npm*"].each {|f| ln_sf f, HOMEBREW_PREFIX/"share/man/#{man}" }
     end
 
     npm_root = node_modules/"npm"


### PR DESCRIPTION
I goofed here on the manpage linkage and location. This fixes that mistake. Given it’s post-install, shouldn’t be any need to regenerate bottles or such.