### PR TITLE
Remove unnecessary :x11's

### DIFF
--- a/Library/Formula/gtkmm.rb
+++ b/Library/Formula/gtkmm.rb
@@ -19,7 +19,6 @@ class Gtkmm < Formula
   depends_on 'pangomm'
   depends_on 'atkmm'
   depends_on 'cairomm'
-  depends_on :x11
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Library/Formula/gtkmm3.rb
+++ b/Library/Formula/gtkmm3.rb
@@ -18,7 +18,6 @@ class Gtkmm3 < Formula
   depends_on "pangomm"
   depends_on "atkmm"
   depends_on "cairomm"
-  depends_on :x11
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Library/Formula/gtksourceview.rb
+++ b/Library/Formula/gtksourceview.rb
@@ -11,7 +11,6 @@ class Gtksourceview < Formula
     sha1 "466836536733808dfbbe8c874b02b3e9afa84006" => :mountain_lion
   end
 
-  depends_on :x11
   depends_on 'pkg-config' => :build
   depends_on 'intltool' => :build
   depends_on 'gettext'

--- a/Library/Formula/gtksourceview3.rb
+++ b/Library/Formula/gtksourceview3.rb
@@ -11,7 +11,6 @@ class Gtksourceview3 < Formula
     sha1 "9cb6385b341def8476ed445ef2223f72601878f7" => :mountain_lion
   end
 
-  depends_on :x11
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext"


### PR DESCRIPTION
These libraries have no direct dep on x11 it is up to whatever gtk is built against.