### PR TITLE
audit: catch empty installations

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -659,6 +659,24 @@ class FormulaAuditor
     end
   end
 
+  def audit_prefix_has_contents
+    return unless formula.prefix.directory?
+
+    Dir.glob("#{formula.prefix}/**/*").each do |file|
+      path = Pathname.new file
+      next if path.directory?
+      basename = path.basename.to_s
+      return if !Metafiles.copy? basename
+      return if !%w[.DS_Store INSTALL_RECEIPT.json].include? basename
+    end
+
+    problem <<-EOS.undent
+      The installation seems to be empty. Please ensure the prefix
+      is set correctly and expected files are installed.
+      The prefix configure/make argument may be case-sensitive.
+    EOS
+  end
+
   def audit_conditional_dep(dep, condition, line)
     quoted_dep = quote_dep(dep)
     dep = Regexp.escape(dep.to_s)
@@ -691,6 +709,7 @@ class FormulaAuditor
     audit_text
     text.without_patch.split("\n").each_with_index { |line, lineno| audit_line(line, lineno+1) }
     audit_installed
+    audit_prefix_has_contents
   end
 
   private


### PR DESCRIPTION
Disclaimer: This is the freaking ugliest code I have ever written, by far. Please try not to judge me too harshly :smile_cat:. I’m hoping a less clunky way of handling this comes to mind before anyone spots this and just laughs. I tried a few things that I thought would work and this ended up being the only one that did. Boo. This is more of a *“This is a cool idea”* rather than an absolute *“This is the right way to do this”*.

Disclaimer out of the way:

This ensures that an installed formula actually has a ` bin/lib/libexec/sbin ` directory, and by implication is likely to have been installed correctly. This should prevent empty bottles/installs *(or rather, bottles/installs that only contain metafiles)* being generated, and catch the times when things are installed outside the expected prefix because of case-sensitive prefix arguments, envs going awry, so on, so forth. We’ve had a few of these in recent months.

This won’t catch everything, formulae for example that ` mkdir_p ` one of these directories prior to install will pass - But that doesn’t apply to any of the formula that have created empty installations in recent memory.

Just rolling some thoughts on this really. It isn’t perfect. It isn’t pretty. It’s kinda clunky and hideous, but it can be worked on if the general idea isn’t pointless.