### PR TITLE
terraform 0.3.6

### DIFF
--- a/Library/Formula/terraform.rb
+++ b/Library/Formula/terraform.rb
@@ -3,8 +3,8 @@ require "language/go"
 
 class Terraform < Formula
   homepage "http://www.terraform.io/"
-  url "https://github.com/hashicorp/terraform/archive/v0.3.5.tar.gz"
-  sha1 "2c53b217faedbcffcdf5fb78f1ab585f36e5f21f"
+  url "https://github.com/hashicorp/terraform/archive/v0.3.6.tar.gz"
+  sha1 "27b95dc159b8fa9c9611bb18a236d2b46d7f6a95"
 
   bottle do
     sha1 "71b4d2cf75a292ef44f6fe8c688d3396275ff7bb" => :yosemite
@@ -39,7 +39,7 @@ class Terraform < Formula
   end
 
   go_resource "github.com/mitchellh/goamz" do
-    url "https://github.com/mitchellh/goamz.git", :revision => "ab653226ea8718749271e08212506d411714e865"
+    url "https://github.com/mitchellh/goamz.git", :revision => "2441a8d0fab90553ec345cfdf3db24bb61ea61c3"
   end
 
   go_resource "github.com/vaughan0/go-ini" do
@@ -132,6 +132,10 @@ class Terraform < Formula
 
   go_resource "github.com/hashicorp/atlas-go" do
     url "https://github.com/hashicorp/atlas-go.git", :revision => "072814b5d05e34466c6c0fdd62cdecf184dc3521"
+  end
+
+  go_resource "github.com/xanzy/go-cloudstack" do
+    url "https://github.com/xanzy/go-cloudstack.git", :revision => "c2c4143ae294b5df4b7b5ae6e087ead01264167f"
   end
 
   def install


### PR DESCRIPTION
Update terraform to 0.3.6. Dependency goamz updated. Dependency go-cloudstack added.

I'm happy to address any issues I might have missed.