### PR TITLE
Fix libav build error when jack is installed

### DIFF
--- a/Library/Formula/libav.rb
+++ b/Library/Formula/libav.rb
@@ -62,6 +62,7 @@ class Libav < Formula
     args = [
       "--disable-debug",
       "--disable-shared",
+      "--disable-indev=jack",
       "--prefix=#{prefix}",
       "--enable-gpl",
       "--enable-nonfree",


### PR DESCRIPTION
Fixes a build error in libav triggered when "Jack OS X" (jack) is installed:

```
Undefined symbols for architecture x86_64:
  "_sem_timedwait", referenced from:
      _audio_read_packet in libavdevice.a(jack_audio.o)
Undefined symbols for architecture x86_64:
  "_sem_timedwait", referenced from:
      _audio_read_packet in libavdevice.a(jack_audio.o)
ld: symbol(s) not found for architecture x86_64
clang: ld: symbol(s) not found for architecture x86_64
error: linker command failed with exit code 1 (use -v to see invocation)
```

This fix was suggested in the libav mailing list: https://lists.libav.org/pipermail/libav-bugs/2013-February/002128.html and disables Jack as input device until a proper patch fixes this issue, thus this is just a workaround.
The error is likely caused by the fact that semaphores are called differently on OS X. See this related ticket in FFmpeg bug tracker (libav is a fork of FFmpeg): https://trac.ffmpeg.org/ticket/43