### PR TITLE
libwebsockets: 1.3

### DIFF
--- a/Library/Formula/libwebsockets.rb
+++ b/Library/Formula/libwebsockets.rb
@@ -2,10 +2,12 @@ require 'formula'
 
 class Libwebsockets < Formula
   homepage 'http://libwebsockets.org'
-  url 'http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot/libwebsockets-1.23-chrome32-firefox24.tar.gz'
-  version '1.23'
-  sha1 '9dda683a342b16feb1cef183f89f9ed4474626f5'
+  url 'http://git.libwebsockets.org/cgi-bin/cgit/libwebsockets/snapshot/libwebsockets-1.3-chrome37-firefox30.tar.gz'
+  version '1.3'
+  sha1 'ee1005165346d2217db4a9c40c4711f741213557'
   head 'git://git.libwebsockets.org/libwebsockets'
+
+  depends_on "openssl"
 
   bottle do
     cellar :any
@@ -20,11 +22,6 @@ class Libwebsockets < Formula
   def install
     system "cmake", ".", *std_cmake_args
     system "make"
-
-    # The `make install` target doesn't work so here's what I think
-    # should be installed:
-    lib.install 'lib/libwebsockets.dylib'
-    (lib+'pkgconfig').install 'libwebsockets.pc'
-    include.install 'lib/libwebsockets.h'
+    system "make", "install"
   end
 end


### PR DESCRIPTION
Updated to version 1.3
make install target fixed so that binaries and other resources are correctly installed.