### PR TITLE
pacvim 1.1.1 (new formula)

### DIFF
--- a/Library/Formula/pacvim.rb
+++ b/Library/Formula/pacvim.rb
@@ -1,0 +1,13 @@
+class Pacvim < Formula
+  homepage "https://github.com/jmoon018/PacVim"
+  url "https://github.com/jmoon018/PacVim/archive/v1.1.1.tar.gz"
+  sha1 "496ed02edba8dad15ade95352a7c6441f97fdf7a"
+  head "https://github.com/jmoon018/PacVim.git"
+
+  needs :cxx11
+
+  def install
+    ENV.cxx11
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+end


### PR DESCRIPTION
[PacVim](https://github.com/jmoon018/PacVim) “is a game that teaches you vim commands”. It has over 300 stars on GitHub and is still actively developed.

There’s no test because it uses curses and doesn’t have any command-line option like `--version` or `--help`.