### PR TITLE
netcat - Fixed netcat SourceForge download url

### DIFF
--- a/Library/Formula/netcat.rb
+++ b/Library/Formula/netcat.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Netcat < Formula
   homepage 'http://netcat.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/sourceforge/netcat/netcat-0.7.1.tar.bz2'
+  url 'http://iweb.dl.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2'
   sha1 'b761d70fe9e3e8b3fe33a329b9bc31300dc04d11'
 
   def install


### PR DESCRIPTION
Switch to using a download link that does not return a redirect page, which breaks downloading altogether.