### PR TITLE
peco 0.2.11 (new formula)

### DIFF
--- a/Library/Formula/peco.rb
+++ b/Library/Formula/peco.rb
@@ -1,0 +1,37 @@
+HOMEBREW_PECO_VERSION="0.2.11"
+class Peco < Formula
+  homepage "https://github.com/peco/peco"
+  if OS.mac?
+    url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_darwin_amd64.zip"
+    sha1 "1c92cfa7f2dc6d85f11c4225c1b2afff506b141f"
+  elsif OS.linux?
+    url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_linux_amd64.tar.gz"
+    sha1 "f83dc6c7334377d368cf0be43220639e3525874f"
+  end
+
+  version HOMEBREW_PECO_VERSION
+  head "https://github.com/peco/peco.git", :branch => "master"
+
+  if build.head?
+    depends_on "go" => :build
+    depends_on "hg" => :build
+  end
+
+  def install
+    if build.head?
+      ENV["GOPATH"] = buildpath
+      mkdir_p buildpath/"src/github.com/peco"
+      ln_s buildpath, buildpath/"src/github.com/peco/peco"
+      system "go", "get", "github.com/jessevdk/go-flags"
+      system "go", "get", "github.com/mattn/go-runewidth"
+      system "go", "get", "github.com/nsf/termbox-go"
+      system "go", "get", "github.com/peco/peco"
+      system "go", "build", "cmd/peco/peco.go"
+    end
+    bin.install "peco"
+  end
+
+  test do
+    system "#{bin}/peco", "--version"
+  end
+end

--- a/Library/Formula/peco.rb
+++ b/Library/Formula/peco.rb
@@ -4,11 +4,9 @@ class Peco < Formula
   sha1 "1c92cfa7f2dc6d85f11c4225c1b2afff506b141f"
   version "0.2.11"
 
-  head "https://github.com/peco/peco.git", :branch => "master"
-
-  if build.head?
+  head do
+    url "https://github.com/peco/peco.git"
     depends_on "go" => :build
-    depends_on "hg" => :build
   end
 
   def install

--- a/Library/Formula/peco.rb
+++ b/Library/Formula/peco.rb
@@ -1,15 +1,9 @@
-HOMEBREW_PECO_VERSION="0.2.11"
 class Peco < Formula
   homepage "https://github.com/peco/peco"
-  if OS.mac?
-    url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_darwin_amd64.zip"
-    sha1 "1c92cfa7f2dc6d85f11c4225c1b2afff506b141f"
-  elsif OS.linux?
-    url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_linux_amd64.tar.gz"
-    sha1 "f83dc6c7334377d368cf0be43220639e3525874f"
-  end
+  url "https://github.com/peco/peco/releases/download/v0.2.11/peco_darwin_amd64.zip"
+  sha1 "1c92cfa7f2dc6d85f11c4225c1b2afff506b141f"
+  version "0.2.11"
 
-  version HOMEBREW_PECO_VERSION
   head "https://github.com/peco/peco.git", :branch => "master"
 
   if build.head?

--- a/Library/Formula/peco.rb
+++ b/Library/Formula/peco.rb
@@ -1,25 +1,37 @@
+require "language/go"
+
 class Peco < Formula
   homepage "https://github.com/peco/peco"
-  url "https://github.com/peco/peco/releases/download/v0.2.11/peco_darwin_amd64.zip"
-  sha1 "1c92cfa7f2dc6d85f11c4225c1b2afff506b141f"
-  version "0.2.11"
+  url "https://github.com/peco/peco/archive/v0.2.11.tar.gz"
+  sha1 "438e76dc7f31215eb1195d5eb14a66cf7fef318e"
 
-  head do
-    url "https://github.com/peco/peco.git"
-    depends_on "go" => :build
+  go_resource "github.com/jessevdk/go-flags" do
+    url "https://github.com/jessevdk/go-flags.git",
+      :revision => "15347ef417a300349807983f15af9e65cd2e1b3a"
   end
 
+  go_resource "github.com/mattn/go-runewidth" do
+    url "https://github.com/mattn/go-runewidth.git",
+      :revision => "8adae32de8a26f36cc7acaa53051407d514bb5f0"
+  end
+
+  go_resource "github.com/nsf/termbox-go" do
+    url "https://github.com/nsf/termbox-go.git",
+      :revision => "9e7f2135126fcf13f331e7b24f5d66fd8e8e1690"
+  end
+
+  go_resource "github.com/peco/peco" do
+    url "https://github.com/peco/peco.git",
+      :revision => "0ad82671a0546fe4cace0eb9787b900bcc77aad0"
+  end
+
+  depends_on "go" => :build
+
   def install
-    if build.head?
-      ENV["GOPATH"] = buildpath
-      mkdir_p buildpath/"src/github.com/peco"
-      ln_s buildpath, buildpath/"src/github.com/peco/peco"
-      system "go", "get", "github.com/jessevdk/go-flags"
-      system "go", "get", "github.com/mattn/go-runewidth"
-      system "go", "get", "github.com/nsf/termbox-go"
-      system "go", "get", "github.com/peco/peco"
-      system "go", "build", "cmd/peco/peco.go"
-    end
+    ENV["GOPATH"] = buildpath
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    system "go", "build", "cmd/peco/peco.go"
     bin.install "peco"
   end
 


### PR DESCRIPTION
peco (pronounced peh-koh) is based on a python tool, percol. peco is written in Go, and therefore you can just grab the binary releases and drop it in your $PATH.

peco can be a great tool to filter stuff like logs, process stats, find files, because unlike grep, you can type as you think and look through the current results.