### PR TITLE
Use HTTPS for formulae Google Code homepages

### DIFF
--- a/Library/Formula/clamz.rb
+++ b/Library/Formula/clamz.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Clamz < Formula
-  homepage 'http://code.google.com/p/clamz/'
+  homepage 'https://code.google.com/p/clamz/'
   url 'https://clamz.googlecode.com/files/clamz-0.5.tar.gz'
   sha1 '54664614e5098f9e4e9240086745b94fe638b176'
   revision 1

--- a/Library/Formula/cmockery.rb
+++ b/Library/Formula/cmockery.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Cmockery < Formula
-  homepage 'http://code.google.com/p/cmockery/'
+  homepage 'https://code.google.com/p/cmockery/'
   url 'https://cmockery.googlecode.com/files/cmockery-0.1.2.tar.gz'
   sha1 '964ed1104a0cbbea8a9a34e88c6e79b546eff1bc'
 

--- a/Library/Formula/crf++.rb
+++ b/Library/Formula/crf++.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Crfxx < Formula
-  homepage 'http://code.google.com/p/crfpp/'
+  homepage 'https://code.google.com/p/crfpp/'
   url 'https://crfpp.googlecode.com/files/CRF++-0.58.tar.gz'
   sha1 '979a686a6d73d14cdd0c96a310888fb6bffd2e91'
 

--- a/Library/Formula/csshx.rb
+++ b/Library/Formula/csshx.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Csshx < Formula
-  homepage 'http://code.google.com/p/csshx/'
+  homepage 'https://code.google.com/p/csshx/'
   url 'https://csshx.googlecode.com/files/csshX-0.74.tgz'
   sha1 'aa686b71161d6144d539d077b960da10d7b96993'
 

--- a/Library/Formula/csvprintf.rb
+++ b/Library/Formula/csvprintf.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Csvprintf < Formula
-  homepage 'http://code.google.com/p/csvprintf/'
+  homepage 'https://code.google.com/p/csvprintf/'
   url 'https://csvprintf.googlecode.com/files/csvprintf-1.0.3.tar.gz'
   sha1 'ee5ee6728a44cc7d0961b0960c7a444372752931'
 

--- a/Library/Formula/darkice.rb
+++ b/Library/Formula/darkice.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Darkice < Formula
-  homepage 'http://code.google.com/p/darkice/'
+  homepage 'https://code.google.com/p/darkice/'
   url 'https://darkice.googlecode.com/files/darkice-1.2.tar.gz'
   sha1 '508eb0560a7cdf0990a8793f4b8d324ae74bc343'
 

--- a/Library/Formula/dircproxy.rb
+++ b/Library/Formula/dircproxy.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Dircproxy < Formula
-  homepage 'http://code.google.com/p/dircproxy/'
+  homepage 'https://code.google.com/p/dircproxy/'
   url 'https://dircproxy.googlecode.com/files/dircproxy-1.2.0-RC1.tar.gz'
   sha1 '7dc4b3aa2e10222f74e280de69c41f571335a96b'
 

--- a/Library/Formula/distcc.rb
+++ b/Library/Formula/distcc.rb
@@ -10,7 +10,7 @@ class PythonWithoutPPC < Requirement
 end
 
 class Distcc < Formula
-  homepage 'http://code.google.com/p/distcc/'
+  homepage 'https://code.google.com/p/distcc/'
   url 'https://distcc.googlecode.com/files/distcc-3.2rc1.tar.gz'
   sha1 '7cd46fe0926a3a859a516274e6ae59fa8ba0262d'
 

--- a/Library/Formula/dnsmap.rb
+++ b/Library/Formula/dnsmap.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Dnsmap < Formula
-  homepage 'http://code.google.com/p/dnsmap/'
+  homepage 'https://code.google.com/p/dnsmap/'
   url 'https://dnsmap.googlecode.com/files/dnsmap-0.30.tar.gz'
   sha1 'a9a8a17102825510d16c1f8af33ca74407c18c70'
 

