### PR TITLE
libebml 1.3.1 / libmatroska 1.4.2

### DIFF
--- a/Library/Formula/libebml.rb
+++ b/Library/Formula/libebml.rb
@@ -1,12 +1,15 @@
-require 'formula'
-
 class Libebml < Formula
-  homepage 'http://www.matroska.org/'
-  url 'http://dl.matroska.org/downloads/libebml/libebml-1.3.0.tar.bz2'
-  mirror 'http://www.bunkus.org/videotools/mkvtoolnix/sources/libebml-1.3.0.tar.bz2'
-  sha256 '83b074d6b62715aa0080406ea84d33df2e44b5d874096640233a4db49b8096de'
+  homepage "http://www.matroska.org/"
+  url "http://dl.matroska.org/downloads/libebml/libebml-1.3.1.tar.bz2"
+  mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libebml-1.3.1.tar.bz2"
+  sha256 "195894b31aaca55657c9bc157d744f23b0c25597606b97cfa5a9039c4b684295"
 
-  head 'https://github.com/Matroska-Org/libebml.git'
+  head do
+    url "https://github.com/Matroska-Org/libebml.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
 
   bottle do
     cellar :any
@@ -19,6 +22,11 @@ class Libebml < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    system "make", "-C", "make/linux", "install", "prefix=#{prefix}", "CXX=#{ENV.cxx}"
+    system "autoreconf", "-fi" if build.head?
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
   end
 end

--- a/Library/Formula/libmatroska.rb
+++ b/Library/Formula/libmatroska.rb
@@ -1,8 +1,15 @@
 class Libmatroska < Formula
   homepage "http://www.matroska.org/"
-  url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.2.tar.bz2"
-  mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.2.tar.bz2"
-  sha256 "bea10320f1f1fd121bbd7db9ffc77b2518e8269f00903549c5425478bbf8393f"
+
+  stable do
+    url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.2.tar.bz2"
+    mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.2.tar.bz2"
+    sha256 "bea10320f1f1fd121bbd7db9ffc77b2518e8269f00903549c5425478bbf8393f"
+
+    # Apply upstream patch to link against libEBML
+    # https://github.com/Matroska-Org/libmatroska/commit/9466bf5f2b
+    patch :DATA
+  end
 
   head do
     url "https://github.com/Matroska-Org/libmatroska.git"
@@ -28,10 +35,6 @@ class Libmatroska < Formula
   end
 
   depends_on "pkg-config" => :build
-
-  # Apply upstream patch to link against libEBML
-  # https://github.com/Matroska-Org/libmatroska/commit/9466bf5f2b
-  patch :DATA if build.stable?
 
   def install
     ENV.cxx11 if build.cxx11?

--- a/Library/Formula/libmatroska.rb
+++ b/Library/Formula/libmatroska.rb
@@ -1,12 +1,15 @@
-require 'formula'
-
 class Libmatroska < Formula
-  homepage 'http://www.matroska.org/'
-  url 'http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.1.tar.bz2'
-  mirror 'http://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.1.tar.bz2'
-  sha256 '086f21873e925679babdabf793c3bb85c353d0cd79423543a3355e08e8a4efb7'
+  homepage "http://www.matroska.org/"
+  url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.2.tar.bz2"
+  mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.2.tar.bz2"
+  sha256 "bea10320f1f1fd121bbd7db9ffc77b2518e8269f00903549c5425478bbf8393f"
 
-  head 'https://github.com/Matroska-Org/libmatroska.git'
+  head do
+    url "https://github.com/Matroska-Org/libmatroska.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
 
   bottle do
     cellar :any
@@ -19,13 +22,61 @@ class Libmatroska < Formula
   option :cxx11
 
   if build.cxx11?
-    depends_on 'libebml' => 'c++11'
+    depends_on "libebml" => "c++11"
   else
-    depends_on 'libebml'
+    depends_on "libebml"
   end
+
+  depends_on "pkg-config" => :build
+
+  # Apply upstream patch to link against libEBML
+  # https://github.com/Matroska-Org/libmatroska/commit/9466bf5f2b
+  patch :DATA if build.stable?
 
   def install
     ENV.cxx11 if build.cxx11?
-    system "make", "-C", "make/linux", "install", "prefix=#{prefix}", "CXX=#{ENV.cxx}"
+
+    system "autoreconf", "-fi" if build.head?
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
   end
 end
+
+__END__
+diff --git a/Makefile.am b/Makefile.am
+index f3b881d..c6a728d
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -27,6 +27,7 @@ libmatroska_la_SOURCES = \
+ 	src/KaxTracks.cpp \
+ 	src/KaxVersion.cpp
+ libmatroska_la_LDFLAGS = -version-info 6:0:0 -no-undefined
++libmatroska_la_LIBADD = $(EBML_LIBS)
+ 
+ nobase_include_HEADERS = \
+ 	matroska/c/libmatroska.h \
+diff --git a/Makefile.in b/Makefile.in
+index dc52565..e677a4f 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -141,7 +141,8 @@ am__uninstall_files_from_dir = { \
+ am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(pkgconfigdir)" \
+ 	"$(DESTDIR)$(includedir)"
+ LTLIBRARIES = $(lib_LTLIBRARIES)
+-libmatroska_la_LIBADD =
++am__DEPENDENCIES_1 =
++libmatroska_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
+ am__dirstamp = $(am__leading_dot)dirstamp
+ am_libmatroska_la_OBJECTS = src/FileKax.lo src/KaxAttached.lo \
+ 	src/KaxAttachments.lo src/KaxBlock.lo src/KaxBlockData.lo \
+@@ -387,6 +398,7 @@ libmatroska_la_SOURCES = \
+ 	src/KaxVersion.cpp
+ 
+ libmatroska_la_LDFLAGS = -version-info 6:0:0 -no-undefined
++libmatroska_la_LIBADD = $(EBML_LIBS)
+ nobase_include_HEADERS = \
+ 	matroska/c/libmatroska.h \
+ 	matroska/c/libmatroska_t.h \


### PR DESCRIPTION
* libebml and libmatroska
  * Update to latest stable releases
  * Use Autotools on HEAD builds
  * Use new configure scripts
  * Modernize Formulas
* libmatroska
  * Apply upstream patch (Matroska-Org/libmatroska@9466bf5f2b) to link against libebml on stable builds
  * Use HTTPS on mirror link