### PR TITLE
libdvdnav 5.0.3, libdvdread 5.0.2, libdvdcss 1.3.99

### DIFF
--- a/Library/Formula/libdvdcss.rb
+++ b/Library/Formula/libdvdcss.rb
@@ -1,11 +1,14 @@
-require "formula"
-
 class Libdvdcss < Formula
-  homepage "http://www.videolan.org/developers/libdvdcss.html"
-  url "http://download.videolan.org/pub/libdvdcss/1.3.0/libdvdcss-1.3.0.tar.bz2"
-  sha1 "b3ccd70a510aa04d644f32b398489a3122a7e11a"
+  homepage "https://www.videolan.org/developers/libdvdcss.html"
+  url "https://download.videolan.org/pub/videolan/libdvdcss/1.3.99/libdvdcss-1.3.99.tar.bz2"
+  sha1 "4da6ae5962a837f47a915def2cd64e685ea72668"
 
-  head "svn://svn.videolan.org/libdvdcss/trunk"
+  head do
+    url "git://git.videolan.org/libdvdcss"
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
 
   bottle do
     cellar :any
@@ -16,8 +19,8 @@ class Libdvdcss < Formula
   end
 
   def install
-    system "./bootstrap" if build.head?
+    system "autoreconf", "-if" if build.head?
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
-    system "make install"
+    system "make", "install"
   end
 end

--- a/Library/Formula/libdvdnav.rb
+++ b/Library/Formula/libdvdnav.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Libdvdnav < Formula
   homepage "https://dvdnav.mplayerhq.hu/"
-  url "http://download.videolan.org/pub/videolan/libdvdnav/5.0.1/libdvdnav-5.0.1.tar.bz2"
-  sha256 "72b1cb8266f163d4a1481b92c7b6c53e6dc9274d2a6befb08ffc351fe7a4a2a9"
+  url "https://download.videolan.org/pub/videolan/libdvdnav/5.0.3/libdvdnav-5.0.3.tar.bz2"
+  sha256 "5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d"
 
   head do
     url "git://git.videolan.org/libdvdnav.git"

--- a/Library/Formula/libdvdread.rb
+++ b/Library/Formula/libdvdread.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Libdvdread < Formula
   homepage "https://dvdnav.mplayerhq.hu/"
-  url "http://download.videolan.org/pub/videolan/libdvdread/5.0.0/libdvdread-5.0.0.tar.bz2"
-  sha256 "66fb1a3a42aa0c56b02547f69c7eb0438c5beeaf21aee2ae2c6aa23ea8305f14"
+  url "https://download.videolan.org/pub/videolan/libdvdread/5.0.2/libdvdread-5.0.2.tar.bz2"
+  sha256 "82cbe693f2a3971671e7428790b5498392db32185b8dc8622f7b9cd307d3cfbf"
 
   head do
     url "git://git.videolan.org/libdvdread.git"


### PR DESCRIPTION
* libdvdcss
  * Update to latest stable release (1.3.99)
  * set HEAD to project's git repository
  * use HTTPS links
  * use SHA-256
  * update HEAD build procedure and require *autotools*
  * remove `require "formula"`
* libdvdread and libdvdnav
  * Update to latest stable releases
  * use HTTPS links
  * remove `require "formula"`

Included all three in a single PR because *libdvdnav* requires the newer *libdvdread* which requires the newer *libdvdcss*.