### PR TITLE
gist-logs: show the formula origin for non core-formula

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -12,6 +12,14 @@ module Homebrew
     Homebrew.dump_verbose_config(s)
     files["config.out"] = { :content => s.string }
     files["doctor.out"] = { :content => `brew doctor 2>&1` }
+    unless f.core_formula?
+      tap = <<-EOS.undent
+        Formula: #{f.name}
+        Tap: #{f.tap}
+        Path: #{f.path}
+      EOS
+      files["tap.out"] = { :content => tap }
+    end
 
     url = create_gist(files)
 


### PR DESCRIPTION
Recently, neovim/homebrew-neovim receives multiple fail installtion reports.
They are caused by homebrew picked up the wrong formula from cache.
Adding the formula origin into gist-logs can be helpful in such circumstance.

Ref: https://github.com/neovim/neovim/issues/1573#issuecomment-73833928