### PR TITLE
Convert all white text to gray text.

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -1262,7 +1262,7 @@ module Homebrew
       unless out.nil? or out.empty?
         if first_warning
           puts <<-EOS.undent
-            #{Tty.white}Please note that these warnings are just used to help the Homebrew maintainers
+            #{Tty.gray}Please note that these warnings are just used to help the Homebrew maintainers
             with debugging if you file an issue. If everything you use Homebrew for is
             working fine: please don't worry and just ignore them. Thanks!#{Tty.reset}
           EOS

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -54,8 +54,8 @@ module Homebrew
       rescue SystemCallError
         to = to.resolved_path if to.symlink?
         opoo <<-EOS.undent if warn_about_conflicts
-          Could not create link for #{Tty.white}#{tap_ref(path)}#{Tty.reset}, as it
-          conflicts with #{Tty.white}#{tap_ref(to)}#{Tty.reset}. You will need to use the
+          Could not create link for #{Tty.gray}#{tap_ref(path)}#{Tty.reset}, as it
+          conflicts with #{Tty.gray}#{tap_ref(to)}#{Tty.reset}. You will need to use the
           fully-qualified name when referring this formula, e.g.
             brew install #{tap_ref(path)}
           EOS

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -88,7 +88,7 @@ module Homebrew
 
     def puts_command
       cmd = @command.join(" ")
-      print "#{Tty.blue}==>#{Tty.white} #{cmd}#{Tty.reset}"
+      print "#{Tty.blue}==>#{Tty.gray} #{cmd}#{Tty.reset}"
       tabs = (80 - "PASSED".length + 1 - cmd.length) / 8
       tabs.times{ print "\t" }
       $stdout.flush
@@ -317,7 +317,7 @@ module Homebrew
     end
 
     def skip formula_name
-      puts "#{Tty.blue}==>#{Tty.white} SKIPPING: #{formula_name}#{Tty.reset}"
+      puts "#{Tty.blue}==>#{Tty.gray} SKIPPING: #{formula_name}#{Tty.reset}"
     end
 
     def satisfied_requirements? formula, spec, dependency=nil

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -9,7 +9,6 @@ require 'open-uri'
 class Tty
   class << self
     def blue; bold 34; end
-    def white; bold 39; end
     def red; underline 31; end
     def yellow; underline 33; end
     def reset; escape 0; end
@@ -44,13 +43,13 @@ end
 
 def ohai title, *sput
   title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
-  puts "#{Tty.blue}==>#{Tty.white} #{title}#{Tty.reset}"
+  puts "#{Tty.blue}==>#{Tty.gray} #{title}#{Tty.reset}"
   puts sput
 end
 
 def oh1 title
   title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
-  puts "#{Tty.green}==>#{Tty.white} #{title}#{Tty.reset}"
+  puts "#{Tty.green}==>#{Tty.gray} #{title}#{Tty.reset}"
 end
 
 def opoo warning

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -168,7 +168,7 @@ rescue RuntimeError, SystemCallError => e
   exit 1
 rescue Exception => e
   onoe e
-  puts "#{Tty.white}Please report this bug:"
+  puts "#{Tty.gray}Please report this bug:"
   puts "    #{Tty.em}#{OS::ISSUES_URL}#{Tty.reset}"
   puts e.backtrace
   exit 1


### PR DESCRIPTION
Due to a vision issue, I have difficulty seeing white text on a black
background, so I configure all my computer things (terminal, editor, etc.)
to use black text on a white background. This makes using programs that
display white text difficult to use, so I'd like to request that all
white text be changed to gray in Homebrew. Thank you for your
consideration :)