### PR TITLE
Node, iojs and npm formula resolution

### DIFF
--- a/Library/Aliases/npm
+++ b/Library/Aliases/npm
@@ -1,1 +1,0 @@
-../Formula/node.rb

--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -9,11 +9,12 @@ class Iojs < Formula
     sha1 "f62a32113ae476095c7bcdee8dffe6c87f3675a8" => :mountain_lion
   end
 
-  keg_only "iojs conflicts with node (which is currently more established)"
+  conflicts_with "node", :because => "node and iojs both install a binary/link named node"
 
   option "with-debug", "Build with debugger hooks"
 
   depends_on :python => :build
+  # Install "npm" with this package :recomended ??? How do I do that?
 
   def install
     args = %W[--prefix=#{prefix} --without-npm]
@@ -21,13 +22,6 @@ class Iojs < Formula
 
     system "./configure", *args
     system "make", "install"
-  end
-
-  def caveats; <<-EOS.undent
-    iojs was installed without npm.
-
-    iojs currently requires a patched npm (i.e. not the npm installed by node).
-    EOS
   end
 
   test do

--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -14,7 +14,6 @@ class Iojs < Formula
   option "with-debug", "Build with debugger hooks"
 
   depends_on :python => :build
-  # Install "npm" with this package :recomended ??? How do I do that?
 
   def install
     args = %W[--prefix=#{prefix} --without-npm]
@@ -31,5 +30,11 @@ class Iojs < Formula
     output = `#{bin}/iojs #{path}`.strip
     assert_equal "hello", output
     assert_equal 0, $?.exitstatus
+  end
+
+  def caveats; <<-EOS.undent
+    you probrably also want to install npm
+      `brew install npm`
+    EOS
   end
 end

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -61,7 +61,6 @@ class Node < Formula
 
     system "./configure", *args
     system "make", "install"
-
   end
 
   test do

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -72,4 +72,10 @@ class Node < Formula
     assert_equal "hello", output
     assert_equal 0, $?.exitstatus
   end
+
+  def caveats; <<-EOS.undent
+    you probrably also want to install npm
+      `brew install npm`
+    EOS
+  end
 end

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -4,11 +4,7 @@ class Node < Formula
   url "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz"
   sha256 "b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81"
 
-  bottle do
-    sha1 "ca405f33a5c8e3356a0f477eee43e492e7925927" => :yosemite
-    sha1 "f17dfa5a02a7f83b46f0deb40a4746a1337ffa88" => :mavericks
-    sha1 "b5d7094ed826813b2cc35303bcde8269b1ad9292" => :mountain_lion
-  end
+  conflicts_with "iojs", :because => "node and iojs both install a binary/link named node"
 
   devel do
     url "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz"
@@ -17,6 +13,7 @@ class Node < Formula
     depends_on "pkg-config" => :build
     depends_on "icu4c" => :optional
     depends_on "openssl" => :optional
+    # Install "npm" :recomended ??? How do I do that?
   end
 
   head do
@@ -29,8 +26,6 @@ class Node < Formula
   deprecated_option "enable-debug" => "with-debug"
 
   option "with-debug", "Build with debugger hooks"
-  option "without-npm", "npm will not be installed"
-  option "without-completion", "npm bash completion will not be installed"
 
   depends_on :python => :build
 
@@ -39,11 +34,6 @@ class Node < Formula
 
   fails_with :llvm do
     build 2326
-  end
-
-  resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.3.0.tgz"
-    sha1 "3588ec5c18fb5ac41e5721b0ea8ece3a85ab8b4b"
   end
 
   def install
@@ -72,76 +62,6 @@ class Node < Formula
     system "./configure", *args
     system "make", "install"
 
-    if build.with? "npm"
-      resource("npm").stage buildpath/"npm_install"
-
-      # make sure npm can find node
-      ENV.prepend_path "PATH", bin
-
-      # set log level temporarily for npm's `make install`
-      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
-
-      cd buildpath/"npm_install" do
-        system "./configure", "--prefix=#{libexec}/npm"
-        system "make", "install"
-      end
-
-      if build.with? "completion"
-        bash_completion.install \
-          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
-      end
-    end
-  end
-
-  def post_install
-    return if build.without? "npm"
-
-    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
-    node_modules.mkpath
-    npm_exec = node_modules/"npm/bin/npm-cli.js"
-    # Kill npm but preserve all other modules across node updates/upgrades.
-    rm_rf node_modules/"npm"
-
-    cp_r libexec/"npm/lib/node_modules/npm", node_modules
-    # This symlink doesn't hop into homebrew_prefix/bin automatically so
-    # remove it and make our own. This is a small consequence of our bottle
-    # npm make install workaround. All other installs **do** symlink to
-    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
-    # so mimics npm's normal install.
-    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
-
-    # Let's do the manpage dance. It's just a jump to the left.
-    # And then a step to the right, with your hand on rm_f.
-    ["man1", "man3", "man5", "man7"].each do |man|
-      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
-      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
-      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      ln_sf Dir[libexec/"npm/share/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
-    end
-
-    npm_root = node_modules/"npm"
-    npmrc = npm_root/"npmrc"
-    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
-  end
-
-  def caveats
-    s = ""
-
-    if build.with? "npm"
-      s += <<-EOS.undent
-        If you update npm itself, do NOT use the npm update command.
-        The upstream-recommended way to update npm is:
-          npm install -g npm@latest
-      EOS
-    else
-      s += <<-EOS.undent
-        Homebrew has NOT installed npm. If you later install it, you should supplement
-        your NODE_PATH with the npm module folder:
-          #{HOMEBREW_PREFIX}/lib/node_modules
-      EOS
-    end
-
-    s
   end
 
   test do
@@ -151,14 +71,5 @@ class Node < Formula
     output = `#{bin}/node #{path}`.strip
     assert_equal "hello", output
     assert_equal 0, $?.exitstatus
-
-    if build.with? "npm"
-      # make sure npm can find node
-      ENV.prepend_path "PATH", opt_bin
-      assert_equal which("node"), opt_bin/"node"
-      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
-      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
-    end
   end
 end

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -7,11 +7,10 @@ class Npm < Formula
 
   depends_on "node" # || "iojs"  how?
 
-  # Patch node-gyp untill github.com/TooTallNate/node-gyp/pull/564 is resolved
+  # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
   patch :DATA
 
   def install
-    #TODO: Patch node-gyp for iojs compatability
     ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
@@ -24,7 +23,7 @@ class Npm < Formula
 
   def post_install
     # This is what makes everyone happy
-    # make npm everything to #{HOMEBREW_PREFIX}/lib/node_modules
+    # make npm install everything to #{HOMEBREW_PREFIX}/lib/node_modules
     npmrc = lib/"node_modules/npm/npmrc"
     npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -19,7 +19,7 @@ class Npm < Formula
     system "make", "install"
 
     if build.with? "completion"
-        bash_completion.install \
+      bash_completion.install \
         buildpath/"lib/utils/completion.sh" => "npm"
     end
   end
@@ -31,7 +31,7 @@ class Npm < Formula
     npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
-  def caveats;
+  def caveats
     s = ""
     s += <<-EOS.undent
       npm is prefixed to #{HOMEBREW_PREFIX} so global modules are installed to
@@ -51,10 +51,10 @@ class Npm < Formula
   end
 
   test do
-      assert_equal which("node"), HOMEBREW_PREFIX/"bin/node"
-      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
-      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+    assert_equal which("node"), HOMEBREW_PREFIX/"bin/node"
+    assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+    assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+    system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
   end
 end
 

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -7,12 +7,6 @@ class Npm < Formula
 
   depends_on :node
 
-  # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
-  patch :p3 do
-    url "https://github.com/iojs/io.js/commit/82227f3.diff"
-    sha1 "285ed82e27b088b9ad503187d810fd2d70defd51"
-  end
-
   def install
     ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
     system "./configure", "--prefix=#{prefix}"

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -5,7 +5,7 @@ class Npm < Formula
 
   option "without-completion", "npm bash completion will not be installed"
 
-  depends_on "node" # || "iojs"  how?
+  depends_on :node
 
   # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
   patch :DATA

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -8,7 +8,10 @@ class Npm < Formula
   depends_on :node
 
   # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
-  patch :DATA
+  patch :p3 do
+    url "https://github.com/iojs/io.js/commit/82227f3.diff"
+    sha1 "285ed82e27b088b9ad503187d810fd2d70defd51"
+  end
 
   def install
     ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
@@ -53,28 +56,4 @@ class Npm < Formula
       assert_equal which("npm"), opt_bin/"npm"
   end
 end
-
-__END__
-diff --git a/node_modules/node-gyp/lib/install.js b/node_modules/node-gyp/lib/install.js
-index 6f72e6a..ebc4e57 100644
---- a/node_modules/node-gyp/lib/install.js
-+++ b/node_modules/node-gyp/lib/install.js
-@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
-     }
-   }
-
--  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
-+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
-
-
-   // Determine which node dev files version we are installing
-@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
-
-       // now download the node tarball
-       var tarPath = gyp.opts['tarball']
--      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
-+      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
-         , badDownload = false
-         , extractCount = 0
-         , gunzip = zlib.createGunzip()
 

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -51,9 +51,10 @@ class Npm < Formula
   end
 
   test do
+      assert_equal which("node"), HOMEBREW_PREFIX/"bin/node"
       assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
       assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-      assert_equal which("npm"), opt_bin/"npm"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
   end
 end
 

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -7,6 +7,9 @@ class Npm < Formula
 
   depends_on "node" # || "iojs"  how?
 
+  # Patch node-gyp untill github.com/TooTallNate/node-gyp/pull/564 is resolved
+  patch :DATA
+
   def install
     #TODO: Patch node-gyp for iojs compatability
     ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
@@ -20,20 +23,59 @@ class Npm < Formula
   end
 
   def post_install
+    # This is what makes everyone happy
+    # make npm everything to #{HOMEBREW_PREFIX}/lib/node_modules
     npmrc = lib/"node_modules/npm/npmrc"
     npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats;
+    s = ""
+    s += <<-EOS.undent
+      npm is prefixed to #{HOMEBREW_PREFIX} so global modules are installed to
+        #{HOMEBREW_PREFIX}/lib/node_modules
+      and then linked into
+        #{HOMEBREW_PREFIX}/bin
+
+    EOS
+
+    s += <<-EOS.undent
+      iojs currently requires a patched npm (i.e. not the npm installed by node).
+      updating npm with npm currently will undo this patch.
+
+    EOS
+
+    s
   end
 
   test do
       assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
       assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-  end
-
-  def caveats; <<-EOS.undent
-    npm is prefixed to #{HOMEBREW_PREFIX} so global modules are installed to
-      #{HOMEBREW_PREFIX}/lib/node_modules
-    and then linked into
-      #{HOMEBREW_PREFIX}/bin
-    EOS
+      assert_equal which("npm"), opt_bin/"npm"
   end
 end
+
+__END__
+diff --git a/node_modules/node-gyp/lib/install.js b/node_modules/node-gyp/lib/install.js
+index 6f72e6a..ebc4e57 100644
+--- a/node_modules/node-gyp/lib/install.js
++++ b/node_modules/node-gyp/lib/install.js
+@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
+     }
+   }
+
+-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
++  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
+
+
+   // Determine which node dev files version we are installing
+@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
+
+       // now download the node tarball
+       var tarPath = gyp.opts['tarball']
+-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
++      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
+         , badDownload = false
+         , extractCount = 0
+         , gunzip = zlib.createGunzip()
+

