### PR TITLE
libxslt: add HEAD install option

### DIFF
--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -17,7 +17,20 @@ class Libxslt < Formula
 
   depends_on 'libxml2'
 
+  head do
+    patch :DATA
+    url 'git://git.gnome.org/libxslt'
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   def install
+    if build.head?
+      ENV["NOCONFIGURE"] = "yes"
+      system "./autogen.sh"
+    end
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-libxml-prefix=#{Formula["libxml2"].prefix}"
@@ -31,3 +44,56 @@ class Libxslt < Formula
     EOS
   end
 end
+__END__
+diff --git a/autogen.sh b/autogen.sh
+index 0eeadd3..5e85821 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -8,7 +8,7 @@ THEDIR=`pwd`
+ cd $srcdir
+ DIE=0
+ 
+-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
++(autoreconf --version) < /dev/null > /dev/null 2>&1 || {
+ 	echo
+ 	echo "You must have autoconf installed to compile libxslt."
+ 	echo "Download the appropriate package for your distribution,"
+@@ -16,22 +16,6 @@ DIE=0
+ 	DIE=1
+ }
+ 
+-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
+-	echo
+-	echo "You must have libtool installed to compile libxslt."
+-	echo "Download the appropriate package for your distribution,"
+-	echo "or see http://www.gnu.org/software/libtool"
+-	DIE=1
+-}
+-
+-(automake --version) < /dev/null > /dev/null 2>&1 || {
+-	echo
+-	DIE=1
+-	echo "You must have automake installed to compile libxslt."
+-	echo "Download the appropriate package for your distribution,"
+-	echo "or see http://www.gnu.org/software/automake"
+-}
+-
+ if test "$DIE" -eq 1; then
+ 	exit 1
+ fi
+@@ -46,14 +30,7 @@ if test -z "$NOCONFIGURE" -a -z "$*"; then
+ 	echo "to pass any to it, please specify them on the $0 command line."
+ fi
+ 
+-echo "Running libtoolize..."
+-libtoolize --copy --force
+-echo "Running aclocal..."
+-aclocal $ACLOCAL_FLAGS
+-echo "Running automake..."
+-automake --add-missing --warnings=all
+-echo "Running autoconf..."
+-autoconf --warnings=all
++autoreconf -v --force --install -Wall
+ 
+ cd $THEDIR
+ 


### PR DESCRIPTION
This pull request adds the HEAD option to the `libxslt` formula to install the latest version from `libxslt`'s [git repo](https://git.gnome.org/browse/libxslt/). For the HEAD version, `autogen.sh` needs to be used for the install and patched due to the `libtoolize` vs `glibtoolize` issue. The embedded patch is one way to achieve a successful install but there might be more elegant ways. I'd be happy to adjust.