### PR TITLE
rakudo-star 2014.12.1

### DIFF
--- a/Library/Formula/rakudo-star.rb
+++ b/Library/Formula/rakudo-star.rb
@@ -6,6 +6,7 @@ class RakudoStar < Formula
   sha256 "c99acb6e7128aa950e97303c337603f831481d5a316e4a72ea3981606b2ce784"
 
   option "with-jvm", "Build also for jvm as an alternate backend."
+  option "with-parrot", "Build also for parrot as an alternate backend."
 
   conflicts_with "parrot"
 
@@ -20,15 +21,26 @@ class RakudoStar < Formula
     ENV.prepend "CPPFLAGS", "-I#{libffi.lib}/libffi-#{libffi.version}/include"
 
     ENV.j1  # An intermittent race condition causes random build failures.
+
+    backends = ["moar"]
+    generate = ["--gen-moar"]
+
     if build.with? "jvm"
-      system "perl", "Configure.pl", "--prefix=#{prefix}", "--backends=parrot,jvm", "--gen-parrot"
-    else
-      system "perl", "Configure.pl", "--prefix=#{prefix}", "--backends=parrot", "--gen-parrot"
+      backends << "jvm"
     end
+    if build.with? "parrot"
+      backends << "parrot"
+      generate << "--gen-parrot"
+    end
+    system "perl", "Configure.pl", "--prefix=#{prefix}", "--backends=" + backends.join(","), *generate
     system "make"
     system "make install"
-    # move the man pages out of the top level into share.
-    mv "#{prefix}/man", share
+
+    # Move the man pages out of the top level into share.
+    # Not all backends seem to generate man pages at this point.
+    if File.directory?("#{prefix}/man")
+        mv "#{prefix}/man", share
+    end
   end
 
   test do

--- a/Library/Formula/rakudo-star.rb
+++ b/Library/Formula/rakudo-star.rb
@@ -2,16 +2,8 @@ require "formula"
 
 class RakudoStar < Formula
   homepage "http://rakudo.org/"
-  url "http://rakudo.org/downloads/star/rakudo-star-2014.09.tar.gz"
-  sha256 "e7cfc6f4d92d9841f03246d68d51ed54d48df08736b0bd73626fe45196498649"
-  revision 1
-
-  bottle do
-    revision 1
-    sha1 "0cecf848006c3efb275c2d1fd005e948f5d74650" => :yosemite
-    sha1 "163f336f077e10bacbe6ab08da520336d0636d78" => :mavericks
-    sha1 "0387a42e9bfdd816312ff1b377391dbebc6e3185" => :mountain_lion
-  end
+  url "http://rakudo.org/downloads/star/rakudo-star-2014.12.1.tar.gz"
+  sha256 "c99acb6e7128aa950e97303c337603f831481d5a316e4a72ea3981606b2ce784"
 
   option "with-jvm", "Build also for jvm as an alternate backend."
 


### PR DESCRIPTION
Updated to current version 2014.12.1.
Build new recommended moar vm by default, and make parrot vm optional.