### PR TITLE
Io: Add pkg-config build dependency

### DIFF
--- a/Library/Formula/io.rb
+++ b/Library/Formula/io.rb
@@ -10,6 +10,7 @@ class Io < Formula
   option "without-addons", "Build without addons"
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
 
   if build.with? "addons"
     depends_on "glib"


### PR DESCRIPTION
Trying to install Io I see this error:

> CMake Error: The following variables are used in this project, but they are set to NOTFOUND. 
> Please set them or make sure they are set and tested correctly in the CMake files: 
> _glibconfig_include_DIR

I think _glibconfig_include_DIR is used when pkg-config is absent: https://github.com/stevedekorte/io/blob/master/modules/FindGLIB2.cmake#L52

Depending on pkg-config avoids this issue and Io installs successfully.