### PR TITLE
Dependencies inheirit --without-x11 and --without-x flags.  #36542

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -292,10 +292,21 @@ class FormulaInstaller
 
   def inherited_options_for(dep)
     inherited_options = Options.new
+
+    # Universal is a special case of an inheritable option
     u = Option.new("universal")
     if (options.include?(u) || formula.require_universal_deps?) && !dep.build? && dep.to_formula.option_defined?(u)
       inherited_options << u
     end
+
+    # Handle other inheritable options
+    inheritableOptions = [Option.new("without-x11"), Option.new("without-x")]
+    inheritableOptions.each do |inheritableOption|
+      if options.include?(inheritableOption) && !dep.build? && dep.to_formula.option_defined?(inheritableOption)
+        inherited_options << inheritableOption
+      end
+    end
+
     inherited_options
   end
 


### PR DESCRIPTION
This change allows --without-x11 and --without-x to propagate to dependencies, which should be the desired behavior.  Having dependencies linked to x11 and the main target linked to quartz causes major issues.