--- a/Library/Formula/npm.rb
+++ b/Library/Formula/npm.rb
@@ -1,0 +1,39 @@
+class Npm < Formula
+  homepage "https://www.npmjs.com/package/npm"
+  url "https://registry.npmjs.org/npm/-/npm-2.3.0.tgz"
+  sha1 "3588ec5c18fb5ac41e5721b0ea8ece3a85ab8b4b"
+
+  option "without-completion", "npm bash completion will not be installed"
+
+  depends_on "node" # || "iojs"  how?
+
+  def install
+    #TODO: Patch node-gyp for iojs compatability
+    ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+
+    if build.with? "completion"
+        bash_completion.install \
+        buildpath/"lib/utils/completion.sh" => "npm"
+    end
+  end
+
+  def post_install
+    npmrc = lib/"node_modules/npm/npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  test do
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+  end
+
+  def caveats; <<-EOS.undent
+    npm is prefixed to #{HOMEBREW_PREFIX} so global modules are installed to
+      #{HOMEBREW_PREFIX}/lib/node_modules
+    and then linked into
+      #{HOMEBREW_PREFIX}/bin
+    EOS
+  end
+end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -115,6 +115,7 @@ class DependencyCollector
     when :hg         then MercurialDependency.new(tags)
     when :python     then PythonDependency.new(tags)
     when :python3    then Python3Dependency.new(tags)