--- a/Library/Formula/fdupes.rb
+++ b/Library/Formula/fdupes.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Fdupes < Formula
-  homepage 'http://code.google.com/p/fdupes/'
+  homepage 'https://code.google.com/p/fdupes/'
   url 'https://fdupes.googlecode.com/files/fdupes-1.51.tar.gz'
   sha1 '8276b39026f57a2f9503d7af18efca0a7d42b8ec'
 

--- a/Library/Formula/ffmbc.rb
+++ b/Library/Formula/ffmbc.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ffmbc < Formula
-  homepage 'http://code.google.com/p/ffmbc/'
+  homepage 'https://code.google.com/p/ffmbc/'
   url 'https://ffmbc.googlecode.com/files/FFmbc-0.7-rc8.tar.bz2'
   sha1 '85a9673ac82a698bb96057fe027222efe6ebae28'
   revision 1

--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ffmpegthumbnailer < Formula
-  homepage 'http://code.google.com/p/ffmpegthumbnailer/'
+  homepage 'https://code.google.com/p/ffmpegthumbnailer/'
   url 'https://ffmpegthumbnailer.googlecode.com/files/ffmpegthumbnailer-2.0.8.tar.gz'
   sha1 '2c54ca16efd953f46547e22799cfc40bd9c24533'
   bottle do

--- a/Library/Formula/garmintools.rb
+++ b/Library/Formula/garmintools.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Garmintools < Formula
-  homepage 'http://code.google.com/p/garmintools/'
+  homepage 'https://code.google.com/p/garmintools/'
   url 'https://garmintools.googlecode.com/files/garmintools-0.10.tar.gz'
   sha1 'f59a761b09575d27abbf5d76811f7ec25a1cbd26'
 

--- a/Library/Formula/gflags.rb
+++ b/Library/Formula/gflags.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Gflags < Formula
-  homepage 'http://code.google.com/p/google-gflags/'
+  homepage 'https://code.google.com/p/google-gflags/'
   url 'https://gflags.googlecode.com/files/gflags-2.0.tar.gz'
   sha1 'dfb0add1b59433308749875ac42796c41e824908'
 

--- a/Library/Formula/git-multipush.rb
+++ b/Library/Formula/git-multipush.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class GitMultipush < Formula
-  homepage 'http://code.google.com/p/git-multipush/'
+  homepage 'https://code.google.com/p/git-multipush/'
   url 'https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2'
   sha1 'a53f171af5e794afe9b1de6ccd9bd0661db6fd91'
 

--- a/Library/Formula/glog.rb
+++ b/Library/Formula/glog.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Glog < Formula
-  homepage 'http://code.google.com/p/google-glog/'
+  homepage 'https://code.google.com/p/google-glog/'
   url 'https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz'
   sha1 'ed40c26ecffc5ad47c618684415799ebaaa30d65'
 

--- a/Library/Formula/gource.rb
+++ b/Library/Formula/gource.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Gource < Formula
-  homepage "http://code.google.com/p/gource/"
+  homepage "https://code.google.com/p/gource/"
   url "https://github.com/acaudwell/Gource/releases/download/gource-0.43/gource-0.43.tar.gz"
   sha1 "dda56952f9cc19821ae7c146736b00556ef51edf"
 

--- a/Library/Formula/hostdb.rb
+++ b/Library/Formula/hostdb.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Hostdb < Formula
-  homepage 'http://code.google.com/p/hostdb/'
+  homepage 'https://code.google.com/p/hostdb/'
   url 'https://hostdb.googlecode.com/files/hostdb-1.004.tgz'
   sha1 '65ec59c2c88b763813fa611d8fd28a45cd9d5278'
 

--- a/Library/Formula/hqx.rb
+++ b/Library/Formula/hqx.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Hqx < Formula
-  homepage 'http://code.google.com/p/hqx/'
+  homepage 'https://code.google.com/p/hqx/'
   url 'https://hqx.googlecode.com/files/hqx-1.1.tar.gz'
   sha1 'bf08ae10db6cce4d29c84524ec13a3101d31db6b'
 

