### PR TITLE
Update Jetty URL

### DIFF
--- a/Library/Formula/jetty.rb
+++ b/Library/Formula/jetty.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Jetty < Formula
   homepage "http://www.eclipse.org/jetty/"
-  url "http://download.eclipse.org/jetty/9.2.5.v20141112/dist/jetty-distribution-9.2.5.v20141112.tar.gz"
+  url "http://eclipse.org/downloads/download.php?file=/jetty/9.2.5.v20141112/dist/jetty-distribution-9.2.5.v20141112.tar.gz"
   version "9.2.5.v20141112"
   sha1 "30a7a34a7ac423fb15885a63f03bffc3669e4d9a"
 


### PR DESCRIPTION
Looks like the Jetty formula is broken right now because the Eclipse guys moved things around. This patch should fix it up.