### PR TITLE
lfe 0.9.1 (new formula)

### DIFF
--- a/Library/Formula/lfe.rb
+++ b/Library/Formula/lfe.rb
@@ -1,0 +1,20 @@
+class Lfe < Formula
+  homepage "http://lfe.io/"
+  url "https://github.com/rvirding/lfe/archive/v0.9.1.tar.gz"
+  sha1 "015c23e7c761c2ccfefb7a9f97f85fe09f1cd648"
+
+  head "https://github.com/rvirding/lfe.git", :branch => "develop"
+
+  depends_on "erlang"
+  depends_on "rebar"
+
+  def install
+    system "rebar", "compile"
+    bin.install Dir["bin/*"]
+    prefix.install "ebin"
+  end
+
+  test do
+    system bin/"lfe", "-eval", "'(io:format \"42\")'"
+  end
+end


### PR DESCRIPTION
A Lisp-Flavoured Erlang for Great Good.

```
dch 🍺  ~/formula git:lfe ❯❯❯brew install lfe && brew test lfe && brew audit lfe
==> Downloading https://github.com/rvirding/lfe/archive/v0.9.1.tar.gz
Already downloaded: /Library/Caches/Homebrew/lfe-0.9.1.tar.gz
==> rebar compile
==> Caveats
To use lfe, simply run:
    lfe
Read more at http://lfe.io/ and https://github.com/lfe/sicp
==> Summary
🍺  /usr/local/Cellar/lfe/0.9.1: 32 files, 696K, built in 3 seconds
Testing lfe
==> /usr/local/Cellar/lfe/0.9.1/bin/lfe -eval '(io:format "42")'
dch 🍺  ~/formula git:lfe ❯❯❯
```