### PR TITLE
libgit2 0.22.0

### DIFF
--- a/Library/Formula/libgit2-glib.rb
+++ b/Library/Formula/libgit2-glib.rb
@@ -1,7 +1,7 @@
 class Libgit2Glib < Formula
   homepage "https://github.com/GNOME/libgit2-glib"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libgit2-glib/0.0/libgit2-glib-0.0.24.tar.xz"
-  sha256 "8a0a6f65d86f2c8cb9bcb20c5e0ea6fd02271399292a71fc7e6852f13adbbdb8"
+  url "http://ftp.gnome.org/pub/GNOME/sources/libgit2-glib/0.22/libgit2-glib-0.22.0.tar.xz"
+  sha256 "8ae19e1dd2a6b37dd81843182d96dc5f8d439013c26658670a08287abfedaee2"
 
   bottle do
     sha1 "7224409d10d2d6e2f23ca18ea5e1025a085583ae" => :yosemite

--- a/Library/Formula/libgit2.rb
+++ b/Library/Formula/libgit2.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Libgit2 < Formula
   homepage "https://libgit2.github.com/"
-  url "https://github.com/libgit2/libgit2/archive/v0.21.3.tar.gz"
-  sha1 "d116cb15f76edf2283c85da40389e4fecc8d5aeb"
+  url "https://github.com/libgit2/libgit2/archive/v0.22.0.tar.gz"
+  sha1 "a37dc29511422eec9828e129ad057e77ca962c5e"
 
   head "https://github.com/libgit2/libgit2.git"
 
@@ -22,7 +20,7 @@ class Libgit2 < Formula
 
   def install
     args = std_cmake_args
-    args << "-DBUILD_TESTS=NO"
+    args << "-DBUILD_CLAR=NO" # Don't build tests.
 
     if build.universal?
       ENV.universal_binary


### PR DESCRIPTION
Version bump, fixed the now unrecognised don’t build tests option.

The API has been broken here, and other packages that use libgit2 now can’t find the correct dylibs, so updates to those will follow in this PR.

Closes #35954.