### PR TITLE
bzr-fastimport 0.13.0 (new formula)

### DIFF
--- a/Library/Formula/bazaar.rb
+++ b/Library/Formula/bazaar.rb
@@ -3,6 +3,7 @@ class Bazaar < Formula
   homepage "http://bazaar.canonical.com/"
   url "https://launchpad.net/bzr/2.6/2.6.0/+download/bzr-2.6.0.tar.gz"
   sha256 "0994797182eb828867eee81cccc79480bd2946c99304266bc427b902cf91dab0"
+  revision 1
 
   bottle do
     cellar :any
@@ -25,10 +26,40 @@ class Bazaar < Formula
     inreplace "bzr", "#! /usr/bin/env python", "#!/usr/bin/python"
     libexec.install "bzr", "bzrlib"
 
-    bin.install_symlink libexec+"bzr"
+    bin.install_symlink libexec/"bzr"
+  end
+
+  def post_install
+    # Install the plugins under /var/bazaar/plugins/
+    plugins_orig = libexec/"bzrlib/plugins"
+    plugins_new = var/"bazaar/plugins"
+
+    Dir[plugins_orig/"*"].each do |plugin|
+      path = Pathname.new plugin
+      plugins_new.install plugin unless File.exist? (plugins_new/path.basename)
+    end
+
+    rm_rf plugins_orig
+    ln_s plugins_new, plugins_orig
+  end
+
+  def caveats; <<-EOS
+      The plugins directory is located at:
+        #{var}/bazaar/plugins
+    EOS
   end
 
   test do
-    system bin/"bzr", "init-repo", "test"
+    bzr = "#{bin}/bzr"
+    whoami = "Homebrew"
+    system bzr, "whoami", whoami
+    assert_match whoami, shell_output("#{bin}/bzr whoami")
+    system bzr, "init-repo", "sample"
+    system bzr, "init", "sample/trunk"
+    touch testpath/"sample/trunk/test.txt"
+    cd "sample/trunk" do
+      system bzr, "add", "test.txt"
+      system bzr, "commit", "-m", "test"
+    end
   end
 end

--- a/Library/Formula/bzr-fastimport.rb
+++ b/Library/Formula/bzr-fastimport.rb
@@ -1,0 +1,52 @@
+class BzrFastimport < Formula
+  desc "Bazaar plugin for fast loading of revision control"
+  homepage "https://launchpad.net/bzr-fastimport"
+  url "https://launchpad.net/bzr-fastimport/trunk/0.13.0/+download/bzr-fastimport-0.13.0.tar.gz"
+  sha256 "5e296dc4ff8e9bf1b6447e81fef41e1217656b43368ee4056a1f024221e009eb"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "bazaar"
+
+  resource "python-fastimport" do
+    url "http://launchpad.net/python-fastimport/trunk/0.9.0/+download/python-fastimport-0.9.0.tar.gz"
+    sha256 "07d1d3800b1cfaa820b62c5a88c40cc7e32be9b14d9c6d3298721f32df8e1dec"
+  end
+
+  def install
+    resource("python-fastimport").stage do
+      system "python", *Language::Python.setup_install_args(libexec/"vendor")
+    end
+
+    libexec.install Dir["*"]
+
+    # The plugin must be symlinked in bazaar/plugins to work
+    target = var/"bazaar/plugins/fastimport"
+    # we need to remove the target before symlinking it because if we don't and
+    # the symlink exists from a previous installation the new symlink will be
+    # created inside libexec instead of overriding the previous one because ln
+    # itself follows symlinks.
+    rm_rf target if target.exist?
+    ln_s libexec, target
+  end
+
+  def caveats; <<-EOS.undent
+    In order to use this plugin you must set your PYTHONPATH in your ~/.bashrc:
+
+      export PYTHONPATH="#{libexec}/vendor/lib/python2.7/site-packages:$PYTHONPATH"
+
+  EOS
+  end
+
+  test do
+    bazaar = Formula["bazaar"]
+    assert File.exist?(bazaar.libexec/"bzrlib/plugins/fastimport/__init__.py"),
+      "The fastimport plugin must have been symlinked under bzrlib/plugins/"
+
+    bzr = bazaar.bin/"bzr"
+    ENV.prepend_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    system bzr, "init"
+    assert_match(/fastimport #{version}/,
+                 shell_output("#{bzr} plugins --verbose"))
+    system bzr, "fast-export", "--plain", "."
+  end
+end

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -475,9 +475,15 @@ module Homebrew
       end
 
       test "brew", "fetch", "--retry", *unchanged_dependencies unless unchanged_dependencies.empty?
-      test "brew", "fetch", "--retry", "--build-bottle", *changed_dependences unless changed_dependences.empty?
-      # Install changed dependencies as new bottles so we don't have checksum problems.
-      test "brew", "install", "--build-bottle", *changed_dependences unless changed_dependences.empty?
+
+      unless changed_dependences.empty?
+        test "brew", "fetch", "--retry", "--build-bottle", *changed_dependences
+        # Install changed dependencies as new bottles so we don't have checksum problems.
+        test "brew", "install", "--build-bottle", *changed_dependences
+        # Run postinstall on them because the tested formula might depend on
+        # this step
+        test "brew", "postinstall", *changed_dependences
+      end
       formula_fetch_options = []
       formula_fetch_options << "--build-bottle" unless ARGV.include? "--no-bottle"
       formula_fetch_options << "--force" if ARGV.include? "--cleanup"


### PR DESCRIPTION
[Bazaar Fast Import](https://launchpad.net/bzr-fastimport) is a plugin for Bazaar to export a repo to a different VCS like git:

```
$ git init
$ bzr fast-export --plain . | git fast-import
```