### PR TITLE
Created WiRouterKeyRec Formula

### DIFF
--- a/Library/Formula/wirouter_keyrec.rb
+++ b/Library/Formula/wirouter_keyrec.rb
@@ -1,0 +1,25 @@
+class WirouterKeyrec < Formula
+  homepage "http://www.salvatorefresta.net/tools/"
+  url "http://tools.salvatorefresta.net/WiRouter_KeyRec_1.1.2.zip"
+  sha1 "3c17f2d0bf3d6201409862fd903ebfd60c1e8a2e"
+
+  def install
+    inreplace "src/agpf.h", /\/etc/, "#{prefix}/etc"
+    inreplace "src/teletu.h", /\/etc/, "#{prefix}/etc"
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{prefix}",
+                          "--exec-prefix=#{prefix}"
+    system "make prefix=#{prefix}"
+    system "make", "install", "DESTDIR=#{prefix}", "BIN_DIR=bin/"
+
+  end
+
+  test do
+
+    system "#{bin}/wirouterkeyrec -s Alice-12345678"
+  end
+end


### PR DESCRIPTION
From Website http://www.salvatorefresta.net/tools/:
WiRouter KeyRec is a powerful and platform independent software to recover the default WPA passphrases of the supported router models (Telecom Italia Alice AGPF, Fastweb Pirelli, Fastweb Tesley, Eircom Netopia, Pirelli TeleTu/Tele 2).