### PR TITLE
JavaDependency: ignore trailing + in the version

### DIFF
--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -3,7 +3,7 @@ class Elasticsearch < Formula
   url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.tar.gz"
   sha1 "ae381615ec7f657e2a08f1d91758714f13d11693"
 
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"
@@ -11,15 +11,15 @@ class Elasticsearch < Formula
   end
 
   def cluster_name
-    "elasticsearch_#{ENV['USER']}"
+    "elasticsearch_#{ENV["USER"]}"
   end
 
   def install
     if build.head?
       # Build the package from source
-      system "mvn clean package -DskipTests"
+      system "mvn", "clean", "package", "-DskipTests"
       # Extract the package to the current directory
-      system "tar --strip 1 -xzf target/releases/elasticsearch-*.tar.gz"
+      system "tar", "--strip", "1", "-xzf", "target/releases/elasticsearch-*.tar.gz"
     end
 
     # Remove Windows files
@@ -44,29 +44,29 @@ class Elasticsearch < Formula
     # Set up Elasticsearch for local development:
     inreplace "#{prefix}/config/elasticsearch.yml" do |s|
       # 1. Give the cluster a unique name
-      s.gsub! /#\s*cluster\.name\: elasticsearch/, "cluster.name: #{cluster_name}"
+      s.gsub!(/#\s*cluster\.name\: elasticsearch/, "cluster.name: #{cluster_name}")
 
       # 2. Configure paths
-      s.sub! /#\s*path\.data: \/path\/to.+$/, "path.data: #{var}/elasticsearch/"
-      s.sub! /#\s*path\.logs: \/path\/to.+$/, "path.logs: #{var}/log/elasticsearch/"
-      s.sub! /#\s*path\.plugins: \/path\/to.+$/, "path.plugins: #{var}/lib/elasticsearch/plugins"
+      s.sub!(%r{#\s*path\.data: /path/to.+$}, "path.data: #{var}/elasticsearch/")
+      s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/elasticsearch/")
+      s.sub!(%r{#\s*path\.plugins: /path/to.+$}, "path.plugins: #{var}/lib/elasticsearch/plugins")
 
       # 3. Bind to loopback IP for laptops roaming different networks
-      s.gsub! /#\s*network\.host\: [^\n]+/, "network.host: 127.0.0.1"
+      s.gsub!(/#\s*network\.host\: [^\n]+/, "network.host: 127.0.0.1")
     end
 
     inreplace "#{bin}/elasticsearch.in.sh" do |s|
       # Configure ES_HOME
-      s.sub!  /#\!\/bin\/sh\n/, "#!/bin/sh\n\nES_HOME=#{prefix}"
+      s.sub!(%r{#\!/bin/sh\n}, "#!/bin/sh\n\nES_HOME=#{prefix}")
       # Configure ES_CLASSPATH paths to use libexec instead of lib
-      s.gsub! /ES_HOME\/lib\//, "ES_HOME/libexec/"
+      s.gsub!(%r{ES_HOME/lib/}, "ES_HOME/libexec/")
     end
 
     inreplace "#{bin}/plugin" do |s|
       # Add the proper ES_CLASSPATH configuration
-      s.sub!  /SCRIPT="\$0"/, %Q|SCRIPT="$0"\nES_CLASSPATH=#{libexec}|
+      s.sub!(/SCRIPT="\$0"/, %(SCRIPT="$0"\nES_CLASSPATH=#{libexec}))
       # Replace paths to use libexec instead of lib
-      s.gsub! /\$ES_HOME\/lib\//, "$ES_CLASSPATH/"
+      s.gsub!(%r{\$ES_HOME/lib/}, "$ES_CLASSPATH/")
     end
   end
 

--- a/Library/Formula/findbugs.rb
+++ b/Library/Formula/findbugs.rb
@@ -1,23 +1,21 @@
-require 'formula'
-
 class Findbugs < Formula
-  homepage 'http://findbugs.sourceforge.net/index.html'
-  url 'https://downloads.sourceforge.net/project/findbugs/findbugs/3.0.0/findbugs-3.0.0.tar.gz'
-  sha1 '50205ecbe340d78a658d5930fc3e2e0e38b07db7'
+  homepage "http://findbugs.sourceforge.net/index.html"
+  url "https://downloads.sourceforge.net/project/findbugs/findbugs/3.0.0/findbugs-3.0.0.tar.gz"
+  sha1 "50205ecbe340d78a658d5930fc3e2e0e38b07db7"
 
-  conflicts_with 'fb-client',
+  conflicts_with "fb-client",
     :because => "findbugs and fb-client both install a `fb` binary"
 
-  depends_on :java => '1.7'
+  depends_on :java => "1.7+"
 
   def install
     # Remove windows files
     rm_f Dir["bin/*.bat"]
     prefix.install_metafiles
-    libexec.install Dir['*']
+    libexec.install Dir["*"]
 
-    bin.write_exec_script libexec/'bin/fb'
-    bin.write_exec_script libexec/'bin/findbugs'
+    bin.write_exec_script libexec/"bin/fb"
+    bin.write_exec_script libexec/"bin/findbugs"
   end
 
   def caveats; <<-EOS.undent

--- a/Library/Formula/galen.rb
+++ b/Library/Formula/galen.rb
@@ -3,7 +3,7 @@ class Galen < Formula
   url "https://github.com/galenframework/galen/releases/download/galen-1.5.1/galen-bin-1.5.1.zip"
   sha1 "ea3e261e0409c8797a3c627536444bfd4c5ff311"
 
-  depends_on :java => "1.6"
+  depends_on :java => "1.6+"
 
   def install
     libexec.install "galen.jar"

--- a/Library/Formula/golo.rb
+++ b/Library/Formula/golo.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Golo < Formula
   homepage "http://golo-lang.org"
   url "http://search.maven.org/remotecontent?filepath=org/golo-lang/golo/2.0.0/golo-2.0.0-distribution.tar.gz"
@@ -10,16 +8,16 @@ class Golo < Formula
     depends_on "maven" => :build
   end
 
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
 
   def install
     if build.head?
       rake "special:bootstrap"
-      libexec.install %w(target/appassembler/bin target/appassembler/lib)
+      libexec.install %w[target/appassembler/bin target/appassembler/lib]
     else
-      libexec.install %w(bin doc lib)
+      libexec.install %w[bin doc lib]
     end
-    libexec.install %w(share samples)
+    libexec.install %w[share samples]
 
     rm_f Dir["#{libexec}/bin/*.bat"]
     bin.install_symlink Dir["#{libexec}/bin/*"]
@@ -29,9 +27,14 @@ class Golo < Formula
   end
 
   def caveats
-    if ENV["SHELL"].include? "zsh"; <<-EOS.undent
-For ZSH users, please add "golo" in yours plugins in ".zshrc"
+    if ENV["SHELL"].include? "zsh"
+      <<-EOS.undent
+        For ZSH users, please add "golo" in yours plugins in ".zshrc"
       EOS
     end
+  end
+
+  test do
+    system "#{bin}/golo", "golo", "--files", "#{libexec}/samples/helloworld.golo"
   end
 end

--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Jenkins < Formula
   homepage "https://jenkins-ci.org"
   url "http://mirrors.jenkins-ci.org/war/1.598/jenkins.war"
@@ -10,7 +8,7 @@ class Jenkins < Formula
     depends_on "maven" => :build
   end
 
-  depends_on :java => "1.6"
+  depends_on :java => "1.6+"
 
   def install
     if build.head?

--- a/Library/Formula/jooby-bootstrap.rb
+++ b/Library/Formula/jooby-bootstrap.rb
@@ -1,11 +1,9 @@
-require "formula"
-
 class JoobyBootstrap < Formula
   homepage "https://github.com/jooby-project/jooby-bootstrap"
   url "https://github.com/jooby-project/jooby-bootstrap/archive/0.2.2.tar.gz"
   sha1 "54802aa2a7bad6a07f25fc4d1dc35767c3525deb"
 
-  depends_on :java => "1.8"
+  depends_on :java => "1.8+"
   depends_on "maven"
 
   def install

--- a/Library/Formula/mesos.rb
+++ b/Library/Formula/mesos.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Mesos < Formula
   homepage "http://mesos.apache.org"
   url "http://mirror.cogentco.com/pub/apache/mesos/0.20.1/mesos-0.20.1.tar.gz"
@@ -11,7 +9,7 @@ class Mesos < Formula
     sha1 "410c88697079563e148b42d4f36ee3687e563b1d" => :mountain_lion
   end
 
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
   depends_on :macos => :mountain_lion
   depends_on "maven" => :build
   # Use our Zookeeper for Yosemite and not the one shipped with Mesos
@@ -19,12 +17,11 @@ class Mesos < Formula
   # See https://github.com/Homebrew/homebrew/issues/32965
   depends_on "zookeeper" if MacOS.version == :yosemite
 
-
   def install
     args = ["--prefix=#{prefix}",
             "--disable-debug",
             "--disable-dependency-tracking",
-            "--disable-silent-rules"
+            "--disable-silent-rules",
            ]
 
     args << "--with-zookeeper=#{Formula["zookeeper"].opt_prefix}" if MacOS.version == :yosemite
@@ -45,7 +42,7 @@ class Mesos < Formula
       exec "#{sbin}/mesos-slave", "--master=127.0.0.1:5050",
                                   "--work_dir=#{testpath}"
     end
-    Timeout::timeout(15) do
+    Timeout.timeout(15) do
       system "#{bin}/mesos", "execute",
                              "--master=127.0.0.1:5050",
                              "--name=execute-touch",
@@ -53,6 +50,6 @@ class Mesos < Formula
     end
     Process.kill("TERM", master)
     Process.kill("TERM", slave)
-    system "[ -e #{testpath}/executed ]"
+    assert File.exist?("#{testpath}/executed")
   end
 end

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -126,7 +126,8 @@ class JavaDependency < Requirement
   satisfy { java_version }
 
   def initialize(tags)
-    @version = tags.shift if /(\d\.)+\d/ === tags.first
+    # ignore trailing +
+    @version = tags.shift.sub(/\+$/, "") if /(\d\.)+\d/ === tags.first
     super
   end
 


### PR DESCRIPTION
See @mikemcquaid’s [comment here](https://github.com/Homebrew/homebrew/pull/35595#issuecomment-72032115).

Roadmap from [my comment here](https://github.com/Homebrew/homebrew/pull/35595#issuecomment-72101042):

> 1. Allow formulae to add a trailing `+` but ignore it in the requirement (i.e. `"1.7+"` would be the same as `"1.7"`)
> 2. Wait a couple days (weeks?) for most taps to update their formulae to the new system (i.e. add a `+` where it’s relevant)
> 3. Stop ignoring the `+` in the requirement and switch to the new system

This PR is the first step. I included a few formulae updates, but not all, because (1) that would be too much overload on your bots and (2) some of the relevant formulae need to be upgraded (I’ll make separate PRs for them). See [this comment](https://github.com/Homebrew/homebrew/pull/35595#issuecomment-72034346) for a list of the formulae which need to be updated in the main repo.

Please comment if you have any suggestion / remark / think it’s a bad idea / etc.