### PR TITLE
objective-caml: pass correct configure flags for bottling

### DIFF
--- a/Library/Formula/objective-caml.rb
+++ b/Library/Formula/objective-caml.rb
@@ -19,10 +19,10 @@ class ObjectiveCaml < Formula
     args = %W[
       --prefix #{HOMEBREW_PREFIX}
       --mandir #{man}
-      -cc #{ENV.cc}
       -with-debug-runtime
     ]
-    args << "-aspp" << "#{ENV.cc} -c"
+    args << "-cc" << "#{ENV.cc} #{ENV.cflags}"
+    args << "-aspp" << "#{ENV.cc} #{ENV.cflags} -c"
     args << "-no-graph" if build.without? "x11"
 
     ENV.deparallelize # Builds are not parallel-safe, esp. with many cores


### PR DESCRIPTION
See https://github.com/ocaml/opam/issues/1853 : not passing the flags to
./configure generates an OCaml compiler that compiles for the current arch,
breaking bottles of projects compiled using OCaml on older CPUs.