### PR TITLE
ruby 1.8 doesn't have `sort_by!`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -615,7 +615,7 @@ class Formula
         }
       end
 
-      hsh["installed"].sort_by! { |i| Version.new(i["version"]) }
+      hsh["installed"] = hsh["installed"].sort_by { |i| Version.new(i["version"]) }
     end
 
     hsh


### PR DESCRIPTION
Closes #36935