### PR TITLE
jenkins: Add maven dependency for HEAD builds

### DIFF
--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -13,7 +13,7 @@ class Jenkins < Formula
   def install
     if build.head?
       system "mvn clean install -pl war -am -DskipTests"
-      libexec.install "war/target/jenkins.war", "."
+      libexec.install "war/target/jenkins.war"
     else
       libexec.install "jenkins.war"
     end

--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -5,7 +5,10 @@ class Jenkins < Formula
   url "http://mirrors.jenkins-ci.org/war/1.597/jenkins.war"
   sha1 "a177d463af1e334a92874378b5c32a923fb62c66"
 
-  head "https://github.com/jenkinsci/jenkins.git"
+  head do
+    url "https://github.com/jenkinsci/jenkins.git"
+    depends_on "maven" => :build
+  end
 
   def install
     if build.head?

--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -5,6 +5,8 @@ class Jenkins < Formula
   url "http://mirrors.jenkins-ci.org/war/1.597/jenkins.war"
   sha1 "a177d463af1e334a92874378b5c32a923fb62c66"
 
+  depends_on :java => "1.6"
+
   head do
     url "https://github.com/jenkinsci/jenkins.git"
     depends_on "maven" => :build


### PR DESCRIPTION
Actually, you could either have `maven` or `mvnvm` installed for this to build. Is there a way to specify `depends_on "maven || mvnvm" => :build` or something?