### PR TITLE
solr 4.10.2 (updated formula)

### DIFF
--- a/Library/Formula/solr.rb
+++ b/Library/Formula/solr.rb
@@ -5,6 +5,8 @@ class Solr < Formula
   url "http://www.apache.org/dyn/closer.cgi?path=lucene/solr/4.10.2/solr-4.10.2.tgz"
   sha1 "b913204d07212d7bb814afe4641992f22404a27d"
 
+  skip_clean 'example/logs'
+
   def install
     libexec.install Dir["*"]
     bin.install "#{libexec}/bin/solr"


### PR DESCRIPTION
An empty "example/logs" directory was removed by brew as part of post-install cleaning.
Solr fails to start out-of-the-box without this directory, so a skip_clean statement was added to ignore this directory.
Fixes issue #35775