### PR TITLE
mongo-c changes

### DIFF
--- a/Library/Formula/libmongoc.rb
+++ b/Library/Formula/libmongoc.rb
@@ -14,8 +14,7 @@ class Libmongoc < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libbson"
-  depends_on "openssl" => :optional
-
+  depends_on "openssl" => :recommended
 
   def install
     # --enable-sasl=no: https://jira.mongodb.org/browse/CDRIVER-447

--- a/Library/Formula/libmongoc.rb
+++ b/Library/Formula/libmongoc.rb
@@ -1,6 +1,6 @@
 require "formula"
 
-class MongoC < Formula
+class Libmongoc < Formula
   homepage "http://docs.mongodb.org/ecosystem/drivers/c/"
   url "https://github.com/mongodb/mongo-c-driver/releases/download/1.1.0/mongo-c-driver-1.1.0.tar.gz"
   sha1 "9277fb0afcf595838da0d5e4715df1526d53e020"

--- a/Library/Formula/libmongoc.rb
+++ b/Library/Formula/libmongoc.rb
@@ -14,11 +14,15 @@ class Libmongoc < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libbson"
-  depends_on "openssl"
+  depends_on "openssl" => :optional
+
 
   def install
     # --enable-sasl=no: https://jira.mongodb.org/browse/CDRIVER-447
-    system "./configure", "--prefix=#{prefix}", "--enable-sasl=no"
+    configuration = "--prefix=#{prefix} --enable-sasl=no"
+    configuration << " --enable-ssl=#{build.with?('openssl') ? 'yes' : 'no'}"
+
+    system "./configure #{configuration}"
     system "make", "install"
   end
 end


### PR DESCRIPTION
 - Rename mongo-c to libmongoc (the proper name)
 - Allow openssl to be optional for libmongoc