### PR TITLE
botan 1.10.9

### DIFF
--- a/Library/Formula/botan.rb
+++ b/Library/Formula/botan.rb
@@ -1,10 +1,7 @@
-require "formula"
-
 class Botan < Formula
   homepage "http://botan.randombit.net/"
-  url "http://files.randombit.net/botan/Botan-1.10.8.tgz"
-  sha1 "078fcb03c9ef0691621eda3ca312ebf08b3890cc"
-  revision 1
+  url "http://botan.randombit.net/releases/Botan-1.10.9.tgz"
+  sha1 "e1c8e97b214b23931f7dc8aba44306fbeca9055c"
 
   bottle do
     sha1 "89d491598019e57540e22089c3c7a3d45a845adc" => :yosemite
@@ -12,7 +9,9 @@ class Botan < Formula
     sha1 "2efea61b9f63b8344617a90eb4dc0445baab0243" => :mountain_lion
   end
 
-  option "enable-debug", "Enable debug build of Botan"
+  option "with-debug", "Enable debug build of Botan"
+
+  deprecated_option "enable-debug" => "with-debug"
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
@@ -32,12 +31,16 @@ class Botan < Formula
       --with-bzip2
     ]
 
-    args << "--enable-debug" if build.include? "enable-debug"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure.py", *args
     # A hack to force them use our CFLAGS. MACH_OPT is empty in the Makefile
     # but used for each call to cc/ld.
     system "make", "install", "MACH_OPT=#{ENV.cflags}"
+  end
+
+  test do
+    assert_match /lcrypto/, shell_output("#{bin}/botan-config-1.10 --libs")
   end
 end
 


### PR DESCRIPTION
Version bump, deprecated an option in favour of newer syntax, added a relatively simple test.