### PR TITLE
juju-quickstart 1.6.0

### DIFF
--- a/Library/Formula/juju-quickstart.rb
+++ b/Library/Formula/juju-quickstart.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class JujuQuickstart < Formula
   homepage "https://launchpad.net/juju-quickstart"
-  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-1.5.0.tar.gz"
-  sha1 "05f27f0d62cd2f7a49f2584b965a78c4502cd4ac"
+  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-1.6.0.tar.gz"
+  sha1 "6631c560bc26b88c85e281df4fe4b5199884ae5a"
 
   bottle do
     cellar :any


### PR DESCRIPTION
* Interactive session improvements: highlight active environments.
* Ability to use jenv environments not listed in the environments.yaml file.
* Ability to remove no longer used jenv files from the Juju home.
* Use the new charm store API to retrieve the most recent GUI charm revision.
* Include the Juju account user name in the program output.
* Support for logging in to the Juju API with non-admin accounts.
* Improve the way the environment's provider type is retrieved.
* Initial support for Ubuntu 15.04 (vivid).