### PR TITLE
WiRouterKeyRec Formula

### DIFF
--- a/Library/Formula/wirouter_keyrec.rb
+++ b/Library/Formula/wirouter_keyrec.rb
@@ -5,11 +5,8 @@ class WirouterKeyrec < Formula
   sha1 "3c17f2d0bf3d6201409862fd903ebfd60c1e8a2e"
 
   def install
-  	ENV.deparallelize
-    ENV.no_optimization
-	
-	inreplace "src/agpf.h", /\/etc\/wirouterkeyrec/, "#{prefix}/etc/config"
-	inreplace "src/teletu.h", /\/etc\/wirouterkeyrec/, "#{prefix}/etc/config"
+  	inreplace "src/agpf.h", /\/etc/, "#{prefix}/etc"
+	inreplace "src/teletu.h", /\/etc/, "#{prefix}/etc"
 	
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -18,9 +15,8 @@ class WirouterKeyrec < Formula
                           "--sysconfdir=#{prefix}",
                           "--exec-prefix=#{prefix}"
     system "make prefix=#{prefix}"
+    system "make", "install", "DESTDIR=#{prefix}", "BIN_DIR=bin/"
     
-    (bin).install "build/wirouterkeyrec"
-    (prefix/"etc").install "config"
   end
 
   test do

--- a/Library/Formula/wirouter_keyrec.rb
+++ b/Library/Formula/wirouter_keyrec.rb
@@ -1,0 +1,31 @@
+class WirouterKeyrec < Formula
+  homepage ""
+  url "http://tools.salvatorefresta.net/WiRouter_KeyRec_1.1.2.zip"
+  version "1.1.2"
+  sha1 "3c17f2d0bf3d6201409862fd903ebfd60c1e8a2e"
+
+
+  def install
+  	ENV.deparallelize
+    ENV.no_optimization
+	
+	inreplace "src/agpf.h", /\/etc\/wirouterkeyrec/, "#{prefix}/etc/config"
+	inreplace "src/teletu.h", /\/etc\/wirouterkeyrec/, "#{prefix}/etc/config"
+	
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{prefix}",
+                          "--exec-prefix=#{prefix}"
+    system "make prefix=#{prefix}"
+    
+    (bin).install "build/wirouterkeyrec"
+    (prefix/"etc").install "config"
+  end
+
+  test do
+    
+    system "#{bin}/wirouterkeyrec -s Alice-123456"
+  end
+end

--- a/Library/Formula/wirouter_keyrec.rb
+++ b/Library/Formula/wirouter_keyrec.rb
@@ -1,9 +1,8 @@
 class WirouterKeyrec < Formula
-  homepage ""
+  homepage "http://www.salvatorefresta.net/tools/"
   url "http://tools.salvatorefresta.net/WiRouter_KeyRec_1.1.2.zip"
   version "1.1.2"
   sha1 "3c17f2d0bf3d6201409862fd903ebfd60c1e8a2e"
-
 
   def install
   	ENV.deparallelize


### PR DESCRIPTION
From Website http://www.salvatorefresta.net/tools/:
WiRouter KeyRec is a powerful and platform independent software to recover the default WPA passphrases of the supported router models (Telecom Italia Alice AGPF, Fastweb Pirelli, Fastweb Tesley, Eircom Netopia, Pirelli TeleTu/Tele 2).