### PR TITLE
mpd 0.19.9

### DIFF
--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -4,8 +4,8 @@ class Mpd < Formula
   homepage "http://www.musicpd.org/"
 
   stable do
-    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.8.tar.xz"
-    sha1 "e5e325b666474bddec6c07502fa2dcf3710a42e3"
+    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.9.tar.xz"
+    sha1 "6683bee5f132eda318c5a61ec14b2df8d9164d60"
   end
 
   bottle do


### PR DESCRIPTION
This is a bugfix release:
* decoder
 - dsdiff, dsf: raise ID3 tag limit to 1 MB
* playlist: fix loading duplicate tag types from state file
* despotify: remove defunct plugin
* fix clock integer overflow on OS X
* fix gcc 5.0 warnings
* fix build failure with uClibc
* fix build failure on non-POSIX operating systems
* fix dependency issue on parallel Android build
* fix database/state file saving on Windows