### PR TITLE
osxfuse: only conflict at build-time.

### DIFF
--- a/Library/Formula/osxfuse.rb
+++ b/Library/Formula/osxfuse.rb
@@ -14,7 +14,9 @@ class Osxfuse < Formula
   depends_on :macos => :snow_leopard
   depends_on :xcode => :build
 
-  depends_on ConflictsWithBinaryOsxfuse
+  # A fairly heinous hack to workaround our dependency resolution getting upset
+  # See https://github.com/Homebrew/homebrew/issues/35073
+  depends_on ConflictsWithBinaryOsxfuse => :build
   depends_on UnsignedKextRequirement => [ :cask => "osxfuse",
       :download => "http://sourceforge.net/projects/osxfuse/files/" ]
 


### PR DESCRIPTION
Feels a bit dirty but it works.

@jacknagel What I _think_ the problem with the dependency resolution logic is that it's somehow evaluating the requirements for a formula even when it's not going to install its default formula (and maybe not even that, I've got very confused). This does seem to fix the problem on the Mavericks box, though, so I wonder if it's worth worrying about.

Closes #35073.