### PR TITLE
fixes #36286

### DIFF
--- a/Library/Formula/fsharp.rb
+++ b/Library/Formula/fsharp.rb
@@ -21,25 +21,41 @@ class Fsharp < Formula
     system "make", "install"
   end
 
+  def post_install
+    mono_ver = Formula["mono"].version
+    %w|3.0 3.1|.each do |fsharp_ver|
+      %w|Microsoft.Portable.FSharp.Targets
+         Microsoft.FSharp.Targets|.each do |fsharp_targ|
+
+        tree_dir   = "lib/mono/Microsoft\ SDKs/F\#/#{fsharp_ver}/Framework/v4.0"
+        source_dir = File.expand_path "#{prefix}/../../mono/#{mono_ver}/#{tree_dir}"
+
+        # variables:
+        #  - tree_dir: the 'convoluted' non-absolute path the the installation, inside mono's prefix
+        #  - source_dir: tree_dir, inside mono's prefix, expanded to a full path
+        #  - fsharp_targ: the target file (for xbuild)
+        mkdir_p source_dir
+        ln_sf "#{prefix}/#{tree_dir}/#{fsharp_targ}", "#{source_dir}/#{fsharp_targ}"
+      end
+    end
+  end
+
   test do
     test_str = "Hello Homebrew"
     # fsharpi and fsharpc needs mono to be in the PATH
     ENV.prepend_path 'PATH', Formula["mono"].bin
 
-    output = `echo 'printfn "#{test_str}"; exit 0' | #{bin}/fsharpi`
-    assert $?.success?
+    output = shell_output %{echo 'printfn "#{test_str}"; exit 0' | #{bin}/fsharpi}
     assert output.include? test_str
 
     hello = (testpath/"hello.fs")
     hello.write("printfn \"#{test_str}\"\n")
-    `#{bin}/fsharpc #{hello}`
-    assert $?.success?
+    compiler_output = shell_output "#{bin}/fsharpc #{hello}"
     # make sure to find the fsharp assemblies even if the user has not set
     # MONO_GAC_PREFIX to HOMEBREW_PREFIX
     ENV["MONO_GAC_PREFIX"] = prefix
-    output = `#{Formula["mono"].bin}/mono hello.exe`
-    assert $?.success?
-    assert_equal test_str, output.strip
+    output = shell_output "#{Formula["mono"].bin}/mono hello.exe"
+    assert_match test_str, output.strip
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
These changes try to deal with the finicky .Targets files for compiling. See #36286 -- but this commit (3eceadf) still gives the latest error mentioned in #36286 (about file not found).

Help to make this work is appreciated.

 - Can this be done somehow, through the makefile instead?
 - What about the GAC links - is that what is breaking? But I'm referencing the files from a nuget, so that shouldn't be a problem, right?

/cc @rneatherway