### PR TITLE
GiNaC: update to 1.6.3

### DIFF
--- a/Library/Formula/ginac.rb
+++ b/Library/Formula/ginac.rb
@@ -2,18 +2,12 @@ require 'formula'
 
 class Ginac < Formula
   homepage 'http://www.ginac.de/'
-  url 'http://www.ginac.de/ginac-1.6.2.tar.bz2'
-  sha1 'c93913c4c543874b2ade4f0390030641be7e0c41'
+  url 'http://www.ginac.de/ginac-1.6.3.tar.bz2'
+  sha1 '39ebd0035491da84ca3406688c15930faebe5ef1'
 
   depends_on 'pkg-config' => :build
   depends_on 'cln'
   depends_on 'readline'
-
-  # Fixes compilation with libc++; already applied upstream
-  patch do
-    url "http://www.ginac.de/ginac.git?p=ginac.git;a=commitdiff_plain;h=5bf87cea66bb2071222c2910ed68c2649a98906c"
-    sha1 "415dad5f0f233268ad743e5beacf99c03bb339ae"
-  end
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
During `brew install ginac`, `curl` can't find the upstream patch for libc++:

```
==> Downloading http://www.ginac.de/ginac.git?p=ginac.git;a=commitdiff_plain;h=5bf87cea66bb2071222c2910ed68c2649a98906c

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "ginac--patch"
Download failed: http://www.ginac.de/ginac.git?p=ginac.git;a=commitdiff_plain;h=5bf87cea66bb2071222c2910ed68c2649a98906c
```

Although it is possible to correct the URL as http://www.ginac.de/ginac.git/?p=ginac.git;a=commitdiff_plain;h=5bf87cea66bb2071222c2910ed68c2649a98906c (`/` before `?` seems to be needed), I would like to suggest to update GiNaC to 1.6.3, released in last November.
