### PR TITLE
GitDownloadStrategy: support submodule changes

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -646,6 +646,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   end
 
   def update_submodules
+    quiet_safe_system "git", "submodule", "sync", "--recursive"
     quiet_safe_system "git", "submodule", "update", "--init", "--recursive"
   end
 


### PR DESCRIPTION
This commits adds support for updating a formula with changed git submodules with GitDownloadStrategy when the cloned repository is still in the cache.
This is done by running `git submodule sync --recursive` before updating the submodules, so that git can reload the submodule config from the updated .gitmodules file.

Fixes #36395