### PR TITLE
fakeroot: Fix openat on Yosemite

### DIFF
--- a/Library/Formula/fakeroot.rb
+++ b/Library/Formula/fakeroot.rb
@@ -23,11 +23,44 @@ class Fakeroot < Formula
     sha1 "a30907ffdcfe159c2ac6b3f829bd5b9a67188940"
   end
 
+  # This patch handles mapping the variadic arguments to the system openat to
+  # the fixed arguments for our next_openat function.
+  # Patch has been submitted to
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766649
+  patch :DATA
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-static",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
+
+    # Yosemite introduces an openat function, which has variadic arguments,
+    # which the "fancy" wrapping scheme used by fakeroot does not handle. So we
+    # have to patch the generated file after it is generated.
+    # Patch has been submitted with detailed explanation to
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766649
+    system "make", "wraptmpf.h"
+    (buildpath/"patch-for-wraptmpf-h").write <<-EOS.undent
+      diff --git a/wraptmpf.h b/wraptmpf.h
+      index dbfccc9..0e04771 100644
+      --- a/wraptmpf.h
+      +++ b/wraptmpf.h
+      @@ -575,6 +575,10 @@ static __inline__ int next_mkdirat (int dir_fd, const char *pathname, mode_t mod
+       #endif /* HAVE_MKDIRAT */
+       #ifdef HAVE_OPENAT
+       extern int openat (int dir_fd, const char *pathname, int flags, ...);
+      +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) __attribute__((always_inline));
+      +static __inline__ int next_openat (int dir_fd, const char *pathname, int flags, mode_t mode) {
+      +  return openat (dir_fd, pathname, flags, mode);
+      +}
+
+       #endif /* HAVE_OPENAT */
+       #ifdef HAVE_RENAMEAT
+    EOS
+
+    system "patch < patch-for-wraptmpf-h"
+
     system "make"
     system "make", "install"
   end
@@ -36,3 +69,16 @@ class Fakeroot < Formula
     assert_equal "root", shell_output("#{bin}/fakeroot whoami").strip
   end
 end
+
+__END__
+index 15fdd1d..29d738d 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -2446,6 +2446,6 @@ int openat(int dir_fd, const char *pathname, int flags, ...)
+         va_end(args);
+         return next_openat(dir_fd, pathname, flags, mode);
+     }
+-    return next_openat(dir_fd, pathname, flags);
++    return next_openat(dir_fd, pathname, flags, NULL);
+ }
+ #endif


### PR DESCRIPTION
This is a horrible, horrible hack.

fakeroot uses a "fancy" function wrapping scheme that doesn't support
the variadic arguments that openat takes in Yosemite. This means that
we have to patch the *generated* wrapper file in order to get a working
openat call.

I'm hopeful that this overall issue will get fixed upstream, but in the
meantime: without this fix, building debs in Yosemite is broken. With
this fix, it works.

See #33400 for more background.