### PR TITLE
test-bot: support --devel and/or --HEAD install

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -27,6 +27,7 @@ require 'date'
 require 'rexml/document'
 require 'rexml/xmldecl'
 require 'rexml/cdata'
+require 'cmd/tap'
 
 module Homebrew
   EMAIL_SUBJECT_FILE = "brew-test-bot.#{MacOS.cat}.email.txt"
@@ -425,6 +426,15 @@ module Homebrew
       install_args = %w[--verbose]
       install_args << "--build-bottle" unless ARGV.include? "--no-bottle"
       install_args << "--HEAD" if ARGV.include? "--HEAD"
+
+      # Pass --devel or --HEAD to install in the event formulae lack stable. Supports devel-only/head-only.
+      # head-only should not have devel, but devel-only can have head. Stable can have all three.
+      if devel_only_tap? formula
+        install_args << "--devel"
+      elsif head_only_tap? formula
+        install_args << "--HEAD"
+      end
+
       install_args << formula_name
       # Don't care about e.g. bottle failures for dependencies.
       ENV["HOMEBREW_DEVELOPER"] = nil
@@ -471,7 +481,7 @@ module Homebrew
         test "brew", "uninstall", "--force", formula_name
       end
 
-      if formula.devel && !ARGV.include?('--HEAD') \
+      if formula.devel && formula.stable? && !ARGV.include?('--HEAD') \
          && satisfied_requirements?(formula, :devel)
         test "brew", "fetch", "--retry", "--devel", *formula_fetch_options
         test "brew", "install", "--devel", "--verbose", formula_name
@@ -570,6 +580,14 @@ module Homebrew
       changed_formulae.map!(&:first)
       unchanged_formulae = @formulae - changed_formulae
       changed_formulae + unchanged_formulae
+    end
+
+    def head_only_tap? formula
+      formula.head && formula.devel.nil? && formula.stable.nil? && formula.tap == "homebrew/homebrew-head-only"
+    end
+
+    def devel_only_tap? formula
+      formula.devel && formula.stable.nil? && formula.tap == "homebrew/homebrew-devel-only"
     end
 
     def run


### PR DESCRIPTION
See discussion in https://github.com/Homebrew/homebrew-devel-only/pull/8

In essence, the test bot currently does this:

```
==> brew install --verbose --build-bottle j2objc			 FAILED
Error: j2objc is a devel-only formula
Install with `brew install --devel j2objc`
```

I’m proposing that we pass that arg to the test-bot automatically to allow the bot to pass head-only and devel-only formulae without that failure message. I’ve also trimmed the arguments further down to prevent it duplicating the —devel install in formulae which define no stable block.