### PR TITLE
apr: fix subversion universal build

### DIFF
--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -28,6 +28,12 @@ class Subversion < Formula
   depends_on "pkg-config" => :build
   depends_on :apr => :build
 
+  if build.universal?
+    depends_on :apr => [:build, :universal]
+  else
+    depends_on :apr => :build
+  end
+
   # Always build against Homebrew versions instead of system versions for consistency.
   depends_on "sqlite"
   depends_on :python => :optional

--- a/Library/Homebrew/requirements/apr_dependency.rb
+++ b/Library/Homebrew/requirements/apr_dependency.rb
@@ -3,12 +3,15 @@ require "requirement"
 class AprDependency < Requirement
   fatal true
   default_formula "apr"
+  default_formula "apr-util"
 
+  satisfy { MacOS::CLT.installed? || Formula["apr-util"].installed? }
   satisfy { MacOS::CLT.installed? || Formula["apr"].installed? }
 
   env do
     unless MacOS::CLT.installed?
-      ENV.prepend_path "PATH", "#{Formula["apr-util"].opt_prefix}/bin"
+      ENV.prepend_path "PATH", "#{Formula["apr-util"].opt_bin}"
+      ENV.prepend_path "PATH", "#{Formula["apr"].opt_bin}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_prefix}/libexec/lib/pkgconfig"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_prefix}/libexec/lib/pkgconfig"
     end


### PR DESCRIPTION
This 'completes' the APR dep, by enforcing the necessary ` apr-util ` at the same time ` apr ` is generated. I realised people haven’t actually been seeing the “Install apr-util” message from the requirement because
it just insta-pulls in the ` apr ` formula if the CLT is not present.

I’ve also created an (*admittedly undocumented*) way to handle apr being pulled in universally, since the requirement was just handing off a non-universal build of apr to subversion every time. Subversion is the only Apr-using build with a universal option, so having it phrased like this isn’t too odious, *hopefully*. Open to better solutions if people have them.

Confirmed multiple times locally this produces universal binaries and compiles successfully. This will solve the universal subversion issues we've been seeing lately.

Closes #36301
Closes #36438