### PR TITLE
xulrunner: source url fixed

### DIFF
--- a/Library/Formula/xulrunner.rb
+++ b/Library/Formula/xulrunner.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 # speed up head clone, see: https://developer.mozilla.org/en-US/docs/Developer_Guide/Source_Code/Mercurial/Bundles
 class HgBundleDownloadStrategy < CurlDownloadStrategy
   def stage
@@ -25,7 +23,8 @@ class Xulrunner < Formula
   homepage "https://developer.mozilla.org/docs/XULRunner"
 
   stable do
-    url "https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/latest/source/xulrunner-33.0.source.tar.bz2"
+    # Always use direct URLs (releases/<version>/) instead of releases/latest/
+    url "https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/33.0/source/xulrunner-33.0.source.tar.bz2"
     sha1 "0fbd6ac263d9c5811a5338252b28e3d08ddfbeb2"
 
     # https://github.com/Homebrew/homebrew/issues/33558


### PR DESCRIPTION
The current `xulrunner` URL is wrong, it’s `…/releases/latest/source/xulrunner-33.0.source.tar.bz2` but the `latest` directory only contains the latest version. The correct URL should be `…/releases/33.0/source/xulrunner-33.0.source.tar.bz2`. Right now you’d get a 404 when downloading it because the latest version is 35.0.1.