### PR TITLE
brew-info: prevent duplicate display in dependencies

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -122,7 +122,7 @@ module Homebrew
     unless f.deps.empty?
       ohai "Dependencies"
       %w{build required recommended optional}.map do |type|
-        deps = f.deps.send(type)
+        deps = f.deps.send(type).uniq
         puts "#{type.capitalize}: #{decorate_dependencies deps}" unless deps.empty?
       end
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -593,7 +593,7 @@ class Formula
       "installed" => [],
       "linked_keg" => (linked_keg.resolved_path.basename.to_s if linked_keg.exist?),
       "keg_only" => keg_only?,
-      "dependencies" => deps.map(&:name),
+      "dependencies" => deps.map(&:name).uniq,
       "conflicts_with" => conflicts.map(&:name),
       "caveats" => caveats
     }


### PR DESCRIPTION
Before:

    $ brew info llvm
    ==> Dependencies
    Build: xz ✔, xz ✔, xz ✔, xz ✔, xz ✔, xz ✔

    $ brew info --json=v1 llvm
    ... "dependencies":["xz","xz","xz","xz","xz","xz"], ...

After

    $ brew info llvm
    ==> Dependencies
    Build: xz ✔

    $ brew info --json=v1 llvm
    ... "dependencies":["xz"], ...