### PR TITLE
Adjust help_regex to match a `help` instead of `.*help`

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -82,7 +82,7 @@ begin
              }
 
   empty_argv = ARGV.empty?
-  help_regex = /(-h$|--help$|--usage$|-\?$|help$)/
+  help_regex = /(-h$|--help$|--usage$|-\?$|^help$)/
   help_flag = false
   cmd = nil
 


### PR DESCRIPTION
This is one way of fixing https://github.com/Homebrew/homebrew/issues/36559 