### PR TITLE
gdbm: add with-libgdbm-compat to build ndbm header

### DIFF
--- a/Library/Formula/gdbm.rb
+++ b/Library/Formula/gdbm.rb
@@ -1,7 +1,7 @@
 class Gdbm < Formula
-  homepage "http://www.gnu.org/software/gdbm/"
-  url "http://ftpmirror.gnu.org/gdbm/gdbm-1.11.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/gdbm/gdbm-1.11.tar.gz"
+  homepage "https://www.gnu.org/software/gdbm/"
+  url "https://ftpmirror.gnu.org/gdbm/gdbm-1.11.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gdbm/gdbm-1.11.tar.gz"
   sha1 "ce433d0f192c21d41089458ca5c8294efe9806b4"
 
   bottle do
@@ -13,12 +13,20 @@ class Gdbm < Formula
   end
 
   option :universal
+  option "with-libgdbm-compat", "Build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
 
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
+
+    args << "--enable-libgdbm-compat" if build.with? "libgdbm-compat"
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
Change to gdbm formula to add an option to pass `--enable-libgdbm-compat` to `./configure`.

Updated urls to use https as advised by `brew audit gdbm`.

One issue is that running `brew audit gdbm` after installing `--with-libgdbm-compat` results in:

    gdbm:
     * Header files that shadow system header files were installed to "/usr/local/Cellar/gdbm/1.11/include"
    The offending files are:
      /usr/local/Cellar/gdbm/1.11/include/ndbm.h
    
    Error: 1 problems in 1 formulae

This seems acceptable given that this is the point of the option, and that it _is_ optional