### PR TITLE
Cryptol

### DIFF
--- a/Library/Formula/cryptol.rb
+++ b/Library/Formula/cryptol.rb
@@ -1,0 +1,36 @@
+require "language/haskell"
+
+class Cryptol < Formula
+  include Language::Haskell::Cabal
+
+  homepage "http://www.cryptol.net/"
+  url "https://github.com/GaloisInc/cryptol.git",
+      :tag => "v2.2.1",
+      :revision => "300ed3cba993e49d0dbe34205d4f404524a3ffdd"
+  sha256 "90d2cbe35db8b2a9fcd78eaa2c08ab0cd81641a30949ab855dde71d17429d3ee"
+  head "https://github.com/GaloisInc/cryptol.git"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+  depends_on "cvc4"
+
+  def install
+    cabal_sandbox do
+      system "make", "PREFIX=#{prefix}", "install"
+    end
+  end
+
+  test do
+    (testpath/"hello.icry").write <<-EOS.undent
+      :prove \\(x : [8]) -> x == x
+      :prove \\(x : [32]) -> x + zero == x
+    EOS
+    result = shell_output "#{bin}/cryptol -b #{(testpath/"hello.icry")}"
+    expected = <<-EOS.undent
+      Loading module Cryptol
+      Q.E.D.
+      Q.E.D.
+    EOS
+    assert_match expected, result
+  end
+end

--- a/Library/Formula/cvc4.rb
+++ b/Library/Formula/cvc4.rb
@@ -1,0 +1,40 @@
+class Cvc4 < Formula
+  homepage "http://cvc4.cs.nyu.edu/"
+  url "http://cvc4.cs.nyu.edu/builds/src/cvc4-1.4.tar.gz"
+  sha256 "76fe4ff9eb9ad7d65589efb47d41aae95f3191bd0d0c3940698a7cb2df3f7024"
+
+  head do
+    url "http://cvc4.cs.nyu.edu/builds/src/unstable/latest-unstable.tar.gz"
+  end
+
+  depends_on "boost" => :build
+  depends_on "gmp"
+  depends_on "libantlr3c"
+  depends_on :arch => :x86_64
+
+  def install
+    args = ["--enable-static",
+            "--enable-shared",
+            "--with-compat",
+            "--bsd",
+            "--with-gmp",
+            "--with-antlr-dir=#{Formula["libantlr3c"].opt_prefix}",
+            "--prefix=#{prefix}"]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"simple.cvc").write <<-EOS.undent
+      x0, x1, x2, x3 : BOOLEAN;
+      ASSERT x1 OR NOT x0;
+      ASSERT x0 OR NOT x3;
+      ASSERT x3 OR x2;
+      ASSERT x1 AND NOT x1;
+      % EXPECT: valid
+      QUERY x2;
+    EOS
+    result = shell_output "#{bin}/cvc4 #{(testpath/"simple.cvc")}"
+    assert_match /valid/, result
+  end
+end

--- a/Library/Formula/libantlr3c.rb
+++ b/Library/Formula/libantlr3c.rb
@@ -1,9 +1,10 @@
-require 'formula'
-
 class Libantlr3c < Formula
-  homepage 'http://www.antlr3.org'
-  url 'http://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz'
-  sha1 'faa9ab43ab4d3774f015471c3f011cc247df6a18'
+  homepage "http://www.antlr3.org"
+  url "http://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz"
+  sha256 "ca914a97f1a2d2f2c8e1fca12d3df65310ff0286d35c48b7ae5f11dcc8b2eb52"
+  revision 1
+
+  option "without-exceptions", "Compile without support for exception handling"
 
   bottle do
     cellar :any
@@ -14,8 +15,32 @@ class Libantlr3c < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make install"
+    args = ["--disable-dependency-tracking",
+            "--disable-antlrdebug",
+            "--prefix=#{prefix}"]
+    args << "--enable-64bit" if MacOS.prefer_64_bit?
+    system "./configure", *args
+    if build.with? "exceptions"
+      inreplace "Makefile" do |s|
+        cflags = s.get_make_var "CFLAGS"
+        cflags = cflags << " -fexceptions"
+        s.change_make_var! "CFLAGS", cflags
+      end
+    end
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.c").write <<-EOS.undent
+      #include <antlr3.h>
+      int main() {
+        if (0) {
+          antlr3GenericSetupStream(NULL);
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cc, "hello.c", "-lantlr3c", "-o", "hello", "-O0"
+    system testpath/"hello"
   end
 end


### PR DESCRIPTION
Adds a formula for [Cryptol](http://www.cryptol.net). The Cryptol formula itself is pretty straightforward; more difficult was adding a formula for CVC4, which in turn required some additions to the libantlr3c formula.

CVC4 is a generally-useful tool in addition to being a Cryptol dependency, so this seems like a net win, and the libantlr3c changes just make that build more flexible rather than changing any current behavior.