### PR TITLE
Update paq8px to pass strict audit/style test

### DIFF
--- a/Library/Formula/paq8px.rb
+++ b/Library/Formula/paq8px.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Paq8px < Formula
   homepage "http://dhost.info/paq8/"
   url "http://dhost.info/paq8/paq8px_v69.zip"
@@ -11,13 +9,13 @@ class Paq8px < Formula
   end
 
   test do
-    system "touch test.txt"
-    system "echo Foobarbaz > test.txt"
+    touch "test.txt"
+    system "echo", "Foobarbaz", ">", "test.txt"
     system "yes | #{bin}/paq8px test.txt"
     system "yes | #{bin}/paq8px test.txt.paq8px"
-    system "rm test.txt"
+    rm "test.txt"
     system "yes | #{bin}/paq8px test.txt.paq8px"
-    system "rm test.txt"
-    system "rm test.txt.paq8px"
+    rm "test.txt"
+    rm "test.txt.paq8px"
   end
 end


### PR DESCRIPTION
I originally wrote this Formula awhile ago, have now updated it to replace `system "touch ..."` and `system "rm ..."` with `touch "..."` and `rm "..."`. I've also removed `require 'formula'`. I tried to break apart the system calls in the `test` block but it seems to break the test for some reason, so I kept that as-is.