### PR TITLE
libressl 2.1.3

### DIFF
--- a/Library/Formula/libressl.rb
+++ b/Library/Formula/libressl.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Libressl < Formula
   homepage "http://www.libressl.org/"
-  url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.2.tar.gz"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/LibreSSL/libressl-2.1.2.tar.gz"
-  sha256 "07c05f12e5d49dbfcf82dd23b6b4877b7cdb1c8e4c8dd27cb4d9e5758a6caf52"
+  url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.3.tar.gz"
+  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/LibreSSL/libressl-2.1.3.tar.gz"
+  sha256 "eb2f370971408fb10af6453e556465c8eee728ac333bf1eb47ec1a5112304f7c"
 
   option "without-libtls", "Build without libtls"
 


### PR DESCRIPTION
Version bump, Fixes for CVE-2015-0206, various other smaller flaws.

Things built against this will probably need recompiling again - The libssl dylib has shifted numbers from 29 to 30, which may break certain applications. In Homebrew/Homebrew this only affects ` curl ` and ` libssh2 `, presuming you've chosen to build those two formulae against LibreSSL rather than the standard defaults.