### PR TITLE
Fix version misdetections for URLs with OSes/archs

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -342,4 +342,18 @@ class VersionParsingTests < Homebrew::TestCase
     assert_version_detected '2.4c',
       'http://loop-aes.sourceforge.net/aespipe/aespipe-v2.4c.tar.bz2'
   end
+
+  def test_win_style
+    assert_version_detected '0.9.17',
+      'http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.17-w32.zip'
+    assert_version_detected '1.29',
+      'http://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip'
+  end
+
+  def test_with_arch
+    assert_version_detected '4.0.18-1',
+      'http://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm'
+    assert_version_detected '2.8',
+      'http://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip'
+  end
 end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -293,6 +293,16 @@ class Version
     m = /-((?:\d+\.)*\d+-beta\d*)$/.match(stem)
     return m.captures.first unless m.nil?
 
+    # e.g. http://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip
+    # e.g. http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.17-w32.zip
+    m = /-(\d+\.\d+(?:\.\d+)?)-w(?:in)?(?:32|64)$/.match(stem)
+    return m.captures.first unless m.nil?
+
+    # e.g. http://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm
+    # e.g. http://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip
+    m = /-(\d+\.\d+(?:\.\d+)?(?:-\d+)?)[-_.](?:i686|x86(?:[-_](?:32|64))?)$/.match(stem)
+    return m.captures.first unless m.nil?
+
     # e.g. foobar4.5.1
     m = /((?:\d+\.)*\d+)$/.match(stem)
     return m.captures.first unless m.nil?


### PR DESCRIPTION
This fixes some misdetections like `mtools-4.0.18-1.i686` -> `4.0.18-1` instead of `686` or `libmicrohttpd-0.9.17-w32.zip` -> `0.9.17` instead of `32`.