### PR TITLE
gcc 5.1, ISL 0.14.1, CLooG 0.18.3

### DIFF
--- a/Library/Formula/cloog.rb
+++ b/Library/Formula/cloog.rb
@@ -1,10 +1,7 @@
-require 'formula'
-
 class Cloog < Formula
-  homepage 'http://www.cloog.org/'
-  url 'http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.1.tar.gz'
-  mirror 'http://gcc.cybermirror.org/infrastructure/cloog-0.18.1.tar.gz'
-  sha1 '2dc70313e8e2c6610b856d627bce9c9c3f848077'
+  homepage "http://www.cloog.org/"
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.3.tar.gz"
+  sha256 "460c6c740acb8cdfbfbb387156b627cf731b3837605f2ec0001d079d89c69734"
 
   bottle do
     cellar :any
@@ -15,15 +12,15 @@ class Cloog < Formula
   end
 
   head do
-    url 'http://repo.or.cz/r/cloog.git'
+    url "http://repo.or.cz/r/cloog.git"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gmp'
-  depends_on 'isl'
+  depends_on "pkg-config" => :build
+  depends_on "gmp"
+  depends_on "isl"
 
   def install
     system "./autogen.sh" if build.head?
@@ -41,7 +38,7 @@ class Cloog < Formula
     args << "--with-osl=bundled" if build.head?
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
   end
 
   test do
@@ -62,6 +59,6 @@ class Cloog < Formula
     EOS
 
     output = pipe_output("#{bin}/cloog /dev/stdin", cloog_source)
-    assert_match /Generated from \/dev\/stdin by CLooG/, output
+    assert_match %r{Generated from /dev/stdin by CLooG}, output
   end
 end

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -19,11 +19,10 @@ class Gcc < Formula
     `uname -r`.chomp
   end
 
-  homepage "http://gcc.gnu.org"
-  url "http://ftpmirror.gnu.org/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2"
-  mirror "ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.2/gcc-4.9.2.tar.bz2"
-  sha1 "79dbcb09f44232822460d80b033c962c0237c6d8"
-  revision 1
+  homepage "https://gcc.gnu.org"
+  url "http://ftpmirror.gnu.org/gcc/gcc-5.1.0/gcc-5.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.1.0/gcc-5.1.0.tar.bz2"
+  sha256 "b7dafdf89cbb0e20333dbf5b5349319ae06e3d1a30bf3515b5488f7e89dca5ad"
 
   bottle do
     revision 1
@@ -35,6 +34,7 @@ class Gcc < Formula
   option "with-java", "Build the gcj compiler"
   option "with-all-languages", "Enable all compilers and languages, except Ada"
   option "with-nls", "Build with native language support (localization)"
+  option "with-jit", "Build the jit compiler"
   option "without-fortran", "Build without the gfortran compiler"
   # enabling multilib on a host that can't run 64-bit results in build failures
   option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
@@ -42,7 +42,6 @@ class Gcc < Formula
   depends_on "gmp"
   depends_on "libmpc"
   depends_on "mpfr"
-  depends_on "cloog"
   depends_on "isl"
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
@@ -68,6 +67,10 @@ class Gcc < Formula
     version.to_s.slice(/\d\.\d/)
   end
 
+  # Fix for libgccjit.so linkage on Darwin
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
@@ -76,14 +79,19 @@ class Gcc < Formula
       ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
     end
 
-    # C, C++, ObjC compilers are always built
-    languages = %w[c c++ objc obj-c++]
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 adds go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ objc obj-c++ fortran java jit]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
 
-    # Everything but Ada, which requires a pre-existing GCC Ada compiler
-    # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
-    # currently only compilable on Linux.
-    languages << "fortran" if build.with?("fortran") || build.with?("all-languages")
-    languages << "java" if build.with?("java") || build.with?("all-languages")
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+      languages << "jit" if build.with? "jit"
+    end
 
     args = [
       "--build=#{arch}-apple-darwin#{osmajor}",
@@ -95,7 +103,6 @@ class Gcc < Formula
       "--with-gmp=#{Formula["gmp"].opt_prefix}",
       "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-      "--with-cloog=#{Formula["cloog"].opt_prefix}",
       "--with-isl=#{Formula["isl"].opt_prefix}",
       "--with-system-zlib",
       "--enable-libstdcxx-time=yes",
@@ -105,8 +112,6 @@ class Gcc < Formula
       # Use 'bootstrap-debug' build configuration to force stripping of object
       # files prior to comparison during bootstrap (broken by Xcode 6.3).
       "--with-build-config=bootstrap-debug",
-      # A no-op unless --HEAD is built because in head warnings will
-      # raise errors. But still a good idea to include.
       "--disable-werror",
       "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
       "--with-bugurl=https://github.com/Homebrew/homebrew/issues",
@@ -132,6 +137,8 @@ class Gcc < Formula
       args << "--enable-multilib"
     end
 
+    args << "--enable-host-shared" if build.with? "jit"
+
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
@@ -139,7 +146,7 @@ class Gcc < Formula
     mkdir "build" do
       unless MacOS::CLT.installed?
         # For Xcode-only systems, we need to tell the sysroot path.
-        # "native-system-header's will be appended
+        # "native-system-headers" will be appended
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{MacOS.sdk_path}"
       end
@@ -235,3 +242,18 @@ class Gcc < Formula
     end
   end
 end
+__END__
+diff --git a/gcc/jit/Make-lang.in b/gcc/jit/Make-lang.in
+index 44d0750..4df2a9c 100644
+--- a/gcc/jit/Make-lang.in
++++ b/gcc/jit/Make-lang.in
+@@ -85,8 +85,7 @@ $(LIBGCCJIT_FILENAME): $(jit_OBJS) \
+ 	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+ 	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+ 	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+ 
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+ 	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)

