### PR TITLE
ncmpcpp 0.6.2

### DIFF
--- a/Library/Formula/ncmpcpp.rb
+++ b/Library/Formula/ncmpcpp.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Ncmpcpp < Formula
-  homepage 'http://ncmpcpp.rybczak.net/'
-  url 'http://ncmpcpp.rybczak.net/stable/ncmpcpp-0.6.tar.bz2'
-  sha1 '7bbd63c6f17aa8cdf1190b19e2dc893df188da1c'
+  homepage "http://ncmpcpp.rybczak.net/"
+  url "http://ncmpcpp.rybczak.net/stable/ncmpcpp-0.6.2.tar.bz2"
+  sha1 "0e7e60d61af42f9fa543e16f06bac8d6c42d5fe9"
 
   bottle do
     cellar :any
@@ -13,16 +11,16 @@ class Ncmpcpp < Formula
   end
 
   head do
-    url 'git://repo.or.cz/ncmpcpp.git'
+    url "git://repo.or.cz/ncmpcpp.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'libmpdclient'
-  depends_on 'readline'
+  depends_on "pkg-config" => :build
+  depends_on "libmpdclient"
+  depends_on "readline"
 
   if MacOS.version < :mavericks
     depends_on "boost" => "c++11"
@@ -32,25 +30,27 @@ class Ncmpcpp < Formula
     depends_on "taglib"
   end
 
-  depends_on 'fftw' if build.include? "visualizer"
+  depends_on "fftw" if build.include? "visualizer"
 
-  option 'outputs', 'Compile with mpd outputs control'
-  option 'visualizer', 'Compile with built-in visualizer'
-  option 'clock', 'Compile with optional clock tab'
+  option "outputs", "Compile with mpd outputs control"
+  option "visualizer", "Compile with built-in visualizer"
+  option "clock", "Compile with optional clock tab"
 
   needs :cxx11
 
   def install
     ENV.cxx11
-    ENV.append 'LDFLAGS', '-liconv'
+    ENV.append "LDFLAGS", "-liconv"
+
     args = ["--disable-dependency-tracking",
             "--prefix=#{prefix}",
             "--with-taglib",
             "--with-curl",
             "--enable-unicode"]
-    args << '--enable-outputs' if build.include? 'outputs'
-    args << '--enable-visualizer' if build.include? 'visualizer'
-    args << '--enable-clock' if build.include? 'clock'
+
+    args << "--enable-outputs" if build.include? "outputs"
+    args << "--enable-visualizer" if build.include? "visualizer"
+    args << "--enable-clock" if build.include? "clock"
 
     if build.head?
       # Also runs configure
@@ -58,6 +58,6 @@ class Ncmpcpp < Formula
     else
       system "./configure", *args
     end
-    system "make install"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
Running some tests for #35977 to see if the failure against Boost is strictly Yosemite only or extends across the whole OS X suite we support.

This should help identify if the problem is strictly compile-only, Yosemite-only, or HEAD-only, or a fun mixture of all/any of the above.