### PR TITLE
git-annex 5.20150205

### DIFF
--- a/Library/Formula/git-annex.rb
+++ b/Library/Formula/git-annex.rb
@@ -24,6 +24,7 @@ class GitAnnex < Formula
   depends_on "libidn"
   depends_on "gnutls"
   depends_on "gmp"
+  depends_on "quvi"
 
   fails_with(:clang) { build 425 } # clang segfaults on Lion
 
@@ -33,7 +34,8 @@ class GitAnnex < Formula
       # gcc required to build gnuidn
       gcc = Formula["gcc"]
       cabal_install "--with-gcc=#{gcc.bin}/gcc-#{gcc.version_suffix}",
-                    "--only-dependencies"
+                    "--only-dependencies",
+                    "--constraint=utf8-string==0.3.8" # use older utf8-string until 'feed' is updated
       cabal_install "--prefix=#{prefix}"
     end
     bin.install_symlink "git-annex" => "git-annex-shell"

--- a/Library/Formula/git-annex.rb
+++ b/Library/Formula/git-annex.rb
@@ -1,12 +1,11 @@
-require "formula"
 require "language/haskell"
 
 class GitAnnex < Formula
   include Language::Haskell::Cabal
 
   homepage "https://git-annex.branchable.com/"
-  url "https://hackage.haskell.org/package/git-annex-5.20150113/git-annex-5.20150113.tar.gz"
-  sha1 "b45b285ef4b75ffd4fd0fa7d9795c507e8edbcfb"
+  url "https://hackage.haskell.org/package/git-annex-5.20150205/git-annex-5.20150205.tar.gz"
+  sha1 "5df6114cb029531e429e2b423f5ae7f755ffa390"
 
   bottle do
     cellar :any


### PR DESCRIPTION
* Update to latest stable release
* Fix dependency building by forcing usage of an older version of *utf8-string* that *feed* currently requires.
* Add *quvi* dependency (per #36309, #36319)