### PR TITLE
sqlmap: modernize and remove outdated dependencies

### DIFF
--- a/Library/Formula/sqlmap.rb
+++ b/Library/Formula/sqlmap.rb
@@ -36,14 +36,4 @@ class Sqlmap < Formula
     assert_match /Sue,\s12/, output
     assert_match /Tim,\s13/, output
   end
-
-  def caveats; <<-EOS.undent
-    The current version of sqlmap (0.9) is very outdated (April 2011) and
-    project developers recommend to use the latest version from the
-    repository.
-
-    You can do this with:
-      brew reinstall --HEAD sqlmap
-    EOS
-  end unless build.head?
 end

--- a/Library/Formula/sqlmap.rb
+++ b/Library/Formula/sqlmap.rb
@@ -36,4 +36,14 @@ class Sqlmap < Formula
     assert_match /Sue,\s12/, output
     assert_match /Tim,\s13/, output
   end
+
+  def caveats; <<-EOS.undent
+    The current version of sqlmap (0.9) is very outdated (April 2011) and
+    project developers recommend to use the latest version from the
+    repository.
+
+    You can do this with:
+      brew reinstall --HEAD sqlmap
+    EOS
+  end unless build.head?
 end

--- a/Library/Formula/sqlmap.rb
+++ b/Library/Formula/sqlmap.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Sqlmap < Formula
   homepage "http://sqlmap.org"
   url "https://github.com/sqlmapproject/sqlmap/archive/0.9.tar.gz"
@@ -7,76 +5,18 @@ class Sqlmap < Formula
   head "https://github.com/sqlmapproject/sqlmap.git"
   revision 1
 
-  option "with-mysql", "Install with support for direct connection to MySQL"
-  option "with-postgresql", "Install with support for direct connection to PostgreSQL"
-  option "with-unixodbc", "Install with ODBC driver"
-
   depends_on :python if MacOS.version <= :snow_leopard
-  depends_on "mysql" => :optional
-  depends_on "postgresql" => :optional
-  depends_on "unixodbc" => :optional
-
-  resource "ibm-db" do
-    url "https://pypi.python.org/packages/source/i/ibm-db-sa-py3/ibm-db-sa-py3-0.3.0-1.tar.gz"
-    sha1 "a48bc74ea0aafba5c56c6981db5213a23c55a33c"
-  end
-
-  resource "impacket" do
-    url "https://pypi.python.org/packages/source/i/impacket/impacket-0.9.11.tar.gz"
-    sha1 "c78855be24f7730182c7914a64b9895f8b244ea2"
-  end
-
-  resource "mysql-python" do
-    url "https://pypi.python.org/packages/source/M/MySQL-python/MySQL-python-1.2.4.zip"
-    sha1 "9af66e09713a79a08a312a7da87f0f0dccfc0a91"
-  end
-
-  resource "ntlm" do
-    url "https://pypi.python.org/packages/source/p/python-ntlm/python-ntlm-1.0.1.tar.gz"
-    sha1 "91644247682f9fe128ce63496cf77b53605f085d"
-  end
-
-  resource "pyodbc" do
-    url "http://pyodbc.googlecode.com/files/pyodbc-3.0.7.zip"
-    sha1 "88cb519411116012402aa0a0d5d7484949ddd99c"
-  end
-
-  resource "psycopg2" do
-    url "https://pypi.python.org/packages/source/p/psycopg2/psycopg2-2.5.2.tar.gz"
-    sha1 "96d071f8e4faa07810976640078742b0a944cd13"
-  end
-
-  resource "pysqlite" do
-    url "https://pypi.python.org/packages/source/p/pysqlite/pysqlite-2.6.3.tar.gz"
-    sha1 "b1eed16107232aebec1826b671c99a76e26afa7b"
-  end
 
   def install
-    ENV["PYTHONPATH"] = lib+"python2.7/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python2.7/site-packages"
-    install_args = [ "setup.py", "install", "--prefix=#{libexec}" ]
+    libexec.install Dir["*"]
 
-    res = %w{ibm-db impacket ntlm pysqlite}
-    res << "mysql-python" if build.with? "mysql"
-    res << "psycopg2" if build.with? "postgresql"
-    res << "pyodbc" if build.with? "unixodbc"
+    bin.install_symlink libexec/"sqlmap.py"
+    bin.install_symlink libexec/"sqlmapapi.py" if build.head?
 
-    res.each do |r|
-      resource(r).stage { system "python", *install_args }
-    end
-
-    prefix.install "doc", "extra", "plugins", "shell", "tamper", "txt", "udf", "xml", "sqlmap.conf"
-    bin.install "sqlmap.py"
-    (libexec+"lib").install Dir["lib/*"]
-    if build.head?
-      prefix.install "procs", "thirdparty", "waf"
-      bin.install "sqlmapapi.py"
-    end
-    bin.env_script_all_files(prefix, :PYTHONPATH => ENV["PYTHONPATH"] + ':' + libexec)
-    bin.install_symlink bin+"sqlmap.py" => "sqlmap"
+    bin.install_symlink bin/"sqlmap.py" => "sqlmap"
   end
 
   test do
-    system bin+"sqlmap", "--version"
+    system bin/"sqlmap", "--version"
   end
 end

--- a/Library/Formula/sqlmap.rb
+++ b/Library/Formula/sqlmap.rb
@@ -5,8 +5,6 @@ class Sqlmap < Formula
   head "https://github.com/sqlmapproject/sqlmap.git"
   revision 1
 
-  depends_on :python if MacOS.version <= :snow_leopard
-
   def install
     libexec.install Dir["*"]
 

--- a/Library/Formula/sqlmap.rb
+++ b/Library/Formula/sqlmap.rb
@@ -9,9 +9,12 @@ class Sqlmap < Formula
     libexec.install Dir["*"]
 
     bin.install_symlink libexec/"sqlmap.py"
-    bin.install_symlink libexec/"sqlmapapi.py" if build.head?
-
     bin.install_symlink bin/"sqlmap.py" => "sqlmap"
+
+    if build.head?
+      bin.install_symlink libexec/"sqlmapapi.py"
+      bin.install_symlink bin/"sqlmapapi.py" => "sqlmapapi"
+    end
   end
 
   test do


### PR DESCRIPTION
I've rewritten the formula, since all the dependencies are not needed anymore (they are included in the repository). Furthermore sqlmap developers claim that it's compatible with python 2.6 and 2.7, so there's no need of the python dependency I think.

Should I include a caveat that recommend the user to install sqlmap with the `--HEAD` switch? Because this is the preferred way according to the developers, and sqlmap 0.9 is pretty outdated (April 2011) and lacks a lot of features.