### PR TITLE
nvm 0.23.2

### DIFF
--- a/Library/Formula/nvm.rb
+++ b/Library/Formula/nvm.rb
@@ -1,8 +1,8 @@
 class Nvm < Formula
   homepage "https://github.com/creationix/nvm"
   head "https://github.com/creationix/nvm.git"
-  url "https://github.com/creationix/nvm/archive/v0.23.1.tar.gz"
-  sha1 "a6e10eaaa413b6929b29ec74c4444bc41c94e53e"
+  url "https://github.com/creationix/nvm/archive/v0.23.2.tar.gz"
+  sha1 "c20926c5b2f40b563e9db8d81917de3edd378d2e"
 
   def install
     prefix.install "nvm.sh"
@@ -10,17 +10,15 @@ class Nvm < Formula
   end
 
   def caveats; <<-EOS.undent
+      Add NVM's working directory to your $HOME path (if it doesn't exist):
+
+        mkdir ~/.nvm
+
       Add the following to $HOME/.bashrc, $HOME/.zshrc, or your shell's
       equivalent configuration file:
 
-        source $(brew --prefix nvm)/nvm.sh
-
-      Node installs will be lost upon upgrading nvm. Add the following above
-      the source line to move install location and prevent this:
-
         export NVM_DIR=~/.nvm
-
-      You may need to `mkdir ~/.nvm` for that to work successfully.
+        source $(brew --prefix nvm)/nvm.sh
 
       Type `nvm help` for further information.
     EOS


### PR DESCRIPTION
* Bump minor version of nvm
* Clarify install instructions, some bug reports filed where
  users were incorrectly exporting the NVM_PATH after calling
  the shell script, which would cause breakage and user confusion.
  https://github.com/creationix/nvm/issues/598