--- a/Library/Formula/htmlcompressor.rb
+++ b/Library/Formula/htmlcompressor.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Htmlcompressor < Formula
-  homepage 'http://code.google.com/p/htmlcompressor/'
+  homepage 'https://code.google.com/p/htmlcompressor/'
   url 'https://htmlcompressor.googlecode.com/files/htmlcompressor-1.5.3.jar'
   sha1 '57db73b92499e018b2f2978f1c7aa7b1238c7a39'
 

--- a/Library/Formula/innotop.rb
+++ b/Library/Formula/innotop.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Innotop < Formula
-  homepage "http://code.google.com/p/innotop/"
+  homepage "https://code.google.com/p/innotop/"
   url "https://innotop.googlecode.com/files/innotop-1.9.1.tar.gz"
   sha1 "6b0b5f492e7188152727f6c157043be180ba516a"
 

--- a/Library/Formula/ioping.rb
+++ b/Library/Formula/ioping.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ioping < Formula
-  homepage 'http://code.google.com/p/ioping/'
+  homepage 'https://code.google.com/p/ioping/'
   url 'https://ioping.googlecode.com/files/ioping-0.8.tar.gz'
   sha1 '7d4fe1414cdd5887c332426a8844e17eca5e5646'
 

--- a/Library/Formula/iphotoexport.rb
+++ b/Library/Formula/iphotoexport.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Iphotoexport < Formula
-  homepage 'http://code.google.com/p/iphotoexport/'
+  homepage 'https://code.google.com/p/iphotoexport/'
   url 'https://iphotoexport.googlecode.com/files/iphotoexport-1.6.4.zip'
   sha1 '50fa0916cf9689efdfd33cd4680424234b4e9023'
 

--- a/Library/Formula/jing.rb
+++ b/Library/Formula/jing.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Jing < Formula
-  homepage 'http://code.google.com/p/jing-trang/'
+  homepage 'https://code.google.com/p/jing-trang/'
   url 'https://jing-trang.googlecode.com/files/jing-20091111.zip'
   sha1 '2e8eacf399249d226ad4f6ca1d6907ff69430118'
 

--- a/Library/Formula/js-test-driver.rb
+++ b/Library/Formula/js-test-driver.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class JsTestDriver < Formula
-  homepage 'http://code.google.com/p/js-test-driver/'
+  homepage 'https://code.google.com/p/js-test-driver/'
   url 'https://js-test-driver.googlecode.com/files/JsTestDriver-1.3.5.jar'
   sha1 '7a29ace71b9d5a82f5f0abe0ea22b73d7fd07826'
 

--- a/Library/Formula/jsdoc-toolkit.rb
+++ b/Library/Formula/jsdoc-toolkit.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class JsdocToolkit < Formula
-  homepage 'http://code.google.com/p/jsdoc-toolkit/'
+  homepage 'https://code.google.com/p/jsdoc-toolkit/'
   url 'https://jsdoc-toolkit.googlecode.com/files/jsdoc_toolkit-2.4.0.zip'
   sha1 'bd276ec58dbd419326760226174eba09810d26ee'
 

--- a/Library/Formula/jslint4java.rb
+++ b/Library/Formula/jslint4java.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Jslint4java < Formula
-  homepage "http://code.google.com/p/jslint4java/"
+  homepage "https://code.google.com/p/jslint4java/"
   url "https://jslint4java.googlecode.com/files/jslint4java-2.0.5-dist.zip"
   sha1 "30a75ce48b64d2c8f0b2b86e20c0d98e6441827d"
 

--- a/Library/Formula/lastfmlib.rb
+++ b/Library/Formula/lastfmlib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lastfmlib < Formula
-  homepage 'http://code.google.com/p/lastfmlib/'
+  homepage 'https://code.google.com/p/lastfmlib/'
   url 'https://lastfmlib.googlecode.com/files/lastfmlib-0.4.0.tar.gz'
   sha1 'b9e15e4eb42a9ccd9b3c5373054b0bd51a406fdd'
 

