### PR TITLE
Couchdb caveats for LaunchAgents and LaunchDaemons

### DIFF
--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -53,8 +53,7 @@ class Couchdb < Formula
     system "make"
     system "make install"
 
-    # Use our plist instead to avoid faffing with a new system user.
-    (prefix+"Library/LaunchDaemons/org.apache.couchdb.plist").delete
+    (prefix+"Library/LaunchDaemons/org.apache.couchdb.plist").chmod 0644
     (lib+"couchdb/bin/couchjs").chmod 0755
     (var+"lib/couchdb").mkpath
     (var+"log/couchdb").mkpath
@@ -98,6 +97,24 @@ class Couchdb < Formula
   end
 
   def caveats; <<-EOS.undent
+    If this is your first install, automatically load on login with:
+        mkdir -p ~/Library/LaunchAgents
+        cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist ~/Library/LaunchAgents/
+        launchctl load -w ~/Library/LaunchAgents/org.apache.couchdb.plist
+
+    If this is an upgrade and you already have the org.apache.couchdb.plist loaded:
+        launchctl unload -w ~/Library/LaunchAgents/org.apache.couchdb.plist
+        cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist ~/Library/LaunchAgents/
+        launchctl load -w ~/Library/LaunchAgents/org.apache.couchdb.plist
+
+    Alternatively, automatically run on startup as a daemon with:
+        sudo launchctl list org.apache.couchdb \>/dev/null 2\>\&1 \&\& \\
+          sudo launchctl unload -w /Library/LaunchDaemons/org.apache.couchdb.plist
+        sudo cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist /Library/LaunchDaemons/
+        sudo launchctl load -w /Library/LaunchDaemons/org.apache.couchdb.plist
+
+    Or start manually as the current user with `couchdb`.
+
     To test CouchDB run:
         curl http://127.0.0.1:5984/
 

--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -97,28 +97,6 @@ class Couchdb < Formula
   end
 
   def caveats; <<-EOS.undent
-    To start manually as the current user:
-        #{prefix}/bin/couchdb
-
-    If you want to automatically load `couchdb` on login:
-      First install:
-        mkdir -p ~/Library/LaunchAgents
-        cp #{prefix}/opt/couchdb/homebrew.mxcl.couchdb.plist ~/Library/LaunchAgents/
-        launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
-
-      Upgrade:
-        launchctl unload -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
-        cp #{prefix}/opt/couchdb/homebrew.mxcl.couchdb.plist ~/Library/LaunchAgents/
-        launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
-
-    If you want to automatically load `couchdb` at boot:
-        # Note: Ensure that the couchdb user is set up according to 
-        # http://docs.couchdb.org/en/latest/install/mac.html#installation-with-homebrew
-        sudo launchctl list org.apache.couchdb \>/dev/null 2\>\&1 \&\& \\
-          sudo launchctl unload -w /Library/LaunchDaemons/org.apache.couchdb.plist
-        sudo cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist /Library/LaunchDaemons/
-        sudo launchctl load -w /Library/LaunchDaemons/org.apache.couchdb.plist
-
     To test CouchDB run:
         curl http://127.0.0.1:5984/
 

--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -97,23 +97,27 @@ class Couchdb < Formula
   end
 
   def caveats; <<-EOS.undent
-    If this is your first install, automatically load on login with:
+    To start manually as the current user:
+        #{prefix}/bin/couchdb
+
+    If you want to automatically load `couchdb` on login:
+      First install:
         mkdir -p ~/Library/LaunchAgents
-        cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist ~/Library/LaunchAgents/
-        launchctl load -w ~/Library/LaunchAgents/org.apache.couchdb.plist
+        cp #{prefix}/opt/couchdb/homebrew.mxcl.couchdb.plist ~/Library/LaunchAgents/
+        launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
 
-    If this is an upgrade and you already have the org.apache.couchdb.plist loaded:
-        launchctl unload -w ~/Library/LaunchAgents/org.apache.couchdb.plist
-        cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist ~/Library/LaunchAgents/
-        launchctl load -w ~/Library/LaunchAgents/org.apache.couchdb.plist
+      Upgrade:
+        launchctl unload -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
+        cp #{prefix}/opt/couchdb/homebrew.mxcl.couchdb.plist ~/Library/LaunchAgents/
+        launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
 
-    Alternatively, automatically run on startup as a daemon with:
+    If you want to automatically load `couchdb` at boot:
+        # Note: Ensure that the couchdb user is set up according to 
+        # http://docs.couchdb.org/en/latest/install/mac.html#installation-with-homebrew
         sudo launchctl list org.apache.couchdb \>/dev/null 2\>\&1 \&\& \\
           sudo launchctl unload -w /Library/LaunchDaemons/org.apache.couchdb.plist
         sudo cp #{prefix}/Library/LaunchDaemons/org.apache.couchdb.plist /Library/LaunchDaemons/
         sudo launchctl load -w /Library/LaunchDaemons/org.apache.couchdb.plist
-
-    Or start manually as the current user with `couchdb`.
 
     To test CouchDB run:
         curl http://127.0.0.1:5984/


### PR DESCRIPTION
Implementation of  https://github.com/Homebrew/homebrew/issues/19733#issuecomment-19666028 https://github.com/Homebrew/homebrew/issues/19733#issuecomment-19879104 and https://github.com/Homebrew/homebrew/issues/19733#issuecomment-73729327 which voted for editing caveats, instead of deleting them.

Partially revert of unexplained delete of org.apache.couchdb.plist in: https://github.com/Homebrew/homebrew/commit/75bdc45396e9735257ca5086b8e93bc14a71846e