### PR TITLE
ffmpeg: update to 2.5.4

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -1,7 +1,7 @@
 class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
-  url "https://www.ffmpeg.org/releases/ffmpeg-2.5.3.tar.bz2"
-  sha1 "160d53a0d6b8df18336fac7f068c390ac2d34cef"
+  url "https://www.ffmpeg.org/releases/ffmpeg-2.5.4.tar.bz2"
+  sha1 "e7d0bab14e82876762531a883c6b48918631d48c"
 
   head "git://git.videolan.org/ffmpeg.git"
 


### PR DESCRIPTION
Update ffmpeg to latest stable version.

> 2.5.4 was released on 2015-02-13. It is the latest stable FFmpeg release from the 2.5 release branch, which was cut from master on 2014-12-15. Amongst lots of other changes, it includes all changes from ffmpeg-mt, libav master of 2014-12-03, libav 11 as of 2014-12-03.