### PR TITLE
hello: remove --next-generation from test

### DIFF
--- a/Library/Formula/hello.rb
+++ b/Library/Formula/hello.rb
@@ -13,6 +13,6 @@ class Hello < Formula
     system "make", "install"
   end
   test do
-     system "#{bin}/hello", "--next-generation", "--greeting=brew"
+     system "#{bin}/hello", "--greeting=brew"
   end
 end


### PR DESCRIPTION
Fix the error: `hello: unrecognized option '--next-generation'`

## Before

```
❯❯❯ brew test hello -v
Testing hello
==> /usr/local/Cellar/hello/2.10/bin/hello --next-generation --greeting=brew
/usr/local/Cellar/hello/2.10/bin/hello: unrecognized option '--next-generation'
/usr/local/Cellar/hello/2.10/bin/hello: extra operand: (null)
```

## After

```
❯❯❯ brew test hello -v
Testing hello
==> /usr/local/Cellar/hello/2.10/bin/hello --greeting=brew
brew
```
