### PR TITLE
ngircd: system openssl fix

### DIFF
--- a/Library/Formula/ngircd.rb
+++ b/Library/Formula/ngircd.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Ngircd < Formula
-  homepage 'http://ngircd.barton.de'
-  url 'http://ngircd.barton.de/pub/ngircd/ngircd-22.tar.gz'
-  mirror 'http://ngircd.mirror.3rz.org/pub/ngircd/ngircd-22.tar.gz'
-  sha256 'a08e18de52bcf09d35ce75a802204ecf000f32663c1c57ad930ebcd139bf4cc8'
+  homepage "http://ngircd.barton.de"
+  url "http://ngircd.barton.de/pub/ngircd/ngircd-22.tar.gz"
+  mirror "http://ngircd.mirror.3rz.org/pub/ngircd/ngircd-22.tar.gz"
+  sha256 "a08e18de52bcf09d35ce75a802204ecf000f32663c1c57ad930ebcd139bf4cc8"
+  revision 1
 
   bottle do
     sha1 "1a370c58b671a989c69e30d0c93755a8f1f79995" => :mavericks
@@ -12,17 +11,18 @@ class Ngircd < Formula
     sha1 "a863f046eb03353d881221fc6a6a725ab098de57" => :lion
   end
 
-  option 'with-iconv', 'Enable character conversion using libiconv.'
-  option 'with-pam', 'Enable user authentication using PAM.'
+  option "with-iconv", "Enable character conversion using libiconv."
+  option "with-pam", "Enable user authentication using PAM."
 
   # Older Formula used the next option by default, so keep it unless
   # deactivated by the user:
-  option 'without-ident', 'Disable "IDENT" ("AUTH") protocol support.'
+  option "without-ident", "Disable 'IDENT' ('AUTH') protocol support."
 
-  depends_on 'libident' if build.with? 'ident'
+  depends_on "libident" if build.with? "ident"
+  depends_on "openssl"
 
   def install
-    args =%W[
+    args = %W[
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
@@ -36,6 +36,19 @@ class Ngircd < Formula
     args << "--with-pam" if build.with? "pam"
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
+
+    prefix.install "contrib/MacOSX/de.barton.ngircd.plist.tmpl" => "de.barton.ngircd.plist"
+    (prefix+"de.barton.ngircd.plist").chmod 0644
+
+    inreplace prefix+"de.barton.ngircd.plist" do |s|
+      s.gsub! ":SBINDIR:", sbin
+      s.gsub! "/Library/Logs/ngIRCd.log", var/"Logs/ngIRCd.log"
+    end
+  end
+
+  test do
+    # Exits non-zero, so test version and match Author's name supplied.
+    assert_match /Alexander/, pipe_output("#{sbin}/ngircd -V 2>&1")
   end
 end

--- a/Library/Homebrew/bottle_version.rb
+++ b/Library/Homebrew/bottle_version.rb
@@ -41,6 +41,10 @@ class BottleVersion < Version
     m = /-(\d+[a-z])/.match(stem)
     return m.captures.first unless m.nil?
 
+    # e.g. 22 from ngircd-22.mavericks.bottle.tar.gz
+    m = /-(\d{2})/.match(stem)
+    return m.captures.first unless m.nil?
+
     super
   end
 end

--- a/Library/Homebrew/test/test_bottle_versions.rb
+++ b/Library/Homebrew/test/test_bottle_versions.rb
@@ -65,4 +65,9 @@ class BottleVersionParsingTests < Homebrew::TestCase
     assert_version_detected '2007f',
       'imap-uw-2007f.yosemite.bottle.tar.gz'
   end
+
+  def test_ngircd_style
+    assert_version_detected '22',
+      'ngircd-22.mavericks.bottle.tar.gz'
+  end
 end


### PR DESCRIPTION
Fix for linking into the system OpenSSL, strict audit fixes, and the plist that’s supposed to get installed but doesn’t because the directory is hardcoded to a place that requires root to install into.