--- a/Library/Formula/libdnet.rb
+++ b/Library/Formula/libdnet.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libdnet < Formula
-  homepage 'http://code.google.com/p/libdnet/'
+  homepage 'https://code.google.com/p/libdnet/'
   url 'https://libdnet.googlecode.com/files/libdnet-1.12.tgz'
   sha1 '71302be302e84fc19b559e811951b5d600d976f8'
 

--- a/Library/Formula/libewf.rb
+++ b/Library/Formula/libewf.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Libewf < Formula
-  homepage "http://code.google.com/p/libewf/"
+  homepage "https://code.google.com/p/libewf/"
   url "https://googledrive.com/host/0B3fBvzttpiiSMTdoaVExWWNsRjg/libewf-20140608.tar.gz"
   sha1 "c17384a3d2c1d63bd5b1aaa2aead6ee3c82a2368"
   revision 1

--- a/Library/Formula/libkml.rb
+++ b/Library/Formula/libkml.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libkml < Formula
-  homepage 'http://code.google.com/p/libkml/'
+  homepage 'https://code.google.com/p/libkml/'
 
   stable do
     url "https://libkml.googlecode.com/files/libkml-1.2.0.tar.gz"

--- a/Library/Formula/liblunar.rb
+++ b/Library/Formula/liblunar.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Liblunar < Formula
-  homepage 'http://code.google.com/p/liblunar/'
+  homepage 'https://code.google.com/p/liblunar/'
   url 'https://liblunar.googlecode.com/files/liblunar-2.2.5.tar.gz'
   sha1 'c149dc32776667ed8d53124eec414ab15ace0981'
 

--- a/Library/Formula/libpgm.rb
+++ b/Library/Formula/libpgm.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libpgm < Formula
-  homepage 'http://code.google.com/p/openpgm/'
+  homepage 'https://code.google.com/p/openpgm/'
   url 'https://openpgm.googlecode.com/files/libpgm-5.2.122%7Edfsg.tar.gz'
   sha1 '788efcb223a05bb68b304bcdd3c37bb54fe4de28'
   version '5.2.122'

--- a/Library/Formula/logstalgia.rb
+++ b/Library/Formula/logstalgia.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Logstalgia < Formula
-  homepage "http://code.google.com/p/logstalgia/"
+  homepage "https://code.google.com/p/logstalgia/"
   url "https://github.com/acaudwell/Logstalgia/releases/download/logstalgia-1.0.6/logstalgia-1.0.6.tar.gz"
   sha1 "92b2b037d289840517d6648bf72f09afbf3f09d5"
 

--- a/Library/Formula/lorem.rb
+++ b/Library/Formula/lorem.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lorem < Formula
-  homepage 'http://code.google.com/p/lorem/'
+  homepage 'https://code.google.com/p/lorem/'
   url 'http://lorem.googlecode.com/svn-history/r4/trunk/lorem', :using => :curl
   version '0.6.1'
   sha1 'aa6ef66e5ee1151397f19b358d772af316cf333b'

--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 # Reference: https://github.com/b4winckler/macvim/wiki/building
 class Macvim < Formula
-  homepage 'http://code.google.com/p/macvim/'
+  homepage 'https://code.google.com/p/macvim/'
   url 'https://github.com/b4winckler/macvim/archive/snapshot-73.tar.gz'
   version '7.4-73'
   sha1 'b87e37fecb305a99bc268becca39f8854e3ff9f0'

--- a/Library/Formula/memcache-top.rb
+++ b/Library/Formula/memcache-top.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class MemcacheTop < Formula
-  homepage 'http://code.google.com/p/memcache-top/'
+  homepage 'https://code.google.com/p/memcache-top/'
   url 'https://memcache-top.googlecode.com/files/memcache-top-v0.6'
   version '0.6'
   sha1 'eaac357e13ac2a531c28081783fdcc3ddbe98ede'

