### PR TITLE
brew-config: check whether java exists in PATH

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -119,9 +119,13 @@ module Homebrew
     s
   end
 
-  def java_version
-    java = `java -version 2>&1`.lines.first.chomp
-    java =~ /java version "(.+?)"/ ? $1 : java
+  def describe_java
+    if which("java").nil? || !quiet_system("/usr/libexec/java_home --failfast")
+      "N/A"
+    else
+      java = `java -version 2>&1`.lines.first.chomp
+      java =~ /java version "(.+?)"/ ? $1 : java
+    end
   end
 
   def dump_verbose_config(f=$stdout)
@@ -145,6 +149,6 @@ module Homebrew
     f.puts "Perl: #{describe_perl}"
     f.puts "Python: #{describe_python}"
     f.puts "Ruby: #{describe_ruby}"
-    f.puts "Java: #{java_version}"
+    f.puts "Java: #{describe_java}"
   end
 end


### PR DESCRIPTION
Per conversation on https://github.com/Homebrew/homebrew/commit/ce73e8334f079ec2b4d8aba88f0fd7c0d4cff5d3. Current implementation has a flaw if java doesn't exist in `PATH`.

Also I renamed the method to follow the same naming pattern of other similar methods.

This PR is still **incomplete**. According to [this](http://osxdaily.com/2013/11/01/install-java-os-x-mavericks/) and my memory, a dumpy java preexists on a clean OS X system. Invoking `java -version` will not only show the wrong message, but more importantly it will pop **a GUI dialog** (as shown in below) which will guide users to the apple website to download the JRE. I don't have clean OS X VM to test for proper fix. So this also serves an opening discussion.

![the gui popout](http://cdn.osxdaily.com/wp-content/uploads/2013/11/install-java-os-x-mavericks.jpg)

/cc @bfontaine.