### PR TITLE
cowsay: modernize, homepage fixed

### DIFF
--- a/Library/Formula/cowsay.rb
+++ b/Library/Formula/cowsay.rb
@@ -1,16 +1,14 @@
-require 'formula'
-
 class Cowsay < Formula
-  homepage 'http://www.nog.net/~tony/warez/cowsay.shtml'
-  url 'http://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03.orig.tar.gz'
-  sha1 'cc65a9b13295c87df94a58caa8a9176ce5ec4a27'
+  homepage "https://web.archive.org/web/20120225123719/http://www.nog.net/~tony/warez/cowsay.shtml"
+  url "http://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03.orig.tar.gz"
+  sha1 "cc65a9b13295c87df94a58caa8a9176ce5ec4a27"
 
   # Official download is 404:
-  # url 'http://www.nog.net/~tony/warez/cowsay-3.03.tar.gz'
+  # url "http://www.nog.net/~tony/warez/cowsay-3.03.tar.gz"
 
   def install
     system "/bin/sh", "install.sh", prefix
-    mv prefix/'man', share
+    mv prefix/"man", share
   end
 
   test do


### PR DESCRIPTION
The host [is down](http://www.downforeveryoneorjustme.com/www.nog.net) and the homepage gives a 404 error on archive.org since June, 2012. This is why I included a snapshot from before this month.