### PR TITLE
Update Jenkins default IP address

### DIFF
--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -36,7 +36,7 @@ class Jenkins < Formula
           <string>-Dmail.smtp.starttls.enable=true</string>
           <string>-jar</string>
           <string>#{opt_libexec}/jenkins.war</string>
-          <string>--httpListenAddress=127.0.0.1</string>
+          <string>--httpListenAddress=0.0.0.0</string>
           <string>--httpPort=8080</string>
         </array>
         <key>RunAtLoad</key>


### PR DESCRIPTION
Use the address of `0.0.0.0` as it is the default Jenkins value, and this will cause listening on all interfaces. This is documented [here](https://wiki.jenkins-ci.org/display/JENKINS/Starting+and+Accessing+Jenkins).