### PR TITLE
Updated Vowpal Wabbit to 7.10

### DIFF
--- a/Library/Formula/vowpal-wabbit.rb
+++ b/Library/Formula/vowpal-wabbit.rb
@@ -3,8 +3,8 @@ require "formula"
 class VowpalWabbit < Formula
   homepage "https://github.com/JohnLangford/vowpal_wabbit"
   head "https://github.com/JohnLangford/vowpal_wabbit.git"
-  url "https://github.com/JohnLangford/vowpal_wabbit/archive/7.7.tar.gz"
-  sha1 "d248bc848ad3919ad0c5002045a83aa29d83e6fd"
+  url "https://github.com/JohnLangford/vowpal_wabbit/archive/7.10.tar.gz"
+  sha1 "66f476926c760d5b604057796f7e19c52d7702a8"
 
   bottle do
     cellar :any
@@ -13,16 +13,70 @@ class VowpalWabbit < Formula
     sha1 "165eca93fb9e839793c90f11da9336ee8388a01c" => :lion
   end
 
-  depends_on "boost" => :build
+  if MacOS.version < :mavericks
+    depends_on "boost" => "c++11"
+  else
+    depends_on "boost"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  needs :cxx11
 
   def install
+    ENV.cxx11
     ENV["AC_PATH"] = "#{HOMEBREW_PREFIX}/share"
     system "./autogen.sh", "--prefix=#{prefix}",
                            "--with-boost=#{Formula['boost'].opt_prefix}"
     system "make"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"house_dataset").write <<-EOS.undent
+      0 | price:.23 sqft:.25 age:.05 2006
+      1 2 'second_house | price:.18 sqft:.15 age:.35 1976
+      0 1 0.5 'third_house | price:.53 sqft:.32 age:.87 1924
+    EOS
+    system bin/"vw", "house_dataset",  "-l", "10",  "-c",  "--passes", "25",  "--holdout_off",  "--audit",  "-f" ,"house.model", "--nn", "5"
+    system bin/"vw", "-t", "-i", "house.model", "-d", "house_dataset", "-p" ,"house.predict"
+
+    (testpath/"csoaa.dat").write <<-EOS.undent
+      1:1.0 a1_expect_1| a
+      2:1.0 b1_expect_2| b
+      3:1.0 c1_expect_3| c
+      1:2.0 2:1.0 ab1_expect_2| a b
+      2:1.0 3:3.0 bc1_expect_2| b c
+      1:3.0 3:1.0 ac1_expect_3| a c
+      2:3.0 d1_expect_2| d
+    EOS
+    system bin/"vw", "--csoaa", "3", "csoaa.dat", "-f", "csoaa.model"
+    system bin/"vw", "-t", "-i", "csoaa.model", "-d", "csoaa.dat", "-p", "csoaa.predict"
+
+    (testpath/"ect.dat").write <<-EOS.undent
+      1 ex1| a
+      2 ex2| a b
+      3 ex3| c d e
+      2 ex4| b a
+      1 ex5| f g
+    EOS
+    system bin/"vw", "--ect", "3", "-d", "ect.dat", "-f", "ect.model"
+    system bin/"vw", "-t", "-i", "ect.model", "-d", "ect.dat", "-p", "ect.predict"
+
+    (testpath/"train.dat").write <<-EOS.undent
+    1:2:0.4 | a c
+      3:0.5:0.2 | b d
+      4:1.2:0.5 | a b c
+      2:1:0.3 | b c
+      3:1.5:0.7 | a d
+    EOS
+    (testpath/"test.dat").write <<-EOS.undent
+      1:2 3:5 4:1:0.6 | a c d
+      1:0.5 2:1:0.4 3:2 4:1.5 | c d
+    EOS
+    system bin/"vw", "-d", "train.dat", "--cb", "4", "-f", "cb.model"
+    system bin/"vw", "-t", "-i", "cb.model", "-d", "test.dat", "-p", "cb.predict"
+
   end
 end


### PR DESCRIPTION
brew tests pass on my local machine.

7.8 is a big update, 7.9 and 7.10 are mostly bug fixes. Below are changelogs from VW's primary author:
Changes in vw 7.8:
1. Learning to Search: Hal completely rewrote the learning to search
system, enough that the numbers here are looking obsolete. Kai-Wei has
also created several advanced applications for entity-relation and
dependency parsing which are promising.
2. Languages Hal also created a good python library, which includes
call-backs for learning to search. You can now develop advanced
structured prediction solutions in a nice language. Jonathan Morra also
contributed an initial Java interface.
3. Exploration The contextual bandit subsystem now allows evaluation of
an arbitrary policy, and an exploration library is now factored out
into an independent library (principally by Luong with help from Sid
and Sarah). This is critical for real applications because
randomization must happen at the point of decision.
4. Reductions The learning reductions subsystem has continued to
mature, although the perfectionist in me is still dissatisfied. As a
consequence, it’s now pretty easy to program new reductions, and the
efficiency of these reductions has generally improved. Several news
ones are cooking.
5. Online Learning Alekh added an online SVM implementation based on
LaSVM. This is known to parallelize well via the para-active approach.

Changes in vw 7.9:
Primarily updates to learning reductions modularity.

Changes in vw 7.10:
No significant changes from 7.9---primarily bugfixes.