### PR TITLE
commonmark 0.17

### DIFF
--- a/Library/Aliases/cmark
+++ b/Library/Aliases/cmark
@@ -1,0 +1,1 @@
+../Formula/commonmark.rb

--- a/Library/Formula/commonmark.rb
+++ b/Library/Formula/commonmark.rb
@@ -1,7 +1,7 @@
 class Commonmark < Formula
   homepage "http://commonmark.org"
-  url "https://github.com/jgm/CommonMark/archive/0.16.tar.gz"
-  sha1 "932c3af5c7357070b8f3d2f418b78e1f56f6df19"
+  url "https://github.com/jgm/cmark/archive/0.17.tar.gz"
+  sha1 "a0bce3d321822ca96f312e9210fc8cd149a8f527"
 
   bottle do
     cellar :any


### PR DESCRIPTION
I renamed the formula from `commonmark` to `cmark` due to the following reason: as of release 0.17, [CommonMark](https://github.com/jgm/CommonMark) has been split into three repositories: [CommonMark](https://github.com/jgm/CommonMark) for specs, [cmark](https://github.com/jgm/cmark) for the C reference implementation, and [commonmark.js](https://github.com/jgm/commonmark.js) for the JS reference implementation. This formula only builds the C program, so it should match the name of the C reference implementation.

See the announcement [here](https://github.com/jgm/CommonMark/releases/tag/0.17).