### PR TITLE
Neo4j: added neo4j-shell-tools, (devel) upgraded to 2.2.0-M03, linked neo4j-import

### DIFF
--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -6,6 +6,13 @@ class Neo4j < Formula
   sha1 "6f790bb9dc50e50ba2409101f809e6b3a6cd709e"
   version "2.1.6"
 
+  option "with-neo4j-shell-tools", "Add neo4j-shell-tools to the standard neo4j-shell"
+
+  resource "neo4j-shell-tools" do
+    url "http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_2.1.zip"
+    sha1 "83011a6dcf1cb49ee609e973fdb61f32f765b224"
+  end
+
   devel do
     url "http://dist.neo4j.org/neo4j-community-2.2.0-M02-unix.tar.gz"
     sha1 "1ccc22000ea52e6f0d6c802fbb12da5c29b34607"
@@ -24,6 +31,14 @@ class Neo4j < Formula
 
     if build.devel?
       bin.install_symlink libexec/"bin/neo4j-import"
+    end
+
+    # Eventually, install neo4j-shell-tools
+    # omiting "opencsv-2.3.jar" because it already comes with neo4j (see libexec/lib)
+    if build.with? "neo4j-shell-tools"
+      resource("neo4j-shell-tools").stage {
+        (libexec/"lib").install "geoff-0.5.0.jar", "import-tools-2.1-SNAPSHOT.jar", "mapdb-0.9.3.jar"
+      }
     end
 
     # Adjust UDC props

--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -14,9 +14,9 @@ class Neo4j < Formula
   end
 
   devel do
-    url "http://dist.neo4j.org/neo4j-community-2.2.0-M02-unix.tar.gz"
-    sha1 "1ccc22000ea52e6f0d6c802fbb12da5c29b34607"
-    version "2.2.0-M02"
+    url "http://dist.neo4j.org/neo4j-community-2.2.0-M03-unix.tar.gz"
+    sha1 "9e8867753e0e4a1d82d90b7455e7383f352a6521"
+    version "2.2.0-M03"
   end
 
   def install

--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -23,7 +23,7 @@ class Neo4j < Formula
     bin.install_symlink Dir["#{libexec}/bin/neo4j{,-shell}"]
 
     if build.devel?
-        bin.install_symlink Dir["#{libexec}/bin/neo4j-import"]
+      bin.install_symlink libexec/"bin/neo4j-import"
     end
 
     # Adjust UDC props

--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -7,9 +7,9 @@ class Neo4j < Formula
   version "2.1.6"
 
   devel do
-    url "http://dist.neo4j.org/neo4j-community-2.2.0-M01-unix.tar.gz"
-    sha1 "ec31ebf7b928711b200a24797bc84a2fb99ffb6c"
-    version "2.2.0-M01"
+    url "http://dist.neo4j.org/neo4j-community-2.2.0-M02-unix.tar.gz"
+    sha1 "1ccc22000ea52e6f0d6c802fbb12da5c29b34607"
+    version "2.2.0-M02"
   end
 
   def install
@@ -21,6 +21,10 @@ class Neo4j < Formula
 
     # Symlink binaries
     bin.install_symlink Dir["#{libexec}/bin/neo4j{,-shell}"]
+
+    if build.devel?
+        bin.install_symlink Dir["#{libexec}/bin/neo4j-import"]
+    end
 
     # Adjust UDC props
     open("#{libexec}/conf/neo4j-wrapper.conf", "a") { |f|

--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -29,9 +29,7 @@ class Neo4j < Formula
     # Symlink binaries
     bin.install_symlink Dir["#{libexec}/bin/neo4j{,-shell}"]
 
-    if build.devel?
-      bin.install_symlink libexec/"bin/neo4j-import"
-    end
+    bin.install_symlink libexec/"bin/neo4j-import" if build.devel?
 
     # Eventually, install neo4j-shell-tools
     # omiting "opencsv-2.3.jar" because it already comes with neo4j (see libexec/lib)


### PR DESCRIPTION
Moved to version 2.2.0-M02 and added missing sym-link to `neo4j-import` (new since Milestone 1)