### PR TITLE
Fixed broken formula solid.rb

### DIFF
--- a/Library/Formula/solid.rb
+++ b/Library/Formula/solid.rb
@@ -8,7 +8,9 @@ class Solid < Formula
 
   option "with-doubles", "Use internal double precision floats"
   option "with-tracer", "Use rounding error tracer"
-
+  
+  # This patch fixes a broken build on clang-600.0.56.
+  # Was reported to bugs@dtecta.com (since it also applies to solid-3.5.6)
   patch :DATA
 
   def install
@@ -30,8 +32,6 @@ class Solid < Formula
   end
 end
 
-# This patch fixes a broken build on clang-600.0.56.
-# Was reported to bugs@dtecta.com (since it also applies to solid-3.5.6)
 __END__
 diff --git a/include/MT/Quaternion.h b/include/MT/Quaternion.h
 index 3726b4f..3393697 100644

--- a/Library/Formula/solid.rb
+++ b/Library/Formula/solid.rb
@@ -30,6 +30,8 @@ class Solid < Formula
   end
 end
 
+# This patch fixes a broken build on clang-600.0.56.
+# Was reported to bugs@dtecta.com (since it also applies to solid-3.5.6)
 __END__
 diff --git a/include/MT/Quaternion.h b/include/MT/Quaternion.h
 index 3726b4f..3393697 100644

--- a/Library/Formula/solid.rb
+++ b/Library/Formula/solid.rb
@@ -1,20 +1,23 @@
-require 'formula'
-
 class Solid < Formula
-  homepage 'http://www.dtecta.com/'
-  url 'http://www.dtecta.com/files/solid-3.5.6.tgz'
-  sha1 'bd0afef7842f826c270cff32fc23994aec0b0d65'
+  homepage "http://www.dtecta.com/"
+  url "http://www.dtecta.com/files/solid-3.5.6.tgz"
+  sha1 "bd0afef7842f826c270cff32fc23994aec0b0d65"
 
-  option 'enable-doubles', 'Use internal double precision floats'
-  option 'enable-tracer', 'Use rounding error tracer'
+  deprecated_option "enable-doubles" => "with-doubles"
+  deprecated_option "enable-tracer" => "with-tracer"
+
+  option "with-doubles", "Use internal double precision floats"
+  option "with-tracer", "Use rounding error tracer"
+
+  patch :DATA
 
   def install
     args = ["--disable-dependency-tracking",
             "--disable-debug",
             "--prefix=#{prefix}",
-            "--infodir=#{info}" ]
-    args << '--enable-doubles' if build.include? 'enable-doubles'
-    args << '--enable-tracer' if build.include? 'enable-tracer'
+            "--infodir=#{info}"]
+    args << "--enable-doubles" if build.with? "doubles"
+    args << "--enable-tracer" if build.with? "tracer"
 
     system "./configure", *args
 
@@ -23,6 +26,32 @@ class Solid < Formula
     # for the GLUT library are not platform independent
     inreplace "Makefile", " examples ", " "
 
-    system "make install"
+    system "make", "install"
   end
 end
+
+__END__
+diff --git a/include/MT/Quaternion.h b/include/MT/Quaternion.h
+index 3726b4f..3393697 100644
+--- a/include/MT/Quaternion.h
++++ b/include/MT/Quaternion.h
+@@ -154,7 +154,7 @@ namespace MT {
+
+ 		Quaternion<Scalar> inverse() const
+ 		{
+-			return conjugate / length2();
++			return conjugate() / length2();
+ 		}
+
+ 		Quaternion<Scalar> slerp(const Quaternion<Scalar>& q, const Scalar& t) const
+diff --git a/src/complex/DT_CBox.h b/src/complex/DT_CBox.h
+index 7fc7c5d..16ce972 100644
+--- a/src/complex/DT_CBox.h
++++ b/src/complex/DT_CBox.h
+@@ -131,4 +131,6 @@ inline DT_CBox operator-(const DT_CBox& b1, const DT_CBox& b2)
+                    b1.getExtent() + b2.getExtent());
+ }
+
++inline DT_CBox computeCBox(MT_Scalar margin, const MT_Transform& xform);
++
+ #endif


### PR DESCRIPTION
Patched two small bugs in code, that prevented solid from building successfully on clang.
Also updated style on formula, and fixed issues pointed out by `brew audit --strict` (except missing test).