### PR TITLE
test-bot: don't test bottles on devel/head-only

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -446,7 +446,7 @@ module Homebrew
       audit_args << "--strict" if @added_formulae.include? formula_name
       test "brew", "audit", *audit_args
       if install_passed
-        unless ARGV.include? '--no-bottle'
+        unless ARGV.include? "--no-bottle" or head_only_tap? formula or devel_only_tap? formula
           bottle_args = ["--rb", formula_name]
           if @tap
             tap_user, tap_repo = @tap.split "/"


### PR DESCRIPTION
Follow up to #36030.

I presumed I could do ` ARGV.include? "--no-bottle" || head_only_tap? formula || devel_only_tap? formula ` but it hated me so much for trying, but the ` or ` statements work.

Before:

```
==> brew install --verbose --build-bottle --devel mlite
==> brew audit mlite
==> brew bottle --rb mlite
==> brew test --verbose mlite
==> brew uninstall --force mlite
```

After:

```
==> brew fetch --retry --build-bottle mlite
==> brew install --verbose --build-bottle --devel mlite
==> brew audit mlite
==> brew test --verbose mlite
==> brew uninstall --force mlite
```