### PR TITLE
awscli: organized files installed in path

### DIFF
--- a/Library/Formula/awscli.rb
+++ b/Library/Formula/awscli.rb
@@ -85,14 +85,16 @@ class Awscli < Formula
 
     system "python", *Language::Python.setup_install_args(libexec)
 
+    # Install bash completion
+    bash_completion.install "bin/aws_completer"
+
     # Install zsh completion
     zsh_completion.install "bin/aws_zsh_completer.sh" => "_aws"
 
     # Install the examples
     (share+"awscli").install "awscli/examples"
 
-    bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    (bin/"aws").write_env_script libexec/"bin/aws", :PYTHONPATH => ENV["PYTHONPATH"]
   end
 
   def caveats; <<-EOS.undent
@@ -100,10 +102,7 @@ class Awscli < Formula
       #{HOMEBREW_PREFIX}/share/awscli/examples
 
     Add the following to ~/.bashrc to enable bash completion:
-      complete -C aws_completer aws
-
-    Add the following to ~/.zshrc to enable zsh completion:
-      source #{HOMEBREW_PREFIX}/share/zsh/site-functions/_aws
+      complete -C #{HOMEBREW_PREFIX}/etc/bash_completion.d/aws_completer aws
 
     Before using awscli, you need to tell it about your AWS credentials.
     The easiest way to do this is to run:


### PR DESCRIPTION
The awscli formula currently adds a 4 scripts/resources to the executable path, 3 of which users generally wouldn't want to execute from the shell and get in the way of everyday work. This PR moves these resources out of the way and, in one case, to more discoverable locations.
1. The bash completions file, `aws_completer`, should be installed with `bash_completion.install`, and removed from `bin`.
2. The zsh completions file, `aws_zsh_completer.sh` was already installed with `zsh_completion.install`, but was also being dropped in `bin` unnecessarily.
3. Lastly, `aws.cmd` is a Windows batch wrapper for `aws` that was also being put into `bin` – I don't think Homebrew users typically (ever?) need it.

Note: As I understand it, the way this should be working is that all these files should still be in `<cellar>/awscli/<version>/libexec/bin`, but only the `aws` executable should be in `<cellar>/awscli/<ver>/bin` and in `<prefix>/bin`.
