### PR TITLE
Add --with-libwebp to ffmpeg formula

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -29,7 +29,7 @@ class Ffmpeg < Formula
   option "with-libvidstab", "Enable vid.stab support for video stabilization"
   option "with-x265", "Enable x265 encoder"
   option "with-libsoxr", "Enable the soxr resample library"
-  option "with-libwebp", "Enable using libwebp to encode WEBP images"
+  option "with-webp", "Enable using libwebp to encode WEBP images"
 
   depends_on "pkg-config" => :build
 
@@ -65,7 +65,7 @@ class Ffmpeg < Formula
   depends_on "libvidstab" => :optional
   depends_on "x265" => :optional
   depends_on "openssl" => :optional
-  depends_on "webp" if build.with? "libwebp"
+  depends_on "webp" => :optional
 
   def install
     args = ["--prefix=#{prefix}",

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -106,7 +106,7 @@ class Ffmpeg < Formula
     args << "--enable-libquvi" if build.with? "libquvi"
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libx265" if build.with? "x265"
-    args << "--enable-libwebp" if build.with? "libwebp"
+    args << "--enable-libwebp" if build.with? "webp"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
 
     if build.with? "openjpeg"

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -29,6 +29,7 @@ class Ffmpeg < Formula
   option "with-libvidstab", "Enable vid.stab support for video stabilization"
   option "with-x265", "Enable x265 encoder"
   option "with-libsoxr", "Enable the soxr resample library"
+  option "with-libwebp", "Enable using libwebp to encode WEBP images"
 
   depends_on "pkg-config" => :build
 
@@ -64,6 +65,7 @@ class Ffmpeg < Formula
   depends_on "libvidstab" => :optional
   depends_on "x265" => :optional
   depends_on "openssl" => :optional
+  depends_on "webp" if build.with? "libwebp"
 
   def install
     args = ["--prefix=#{prefix}",
@@ -104,6 +106,7 @@ class Ffmpeg < Formula
     args << "--enable-libquvi" if build.with? "libquvi"
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libx265" if build.with? "x265"
+    args << "--enable-libwebp" if build.with? "libwebp"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
 
     if build.with? "openjpeg"


### PR DESCRIPTION
This changeset adds a `with` option to the `ffmpeg` formula in order to be able to (re)install it with support for encoding WEBP files (through libwebp). This is mapped on ffmpeg's `--enable-libwebp` configuration option and adds `libwebp` as an optional dependency.