### PR TITLE
pinentry-mac: halt remote-code execution in make

### DIFF
--- a/Library/Formula/pinentry-mac.rb
+++ b/Library/Formula/pinentry-mac.rb
@@ -1,10 +1,17 @@
-require "formula"
-
 class PinentryMac < Formula
   homepage "https://github.com/GPGTools/pinentry-mac"
-  url "https://github.com/GPGTools/pinentry-mac/archive/v0.8.1.tar.gz"
-  sha256 "79aaa11fa8076ff335b3a1f41c230ef7c8435a757705e6484199f562f26b490f"
   head "https://github.com/GPGTools/pinentry-mac.git"
+
+  stable do
+    url "https://github.com/GPGTools/pinentry-mac/archive/v0.8.1.tar.gz"
+    sha256 "79aaa11fa8076ff335b3a1f41c230ef7c8435a757705e6484199f562f26b490f"
+
+    # Removes the remote code execution previously run automatically.
+    patch do
+      url "https://github.com/GPGTools/pinentry-mac/commit/89dd4789818894.diff"
+      sha1 "ab4db3264e1eb5ec9f9e1a31ad28b43d869c0f82"
+    end
+  end
 
   bottle do
     cellar :any
@@ -13,9 +20,18 @@ class PinentryMac < Formula
     sha1 "4d80f3954ddb16618074d9d978f3a83aedddb8db" => :mountain_lion
   end
 
+  # Manual cloning of this repo is now the upstream default:
+  # https://github.com/GPGTools/pinentry-mac/commit/89dd47898188
+  resource "core_clone" do
+    url "https://github.com/GPGTools/GPGTools_Core.git",
+        :revision => "f1e458ab2daeb104328ea4ec2aa7c71e8fca758d"
+  end
+
   depends_on :xcode => :build
 
   def install
+    (buildpath/"Dependencies/GPGTools_Core").install resource("core_clone")
+
     system "make"
     prefix.install "build/Release/pinentry-mac.app"
     bin.write_exec_script "#{prefix}/pinentry-mac.app/Contents/MacOS/pinentry-mac"


### PR DESCRIPTION
Because I had half an hour spare, and because for some reason I decided to take a crack at this rather than finish reading my book.

I’ve explained everything done in the formulae, so hopefully it’s easy enough to follow. But this would:

1) Halt unchecked remote code execution
2) By tying the Brew formulae to a specific upstream commit we reduce the potential upstream does something to break the core tools repo and suddenly all our from-source builds break.
3) Presuming you have the git clone and script stashed in your ` HOMEBREW_CACHE ` already restore the ability to compile completely offline.

Will almost certainly not be accepted because it makes changes that upstream probably won’t, and because it’s a messy solution, and the maintainers don’t love either of those things, which is perfectly reasonable.

But for the sake of discussion/humour/etc: Closes #36873