### PR TITLE
Make compatible_cellar? respect symlinks

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -234,7 +234,8 @@ class Bottle
   end
 
   def compatible_cellar?
-    cellar == :any || cellar == HOMEBREW_CELLAR.to_s
+    cellar == :any || cellar == HOMEBREW_CELLAR.to_s ||
+    (File.directory?(cellar) && Pathname.new(cellar).realpath().to_s == HOMEBREW_CELLAR.to_s)
   end
 
   def stage


### PR DESCRIPTION
This allows bottles to be used if their required cellar path is a symlink to Homebrew's cellar path.
`brew test gcc` and `brew test ghc` run without issues.