### PR TITLE
outdated: handle fully qualified tapped formulae.

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -17,9 +17,21 @@ module Homebrew
 
   def outdated_brews(formulae)
     formulae.map do |f|
-      versions = f.rack.subdirs.map { |d| Keg.new(d).version }.sort!
-        if versions.all? { |version| f.pkg_version > version }
-        yield f, versions if block_given?
+      all_versions = []
+      same_tap_versions = []
+      f.rack.subdirs.each do |dir|
+        keg = Keg.new dir
+        version = keg.version
+        all_versions << version
+
+        tap = Tab.for_keg(keg).tapped_from
+        if f.tap == tap || f.version == version
+          same_tap_versions << version
+        end
+      end
+
+      if same_tap_versions.all? { |version| f.pkg_version > version }
+        yield f, all_versions if block_given?
         f
       end
     end.compact


### PR DESCRIPTION
Previously if I did `brew install boxen/brews/imagemagick` and then `brew upgrade boxen/brews/imagemagick` and the version of `imagemagick` in `boxen/brews` was older than the version in `Homebrew/homebrew` then it would install the correct version from the `boxen/brews` tap and then try to immediately upgrade it to the version from `Homebrew/homebrew`. I'd argue fairly strongly that this behaviour is pretty unintuitive; when you fully specify a formula from a tap then it should be prioritised by `brew upgrade` and `brew outdated.

This commit makes `brew upgrade boxen/brews/imagemagick` only upgrade the version of `imagemagick` if the version in the `boxen/brews` tap is newer. Similarly `brew outdated imagemagick` and `brew outdated
boxen/brews/imagemagick` will show different results if the newer version differs between `boxen/brews` and `Homebrew/homebrew`.

I guess there's an argument that this case should be handled in Boxen itself but I think this change is simple enough and applies to other taps such that it makes sense to be in Homebrew core (and avoids doing any more horrible monkeypatching in Boxen).

@Homebrew/owners Any thoughts/objections? If not I'll merge this in the next few days. Thanks!