### PR TITLE
xar: kegging and openssl fix

### DIFF
--- a/Library/Formula/xar.rb
+++ b/Library/Formula/xar.rb
@@ -1,20 +1,31 @@
-require 'formula'
-
 class Xar < Formula
-  homepage 'http://code.google.com/p/xar/'
-  url 'https://xar.googlecode.com/files/xar-1.5.2.tar.gz'
-  sha1 'eb411a92167387aa5d06a81970f7e929ec3087c9'
+  homepage "https://code.google.com/p/xar/"
+  url "https://xar.googlecode.com/files/xar-1.5.2.tar.gz"
+  sha1 "eb411a92167387aa5d06a81970f7e929ec3087c9"
+  revision 1
+
+  depends_on "openssl"
+
+  keg_only :provided_by_osx
 
   # Known issue upstream:
-  # http://code.google.com/p/xar/issues/detail?id=51
+  # https://code.google.com/p/xar/issues/detail?id=51
   patch :DATA
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+                          "--prefix=#{prefix}", "--mandir=#{man}"
     system "make"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    cd testpath do
+      touch "testfile.txt"
+      system bin/"xar", "-cv", "testfile.txt", "-f", "test.xar"
+      assert File.exist?("test.xar")
+      assert_match /testfile.txt/, shell_output("#{bin}/xar -tv -f test.xar")
+    end
   end
 end
 


### PR DESCRIPTION
Makes Xar ` keg_only ` because it overrides the ` xar ` in /usr/bin which actually appears to be newer. Also adds an OpenSSL dep to stop it tapping the defunct system OpenSSL.