### PR TITLE
node 0.12.0

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -1,8 +1,9 @@
 # Note that x.even are stable releases, x.odd are devel releases
 class Node < Formula
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz"
-  sha256 "b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81"
+  url "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz"
+  sha256 "9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32"
+  head "https://github.com/joyent/node.git", :branch => "v0.12"
 
   bottle do
     sha1 "ca405f33a5c8e3356a0f477eee43e492e7925927" => :yosemite
@@ -10,56 +11,35 @@ class Node < Formula
     sha1 "b5d7094ed826813b2cc35303bcde8269b1ad9292" => :mountain_lion
   end
 
-  devel do
-    url "https://nodejs.org/dist/v0.11.16/node-v0.11.16.tar.gz"
-    sha256 "f0d141faa1f7da3aff53e9615d76040d29c0650542be3b09ee80aca2f2cc61f6"
-
-    depends_on "pkg-config" => :build
-    depends_on "icu4c" => :optional
-    depends_on "openssl" => :optional
-  end
-
-  head do
-    url "https://github.com/joyent/node.git", :branch => "v0.12"
-
-    depends_on "pkg-config" => :build
-    depends_on "icu4c"
-  end
-
-  deprecated_option "enable-debug" => "with-debug"
-
   option "with-debug", "Build with debugger hooks"
   option "without-npm", "npm will not be installed"
   option "without-completion", "npm bash completion will not be installed"
 
-  depends_on :python => :build
+  deprecated_option "enable-debug" => "with-debug"
 
-  # Once we kill off SSLv3 in our OpenSSL consider making our OpenSSL
-  # an optional dep across the whole range of Node releases.
+  depends_on :python => :build
+  depends_on "pkg-config" => :build
+  depends_on "icu4c" => :recommended
+  depends_on "openssl" => :optional
 
   fails_with :llvm do
     build 2326
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.3.0.tgz"
-    sha1 "3588ec5c18fb5ac41e5721b0ea8ece3a85ab8b4b"
+    url "https://registry.npmjs.org/npm/-/npm-2.5.1.tgz"
+    sha1 "23e4b0fdd1ffced7d835780e692a9e5a0125bb02"
   end
 
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
-    args << "--without-ssl2" << "--without-ssl3" if build.stable?
-    args << "--with-intl=system-icu" if build.head?
+    args << "--with-intl=system-icu" if build.with? "icu4c"
 
-    if build.devel?
-      args << "--with-intl=system-icu" if build.with? "icu4c"
-
-      if build.with? "openssl"
-        args << "--shared-openssl"
-      else
-        args << "--without-ssl2" << "--without-ssl3"
-      end
+    if build.with? "openssl"
+      args << "--shared-openssl"
+    else
+      args << "--without-ssl2" << "--without-ssl3"
     end
 
     system "./configure", *args


### PR DESCRIPTION
Shoot me in the arm and colour me surprised, Node 0.12 has landed stable.

Also bump npm to 2.5.1 - Although marked pre-release by upstream this is the npm version shipped in this Node release, and currently in iojs as well, and npm is actively nudging people into deliberately jumping over the normal release schedule just for once, so following that lead here.

I’ve also taken the chance to simplify the formula quite a bit, removing the increasingly complicated devel/head/stable logic and meshing it back into one easier block. The icu4c dep lands as recommended because Node upstream are shipping binaries with that support (in English) available. OpenSSL remains optional, but is moved to general availability rather than just devel for the sake of simplification and having it optional everywhere causing no harm.

Deps may need rebuilding. I’m hoping the bot is kind enough to check the bottles of the formulae that have them, but I’ll do a general double check ASAP. Despite the 0.11.x branch being technically older than 0.12 stable the 0.11.x branch remains devel for now, even though the bot won’t like that at all.