### PR TITLE
Allow environment variable to indicate we can load unsigned kexts.

### DIFF
--- a/Library/Homebrew/requirements/unsigned_kext_requirement.rb
+++ b/Library/Homebrew/requirements/unsigned_kext_requirement.rb
@@ -3,12 +3,16 @@ require 'requirement'
 class UnsignedKextRequirement < Requirement
   fatal true
 
-  satisfy { MacOS.version < :yosemite }
+  satisfy { MacOS.version < :yosemite || !!ENV["HOMEBREW_KEXT_DEV_MODE"] }
 
   def message
     s = <<-EOS.undent
       Building this formula from source isn't possible due to OS X
-      Yosemite and above's strict unsigned kext ban.
+      Yosemite and above's unsigned kext ban.  Loading unsigned kexts
+      requires booting with the "kext-dev-mode=1" argument, which can
+      be placed in the "boot-args" nvram variable.  To indicate that
+      you're running with this configuration and can load unsigned kexts,
+      set the environment variable "HOMEBREW_KEXT_DEV_MODE".
     EOS
     s += super
     s


### PR DESCRIPTION
Brew formulae that require unsigned kexts currently refuse to work on Yosemite because of the default of requiring signed kexts. However, if you boot Yosemite with "kext-dev-mode=1" among the boot arguments, unsigned kexts work just fine, and you can make this persistent for a given machine via the "nvram" command.

This patch lets you set the HOMEBREW_KEXT_DEV_MODE environment variable to indicate that you've configured your system to permit unsigned kexts, satisfying the requirement.