### PR TITLE
explicitly disable libsodium in zeromq

### DIFF
--- a/Library/Formula/zeromq.rb
+++ b/Library/Formula/zeromq.rb
@@ -1,7 +1,5 @@
 class Zeromq < Formula
   homepage "http://www.zeromq.org/"
-  url "http://download.zeromq.org/zeromq-4.0.5.tar.gz"
-  sha1 "a664ec63661a848ef46114029156a0a6006feecd"
   revision 2
 
   bottle do
@@ -17,6 +15,18 @@ class Zeromq < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+  end
+
+  stable do
+    url "http://download.zeromq.org/zeromq-4.0.5.tar.gz"
+    sha1 "a664ec63661a848ef46114029156a0a6006feecd"
+
+    patch do
+      # enable --without-libsodium on libzmq < 4.1
+      # zeromq/zeromq4-x#105
+      url "https://gist.githubusercontent.com/minrk/478aab66adf7016158ff/raw/b5ea2d61c3f66db6ff3e266b76d1bec4ad4a238b/without-libsodium.patch"
+      sha1 "68543ff1b0f64b22994cb13b4d24bce8f76cf431"
+    end
   end
 
   option :universal
@@ -39,7 +49,11 @@ class Zeromq < Formula
       args << "--with-system-pgm"
     end
 
-    args << "--with-libsodium" if build.with? "libsodium"
+    if build.with? "libsodium"
+      args << "--with-libsodium"
+    else
+      args << "--without-libsodium"
+    end
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
when `--with-libsodium` is omitted. Default value for `--with-libsodium` changed from false to true between 4.0 and 4.1.

changed in zeromq/libzmq@510eabaec8f83e21fc780c7dd29fe97b6271f55d

closes #36874

The upstream change also suggests that libsodium really should be treated as at least a recommended dependency for zeromq, but that can wait until the wierd problems in ntopng (#33677) are resolved.