### PR TITLE
mackup 0.8.1

### DIFF
--- a/Library/Formula/mackup.rb
+++ b/Library/Formula/mackup.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Mackup < Formula
   homepage "https://github.com/lra/mackup"
-  url "https://github.com/lra/mackup/archive/0.7.4.tar.gz"
-  sha1 "6de195ec94018c0e225f115278a9f8d720ad5c75"
+  url "https://github.com/lra/mackup/archive/0.8.1.tar.gz"
+  sha1 "958308cc584cd0c734a620625c18f70fad333a47"
 
   head "https://github.com/lra/mackup.git"
 


### PR DESCRIPTION
upgrades mackup from 0.7.4 to 0.8.1 which is the most current version from just 2 hours ago.