### PR TITLE
bear 2.0.1

### DIFF
--- a/Library/Formula/bear.rb
+++ b/Library/Formula/bear.rb
@@ -1,10 +1,10 @@
-require "formula"
-
 class Bear < Formula
   homepage "https://github.com/rizsotto/Bear"
-  url "https://github.com/rizsotto/Bear/archive/1.4.3.tar.gz"
-  sha1 "10a212ba608b9fae4101fb5cf8c05c4279524209"
+  url "https://github.com/rizsotto/Bear/archive/2.0.1.tar.gz"
+  sha1 "31cf2b82a44f6eb5a3740c9f8aa9f2cd662e9a68"
+  head "https://github.com/rizsotto/Bear.git"
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "libconfig"
@@ -17,6 +17,7 @@ class Bear < Formula
   end
 
   test do
-    system "#{bin}/bear", "--", "true"
+    system "#{bin}/bear", "true"
+    assert File.exist? "compile_commands.json"
   end
 end


### PR DESCRIPTION
The existing test seems to be erroring out now, so I’ve replaced it with what existed previously. Otherwise, just a bump.

Python dep as per `  python is a runtime dependency. The bear command is written in Python. (version >= 2.7) `.