### PR TITLE
Remove darwin/386 from --with-cc-common

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -40,7 +40,7 @@ class Go < Formula
       targets = [
         ["linux",   ["386", "amd64", "arm"]],
         ["windows", ["386", "amd64"]],
-        ["darwin",  ["386", "amd64"]],
+        ["darwin",  ["", "amd64"]],
       ]
     else
       targets = [["darwin", [""]]]


### PR DESCRIPTION
Darwin/386 is an exotic architecture for the Golang (used only for some 10.6 systems). On OS X 10.7+ Golang applications really should be 64-bit for performance reasons.

I think, we want to remove OSX/386 support in `brew install go --with-cc-common`.