### PR TITLE
bibtex2html: fix test on 10.8.

### DIFF
--- a/Library/Formula/bibtex2html.rb
+++ b/Library/Formula/bibtex2html.rb
@@ -37,7 +37,7 @@ class Bibtex2html < Formula
       }
     EOS
     system "#{bin}/bib2bib", "test.bib", "--remove", "pages", "-ob", "out.bib"
-    assert_not_match /pages\s*=\s*{3--4}/, File.read("out.bib")
+    assert /pages\s*=\s*{3--4}/ !~ File.read("out.bib")
     assert_match /pages\s*=\s*{3--4}/, File.read("test.bib")
   end
 end


### PR DESCRIPTION
assert_not_match is not available there.