+    when :node       then NodeDependency.new(tags)
     when :java       then JavaDependency.new(tags)
     when :osxfuse    then OsxfuseDependency.new(tags)
     when :tuntap     then TuntapDependency.new(tags)

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -118,6 +118,13 @@ class GitDependency < Requirement
   satisfy { !!which('git') }
 end
 
+class NodeDependency < Requirement
+  fatal true
+  default_formula "node"
+
+  satisfy { which("node") || which("iojs") }
+end
+
 class JavaDependency < Requirement
   fatal true
   cask "java"


### PR DESCRIPTION
I'm aware of the historical baggage of a separate `npm` formula, but I think the introduction of `iojs` warrants at least revisiting this solution taking into what has been learned from the current node formula.  I appreciate your consideration in advance.  If this is just too wacky, I understand, but I believe its a step forward.

### This PR: 
- separates `npm` into its own formula
- applies the minor patch needed to make `npm` compatible with `iojs`.  
  - the patch is still compatible with joyent `node`: http://logs.libuv.org/npm/2015-01-28#21:53:34.823
- sets npm's "prefix" to `#{HOMEBREW_PREFIX}`, replicating existing `npm` tarball install behavior.  (this part is key)
 - this results in `npm` installing modules into `#{HOMEBREW_PREFIX}/lib/node_modules` which then link to `#{HOMEBREW_PREFIX}/bin`
