### PR TITLE
freeradius-server: revision for openssl

### DIFF
--- a/Library/Formula/freeradius-server.rb
+++ b/Library/Formula/freeradius-server.rb
@@ -1,14 +1,19 @@
-require "formula"
-
 class FreeradiusServer < Formula
   homepage "http://freeradius.org/"
-  url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-2.2.6.tar.gz"
-  sha1 "25b0a057b1fffad5a030946e8af0c6170e5cdf46"
-  revision 1
+  revision 2
+
+  stable do
+    url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-2.2.6.tar.gz"
+    sha1 "25b0a057b1fffad5a030946e8af0c6170e5cdf46"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
 
   devel do
-    url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.5.tar.bz2"
-    sha1 "53432d83618f0719f8cab5957567fc173959f6e7"
+    url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.6.tar.bz2"
+    sha1 "37c5a38f74a8b228abe9682db9f3184a9c7d9639"
     depends_on "talloc" => :build
   end
 
@@ -20,38 +25,30 @@ class FreeradiusServer < Formula
 
   depends_on "openssl"
 
-  # libtool is glibtool on OS X
-  stable do
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-    patch :DATA
-  end
-
   def install
-    openssl = Formula["openssl"]
-
     ENV.deparallelize
 
-    args = [
-      "--prefix=#{prefix}",
-      "--sbindir=#{bin}",
-      "--localstatedir=#{var}",
-      "--with-openssl-includes=#{openssl.opt_include}",
-      "--with-openssl-libraries=#{openssl.opt_lib}",
+    args = %W[
+      --prefix=#{prefix}
+      --sbindir=#{bin}
+      --localstatedir=#{var}
+      --with-openssl-includes=#{Formula["openssl"].opt_include}
+      --with-openssl-libraries=#{Formula["openssl"].opt_lib}
     ]
 
     if build.stable?
+      # libtool is glibtool on OS X
+      inreplace "configure.in", "libtool,,", "glibtool,,"
+      inreplace "autogen.sh", "libtool", "glibtool"
+
       args << "--with-system-libtool"
       args << "--with-system-libltdl"
-      inreplace "autogen.sh", "libtool", "glibtool"
       system "./autogen.sh"
     end
 
     if build.devel?
-      talloc = Formula["talloc"]
-      args << "--with-talloc-lib-dir=#{talloc.opt_lib}"
-      args << "--with-talloc-include-dir=#{talloc.opt_include}"
+      args << "--with-talloc-lib-dir=#{Formula["talloc"].opt_lib}"
+      args << "--with-talloc-include-dir=#{Formula["talloc"].opt_include}"
     end
 
     system "./configure", *args
@@ -63,19 +60,8 @@ class FreeradiusServer < Formula
     (var/"run/radiusd").mkpath
     (var/"log/radius").mkpath
   end
-end
 
-__END__
-diff --git a/configure.in b/configure.in
-index 62b0de8..97e0243 100644
---- a/configure.in
-+++ b/configure.in
-@@ -101,7 +101,7 @@ AC_SUBST(LTDL_SUBDIRS)
- dnl use system-wide libtool, if it exists
- AC_ARG_WITH(system-libtool,
- [  --with-system-libtool   Use the libtool installed in your system (default=use our own)],
--[ AC_PATH_PROG(LIBTOOL, libtool,,$PATH:/usr/local/bin) AC_LIBTOOL_DLOPEN
-+[ AC_PATH_PROG(LIBTOOL, glibtool,,$PATH:/usr/local/bin) AC_LIBTOOL_DLOPEN
-  AC_PROG_LIBTOOL],
- [
-   LIBTOOL="`pwd`/libtool"
+  test do
+    assert_match /77C8009C912CFFCF3832C92FC614B7D1/, shell_output("#{bin}/smbencrypt homebrew")
+  end
+end


### PR DESCRIPTION
Forgot to do this last time and it started firing off failures in places, as in #36889.

Also:
* Devel bump to 3.0.6
* Merged the `stable do` depends_on block into a ` stable do ` block with ` url ` and ` sha1 ` as now standard.
* Style tweaks.
* Killed the patch and added an inreplace instead because it works fine and looks neater.
* Added a test, which should work.

Closes #36889.