### PR TITLE
Add formula fizsh

### DIFF
--- a/Library/Formula/fizsh.rb
+++ b/Library/Formula/fizsh.rb
@@ -1,0 +1,24 @@
+class Fizsh < Formula
+  homepage "https://github.com/zsh-users/fizsh"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/fizsh/fizsh-1.0.8.tar.gz"
+    sha1 "515f8828c8bd9f2da1e2716bb3d60727e2f26e90"
+  end
+
+  head "https://github.com/zsh-users/fizsh", :using => :git
+
+  depends_on "zsh"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    assert_equal "hello", shell_output("#{bin}/fizsh -c \"echo hello\"").strip
+  end
+end


### PR DESCRIPTION
brew has factored out pieces of this (zsh-history-substring-search, for example), but this is a preconfigured, complete fish-like shell for zsh.

Upstream appears to be maintained, being updated somewhat regularly.