- takes `iojs` out of its keg-only status
- conflicts `iojs` with `node`, so they can't be linked at the same time.
  - advanced `brew` users can unlink and link in and out the version they want, if the choose to have both built at the same time.  
- reduces over all complexity of the three formulae imo.

### Issues that still need resolution:
- [x] ~~the `npm` formula should depend on `node` OR `iojs`.  Right now, it only depends on `node`.  I don't know how to do this.  Can someone help me wrangle `Library/Homebrew/requirements.rb` to enable this?~~
- ~~[ ] Neither `iojs` or `node` "depend" on `npm`.  But it should probably be installed automatically with these unless told not to.  Is there a way to do that?  Right now I just added a caveat instructing people to `brew install npm`.~~
- [ ] Find out if there is any way to happily install npm to the cellar.
- [x] Fix testing errors

### Why this arrangement works well
- users can either `brew install node` OR `brew install iojs` and everything "just works".  I believe this will resolve the recent pushback related to `iojs` formula as this puts the two projects on equal footing.
- `npm` can be installed and patched according to the needs of homebrew and a dependency chain can be enforced.
- users are free to install global `npm` modules, and these stay out of the way of homebrew's `npm` cellar. 
- `npm` is free to update itself (eg `npm install -g npm@latest` or `npm install -g npm@next`) and it works as well as it should.
- brew doctor does not start to complain after `npm` updates itself.
- `brew` can update `npm` and it works the way one would expect.

### Wackiness
- updating `npm` with `npm` installs a second copy of `npm` into `#{HOMEBREW_PREFIX}/lib/node_modules`.  
- whichever method (`brew update npm` or `npm install -g npm@latest`) is run last will take precedence over which version of `npm` is used.  Users can also use `brew unlink npm && brew link npm` to put brews npm back in place.
- Currently, updating `npm` with `npm` would undo the `npm` patch applied by `brew`.  In the future, this wont be such a big issue as the `npm` devs are committed to keeping compatibility between `iojs` and `node` patches won't be needed. 

As both a `homebrew` user and a `node` user, I don't find this wackiness to be unreasonable. 

#### Current iojs formula discussions
- https://github.com/Homebrew/homebrew/pull/36357 Patched npm install for iojs compatibility
- https://github.com/Homebrew/homebrew/pull/36343 Node, iojs and npm formula resolution
- https://github.com/Homebrew/homebrew/pull/36369 Graduate iojs out of keg-only

#### working iojs taps
- https://github.com/aredridel/homebrew-iojs

#### Past iojs formula discussions
- https://github.com/Homebrew/homebrew/pull/35853
- https://github.com/Homebrew/homebrew/pull/36039
- https://github.com/Homebrew/homebrew/pull/36193

####  npm formula issues:
- https://github.com/Homebrew/homebrew/issues/3762
- https://github.com/Homebrew/homebrew/issues/22408
- https://github.com/Homebrew/homebrew/pull/27479
- https://github.com/Homebrew/homebrew/pull/28075

Extra thanks for all the info and help from @othiym23, @mistydemeo, @DomT4, @rvagg, @aredridel and @mikemcquaid 