--- a/Library/Formula/mfcuk.rb
+++ b/Library/Formula/mfcuk.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mfcuk < Formula
-  homepage 'http://code.google.com/p/mfcuk/'
+  homepage 'https://code.google.com/p/mfcuk/'
   url 'https://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz'
   sha1 '2a8259440ac5bed8516c8d771a945b713dacd2bc'
 

--- a/Library/Formula/mfoc.rb
+++ b/Library/Formula/mfoc.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mfoc < Formula
-  homepage 'http://code.google.com/p/mfoc/'
+  homepage 'https://code.google.com/p/mfoc/'
   url 'https://mfoc.googlecode.com/files/mfoc-0.10.7.tar.bz2'
   sha1 '162a464baf6498926a72383c6b0040654321012d'
 

--- a/Library/Formula/mp3check.rb
+++ b/Library/Formula/mp3check.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mp3check < Formula
-  homepage 'http://code.google.com/p/mp3check/'
+  homepage 'https://code.google.com/p/mp3check/'
   url 'https://mp3check.googlecode.com/files/mp3check-0.8.7.tgz'
   sha1 '31fe95bb7949343f6ebc04fcaa2faffd2b738264'
 

--- a/Library/Formula/mp4v2.rb
+++ b/Library/Formula/mp4v2.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Mp4v2 < Formula
-  homepage "http://code.google.com/p/mp4v2/"
+  homepage "https://code.google.com/p/mp4v2/"
   url "https://mp4v2.googlecode.com/files/mp4v2-2.0.0.tar.bz2"
   sha1 "193260cfb7201e6ec250137bcca1468d4d20e2f0"
 

--- a/Library/Formula/open-vcdiff.rb
+++ b/Library/Formula/open-vcdiff.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class OpenVcdiff < Formula
-  homepage 'http://code.google.com/p/open-vcdiff/'
+  homepage 'https://code.google.com/p/open-vcdiff/'
   url 'https://open-vcdiff.googlecode.com/files/open-vcdiff-0.8.3.tar.gz'
   sha1 'fd14e8d46edac14988f1a6cab479bc07677d487c'
 

--- a/Library/Formula/oscats.rb
+++ b/Library/Formula/oscats.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Oscats < Formula
-  homepage 'http://code.google.com/p/oscats/'
+  homepage 'https://code.google.com/p/oscats/'
   url 'https://oscats.googlecode.com/files/oscats-0.6.tar.gz'
   sha1 'f57fa06ee0d842ed4c547dd7ab599fd5090d7550'
 

--- a/Library/Formula/pdf2json.rb
+++ b/Library/Formula/pdf2json.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Pdf2json < Formula
-  homepage 'http://code.google.com/p/pdf2json/'
+  homepage 'https://code.google.com/p/pdf2json/'
   url 'https://pdf2json.googlecode.com/files/pdf2json-0.68.tar.gz'
   sha1 '1cb0f4b3b1216c6ce515fd256d92ac196d002a7e'
 

--- a/Library/Formula/picoc.rb
+++ b/Library/Formula/picoc.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Picoc < Formula
-  homepage 'http://code.google.com/p/picoc/'
+  homepage 'https://code.google.com/p/picoc/'
   url 'https://picoc.googlecode.com/files/picoc-2.1.tar.bz2'
   sha1 '24fdc3c8302915d663fcaefaf878ab5ad5a2d69b'
 

--- a/Library/Formula/picocom.rb
+++ b/Library/Formula/picocom.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Picocom < Formula
-  homepage 'http://code.google.com/p/picocom/'
+  homepage 'https://code.google.com/p/picocom/'
   url 'https://picocom.googlecode.com/files/picocom-1.7.tar.gz'
   sha1 'bde6e36af71db845913f9d61f28dee1b485218fa'
 

--- a/Library/Formula/plowshare.rb
+++ b/Library/Formula/plowshare.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Plowshare < Formula
-  homepage 'http://code.google.com/p/plowshare/'
+  homepage 'https://code.google.com/p/plowshare/'
   url 'https://code.google.com/p/plowshare/', :tag => 'v1.0.5', :using => :git
   head 'https://code.google.com/p/plowshare/', :using => :git
 

