### PR TITLE
formula_cellar_checks: adapt ssl check for .so

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -139,7 +139,7 @@ module FormulaCellarChecks
     keg = Keg.new(formula.prefix)
     system_openssl = keg.mach_o_files.select do |obj|
       dlls = obj.dynamically_linked_libraries
-      dlls.any? { |dll| /\/usr\/lib\/lib(crypto|ssl).(\d\.)*dylib/.match dll }
+      dlls.any? { |dll| /\/usr\/lib\/lib(crypto|ssl).(\d\.)*(dylib|so)/.match dll }
     end
     return if system_openssl.empty?
 


### PR DESCRIPTION
Currently the check is only picking up on dylibs and their SSL connections, but there are a few places where we build shared objects still because it isn’t easy to patch, upstream doesn’t support it, etc etc. This just very simply extends the check to include checking shared objects as well as dylibs.