### PR TITLE
Fix youtube-dl which now requires Python 2.7 or above.  

### DIFF
--- a/Library/Formula/youtube-dl.rb
+++ b/Library/Formula/youtube-dl.rb
@@ -20,6 +20,7 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "rtmpdump" => :optional
 
   def install


### PR DESCRIPTION
This is only available on OS X > Snow Leopard.  Sorry about all the trouble.  I had to remove the tigerbrew changes and rebase off of your master.