### PR TITLE
ocaml: get rid of site-lib symlink shenanigans

### DIFF
--- a/Library/Formula/objective-caml.rb
+++ b/Library/Formula/objective-caml.rb
@@ -4,17 +4,14 @@ class ObjectiveCaml < Formula
   homepage "http://ocaml.org"
   url "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
   sha1 "6af8c67f2badece81d8e1d1ce70568a16e42313e"
+  revision 2
 
   head "http://caml.inria.fr/svn/ocaml/trunk", :using => :svn
-  revision 1
 
   option "with-x11", "Install with the Graphics module"
   depends_on :x11 => :optional
 
   bottle do
-    sha1 "9a734836f27712fbd3a454152100fcd696932bf8" => :yosemite
-    sha1 "4d80628d7bea7d38888dd3ceb4fb1393613ccea1" => :mavericks
-    sha1 "625826bbc9c7fc5b082abbe59b099f17032a3a00" => :mountain_lion
   end
 
   def install
@@ -33,12 +30,5 @@ class ObjectiveCaml < Formula
     system "make", "opt"
     system "make", "opt.opt"
     system "make", "PREFIX=#{prefix}", "install"
-    (lib/"ocaml/site-lib").mkpath
-  end
-
-  def post_install
-    # site-lib in the Cellar will be a symlink to the HOMEBREW_PREFIX location,
-    # which is mkpath'd by Keg#link when something installs into it
-    (lib/"ocaml").install_symlink HOMEBREW_PREFIX/"lib/ocaml/site-lib"
   end
 end

--- a/Library/Formula/ocamlsdl.rb
+++ b/Library/Formula/ocamlsdl.rb
@@ -4,12 +4,9 @@ class Ocamlsdl < Formula
   homepage "http://ocamlsdl.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha1 "2e54f8984b06cede493c3ad29006dde17077a79a"
+  revision 1
 
   bottle do
-    cellar :any
-    sha1 "69e4eab5739ee4cece742d1064c36f61fb055395" => :mavericks
-    sha1 "d12bd3c25db05daa8e2a9a40f8f4d821b0e31073" => :mountain_lion
-    sha1 "c2d29344d6062efb1a5c5dced9de2b58d3778312" => :lion
   end
 
   depends_on "sdl"


### PR DESCRIPTION
This hack probably should have been removed at e995ddde8e8186f8fd9651f3d6fe69546544692e.