### PR TITLE
scala 2.11.5

### DIFF
--- a/Library/Formula/scala.rb
+++ b/Library/Formula/scala.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Scala < Formula
   homepage 'http://www.scala-lang.org/'
-  url 'http://www.scala-lang.org/files/archive/scala-2.11.4.tgz'
-  sha1 'a6d319b26ccabe9c609fadebc32e797bf9cb1084'
+  url 'http://www.scala-lang.org/files/archive/scala-2.11.5.tgz'
+  sha1 '10820b7d65727fe8d3d67855ef603c425cf65a4e'
 
   bottle do
     cellar :any
@@ -16,18 +16,13 @@ class Scala < Formula
   option 'with-src', 'Also install sources for IDE support'
 
   resource 'docs' do
-    url 'http://www.scala-lang.org/files/archive/scala-docs-2.11.4.zip'
-    sha1 'de6a5545f13542667d8ff795883fdf192effce2f'
+    url 'http://www.scala-lang.org/files/archive/scala-docs-2.11.5.zip'
+    sha1 '4a6856a822fbdda7b76674e999a70666d0cdfc3a'
   end
 
   resource 'src' do
-    url 'https://github.com/scala/scala/archive/v2.11.4.tar.gz'
-    sha1 '15f9a8f1d3947b5e1ddd3c653968481626caf418'
-  end
-
-  resource 'completion' do
-    url 'https://raw.githubusercontent.com/scala/scala-dist/v2.11.4/bash-completion/src/main/resources/completion.d/2.9.1/scala'
-    sha1 'e2fd99fe31a9fb687a2deaf049265c605692c997'
+    url 'https://github.com/scala/scala/archive/v2.11.5.tar.gz'
+    sha1 '065fbaa0b982256c84df20d444dff03368332b38'
   end
 
   def install
@@ -36,7 +31,6 @@ class Scala < Formula
     share.install "man"
     libexec.install "bin", "lib"
     bin.install_symlink Dir["#{libexec}/bin/*"]
-    bash_completion.install resource('completion')
     doc.install resource('docs') if build.with? 'docs'
     libexec.install resource('src').files('src') if build.with? 'src'
 


### PR DESCRIPTION
Removes bash-completion as it is currently unmaitained (https://github.com/scala/scala-dist/tree/v2.11.5#legacy)