### PR TITLE
iojs 1.1.0

### DIFF
--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -1,7 +1,7 @@
 class Iojs < Formula
   homepage "https://iojs.org/"
-  url "https://iojs.org/dist/v1.0.4/iojs-v1.0.4.tar.xz"
-  sha256 "c902f5abbd59c56346680f0b4a71056c51610847b9576acf83a9c210bf664e98"
+  url "https://iojs.org/dist/v1.1.0/iojs-v1.1.0.tar.xz"
+  sha256 "2baa9b076c84c13b0572de4618ac94058fc98a87266925bcd18fb70fb7d521a7"
 
   bottle do
     sha1 "a88bf32209a487ed8329476325aeeed2cc5ddb33" => :yosemite
@@ -12,12 +12,20 @@ class Iojs < Formula
   keg_only "iojs conflicts with node (which is currently more established)"
 
   option "with-debug", "Build with debugger hooks"
+  option "with-icu4c", "Build with Intl (icu4c) support"
 
+  depends_on "pkg-config" => :build
+  depends_on "icu4c" => :optional
   depends_on :python => :build
 
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
+
+    if build.with? "icu4c"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["icu4c"].opt_lib}/pkgconfig"
+      args << "--with-intl=system-icu"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Version bump, and added the icu4c support already in Node’s devel and head versions, which match to iojs’ current releases.