### PR TITLE
riemann-client 1.3.0 (new formula)

### DIFF
--- a/Library/Formula/riemann-client.rb
+++ b/Library/Formula/riemann-client.rb
@@ -1,0 +1,25 @@
+class RiemannClient < Formula
+  homepage "https://github.com/algernon/riemann-c-client"
+  url "https://github.com/algernon/riemann-c-client/archive/riemann-c-client-1.3.0.tar.gz"
+  sha1 "0b360e12839683a3a89caf2cd58a8fb1e337e19e"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libtool" => :build
+
+  depends_on "json-c"
+  depends_on "protobuf-c"
+
+  def install
+    system "autoreconf", "-i"
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/riemann-client", "send", "-h"
+  end
+end


### PR DESCRIPTION
Passes brew test, audit & friends.

```
==> Downloading https://github.com/algernon/riemann-c-client/archive/riemann-c-client-1.3.0.tar.gz
Already downloaded: /Library/Caches/Homebrew/riemann-client-1.3.0.tar.gz
==> autoreconf -i
==> ./configure --prefix=/usr/local/Cellar/riemann-client/1.3.0
==> make
==> make check
==> make install
🍺  /usr/local/Cellar/riemann-client/1.3.0: 15 files, 152K, built in 24 seconds
Testing riemann-client
==> /usr/local/Cellar/riemann-client/1.3.0/bin/riemann-client send -h
🍺 formula is OK 🍺
```