### PR TITLE
boot2docker 1.5.0

### DIFF
--- a/Library/Formula/boot2docker.rb
+++ b/Library/Formula/boot2docker.rb
@@ -4,7 +4,7 @@ class Boot2docker < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
-  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.4.1"
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.5.0"
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
   bottle do


### PR DESCRIPTION
refs #36718

I wonder if it is better to provide a git URL + tag or rather a solid tar.gz file URL + sha1sum?