### PR TITLE
typesafe-activator: fix permissions

### DIFF
--- a/Library/Formula/typesafe-activator.rb
+++ b/Library/Formula/typesafe-activator.rb
@@ -9,6 +9,7 @@ class TypesafeActivator < Formula
     rm Dir["*.bat"] # Remove Windows .bat files
     prefix.install_metafiles
     libexec.install Dir['*']
+    chmod 'a+x', libexec/'activator'
     bin.write_exec_script libexec/'activator'
   end
 end

--- a/Library/Formula/typesafe-activator.rb
+++ b/Library/Formula/typesafe-activator.rb
@@ -9,7 +9,7 @@ class TypesafeActivator < Formula
     rm Dir["*.bat"] # Remove Windows .bat files
     prefix.install_metafiles
     libexec.install Dir['*']
-    chmod 'a+x', libexec/'activator'
+    chmod 0755, libexec/'activator'
     bin.write_exec_script libexec/'activator'
   end
 end


### PR DESCRIPTION
Resolves #35922
libexec/activator wasn't executable by other users.