### PR TITLE
ecm: urls fixed

### DIFF
--- a/Library/Formula/ecm.rb
+++ b/Library/Formula/ecm.rb
@@ -1,13 +1,12 @@
-require 'formula'
-
 class Ecm < Formula
-  homepage 'http://www.neillcorlett.com/ecm/'
-  url 'http://critical.ch/distfiles/ecm-1.0.tar.gz'
-  sha1 'bfda1031e22b23e3c4d1a713f675de2a9778a421'
+  homepage "https://web.archive.org/web/20140227165748/http://www.neillcorlett.com/ecm/"
+  url "https://web.archive.org/web/20091021035854/http://www.neillcorlett.com/downloads/ecm100.zip"
+  sha1 "ec8884b547bebee69fa3d2901dbd076f9a84c2ce"
+  version "1.0"
 
   def install
-    system "#{ENV.cc} -o ecm ecm.c"
-    system "#{ENV.cc} -o unecm unecm.c"
-    bin.install 'ecm', 'unecm'
+    system ENV.cc, "-o", "ecm", "ecm.c"
+    system ENV.cc, "-o", "unecm", "unecm.c"
+    bin.install "ecm", "unecm"
   end
 end


### PR DESCRIPTION
The current URLs don’t work (404 errors).