### PR TITLE
polarssl 1.3.10

### DIFF
--- a/Library/Aliases/mbedtls
+++ b/Library/Aliases/mbedtls
@@ -1,0 +1,1 @@
+../Formula/polarssl.rb

--- a/Library/Formula/polarssl.rb
+++ b/Library/Formula/polarssl.rb
@@ -1,9 +1,8 @@
 class Polarssl < Formula
   homepage "https://polarssl.org/"
   # 1.4.0 will need dependents recompiled due to breaking binary compat.
-  url "https://polarssl.org/download/polarssl-1.3.9-gpl.tgz"
-  sha256 "d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755"
-  revision 1
+  url "https://polarssl.org/download/mbedtls-1.3.10-gpl.tgz"
+  sha256 "d221b02acc96fda8259d9e57798dee9de72977902afb0c63e552b5510c6503a3"
 
   head "https://github.com/polarssl/polarssl.git"
 
@@ -17,10 +16,6 @@ class Polarssl < Formula
   depends_on "cmake" => :build
 
   conflicts_with "md5sha1sum", :because => "both install conflicting binaries"
-
-  # Upstream patch for CVE-2015-1182. Remove with next release.
-  # https://polarssl.org/tech-updates/security-advisories/polarssl-security-advisory-2014-04
-  patch :DATA
 
   def install
     # Kills SSL2 Handshake & SSLv3 using upstream's recommended method.
@@ -46,19 +41,3 @@ class Polarssl < Formula
     assert_equal expected_checksum, shell_output("#{bin}/sha1sum testfile.txt").strip
   end
 end
-
-__END__
-
-diff --git a/library/asn1parse.c b/library/asn1parse.c
-index a3a2b56..e2117bf 100644
---- a/library/asn1parse.c
-+++ b/library/asn1parse.c
-@@ -278,6 +278,8 @@ int asn1_get_sequence_of( unsigned char **p,
-             if( cur->next == NULL )
-                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
-
-+            memset( cur->next, 0, sizeof( asn1_sequence ) );
-+
-             cur = cur->next;
-         }
-     }


### PR DESCRIPTION
Version bump.

The URL will be named mbedtls from this point forwards, and in the future the website and git will follow. An alias has been created consequently so people can find it under the new name as well as the ‘old’ name. See #36775.