### PR TITLE
Enable installing completion scripts for fish.

### DIFF
--- a/Library/Formula/youtube-dl.rb
+++ b/Library/Formula/youtube-dl.rb
@@ -28,6 +28,7 @@ class YoutubeDl < Formula
     man1.install "youtube-dl.1"
     bash_completion.install "youtube-dl.bash-completion"
     zsh_completion.install "youtube-dl.zsh" => "_youtube-dl"
+    fish_completion.install "youtube-dl.fish"
   end
 
   def caveats

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -403,13 +403,13 @@ class Formula
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
-  def bash_completion; prefix+'etc/bash_completion.d' end
+  def bash_completion; prefix+'etc/bash_completion.d'    end
 
   # The directory where the formula's ZSH completion files should be
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
-  def zsh_completion;  share+'zsh/site-functions'     end
+  def zsh_completion;  share+'zsh/site-functions'        end
 
   # The directory where the formula's fish completion files should be
   # installed.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -411,6 +411,12 @@ class Formula
   # `brew link` for formulae that are not keg-only.
   def zsh_completion;  share+'zsh/site-functions'     end
 
+  # The directory where the formula's fish completion files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not key-only.
+  def fish_completion; share+'fish/vendor_completions.d' end
+
   # The directory used for as the prefix for {#etc} and {#var} files on
   # installation so, despite not being in `HOMEBREW_CELLAR`, they are installed
   # there after pouring a bottle.


### PR DESCRIPTION
It would be nice if Homebrew kept fish-completion scripts for formulae that provided them (e.g., youtube-dl).

N.B. the current stable release of fish does *not* use `$(brew --prefix)/share/fish/vendor_completions.d`, but HEAD does and a new release is coming out soon-ish.