### PR TITLE
autoconf: autoreconf manpage generation fixed

### DIFF
--- a/Library/Formula/autoconf.rb
+++ b/Library/Formula/autoconf.rb
@@ -1,8 +1,11 @@
 class Autoconf < Formula
-  homepage "http://www.gnu.org/software/autoconf"
+  homepage "https://www.gnu.org/software/autoconf"
   url "http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
   sha1 "562471cbcb0dd0fa42a76665acf0dbb68479b78a"
+  revision 1
+
+  depends_on "help2man" => :build
 
   bottle do
     revision 1
@@ -19,8 +22,6 @@ class Autoconf < Formula
 
     # force autoreconf to look for and use our glibtoolize
     inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"
-    # also touch the man page so that it isn't rebuilt
-    inreplace "man/autoreconf.1", "libtoolize", "glibtoolize"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
     rm_f info/"standards.info"


### PR DESCRIPTION
Without this, when you type `man autoreconf`, you’d get:

    help2man is required to generate this page

You can see it in the file:

```
$ cat Cellar/autoconf/2.69/share/man/man1/autoreconf.1
.ab help2man is required to generate this page
```