### PR TITLE
google-app-engine 1.9.17

### DIFF
--- a/Library/Formula/google-app-engine.rb
+++ b/Library/Formula/google-app-engine.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class GoogleAppEngine < Formula
   homepage "https://developers.google.com/appengine/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.15.zip"
-  sha256 "755852727e377e649f0f16e0147cef71fe820a48e52e38fe23f187e431d45279"
+  url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip"
+  sha256 "e76511c536c66340473e3668741aeb49c4019295f5516ea5613c15415d74aa42"
 
   def install
     cd ".."
@@ -20,7 +20,6 @@ class GoogleAppEngine < Formula
       endpointscfg.py
       gen_protorpc.py
       google_sql.py
-      old_dev_appserver.py
       remote_api_shell.py
     ].each do |fn|
       bin.install_symlink share/name/fn


### PR DESCRIPTION
The current formula is failing to install because the download URL is returning a 404. `old_dev_appserver.py` has been removed in 1.9.17 so I've removed it from the list of symlinks to create.