### PR TITLE
dnscrypt-proxy: use dummy test

### DIFF
--- a/Library/Formula/dnscrypt-proxy.rb
+++ b/Library/Formula/dnscrypt-proxy.rb
@@ -95,6 +95,6 @@ class DnscryptProxy < Formula
   end
 
   test do
-    system "#{bin}/hostip", "-r", "8.8.8.8", "www.google.com"
+    system "#{sbin}/dnscrypt-proxy", "--version"
   end
 end


### PR DESCRIPTION
Since the real test keeps failing on CI due to unknown network problem.
This replaces the test with a dummy one.