### PR TITLE
node 0.11.15 (devel)

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -12,6 +12,15 @@ class Node < Formula
     sha1 "977332381c033626b991002c27e738c144ebbaac" => :mountain_lion
   end
 
+  devel do
+    url "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz"
+    sha256 "e613d274baa4c99a0518038192491433f7877493a66d8505af263f6310991d01"
+
+    depends_on "pkg-config" => :build
+    depends_on "icu4c" => :optional
+    depends_on "openssl" => :optional
+  end
+
   head do
     url "https://github.com/joyent/node.git", :branch => "v0.12"
 
@@ -27,30 +36,39 @@ class Node < Formula
 
   depends_on :python => :build
 
-  # Once we kill off SSLv3 in our OpenSSL consider forcing our OpenSSL
-  # over Node's shipped version with --shared-openssl.
-  # Would allow us quicker security fixes than Node's release schedule.
-  # See https://github.com/joyent/node/issues/3557 for prior discussion.
+  # Once we kill off SSLv3 in our OpenSSL consider making our OpenSSL
+  # an optional dep across the whole range of Node releases.
 
   fails_with :llvm do
     build 2326
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.1.18.tgz"
-    sha1 "e2af4c5f848fb023851cd2ec129005d33090bd57"
+    url "https://registry.npmjs.org/npm/-/npm-2.3.0.tgz"
+    sha1 "3588ec5c18fb5ac41e5721b0ea8ece3a85ab8b4b"
   end
 
   def install
-    args = %W{--prefix=#{prefix} --without-npm}
+    args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
     args << "--without-ssl2" << "--without-ssl3" if build.stable?
 
-    # This should eventually be able to use the system icu4c, but right now
-    # it expects to find this dependency using pkgconfig.
     if build.head?
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["icu4c"].opt_prefix}/lib/pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["icu4c"].opt_lib}/pkgconfig"
       args << "--with-intl=system-icu"
+    end
+
+    if build.devel?
+      if build.with? "icu4c"
+        ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["icu4c"].opt_lib}/pkgconfig"
+        args << "--with-intl=system-icu"
+      end
+
+      if build.with? "openssl"
+        args << "--shared-openssl"
+      else
+        args << "--without-ssl2" << "--without-ssl3"
+      end
     end
 
     system "./configure", *args


### PR DESCRIPTION
Closes #36159.

Also includes an npm bump, some audit fixes, a rewording of my previous OpenSSL notes. We may want to consider an npm revision, but I don’t think it’s urgent just yet - Nobody has reported any issues updating between the old 2.1.x branch and the new 2.3.0 branch.