### PR TITLE
daemonlogger: modernize, homepage fixed

### DIFF
--- a/Library/Formula/daemonlogger.rb
+++ b/Library/Formula/daemonlogger.rb
@@ -1,15 +1,16 @@
-require 'formula'
-
 class Daemonlogger < Formula
-  homepage 'http://www.snort.org/snort-downloads/additional-downloads#daemonlogger'
-  url 'http://www.snort.org/downloads/463'
-  version '1.2.1'
-  sha1 'ce0aa20b38f18eca94a6d00fe9126d441fe2818a'
+  homepage "http://sourceforge.net/projects/daemonlogger/"
+  url "https://downloads.sourceforge.net/project/daemonlogger/daemonlogger-1.2.1.tar.gz"
+  sha1 "ce0aa20b38f18eca94a6d00fe9126d441fe2818a"
 
-  depends_on 'libdnet'
+  depends_on "libdnet"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/daemonlogger", "-h"
   end
 end


### PR DESCRIPTION
The current homepage doesn’t exist anymore, like the download URL:

```
$ brew install daemonlogger
==> Downloading http://www.snort.org/downloads/463

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "daemonlogger"
Download failed: http://www.snort.org/downloads/463
```