### PR TITLE
autojump 22.2.4

### DIFF
--- a/Library/Formula/autojump.rb
+++ b/Library/Formula/autojump.rb
@@ -19,10 +19,10 @@ class Autojump < Formula
   def caveats; <<-EOS.undent
     Add the following line to your ~/.bash_profile or ~/.zshrc file (and remember
     to source the file to update your current session):
-      [[ -s `brew --prefix`/etc/profile.d/autojump.sh ]] && . `brew --prefix`/etc/profile.d/autojump.sh
+      [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh
 
     If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
-      if test -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish; . #{HOMEBREW_PREFIX}/share/autojump/autojump.fish; end
+      [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ] && . #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
     EOS
   end
 

--- a/Library/Formula/autojump.rb
+++ b/Library/Formula/autojump.rb
@@ -1,7 +1,7 @@
 class Autojump < Formula
   homepage "https://github.com/joelthelion/autojump"
-  url "https://github.com/joelthelion/autojump/archive/release-v22.2.2.tar.gz"
-  sha1 "d23d482077049fb07dcdc1e7764694f95937db24"
+  url "https://github.com/joelthelion/autojump/archive/release-v22.2.4.tar.gz"
+  sha1 "df9ff56e128efb8a8e1af574dbac9e4b3c47c1d6"
 
   head "https://github.com/joelthelion/autojump.git"
 

--- a/Library/Formula/autojump.rb
+++ b/Library/Formula/autojump.rb
@@ -6,37 +6,35 @@ class Autojump < Formula
   head "https://github.com/joelthelion/autojump.git"
 
   def install
-    inreplace "bin/autojump.sh", " /usr/local/share/autojump/", " #{prefix}/etc/"
+    system "./install.py", "-d", prefix, "-z", zsh_completion
 
-    libexec.install "bin/autojump"
-    libexec.install "bin/autojump_argparse.py", "bin/autojump_data.py", "bin/autojump_utils.py"
-    man1.install "docs/autojump.1"
-    (prefix/"etc").install "bin/autojump.sh", "bin/autojump.bash", "bin/autojump.zsh",
-                           "bin/autojump.fish", "bin/autojump.tcsh"
-    zsh_completion.install "bin/_j"
+    # Backwards compatibility for users that have the old path in .bash_profile
+    # or .zshrc
+    (prefix/"etc").install_symlink prefix/"etc/profile.d/autojump.sh"
 
-    bin.write_exec_script libexec+"autojump"
+    libexec.install bin
+    bin.write_exec_script libexec/"bin/autojump"
   end
 
   def caveats; <<-EOS.undent
     Add the following line to your ~/.bash_profile or ~/.zshrc file (and remember
     to source the file to update your current session):
-      [[ -s $(brew --prefix)/etc/autojump.sh ]] && . $(brew --prefix)/etc/autojump.sh
+      [[ -s `brew --prefix`/etc/profile.d/autojump.sh ]] && . `brew --prefix`/etc/profile.d/autojump.sh
 
-    Add the following line to your ~/.config/fish/config.fish:
-      . #{etc}/autojump.fish
+    If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
+      if test -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish; . #{HOMEBREW_PREFIX}/share/autojump/autojump.fish; end
     EOS
   end
 
   test do
     path = testpath/"foo"
     path.mkdir
-    output = %x{
-      source #{HOMEBREW_PREFIX}/etc/autojump.sh
+    output = %x(
+      source #{HOMEBREW_PREFIX}/etc/profile.d/autojump.sh
       j -a foo
       j foo >/dev/null
       pwd
-    }.strip
+    ).strip
     assert_equal path.to_s, output
   end
 end


### PR DESCRIPTION
The install script has been fixed and we can use it.