### PR TITLE
cgdb: updated current formula to 0.6.8

### DIFF
--- a/Library/Formula/cgdb.rb
+++ b/Library/Formula/cgdb.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Cgdb < Formula
-  homepage "http://cgdb.github.io/"
-  url "http://cgdb.me/files/cgdb-0.6.7.tar.gz"
-  sha1 "5e29e306502888dd660a9dd55418e5c190ac75bb"
+  homepage "https://cgdb.github.io/"
+  url "http://cgdb.me/files/cgdb-0.6.8.tar.gz"
+  sha1 "0892ae59358fa98264269cf6fe57928314ef7942"
 
   bottle do
     sha1 "97d618f51a59e82d00e9957e545cbf8c55430919" => :mavericks
@@ -13,17 +13,15 @@ class Cgdb < Formula
 
   head do
     url "https://github.com/cgdb/cgdb.git"
-
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "help2man" => :build
   end
 
+  depends_on "help2man" => :build
   depends_on "readline"
 
   def install
     system "sh", "autogen.sh" if build.head?
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-readline=#{Formula['readline'].opt_prefix}"

--- a/Library/Formula/cgdb.rb
+++ b/Library/Formula/cgdb.rb
@@ -13,6 +13,7 @@ class Cgdb < Formula
 
   head do
     url "https://github.com/cgdb/cgdb.git"
+
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end


### PR DESCRIPTION
Follow up to: https://github.com/Homebrew/homebrew/pull/35843

Description:

As of November 13th of 2014, with commit cgdb 0.6.8 was released. The release addresses, among others, a bug affecting OS X distributions. The full description of the update is available here.

I have updated the formula for cgdb.rb so homebrew will download the 0.6.8 release. Please let me know of any feedback you have for this pull request.

Thank you,
-Henry Lin