### PR TITLE
Use #to_proc instead of a block.

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -128,7 +128,7 @@ class Formula
     elsif opt_prefix.directory?
       # SHA records were added to INSTALL_RECEIPTS the same day as opt symlinks
       !Formula.installed.
-        select{ |ff| ff.deps.map{ |d| d.to_s }.include? name }.
+        select{ |ff| ff.deps.map(&:to_s).include? name }.
         map{ |ff| ff.rack.subdirs rescue [] }.
         flatten.
         map{ |keg_path| Tab.for_keg(keg_path).HEAD }.

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -49,7 +49,7 @@ module Homebrew
          else
            ARGV.formulae
          end
-    json = ff.map {|f| f.to_hash}
+    json = ff.map(&:to_hash)
     puts Utils::JSON.dump(json)
   end
 


### PR DESCRIPTION
As stated in [fast-ruby/#block-vs-symbolto_proc](https://github.com/JuanitoFatas/fast-ruby#block-vs-symbolto_proc-code), using a block is 1.20x slower than `Symbol#to_proc`, so this pull request converts a couple of the `foo.map { |f| f.to_s }` to `foo.map(&:to_s)` in the Homebrew codebase.

I hope you'll merge this one.