### PR TITLE
'brew version' added

### DIFF
--- a/Library/Homebrew/cmd/version.rb
+++ b/Library/Homebrew/cmd/version.rb
@@ -1,0 +1,9 @@
+module Homebrew
+  def version
+    raise FormulaUnspecifiedError if ARGV.named.empty?
+
+    ARGV.formulae.each do |f|
+      puts "#{f.name} #{f.version}"
+    end
+  end
+end

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -398,6 +398,9 @@ Note that these flags should only appear after a command.
     If <formulae> are given, upgrade only the specified brews (but do so even
     if they are pinned; see `pin`, `unpin`).
 
+  * `version <formulae>`
+    Print the version of <formulae>.
+
   * `uses [--installed] [--recursive] [--devel|--HEAD]` <formulae>:
     Show the formulae that specify <formulae> as a dependency. When given
     multiple formula arguments, show the intersection of formulae that use


### PR DESCRIPTION
This adds a `version` command to `brew`, which takes one or more formulae and prints each one’s version. This is useful when you’re looking for upgrades for a formula and need to have its current version. If no formulae are given it behaves like `brew --version` (except that it prints on standard output) instead of failing.

Let me know if you think this is useful. It overlaps `brew info` but in a less verbose way.