--- a/Library/Formula/psgrep.rb
+++ b/Library/Formula/psgrep.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Psgrep < Formula
-  homepage 'http://code.google.com/p/psgrep/'
+  homepage 'https://code.google.com/p/psgrep/'
   url 'https://psgrep.googlecode.com/files/psgrep-1.0.6.tar.bz2'
   sha1 'fe1102546971358a5eff2cff613d70ee63395444'
 

--- a/Library/Formula/pulledpork.rb
+++ b/Library/Formula/pulledpork.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Pulledpork < Formula
-  homepage 'http://code.google.com/p/pulledpork/'
+  homepage 'https://code.google.com/p/pulledpork/'
   url 'https://pulledpork.googlecode.com/files/pulledpork-0.7.0.tar.gz'
   sha1 'fd7f2b195b473ba80826c4f06dd6ef2dd445814e'
 

--- a/Library/Formula/reaver.rb
+++ b/Library/Formula/reaver.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Reaver < Formula
-  homepage 'http://code.google.com/p/reaver-wps/'
+  homepage 'https://code.google.com/p/reaver-wps/'
   url 'https://reaver-wps.googlecode.com/files/reaver-1.4.tar.gz'
   sha1 '2ebec75c3979daa7b576bc54adedc60eb0e27a21'
 

--- a/Library/Formula/sam2p.rb
+++ b/Library/Formula/sam2p.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Sam2p < Formula
-  homepage 'http://code.google.com/p/sam2p/'
+  homepage 'https://code.google.com/p/sam2p/'
   url 'https://sam2p.googlecode.com/files/sam2p-0.49.2.tar.gz'
   sha1 'a26db7408dfa42ab615d087774128cc5b20ab61d'
 

--- a/Library/Formula/scrub.rb
+++ b/Library/Formula/scrub.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Scrub < Formula
-  homepage 'http://code.google.com/p/diskscrub/'
+  homepage 'https://code.google.com/p/diskscrub/'
   url 'https://diskscrub.googlecode.com/files/scrub-2.5.2.tar.bz2'
   sha1 '863e5894e6acb3f922cb25f58e260f9c59b55c14'
 

--- a/Library/Formula/skipfish.rb
+++ b/Library/Formula/skipfish.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Skipfish < Formula
-  homepage 'http://code.google.com/p/skipfish/'
+  homepage 'https://code.google.com/p/skipfish/'
   url 'https://skipfish.googlecode.com/files/skipfish-2.10b.tgz'
   sha1 '2564162a13d02f8310eef5edcbaf74ed6043be99'
 

--- a/Library/Formula/slowhttptest.rb
+++ b/Library/Formula/slowhttptest.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Slowhttptest < Formula
-  homepage 'http://code.google.com/p/slowhttptest/'
+  homepage 'https://code.google.com/p/slowhttptest/'
   url 'https://slowhttptest.googlecode.com/files/slowhttptest-1.6.tar.gz'
   sha1 'f5a64365b987083015ac98f6c20746021176292e'
 

--- a/Library/Formula/szl.rb
+++ b/Library/Formula/szl.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Szl < Formula
-  homepage "http://code.google.com/p/szl/"
+  homepage "https://code.google.com/p/szl/"
   url "https://szl.googlecode.com/files/szl-1.0.tar.gz"
   sha1 "e4c6d4aec1afc025257d41dd77b8f5c25ea120d4"
   revision 3

--- a/Library/Formula/tesseract.rb
+++ b/Library/Formula/tesseract.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Tesseract < Formula
-  homepage 'http://code.google.com/p/tesseract-ocr/'
+  homepage 'https://code.google.com/p/tesseract-ocr/'
   url 'https://tesseract-ocr.googlecode.com/files/tesseract-ocr-3.02.02.tar.gz'
   sha1 'a950acf7b75cf851de2de787e9abb62c58ca1827'
   revision 3

