### PR TITLE
updating gsasl to working download url

### DIFF
--- a/Library/Formula/gsasl.rb
+++ b/Library/Formula/gsasl.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gsasl < Formula
   homepage 'http://www.gnu.org/software/gsasl/'
-  url 'http://ftpmirror.gnu.org/gsasl/gsasl-1.8.0.tar.gz'
+  url 'ftp://ftp.gnu.org/gnu/gsasl/gsasl-1.8.0.tar.gz'
   bottle do
     cellar :any
     revision 1


### PR DESCRIPTION
The current URL for the lib is broken, this PR points it to a working URL.

Here is where the lib is being kept now:
ftp://ftp.gnu.org/gnu/gsasl/