### PR TITLE
New Formula: launchdns

### DIFF
--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -1,0 +1,54 @@
+class Launchdns < Formula
+  homepage "https://github.com/josh/launchdns"
+  url "https://github.com/josh/launchdns/archive/v1.0.1.tar.gz"
+  head "https://github.com/josh/launchdns.git"
+  sha1 "7310bb558a3b910e98b5364652e3a4fb48375494"
+
+  def install
+    ENV["PREFIX"] = prefix
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/launchdns", "-p0", "-t1"
+  end
+
+  def caveats; <<-EOS.undent
+      To have *.dev resolved to 127.0.0.1:
+          sudo mkdir -p /etc/resolver
+          printf "nameserver 127.0.0.1\\nport 55353\\n" | sudo tee /etc/resolver/dev
+    EOS
+  end
+
+  plist_options :manual => "launchdns"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/launchdns</string>
+          <string>--socket=Listeners</string>
+          <string>--timeout=30</string>
+        </array>
+        <key>Sockets</key>
+        <dict>
+          <key>Listeners</key>
+          <dict>
+            <key>SockType</key>
+            <string>dgram</string>
+            <key>SockNodeName</key>
+            <string>127.0.0.1</string>
+            <key>SockServiceName</key>
+            <string>55353</string>
+          </dict>
+        </dict>
+      </dict>
+    </plist>
+    EOS
+  end
+end

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -7,6 +7,8 @@ class Launchdns < Formula
   def install
     ENV["PREFIX"] = prefix
     system "make", "install"
+
+    (prefix+"etc/resolver/dev").write("nameserver 127.0.0.1\nport 55353\n")
   end
 
   test do
@@ -15,8 +17,7 @@ class Launchdns < Formula
 
   def caveats; <<-EOS.undent
       To have *.dev resolved to 127.0.0.1:
-          sudo mkdir -p /etc/resolver
-          printf "nameserver 127.0.0.1\\nport 55353\\n" | sudo tee /etc/resolver/dev
+          sudo ln -s #{HOMEBREW_PREFIX}/etc/resolver /etc/resolver
     EOS
   end
 


### PR DESCRIPTION
[launchdns](https://github.com/josh/launchdns) is a mini dns server designed with a single purpose of routing queries to localhost. Its pretty much a standalone version of the DNS component popularized by [Pow](http://pow.cx/manual.html). Even though its optimized for OSX's launchd, it compiles and runs just fine on linux too.

I'm not sure if this is too niche or not by todays standards or if it would be better suited in another Tap, just let me know. Thanks!

I'm curious if the hombrew test bot is able to run the little test block I included. 

/cc @mikemcquaid 