### PR TITLE
unittest-cpp: homepage/url move

### DIFF
--- a/Library/Formula/unittest-cpp.rb
+++ b/Library/Formula/unittest-cpp.rb
@@ -1,21 +1,44 @@
-require 'formula'
-
 class UnittestCpp < Formula
-  homepage 'http://unittest-cpp.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/unittest-cpp/UnitTest++/1.4/unittest-cpp-1.4.zip'
-  sha1 'dad944159e2e135aea74039987490eaaee00f2ad'
+  homepage "https://github.com/unittest-cpp/unittest-cpp"
+
+  stable do
+    url "https://github.com/unittest-cpp/unittest-cpp/archive/v1.4.tar.gz"
+    sha1 "ec7bdbebeb6f4d7a069f1125f7b4f473198e491d"
+
+    # Clang failure fixed in the HEAD already
+    fails_with :clang do
+      build 600
+      cause "Failure in test: Expected 2 but was 0"
+    end
+  end
+
+  head do
+    url "https://github.com/unittest-cpp/unittest-cpp.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
 
   def install
-    system "make"
+    if build.head?
+      system "autoreconf", "-fvi"
+      system "./configure", "--prefix=#{prefix}", "--disable-silent-rules"
+      system "make", "install"
+    end
 
-    # Install the headers
-    include.install Dir['src/*.h']
-    include.install 'src/Posix'
+    if build.stable?
+      system "make"
 
-    # Install the compiled library
-    lib.install 'libUnitTest++.a'
+      # Install the headers
+      include.install Dir["src/*.h"]
+      include.install "src/Posix"
 
-    # Install the documentation
-    doc.install 'docs/UnitTest++.html'
+      # Install the compiled library
+      lib.install "libUnitTest++.a"
+
+      # Install the documentation
+      doc.install "docs/UnitTest++.html"
+    end
   end
 end


### PR DESCRIPTION
The Homepage and URL have moved from SourceForge to Github. The latter is a “fork” maintained by one of the original SourceForge authors and a new maintainer.

Closes #36400