### PR TITLE
Add formula for Agda

### DIFF
--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -1,0 +1,41 @@
+require "language/haskell"
+
+class Agda < Formula
+  include Language::Haskell::Cabal
+
+  homepage "http://wiki.portal.chalmers.se/agda/"
+  url "http://hackage.haskell.org/package/Agda-2.4.2.2/Agda-2.4.2.2.tar.gz"
+  sha1 "fbdf7df3d5a036e683210ac7ccf4f8ec0c9fea05"
+
+  devel do
+    url "https://github.com/agda/agda.git", :branch => "maint-2.4.2"
+    version "2.4.2.3-beta"
+  end
+
+  head "https://github.com/agda/agda.git", :branch => "master"
+
+  option "without-epic-backend", "Exclude the 'epic' compiler backend"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+  depends_on "gmp"
+  depends_on "bdw-gc" if build.with? "epic-backend"
+
+  def install
+    if build.with? "epic-backend"
+      epicFlag = "-fepic"
+    else
+      epicFlag = "-f-epic"
+    end
+    cabal_sandbox do
+      cabal_install_tools "alex", "happy", "cpphs"
+      cabal_install "--only-dependencies", epicFlag
+      cabal_install "--prefix=#{prefix}", epicFlag
+    end
+    cabal_clean_lib
+  end
+
+  test do
+    system "#{bin}/agda", "--test"
+  end
+end

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -36,6 +36,22 @@ class Agda < Formula
   end
 
   test do
-    system "#{bin}/agda", "--test"
+    # run Agda's built-in test suite
+    system bin/"agda", "--test"
+    
+    # typecheck and compile a simple module
+    path = testpath/"test.agda"
+    path.write <<-EOS.undent
+      module test where
+      open import Agda.Primitive
+      infixr 6 _::_
+      data List {i} (A : Set i) : Set i where
+        [] : List A
+        _::_ : A -> List A -> List A
+      snoc : forall {i} {A : Set i} -> List A -> A -> List A
+      snoc [] x = x :: []
+      snoc (x :: xs) y = x :: (snoc xs y)
+    EOS
+    system bin/"agda", "-c", "--no-main", "--safe", "--without-K", path
   end
 end

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -38,7 +38,7 @@ class Agda < Formula
   test do
     # run Agda's built-in test suite
     system bin/"agda", "--test"
-    
+
     # typecheck and compile a simple module
     path = testpath/"test.agda"
     path.write <<-EOS.undent

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -23,14 +23,14 @@ class Agda < Formula
 
   def install
     if build.with? "epic-backend"
-      epicFlag = "-fepic"
+      epic_flag = "-fepic"
     else
-      epicFlag = "-f-epic"
+      epic_flag = "-f-epic"
     end
     cabal_sandbox do
       cabal_install_tools "alex", "happy", "cpphs"
-      cabal_install "--only-dependencies", epicFlag
-      cabal_install "--prefix=#{prefix}", epicFlag
+      cabal_install "--only-dependencies", epic_flag
+      cabal_install "--prefix=#{prefix}", epic_flag
     end
     cabal_clean_lib
   end


### PR DESCRIPTION
This doesn't set up `agda-mode` for Emacs, nor does it download and precompile the standard library; I'm not adept enough at either Ruby or Homebrew's API to figure out how to do that.