### PR TITLE
kafka 0.8.2.0

### DIFF
--- a/Library/Formula/kafka.rb
+++ b/Library/Formula/kafka.rb
@@ -32,7 +32,7 @@ class Kafka < Formula
     libexec.install %w(clients contrib core examples system_test)
 
     prefix.install "bin"
-    bin.env_script_all_files(libexec/"bin", :JAVA_HOME => "${JAVA_HOME:=`/usr/libexec/java_home`}")
+    bin.env_script_all_files(libexec/"bin", :JAVA_HOME => "`/usr/libexec/java_home`")
 
     mv "config", "kafka"
     etc.install "kafka"

--- a/Library/Formula/kafka.rb
+++ b/Library/Formula/kafka.rb
@@ -3,18 +3,17 @@ require "formula"
 class Kafka < Formula
   homepage "http://kafka.apache.org"
   head "http://git-wip-us.apache.org/repos/asf/kafka.git"
-  url "http://mirrors.ibiblio.org/apache/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz"
-  mirror "http://mirror.sdunix.com/apache/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz"
-  sha1 "104c15d22da36216a678e6a0c3243c552e47af87"
+  url "http://mirrors.ibiblio.org/apache/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz"
+  mirror "http://mirror.sdunix.com/apache/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz"
+  sha1 "d2c35b60a2f534fb552030dcc7855d13292b2414"
 
+  depends_on "gradle"
   depends_on "zookeeper"
   depends_on :java => "1.7"
 
   def install
-    system "./gradlew", "jar"
-
-    # Use 1 partition by default so individual consumers receive all topic messages
-    inreplace "config/server.properties", "num.partitions=2", "num.partitions=1"
+    system "gradle"
+    system "gradle", "jar"
 
     logs = var/"log/kafka"
     inreplace "config/log4j.properties", "kafka.logs.dir=logs", "kafka.logs.dir=#{logs}"
@@ -27,10 +26,13 @@ class Kafka < Formula
     inreplace "config/zookeeper.properties",
       "dataDir=/tmp/zookeeper", "dataDir=#{data}/zookeeper"
 
-    libexec.install %w(contrib core examples lib perf system_test)
+    # Workaround for conflicting slf4j-log4j12 jars (1.7.6 is preferred)
+    rm_f "core/build/dependant-libs-2.10.4/slf4j-log4j12-1.6.1.jar"
+
+    libexec.install %w(clients contrib core examples system_test)
 
     prefix.install "bin"
-    bin.env_script_all_files(libexec/"bin", :JAVA_HOME => "`/usr/libexec/java_home`")
+    bin.env_script_all_files(libexec/"bin", :JAVA_HOME => "${JAVA_HOME:=`/usr/libexec/java_home`}")
 
     mv "config", "kafka"
     etc.install "kafka"
@@ -40,13 +42,6 @@ class Kafka < Formula
   def caveats; <<-EOS.undent
     To start Kafka, ensure that ZooKeeper is running and then execute:
       kafka-server-start.sh #{etc}/kafka/server.properties
-
-    Gradle's Scala plugin is not Java 8 compatible, so you may have to
-    use Java 7, see:
-      http://issues.gradle.org/browse/GRADLE-3023
-
-    If you have Java 7 installed along with other versions, try:
-      JAVA_HOME=$(/usr/libexec/java_home -v 1.7) brew install kafka
     EOS
   end
 end

--- a/Library/Formula/kafka.rb
+++ b/Library/Formula/kafka.rb
@@ -9,7 +9,7 @@ class Kafka < Formula
 
   depends_on "gradle"
   depends_on "zookeeper"
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
 
   def install
     system "gradle"


### PR DESCRIPTION
- Upgrade to latest stable kafka server
- Regenerate the gradle wrapper before building the jar
- Remove the number of partitions replace; `num.partitions=1` is now the default
- Update installed folders to match upstream refactoring
- Remove warning about Java 7, latest stable supports both Java 7 and 8