### PR TITLE
bibtex2html: modernize and add test

### DIFF
--- a/Library/Formula/bibtex2html.rb
+++ b/Library/Formula/bibtex2html.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Bibtex2html < Formula
-  homepage 'http://www.lri.fr/~filliatr/bibtex2html/'
-  url 'http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz'
-  sha1 'daaa082885a30dae38263614565298d4862b8331'
+  homepage "http://www.lri.fr/~filliatr/bibtex2html/"
+  url "http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz"
+  sha1 "daaa082885a30dae38263614565298d4862b8331"
 
   bottle do
     cellar :any
@@ -12,17 +10,34 @@ class Bibtex2html < Formula
     sha1 "32377bea1f584fedf5d2abb604a1d46e5e92ac5c" => :mountain_lion
   end
 
-  depends_on 'objective-caml'
-  depends_on 'hevea'
+  depends_on "objective-caml"
+  depends_on "hevea"
+  depends_on :tex => :optional
 
   def install
     # See: https://trac.macports.org/ticket/26724
-    inreplace 'Makefile.in' do |s|
-      s.remove_make_var! 'STRLIB'
+    inreplace "Makefile.in" do |s|
+      s.remove_make_var! "STRLIB"
     end
 
     system "./configure", "--prefix=#{prefix}"
     system "make"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.bib").write <<-EOS.undent
+      @article{Homebrew,
+          title   = {Something},
+          author  = {Someone},
+          journal = {Something},
+          volume  = {1},
+          number  = {2},
+          pages   = {3--4}
+      }
+    EOS
+    system "#{bin}/bib2bib", "test.bib", "--remove", "pages", "-ob", "out.bib"
+    assert_not_match /pages\s*=\s*{3--4}/, File.read("out.bib")
+    assert_match /pages\s*=\s*{3--4}/, File.read("test.bib")
   end
 end


### PR DESCRIPTION
This formula is kind of special. It offers multi command line tools. Some of them don't require `:tex` environment(e.g. the one in the test), while others do. The building process doesn't require `:tex`, either.

So should I put a `depends_on :tex` in it?