### PR TITLE
mpd 0.19.8

### DIFF
--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -4,8 +4,8 @@ class Mpd < Formula
   homepage "http://www.musicpd.org/"
 
   stable do
-    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.7.tar.xz"
-    sha1 "6f67d8ac14881c2d72c2907c2c1e14c6b2fd04c5"
+    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.8.tar.xz"
+    sha1 "e5e325b666474bddec6c07502fa2dcf3710a42e3"
   end
 
   bottle do


### PR DESCRIPTION
This is a bugfix release:
* input
 - curl: fix bug after rewinding from end-of-file
 - mms: reduce delay at the beginning of playback
* decoder
 - dsdiff, dsf: allow ID3 tags larger than 4 kB
 - ffmpeg: support interleaved floating point
* fix clang 3.6 warnings
* fix build failure on NetBSD