### PR TITLE
node: prefer list form of ln_sf

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -100,7 +100,7 @@ class Node < Formula
       # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
       mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      Dir[libexec/"npm/share/man/#{man}/npm*"].each {|f| ln_sf f, HOMEBREW_PREFIX/"share/man/#{man}" }
+      ln_sf Dir[libexec/"npm/share/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 
     npm_root = node_modules/"npm"


### PR DESCRIPTION
Pass a list to ln_sf instead of iterating over the result of Dir[]. This
form raises an error if the second argument is not a directory.

Related to #35969 and #35971; this form would have raised an error on the bot instead of mis-succeeding so it's a little more robust.