### PR TITLE
Updated download URL for Transmission formula.

### DIFF
--- a/Library/Formula/transmission.rb
+++ b/Library/Formula/transmission.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Transmission < Formula
   homepage "http://www.transmissionbt.com/"
-  url "http://download.transmissionbt.com/files/transmission-2.84.tar.xz"
+  url "https://transmission.cachefly.net/transmission-2.84.tar.xz"
   sha1 "455359bc1fa34aeecc1bac9255ad0c884b94419c"
 
   option "with-nls", "Build with native language support"


### PR DESCRIPTION
The old url not longer works, as they have moved to a CDN. It is the
same file though, so SHA1 checksum remains.