### PR TITLE
Adds flag to patch npm install for iojs compatibility 

### DIFF
--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -24,9 +24,15 @@ class Iojs < Formula
   end
 
   def caveats; <<-EOS.undent
-    iojs was installed without npm.
+    iojs was installed without npm. To install npm either:
+      brew install node
+    or follow:
+      https://github.com/npm/npm#fancy-install-unix
 
-    iojs currently requires a patched npm (i.e. not the npm installed by node).
+    To prepend iojs to your PATH add to your ~/.bashrc:
+      export PATH="#{Formula["iojs"].opt_bin}:$PATH"
+
+    This will also e.g. make npm use iojs's node.
     EOS
   end
 

--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -24,10 +24,8 @@ class Iojs < Formula
   end
 
   def caveats; <<-EOS.undent
-    iojs was installed without npm. To install npm either:
-      brew install node
-    or follow:
-      https://github.com/npm/npm#fancy-install-unix
+    iojs was installed without npm. To install npm with iojs compatability:
+      brew install node --with-iojs-patch
 
     To prepend iojs to your PATH add to your ~/.bashrc:
       export PATH="#{Formula["iojs"].opt_bin}:$PATH"

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -94,8 +94,7 @@ class Node < Formula
       end
 
       if build.with? "completion"
-        bash_completion.install \
-          npm_buildpath/"lib/utils/completion.sh" => "npm"
+        bash_completion.install npm_buildpath/"lib/utils/completion.sh" => "npm"
       end
     end
   end

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -82,6 +82,8 @@ class Node < Formula
       ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
 
       cd buildpath/"npm_install" do
+        # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
+        patch :DATA
         system "./configure", "--prefix=#{libexec}/npm"
         system "make", "install"
       end
@@ -162,3 +164,28 @@ class Node < Formula
     end
   end
 end
+
+__END__
+diff --git a/node_modules/node-gyp/lib/install.js b/node_modules/node-gyp/lib/install.js
+index 6f72e6a..ebc4e57 100644
+--- a/node_modules/node-gyp/lib/install.js
++++ b/node_modules/node-gyp/lib/install.js
+@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
+     }
+   }
+
+-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
++  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
+
+
+   // Determine which node dev files version we are installing
+@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
+
+       // now download the node tarball
+       var tarPath = gyp.opts['tarball']
+-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
++      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
+         , badDownload = false
+         , extractCount = 0
+         , gunzip = zlib.createGunzip()
+

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -74,8 +74,7 @@ class Node < Formula
     system "make", "install"
 
     if build.with? "npm"
-      npm_buildpath = buildpath/"npm_install"
-      resource("npm").stage npm_buildpath
+      resource("npm").stage npm_buildpath = buildpath/"npm_install"
       # make sure npm can find node
       ENV.prepend_path "PATH", bin
 
@@ -94,7 +93,8 @@ class Node < Formula
       end
 
       if build.with? "completion"
-        bash_completion.install npm_buildpath/"lib/utils/completion.sh" => "npm"
+        bash_completion.install \
+          npm_buildpath/"lib/utils/completion.sh" => "npm"
       end
     end
   end


### PR DESCRIPTION
I extracted the relevant patches from https://github.com/iojs/io.js/commit/d1fc9c6caec68883401fe601d99f3a69fee52556 2015-01-24 io.js v1.0.4 Release
- https://github.com/iojs/io.js/commit/82227f3 deps: make node-gyp fetch tarballs from iojs.org

So that now the npm homebrew installs can work with the keg-only iojs for now.

> the patch is still compatible with joyent node: http://logs.libuv.org/npm/2015-01-28#21:53:34.823

#### Current iojs formula discussions
- https://github.com/Homebrew/homebrew/pull/36357 Adds flag to patch npm install for iojs compatibility
- ~~https://github.com/Homebrew/homebrew/pull/36343 Node, iojs and npm formula resolution~~
- https://github.com/Homebrew/homebrew/pull/36369 Graduate iojs out of keg-only

#### working iojs taps
- https://github.com/aredridel/homebrew-iojs

#### Past iojs formula discussions
- https://github.com/Homebrew/homebrew/pull/35853
- https://github.com/Homebrew/homebrew/pull/36039
- https://github.com/Homebrew/homebrew/pull/36193

####  npm formula issues:
- https://github.com/Homebrew/homebrew/issues/3762
- https://github.com/Homebrew/homebrew/issues/22408
- https://github.com/Homebrew/homebrew/pull/27479
- https://github.com/Homebrew/homebrew/pull/28075
