### PR TITLE
groovy 2.4.0

### DIFF
--- a/Library/Formula/groovy.rb
+++ b/Library/Formula/groovy.rb
@@ -2,16 +2,10 @@ require 'formula'
 
 class Groovy < Formula
   homepage 'http://groovy.codehaus.org/'
-  url 'http://dl.bintray.com/groovy/maven/groovy-binary-2.3.9.zip'
-  sha1 '22e899457642f139bf9dc388933b5d73efdb0c49'
+  url 'http://dl.bintray.com/groovy/maven/groovy-binary-2.4.0.zip'
+  sha1 '1e521a0c0018e35945e3ab93ae93a9b2dfc43b8e'
 
   option 'invokedynamic', "Install the InvokeDynamic version of Groovy (only works with Java 1.7+)"
-
-  devel do
-    url 'http://dl.bintray.com/groovy/maven/groovy-binary-2.4.0-rc-1.zip'
-    sha1 '20427c947e263cd6d41ab7ace9be17046b18e20e'
-    version '2.4.0-rc-1'
-  end
 
   def install
     # Don't need Windows files.


### PR DESCRIPTION
Groovy 2.4.0 has been released.

This pull request also removes the 2.4.0 release candidates from --devel.