--- a/Library/Formula/trang.rb
+++ b/Library/Formula/trang.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Trang < Formula
-  homepage 'http://code.google.com/p/jing-trang/'
+  homepage 'https://code.google.com/p/jing-trang/'
   url 'https://jing-trang.googlecode.com/files/trang-20091111.zip'
   sha1 'b5f1fd4b63f347c8d0575bd1922f94316240cb29'
 

--- a/Library/Formula/ttf2eot.rb
+++ b/Library/Formula/ttf2eot.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ttf2eot < Formula
-  homepage 'http://code.google.com/p/ttf2eot/'
+  homepage 'https://code.google.com/p/ttf2eot/'
   url 'https://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz'
   sha1 'c9a64216e7a090cb50f7a5074865218623dea75d'
 

--- a/Library/Formula/uchardet.rb
+++ b/Library/Formula/uchardet.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Uchardet < Formula
-  homepage 'http://code.google.com/p/uchardet/'
+  homepage 'https://code.google.com/p/uchardet/'
   url 'https://uchardet.googlecode.com/files/uchardet-0.0.1.tar.gz'
   sha1 'c81264cca67f3e7c46e284288f8cab7a34b3f386'
 

--- a/Library/Formula/uim.rb
+++ b/Library/Formula/uim.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Uim < Formula
-  homepage 'http://code.google.com/p/uim/'
+  homepage 'https://code.google.com/p/uim/'
   url 'https://uim.googlecode.com/files/uim-1.6.0.tar.bz2'
   sha1 'd27f2ca8136da0702c82f0522911d06b2b8f8ea7'
 

--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -6,7 +6,7 @@ require 'formula'
 # http://omahaproxy.appspot.com/
 
 class V8 < Formula
-  homepage 'http://code.google.com/p/v8/'
+  homepage 'https://code.google.com/p/v8/'
   url 'https://github.com/v8/v8/archive/3.25.30.tar.gz'
   sha1 '207d0bb1dd5954fe691570e799b3c1e318741290'
 

--- a/Library/Formula/visualnetkit.rb
+++ b/Library/Formula/visualnetkit.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Visualnetkit < Formula
-  homepage 'http://code.google.com/p/visual-netkit/'
+  homepage 'https://code.google.com/p/visual-netkit/'
   url 'https://visual-netkit.googlecode.com/files/visualnetkit-1.4.tar.bz'
   version '1.4'
   sha1 '17dbc3a6b7e62b1b2183f2a4426b9021781e4ec4'

--- a/Library/Formula/xar.rb
+++ b/Library/Formula/xar.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Xar < Formula
-  homepage 'http://code.google.com/p/xar/'
+  homepage 'https://code.google.com/p/xar/'
   url 'https://xar.googlecode.com/files/xar-1.5.2.tar.gz'
   sha1 'eb411a92167387aa5d06a81970f7e929ec3087c9'
 

--- a/Library/Formula/xsw.rb
+++ b/Library/Formula/xsw.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Xsw < Formula
-  homepage 'http://code.google.com/p/xsw/'
+  homepage 'https://code.google.com/p/xsw/'
   url 'https://xsw.googlecode.com/files/xsw-0.3.5.tar.gz'
   sha1 'fe4cffcc8bcd3149f4ecbf2011ad78a8ab7f1dd4'
 

--- a/Library/Formula/yaml-cpp.rb
+++ b/Library/Formula/yaml-cpp.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class YamlCpp < Formula
-  homepage 'http://code.google.com/p/yaml-cpp/'
+  homepage 'https://code.google.com/p/yaml-cpp/'
   url 'https://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz'
   sha1 '9c5414b4090491e96d1b808fe8628b31e625fdaa'
 


### PR DESCRIPTION
This PR modifies the homepages of all formulae whose homepages are hosted on Google Code to use HTTPS.

`brew audit` before :

```
285 problems in 224 formulae
```

`brew audit` after :

```
216 problems in 155 formulae
```

That's not much, but it cleans up audit results a bit ;)