### PR TITLE
Add Pentaho Kettle (PDI) formula

### DIFF
--- a/Library/Formula/kettle.rb
+++ b/Library/Formula/kettle.rb
@@ -1,0 +1,55 @@
+class Kettle < Formula
+  homepage "http://community.pentaho.com/projects/data-integration/"
+  url "https://downloads.sourceforge.net/project/pentaho/Data%20Integration/5.0.1-stable/pdi-ce-5.0.1-stable.zip"
+  sha1 "c34fa3dbe8b75280fd3f7ddcaf609acbcdd2ed78"
+
+  def install
+    rm_rf Dir["*.{bat}"]
+    libexec.install Dir["*"]
+
+    (etc+"kettle").install libexec+"pwd/carte-config-master-8080.xml" => "carte-config.xml"
+    (etc+"kettle/.kettle").install libexec+"pwd/kettle.pwd"
+    (etc+"kettle/simple-jndi").mkpath
+
+    (var+"log/kettle").mkpath
+
+    # We don't assume that carte, kitchen or pan are in anyway unique command names so we'll prepend "pdi"
+    %w[carte kitchen pan].each do |command|
+      (bin+"pdi#{command}").write_env_script libexec+"#{command}.sh", :BASEDIR => libexec
+    end
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{bin}/pdicarte</string>
+          <string>#{etc}/kettle/carte-config.xml</string>
+        </array>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>KETTLE_HOME</key>
+          <string>#{etc}/kettle</string>
+        </dict>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/kettle/carte.log</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/kettle/carte.log</string>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/pdikitchen", "-file=#{libexec}/samples/jobs/Slowly\ Changing\ Dimension/create\ -\ populate\ -\ update\ slowly\ changing\ dimension.kjb", "-level=RowLevel"
+    system "#{bin}/pdipan", "-file=#{libexec}/samples/transformations/Encrypt\ Password.ktr", "-level=RowLevel"
+  end
+end


### PR DESCRIPTION
@mistydemeo, I'm moving this pull request over to the regular repo as you said java projects are allowed here and it will make usage easier.  This corresponds to https://github.com/Homebrew/homebrew-binary/pull/156.

I have added kitchen, spoon and pan commands to bin (under the names pdikitchen, pdispoon and pdipan to prevent collision with other commands with the same name.  I had to provide wrappers for those commands as they are very temperamental about the working directory.

Let me know if you need anything else.