### PR TITLE
openssl 1.0.2

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,8 +1,8 @@
 class Openssl < Formula
   homepage "https://openssl.org"
-  url "https://www.openssl.org/source/openssl-1.0.1l.tar.gz"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.1l.tar.gz"
-  sha256 "b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4"
+  url "https://www.openssl.org/source/openssl-1.0.2.tar.gz"
+  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.2.tar.gz"
+  sha256 "8c48baf3babe0d505d16cfc0cf272589c66d3624264098213db0fb00034728e9"
 
   bottle do
     sha1 "1d804c229e7a49cf98c1211dd2524c1b258a0388" => :yosemite


### PR DESCRIPTION
Major version bump from the 1.0.1 branch to the 1.0.2 branch. Testing locally seems to indicate no issues despite the new major branch.

Although SSLv3 remains alive in this PR, Once Debian Jessie lands stable and consequently a mainstream Linux distro is carrying no SSLv3 by default, I will draw up a PR on only SSLv3 removal with revisions elsewhere for maintainer review.