### PR TITLE
Install man pages for hub

### DIFF
--- a/Library/Formula/hub.rb
+++ b/Library/Formula/hub.rb
@@ -23,6 +23,7 @@ class Hub < Formula
       ENV["GIT_DIR"] = cached_download/".git"
       system "script/build"
       bin.install "hub"
+      man1.install Dir["man/*"]
     else
       rake "install", "prefix=#{prefix}"
     end


### PR DESCRIPTION
The `hub` command was not previously installing man pages when built from HEAD.
This fixes that.