### PR TITLE
Update ipmiutil to latest version, drop patch

### DIFF
--- a/Library/Formula/ipmiutil.rb
+++ b/Library/Formula/ipmiutil.rb
@@ -2,11 +2,8 @@ require 'formula'
 
 class Ipmiutil < Formula
   homepage 'http://ipmiutil.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.1.tar.gz'
-  sha1 'f23fabe8339842fea9b8c2a601717dc002e44a9d'
-
-  # Make ipmiutil treat Darwin as BSD
-  patch :DATA
+  url 'https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz'
+  sha1 '265f022c876da373b2ecb4be2bc0f98e65f70977'
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
@@ -28,17 +25,3 @@ class Ipmiutil < Formula
     system "#{bin}/ipmiutil", "delloem", "help"
   end
 end
-
-__END__
-diff -u ./configure.bak ./configure
---- ./configure.bak	2012-09-18 23:19:11.000000000 +0800
-+++ ./configure	2012-09-18 23:21:04.000000000 +0800
-@@ -20983,7 +20983,7 @@
-	OS_CFLAGS="-DLINUX $MD2_CFLAGS $cfwarn"
-   else
-      # usually "x$sysname" = "xFreeBSD", but allow NetBSD
--     echo $sysname | grep BSD >/dev/null 2>&1
-+     echo $sysname | grep 'BSD\|Darwin' >/dev/null 2>&1
-      if test $? -eq 0; then
-	os=bsd
-	OS_CFLAGS="-DBSD"

--- a/Library/Formula/ipmiutil.rb
+++ b/Library/Formula/ipmiutil.rb
@@ -7,7 +7,11 @@ class Ipmiutil < Formula
 
   depends_on "openssl"
 
+  # Ensure ipmiutil does not try to link against (disabled) OpenSSL's MD2
+  # support. Patch submitted upstream in
+  # http://sourceforge.net/p/ipmiutil/mailman/message/33373858/
   patch :DATA
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Library/Formula/ipmiutil.rb
+++ b/Library/Formula/ipmiutil.rb
@@ -5,6 +5,8 @@ class Ipmiutil < Formula
   url 'https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz'
   sha1 '265f022c876da373b2ecb4be2bc0f98e65f70977'
 
+  depends_on "openssl"
+
   patch :DATA
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Library/Formula/ipmiutil.rb
+++ b/Library/Formula/ipmiutil.rb
@@ -5,6 +5,7 @@ class Ipmiutil < Formula
   url 'https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz'
   sha1 '265f022c876da373b2ecb4be2bc0f98e65f70977'
 
+  patch :DATA
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -25,3 +26,26 @@ class Ipmiutil < Formula
     system "#{bin}/ipmiutil", "delloem", "help"
   end
 end
+
+__END__
+diff -u ./configure.bak ./configure
+--- ./configure.bak       2015-02-04 22:15:07.000000000 +0100
++++ ./configure   2015-02-04 22:16:18.000000000 +0100
+@@ -20739,7 +20739,7 @@
+            echo "Detected HP-UX"
+            os=hpux
+            MD2_CFLAGS="-DSKIP_MD2"
+-           OS_CFLAGS="-DHPUX"
++           OS_CFLAGS="-DHPUX $MD2_CFLAGS"
+            OS_LFLAGS=""
+            OS_DRIVERS="ipmimv.c"
+            drivers="open"
+@@ -20748,7 +20748,7 @@
+            echo "Detected MacOSX"
+            os=macos
+            MD2_CFLAGS="-DSKIP_MD2"
+-           OS_CFLAGS="-DMACOS"
++           OS_CFLAGS="-DMACOS $MD2_CFLAGS"
+            OS_LFLAGS=""
+           OS_DRIVERS="ipmimv.c ipmidir.c"
+           drivers="open direct"


### PR DESCRIPTION
ipmiutil now compiles only when dropping the patch (which was added in d3e4b08b93f4d59d4c1ea87788d61eb4b0aceb1e / #15049, described as "just made it compile"); after install, `ipmiutil discover` worked (more testing is pending).

Caveat: I've just updated the formula to the latest version, not done much quality assurance beyond "it compiles".

However, `brew audit` reports I should probably depend on OpenSSL:
```
$ brew audit ipmiutil
ipmiutil:
 * object files were linked against system openssl
These object files were linked against the deprecated system OpenSSL.
Adding `depends_on "openssl"` to the formula may help.
  /usr/local/Cellar/ipmiutil/2.9.5/bin/ipmiutil
  /usr/local/Cellar/ipmiutil/2.9.5/sbin/iseltime

Error: 1 problems in 1 formulae
```

But if I add the dependency, I get errors (which I didn't investigate yet):
```
==> make TMPDIR=/var/folders/_7/hlxv4yv95x95vgnn416b4q4m0000gp/T/
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libipmiutil.a(ipmild.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libipmiutil.a(ipmibmc.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libipmiutil.a(ipmilipmi.o) has no symbols
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```