### PR TITLE
Add imagejs v0.7.1

### DIFF
--- a/Library/Formula/imagejs.rb
+++ b/Library/Formula/imagejs.rb
@@ -1,0 +1,16 @@
+class Imagejs < Formula
+  homepage "http://jklmnn.de/imagejs/"
+  url "https://github.com/jklmnn/imagejs/archive/0.7.1.tar.gz"
+  sha1 "4c3e1c2134194cced5924c9cc577d36165548575"
+  head "https://github.com/jklmnn/imagejs.git"
+
+  def install
+    system "make"
+    bin.install "imagejs"
+  end
+
+  test do
+    (testpath/"test.js").write "alert('Hello World!')"
+    system "#{bin}/imagejs", "bmp", "test.js", "-l"
+  end
+end


### PR DESCRIPTION
From the homepage, http://jklmnn.de/imagejs/:
> imagejs is a small tool to hide javascript inside a valid image file. The image file is recognized as one by content checking software, e.g. the file command you might now from Linux or other Unix based operation systems.