### PR TITLE
Include GHC 7.10.1-RC2 as `devel`

### DIFF
--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -11,6 +11,7 @@ class Ghc < Formula
 
   devel do
     url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-src.tar.xz"
+    version "7.10.1-rc2"
     sha256 "258e6fd9f5faa9cc3bd86c9d0d62e2c122a27af36f1e139027b86bce4d03a96e"
   end
 
@@ -49,7 +50,6 @@ class Ghc < Formula
   else
     resource "testsuite" do
       url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-testsuite.tar.xz"
-      version "7.10.1-rc2"
       sha256 "2f668b63649be1734281c3d4167877f596a98ed644a4273bfbf0c60416cb18ec"
     end
   end

--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -9,6 +9,11 @@ class Ghc < Formula
     sha1 "296802648e2b2bc26fcb01025fb1fa8ab583e64a" => :mountain_lion
   end
 
+  devel do
+    url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-src.tar.xz"
+    sha256 "258e6fd9f5faa9cc3bd86c9d0d62e2c122a27af36f1e139027b86bce4d03a96e"
+  end
+
   option "32-bit"
   option "tests", "Verify the build using the testsuite."
 
@@ -36,9 +41,17 @@ class Ghc < Formula
     end
   end
 
-  resource "testsuite" do
-    url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
-    sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+  if build.devel?
+    resource "testsuite" do
+      url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
+      sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+    end
+  else
+    resource "testsuite" do
+      url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-testsuite.tar.xz"
+      version "7.10.1-rc2"
+      sha256 "2f668b63649be1734281c3d4167877f596a98ed644a4273bfbf0c60416cb18ec"
+    end
   end
 
   if build.build_32_bit? || !MacOS.prefer_64_bit? || MacOS.version < :mavericks

--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -12,7 +12,7 @@ class Ghc < Formula
   devel do
     url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-src.tar.xz"
     version "7.10.1-rc2"
-    sha256 "258e6fd9f5faa9cc3bd86c9d0d62e2c122a27af36f1e139027b86bce4d03a96e"
+    sha256 "766596f9b09b2cdd8bd477754f0e02ea8f7e40e4f5b0522cf585942fb2fec546"
   end
 
   option "32-bit"
@@ -46,13 +46,13 @@ class Ghc < Formula
 
   if build.devel?
     resource "testsuite" do
-      url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
-      sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+      url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-testsuite.tar.xz"
+      sha256 "051d4659421dec257827d7de7df8a99806f4bf575102013dda4006fccee11f76"
     end
   else
     resource "testsuite" do
-      url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-testsuite.tar.xz"
-      sha256 "2f668b63649be1734281c3d4167877f596a98ed644a4273bfbf0c60416cb18ec"
+      url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
+      sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
     end
   end
 

--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -16,7 +16,9 @@ class Ghc < Formula
   end
 
   option "32-bit"
-  option "tests", "Verify the build using the testsuite."
+  option "with-tests", "Verify the build using the testsuite."
+
+  deprecated_option "tests" => "with-tests"
 
   # http://hackage.haskell.org/trac/ghc/ticket/6009
   depends_on :macos => :snow_leopard
@@ -113,7 +115,7 @@ class Ghc < Formula
                             "--with-gcc=#{ENV.cc}"
       system "make"
 
-      if build.include? "tests"
+      if build.with? "tests"
         resource("testsuite").stage do
           cd "testsuite" do
             (buildpath+"Ghcsource/config").install Dir["config/*"]

--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -44,15 +44,15 @@ class Ghc < Formula
     end
   end
 
-  if build.devel?
+  resource "testsuite" do
+    url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
+    sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+  end
+
+  devel do
     resource "testsuite" do
       url "https://downloads.haskell.org/~ghc/7.10.1-rc2/ghc-7.10.0.20150123-testsuite.tar.xz"
       sha256 "051d4659421dec257827d7de7df8a99806f4bf575102013dda4006fccee11f76"
-    end
-  else
-    resource "testsuite" do
-      url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
-      sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
     end
   end
 

--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -44,9 +44,11 @@ class Ghc < Formula
     end
   end
 
-  resource "testsuite" do
-    url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
-    sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+  stable do
+    resource "testsuite" do
+      url "https://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-testsuite.tar.xz"
+      sha256 "d0332f30868dcd0e7d64d1444df05737d1f3cf4b09f9cfbfec95f8831ce42561"
+    end
   end
 
   devel do


### PR DESCRIPTION
This pull request also modernizes the option style of the GHC formula.