--- a/Library/Formula/gnu-cobol.rb
+++ b/Library/Formula/gnu-cobol.rb
@@ -1,11 +1,9 @@
-require "formula"
-
 class GnuCobol < Formula
   homepage "http://www.opencobol.org/"
 
   stable do
     url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/1.1/gnu-cobol-1.1.tar.gz"
-    sha1 "86e928c43cb3372f1f4564f3fd5e1dde668e8c1f"
+    sha256 "5cd6c99b2b1c82fd0c8fffbb350aaf255d484cde43cf5d9b92de1379343b3d7e"
 
     fails_with :clang do
       cause <<-EOS.undent
@@ -14,11 +12,12 @@ class GnuCobol < Formula
       EOS
     end
   end
+  revision 1
 
   devel do
     version "2.0_nightly_r411"
     url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/2.0/gnu-cobol-2.0_nightly_r411.tar.gz"
-    sha1 "009215c090b9a90fbf02bbc913095ce2a9b31910"
+    sha256 "5d6d767bf0255fa63bc5c26493d53f4749eb0e369b81c626d156f346b3664fe7"
   end
 
   bottle do

--- a/Library/Formula/isl.rb
+++ b/Library/Formula/isl.rb
@@ -6,11 +6,8 @@ class Isl < Formula
   # and update isl_version() function accordingly.  All other names will
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
-  #
-  # 0.13 is out, but we can't upgrade until a compatible version of cloog is
-  # released.
-  url "http://isl.gforge.inria.fr/isl-0.12.2.tar.bz2"
-  sha1 "ca98a91e35fb3ded10d080342065919764d6f928"
+  url "http://isl.gforge.inria.fr/isl-0.14.tar.xz"
+  sha1 "259678a0b1d12f8bc45b9aaeaa14feded9d5b3e1"
 
   bottle do
     cellar :any

--- a/Library/Formula/isl.rb
+++ b/Library/Formula/isl.rb
@@ -6,8 +6,8 @@ class Isl < Formula
   # and update isl_version() function accordingly.  All other names will
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
-  url "http://isl.gforge.inria.fr/isl-0.14.tar.xz"
-  sha1 "259678a0b1d12f8bc45b9aaeaa14feded9d5b3e1"
+  url "http://isl.gforge.inria.fr/isl-0.14.1.tar.xz"
+  sha256 "8882c9e36549fc757efa267706a9af733bb8d7fe3905cbfde43e17a89eea4675"
 
   bottle do
     cellar :any

--- a/Library/Formula/mpich2.rb
+++ b/Library/Formula/mpich2.rb
@@ -4,7 +4,8 @@ class Mpich2 < Formula
   homepage "https://www.mpich.org/"
   url "https://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz"
   mirror "https://fossies.org/linux/misc/mpich-3.1.4.tar.gz"
-  sha1 "af4f563e2772d610e57e17420c9dcc5c3c9fec4e"
+  sha256 "f68b5330e94306c00ca5a1c0e8e275c7f53517d01d6c524d51ce9359d240466b"
+  revision 1
 
   bottle do
     sha1 "96a6ef7dff3f1902790317124ff608c481a2a885" => :yosemite
@@ -22,7 +23,7 @@ class Mpich2 < Formula
 
   devel do
     url "https://www.mpich.org/static/downloads/3.2b2/mpich-3.2b2.tar.gz"
-    sha1 "8e954e54d1c1a08ef7d042c18ed308d566e32cd5"
+    sha256 "8ef37f88bbcfab0e9e173c36745b79f4dbbc3409476773c4489670d82d923155"
   end
 
   deprecated_option "disable-fortran" => "without-fortran"


### PR DESCRIPTION
* ISL
  * Update to 0.14.1
  * Remove obsolete comment
* CLooG
  * Update to 0.18.3
  * Remove outdated mirror
  * Modernize formula
* GCC
  * Update to 5.1.0
  * Add HEAD
  * Add option and patch for JIT
  * Remove CLooG dependency
  * Refactor language selection
* mpich
  * Bump revision
  * Use SHA256
* gnu-cobol
  * Bump revision
  * Use SHA256
  * Remove `require "formula"`