### PR TITLE
Upgrade to ipmitool 1.8.15

### DIFF
--- a/Library/Formula/ipmitool.rb
+++ b/Library/Formula/ipmitool.rb
@@ -5,6 +5,8 @@ class Ipmitool < Formula
   url 'https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.15/ipmitool-1.8.15.tar.bz2'
   sha1 '2c9c5d7c5a285586df508ad933577f275684353a'
 
+  depends_on "openssl"
+
   def install
     # tracking upstream: http://sourceforge.net/p/ipmitool/feature-requests/47/
     # fix build errors w/ clang

--- a/Library/Formula/ipmitool.rb
+++ b/Library/Formula/ipmitool.rb
@@ -2,18 +2,15 @@ require 'formula'
 
 class Ipmitool < Formula
   homepage 'http://ipmitool.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.13/ipmitool-1.8.13.tar.bz2'
-  sha1 '22254a2b814c8cd323866a4dd835e390521c1dfa'
+  url 'https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.15/ipmitool-1.8.15.tar.bz2'
+  sha1 '2c9c5d7c5a285586df508ad933577f275684353a'
 
   def install
     # tracking upstream: http://sourceforge.net/p/ipmitool/feature-requests/47/
     # fix build errors w/ clang
     inreplace 'include/ipmitool/ipmi_user.h', 'HAVE_PRAGMA_PACK', 'DISABLE_PRAGMA_PACK'
-    # undefined non-posix symbols
-    inreplace 'src/plugins/serial/serial_basic.c', 'IUCLC', '0'
-    inreplace 'src/plugins/serial/serial_basic.c', 'TCFLSH', '0'
-    inreplace 'src/plugins/serial/serial_terminal.c', 'IUCLC', '0'
-    inreplace 'src/plugins/serial/serial_terminal.c', 'TCFLSH', '0'
+    # s6_addr16 is not available in Mac OS X
+    inreplace 'src/plugins/ipmi_intf.c', 's6_addr16', 's6_addr'
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
- 1.8.15 resolves annoying ProcessSOLUserInput messages when using
  Serial-Over-Lan
- Fixed compilation errors caused by IUCLC & TCFLSH replacements
- Replace s6_addr16 with s6_addr since s6_addr16 is not available on Mac