### PR TITLE
Improve ffmpeg caveats regarding AAC

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -158,8 +158,8 @@ class Ffmpeg < Formula
       FFmpeg has been built without libfaac for licensing reasons.
       To install with libfaac, you can:
         brew reinstall ffmpeg --with-faac
-      
-      You can also use the experimental FFmpeg encoder, libfdk-aac, or 
+
+      You can also use the experimental FFmpeg encoder, libfdk-aac, or
       libvo_aacenc to encode AAC audio:
         ffmpeg -i input.wav -c:a aac -strict experimental output.m4a
       Or:

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -158,12 +158,15 @@ class Ffmpeg < Formula
       FFmpeg has been built without libfaac for licensing reasons.
       To install with libfaac, you can:
         brew reinstall ffmpeg --with-faac
-
-      You can also use the libvo-aacenc or experimental FFmpeg encoder to
-      encode AAC audio:
-        -c:a libvo_aacenc
+      
+      You can also use the experimental FFmpeg encoder, libfdk-aac, or 
+      libvo_aacenc to encode AAC audio:
+        ffmpeg -i input.wav -c:a aac -strict experimental output.m4a
       Or:
-        -c:a aac -strict -2
+        brew reinstall ffmpeg --with-fdk-aac
+        ffmpeg -i input.wav -c:a libfdk_aac output.m4a
+      Or:
+        ffmpeg -i input.wav -c:a libvo_aacenc output.m4a
       EOS
     end
   end


### PR DESCRIPTION
ffmpeg's internal AAC encoder should be preferred over `libvo_aacenc` due to its much better quality. The experimental label is there for historic reasons – there is nothing unstable about it. 

Changed `-2` to `experimental` argument, because easier to remember.

Added `libfdk-aac` as it's preferred over `libvo_aacenc` for quality reasons (and prominently featured on the FFmpeg Wiki).

Added meaningful command line examples rather than just the codec snippets.

For context see https://trac.ffmpeg.org/wiki/Encode/AAC