### PR TITLE
carthage 0.5.3

### DIFF
--- a/Library/Formula/carthage.rb
+++ b/Library/Formula/carthage.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Carthage < Formula
   homepage "https://github.com/Carthage/Carthage"
-  url "https://github.com/Carthage/Carthage.git", :tag => "0.5.2",
+  url "https://github.com/Carthage/Carthage.git", :tag => "0.5.3",
                                                   :shallow => false
   head "https://github.com/Carthage/Carthage.git", :shallow => false
 
@@ -20,9 +20,6 @@ class Carthage < Formula
     cp_r cached_download/".git", "."
 
     system "make", "prefix_install", "PREFIX=#{prefix}"
-
-    # Carthage puts some stuff in /tmp so clean it up after we're done.
-    system "make", "clean"
   end
 
   test do


### PR DESCRIPTION
Also, the `make clean` step can now be removed, per @mikemcquaid in https://github.com/Carthage/Carthage/pull/284#issuecomment-70677079.

Sorry about the noise with #36645—I made a tagging mistake that had to be fixed.