### PR TITLE
Add support for the "ny" node version manager

### DIFF
--- a/Library/Formula/ny.rb
+++ b/Library/Formula/ny.rb
@@ -1,0 +1,11 @@
+class Ny < Formula
+  homepage "https://github.com/kenansulayman/ny"
+  head "https://github.com/kenansulayman/ny.git"
+  url "https://github.com/KenanSulayman/ny/archive/1.3.7.tar.gz"
+  sha1 "ff0fbba7bac8f4f77507c23182d4873a67b4e746"
+
+  def install
+    bin.mkdir
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+end


### PR DESCRIPTION
Adds a formula for "ny", so that one is able to install a given version of io.js without having io.js installed in the first place.