### PR TITLE
audit: extend ssl checks

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -238,13 +238,40 @@ class FormulaAuditor
       problem "Savannah homepages should be https:// links (URL is #{homepage})."
     end
 
+    if homepage =~ %r[^http://((?:trac|tools|www)\.)?ietf\.org]
+      problem "ietf homepages should be https:// links (URL is #{homepage})."
+    end
+
+    if homepage =~ %r[^http://((?:www)\.)?gnupg.org/]
+      problem "GnuPG homepages should be https:// links (URL is #{homepage})."
+    end
+
+    # Freedesktop is complicated to handle - It has SSL/TLS, but only on certain subdomains.
+    # To enable https Freedesktop change the url from http://project.freedesktop.org/wiki to
+    # https://wiki.freedesktop.org/project_name.
+    # "Software" is redirected to https://wiki.freedesktop.org/www/Software/project_name
+    if homepage =~ %r[^http://((?:www|nice|libopenraw|liboil|telepathy|xorg)\.)?freedesktop\.org/(?:wiki/)?]
+      if homepage =~ /Software/
+        problem "The url should be styled `https://wiki.freedesktop.org/www/Software/project_name`, not #{homepage})."
+      else
+        problem "The url should be styled `https://wiki.freedesktop.org/project_name`, not #{homepage})."
+      end
+    end
+
+    if homepage =~ %r[^http://wiki\.freedesktop\.org/]
+      problem "Freedesktop's Wiki subdomain should be https:// (URL is #{homepage})."
+    end
+
     # There's an auto-redirect here, but this mistake is incredibly common too.
     if homepage =~ %r[^http://packages\.debian\.org]
       problem "Debian homepage should be https:// links (URL is #{homepage})."
     end
 
-    if homepage =~ %r[^http://((?:trac|tools|www)\.)?ietf\.org]
-      problem "ietf homepages should be https:// links (URL is #{homepage})."
+    # People will run into mixed content sometimes, but we should enforce and then add
+    # exemptions as they are discovered. Treat mixed content on homepages as a bug.
+    # Justify each exemptions with a code comment so we can keep track here.
+    if homepage =~ %r[^http://[^/]*github\.io/]
+      problem "Github Pages links should be https:// (URL is #{homepage})."
     end
 
     # There's an auto-redirect here, but this mistake is incredibly common too.
@@ -355,11 +382,11 @@ class FormulaAuditor
   end
 
   def audit_specs
-    if head_only?(formula) && formula.tap != "homebrew/homebrew-head-only"
+    if head_only?(formula) && formula.tap != "Homebrew/homebrew-head-only"
       problem "Head-only (no stable download)"
     end
 
-    if devel_only?(formula) && formula.tap != "homebrew/homebrew-devel-only"
+    if devel_only?(formula) && formula.tap != "Homebrew/homebrew-devel-only"
       problem "Devel-only (no stable download)"
     end
 


### PR DESCRIPTION
I don't think this will be too controversial, but I could be wrong.

Extends the audit checks to GnuPG, a significant chunk of Freedesktop domains, and Github Pages. I’ve somewhat hardened my stance towards Github Pages from the last time we extended this, hence the new inclusion - I did a pretty thorough check through the Homebrew formulae that use Github Pages for homepage links and found very few places where enforcing SSL/TLS would cause issues - I think a wider enforcement is worthwhile.

I’ve also fixed the capitalisation of the taps, if only because at the moment it disagrees with what ` puts formula.tap ` outputs (We get Homebrew/homebrew-head-only rather than homebrew/homebrew-head-only for example).