### PR TITLE
pcre2: new formula

### DIFF
--- a/Library/Formula/pcre2.rb
+++ b/Library/Formula/pcre2.rb
@@ -1,0 +1,27 @@
+class Pcre2 < Formula
+  homepage "http://www.pcre.org/"
+  url "https://downloads.sourceforge.net/pcre/pcre2/10.00/pcre2-10.00.tar.bz2"
+  mirror "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.00.tar.bz2"
+  sha256 "487e605cf6ea273b416ad86fb8f2746c36f9959dcc730a6f49a4beca7c73888b"
+
+  option :universal
+
+  def install
+    ENV.universal_binary if build.universal?
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--enable-pcre2-16",
+                          "--enable-pcre2-32",
+                          "--enable-pcre2grep-libz",
+                          "--enable-pcre2grep-libbz2",
+                          "--enable-jit"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/pcre2grep", "regular expression", "#{prefix}/README"
+  end
+end


### PR DESCRIPTION
This is the new, compatibility breaking version of PCRE (PCRE1).

The header, library and tool names are all different from PCRE1, 
so it's safe to install in parallel. Apps need to explicitly use the new 
header name to use PCRE2.

Quoting from the [release notes](https://lists.exim.org/lurker/message/20150105.162835.0666407a.en.html):

> This does not replace the pcre-8.36 release, because the API is not 
> compatible. Further 8.xx releases will happen if bugs are fixed, but 
> development work will concentrate on PCRE2. New projects should 
> therefore use PCRE2 if possible. 

[...]

> You should treat this as a new project, not just a drastic update to PCRE1. 
> A lot has changed, though the underlying structure of the code is much the 
> same. We have started the version numbers from 10.00 so as to avoid any 
> confusion with PCRE1 versions.