### PR TITLE
Added support for Yosemite systems booted with boot-args including kext-dev-mode=1.

### DIFF
--- a/Library/Formula/nvm.rb
+++ b/Library/Formula/nvm.rb
@@ -1,8 +1,8 @@
 class Nvm < Formula
   homepage "https://github.com/creationix/nvm"
   head "https://github.com/creationix/nvm.git"
-  url "https://github.com/creationix/nvm/archive/v0.23.0.tar.gz"
-  sha1 "41ee5d4a09e3ac152bd8894c6542fa7994043306"
+  url "https://github.com/creationix/nvm/archive/v0.23.1.tar.gz"
+  sha1 "a6e10eaaa413b6929b29ec74c4444bc41c94e53e"
 
   def install
     prefix.install "nvm.sh"

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -146,10 +146,6 @@ module HomebrewArgvExtension
     switch?("s") || include?("--build-from-source") || !!ENV["HOMEBREW_BUILD_FROM_SOURCE"]
   end
 
-  def kext_dev_mode?
-      include?("--kext-dev-mode") || !!ENV["HOMEBREW_KEXT_DEV_MODE"]
-  end
-
   def flag? flag
     options_only.include?(flag) || switch?(flag[2, 1])
   end

--- a/Library/Homebrew/requirements/unsigned_kext_requirement.rb
+++ b/Library/Homebrew/requirements/unsigned_kext_requirement.rb
@@ -3,12 +3,16 @@ require 'requirement'
 class UnsignedKextRequirement < Requirement
   fatal true
 
-  satisfy { MacOS.version < :yosemite }
+  satisfy { MacOS.version < :yosemite || !!ENV["HOMEBREW_KEXT_DEV_MODE"] }
 
   def message
     s = <<-EOS.undent
       Building this formula from source isn't possible due to OS X
-      Yosemite and above's strict unsigned kext ban.
+      Yosemite and above's unsigned kext ban.  Loading unsigned kexts
+      requires booting with the "kext-dev-mode=1" argument, which can
+      be placed in the "boot-args" nvram variable.  To indicate that
+      you're running with this configuration and can load unsigned kexts,
+      set the environment variable "HOMEBREW_KEXT_DEV_MODE".
     EOS
     s += super
     s

--- a/Library/Homebrew/requirements/unsigned_kext_requirement.rb
+++ b/Library/Homebrew/requirements/unsigned_kext_requirement.rb
@@ -1,19 +1,14 @@
 require 'requirement'
-require 'extend/ARGV'
 
 class UnsignedKextRequirement < Requirement
   fatal true
 
-  
-  satisfy { MacOS.version < :yosemite || ARGV.kext_dev_mode? }
+  satisfy { MacOS.version < :yosemite }
 
   def message
     s = <<-EOS.undent
       Building this formula from source isn't possible due to OS X
-      Yosemite and above's strict unsigned kext ban, unless you run
-      in kext development mode.  To indicate that, either use the
-      --kext-dev-mode argument or set the HOMEBREW_KEXT_DEV_MODE
-      environment variable.
+      Yosemite and above's strict unsigned kext ban.
     EOS
     s += super
     s


### PR DESCRIPTION
Brew formulae that require unsigned kexts currently refuse to work on Yosemite because of the default of requiring signed kexts.  However, if you boot Yosemite with "kext-dev-mode=1" among the boot arguments, unsigned kexts work just fine, and you can make this persistent for a given machine via the "nvram" command.

I had considered actually reading the nvram setting to determine if this requirement was met, but one does not always build on the system one will deploy on, and the kernel arguments aren't fixed over time, so I thought it better to let the user specify intent rather than trying to figure it out on our own.

The changes to extend/ARGV.rb set "ARGV.kext_dev_mode?" if either --kext-dev-mode is used on the command line or the HOMEBREW_KEXT_DEV_MODE environment variable is set.

The changes to requirements/unsigned_kext_requirement.rb indicate that the requirement is satisfied if either the version is prior to Yosemite or the user indicated kext-dev-mode would be used.

I'm not sure I did this precisely correctly; I'm currently a novice at both Ruby and Homebrew.  But I can tell you that it works for me.