### PR TITLE
node: Fix npm install when the user has a ~/.npmrc that sets 'prefix'

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -60,7 +60,7 @@ class Node < Formula
 
       cd buildpath/"npm_install" do
         system "./configure", "--prefix=#{libexec}/npm"
-        system "make", "install"
+        system "make", "install", "NPMOPTS=--prefix=#{libexec}/npm"
       end
 
       if build.with? "completion"


### PR DESCRIPTION
Npm's configure sets ./npmrc which is lower priority than ~/.npmrc. So we
have to pass an extra argument to make to force the prefix.  We also have to
keep the configure command because the ./npmrc gets installed as the
default.