### PR TITLE
Update Carte working directory in plist

### DIFF
--- a/Library/Formula/kettle.rb
+++ b/Library/Formula/kettle.rb
@@ -37,6 +37,8 @@ class Kettle < Formula
           <key>KETTLE_HOME</key>
           <string>#{etc}/kettle</string>
         </dict>
+        <key>WorkingDirectory</key>
+        <string>#{etc}/kettle</string>
         <key>StandardOutPath</key>
         <string>#{var}/log/kettle/carte.log</string>
         <key>StandardErrorPath</key>


### PR DESCRIPTION
Without the working directory set in the plist, we start in `/` and none of the expected files are present (namely, `simple-jndi`).