### PR TITLE
node: fix manpage linkage

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -97,6 +97,8 @@ class Node < Formula
     # Let's do the manpage dance. It's just a jump to the left.
     # And then a step to the right, with your hand on rm_f.
     ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
       Dir[libexec/"npm/share/man/#{man}/npm*"].each {|f| ln_sf f, HOMEBREW_PREFIX/"share/man/#{man}" }
     end


### PR DESCRIPTION
Fixes the situation where the links would skew in the event that man1, man3, man5 and/or man7 didn't exist. 

This should be pretty rare unless from a clean system, but this will guard against the failure at least.

Closes #35969