### PR TITLE
qts: move to new urls

### DIFF
--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -1,12 +1,9 @@
-require 'formula'
-
 class Qt < Formula
   homepage "http://qt-project.org/"
 
   stable do
-    # Mirror rather than source set as primary because source is very slow.
-    url "http://qtmirror.ics.com/pub/qtproject/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz"
-    mirror "http://download.qt-project.org/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz"
+    url "https://download.qt.io/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz"
+    mirror "http://qtmirror.ics.com/pub/qtproject/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz"
     sha1 "ddf9c20ca8309a116e0466c42984238009525da6"
 
     # This patch should be able to be removed with the next stable Qt4 release.
@@ -26,15 +23,16 @@ class Qt < Formula
   head "https://gitorious.org/qt/qt.git", :branch => "4.8"
 
   option :universal
-  option 'with-qt3support', 'Build with deprecated Qt3Support module support'
-  option 'with-docs', 'Build documentation'
-  option 'developer', 'Build and link with developer options'
+  option "with-qt3support", "Build with deprecated Qt3Support module support"
+  option "with-docs", "Build documentation"
+  option "with-developer", "Build and link with developer options"
 
   depends_on "d-bus" => :optional
   depends_on "mysql" => :optional
   depends_on "postgresql" => :optional
 
   deprecated_option "qtdbus" => "with-d-bus"
+  deprecated_option "developer" => "with-developer"
 
   def install
     ENV.universal_binary if build.universal?
@@ -56,10 +54,10 @@ class Qt < Formula
         end
     end
 
-    args << "-plugin-sql-mysql" if build.with? 'mysql'
-    args << "-plugin-sql-psql" if build.with? 'postgresql'
+    args << "-plugin-sql-mysql" if build.with? "mysql"
+    args << "-plugin-sql-psql" if build.with? "postgresql"
 
-    if build.with? 'd-bus'
+    if build.with? "d-bus"
       dbus_opt = Formula["d-bus"].opt_prefix
       args << "-I#{dbus_opt}/lib/dbus-1.0/include"
       args << "-I#{dbus_opt}/include/dbus-1.0"
@@ -68,34 +66,34 @@ class Qt < Formula
       args << "-dbus-linked"
     end
 
-    if build.with? 'qt3support'
+    if build.with? "qt3support"
       args << "-qt3support"
     else
       args << "-no-qt3support"
     end
 
-    args << "-nomake" << "docs" if build.without? 'docs'
+    args << "-nomake" << "docs" if build.without? "docs"
 
     if MacOS.prefer_64_bit? or build.universal?
-      args << '-arch' << 'x86_64'
+      args << "-arch" << "x86_64"
     end
 
     if !MacOS.prefer_64_bit? or build.universal?
-      args << '-arch' << 'x86'
+      args << "-arch" << "x86"
     end
 
-    args << '-developer-build' if build.include? 'developer'
+    args << "-developer-build" if build.with? "developer"
 
     system "./configure", *args
     system "make"
     ENV.j1
-    system "make install"
+    system "make", "install"
 
     # what are these anyway?
-    (bin+'pixeltool.app').rmtree
-    (bin+'qhelpconverter.app').rmtree
+    (bin+"pixeltool.app").rmtree
+    (bin+"qhelpconverter.app").rmtree
     # remove porting file for non-humans
-    (prefix+'q3porting.xml').unlink if build.without? 'qt3support'
+    (prefix+"q3porting.xml").unlink if build.without? "qt3support"
 
     # Some config scripts will only find Qt in a "Frameworks" folder
     frameworks.install_symlink Dir["#{lib}/*.framework"]
@@ -111,7 +109,7 @@ class Qt < Formula
   end
 
   test do
-    system "#{bin}/qmake", '-project'
+    system "#{bin}/qmake", "-project"
   end
 
   def caveats; <<-EOS.undent

--- a/Library/Formula/qt5.rb
+++ b/Library/Formula/qt5.rb
@@ -11,8 +11,8 @@ end
 
 class Qt5 < Formula
   homepage "http://qt-project.org/"
-  url "http://qtmirror.ics.com/pub/qtproject/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.xz"
-  mirror "http://download.qt-project.org/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.xz"
+  url "https://download.qt.io/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.xz"
+  mirror "http://qtmirror.ics.com/pub/qtproject/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.xz"
   sha1 "2f5558b87f8cea37c377018d9e7a7047cc800938"
 
   bottle do
@@ -28,8 +28,11 @@ class Qt5 < Formula
   option :universal
   option "with-docs", "Build documentation"
   option "with-examples", "Build examples"
-  option "developer", "Build and link with developer options"
+  option "with-developer", "Build and link with developer options"
   option "with-oci", "Build with Oracle OCI plugin"
+
+  deprecated_option "developer" => "with-developer"
+  deprecated_option "qtdbus" => "with-d-bus"
 
   # Snow Leopard is untested and support has been removed in 5.4
   # https://qt.gitorious.org/qt/qtbase/commit/5be81925d7be19dd0f1022c3cfaa9c88624b1f08
@@ -42,11 +45,10 @@ class Qt5 < Formula
   # There needs to be an OpenSSL dep here ideally, but qt keeps ignoring it.
   # Keep nagging upstream for a fix to this problem, and revision when possible.
   # https://github.com/Homebrew/homebrew/pull/34929
-  # https://bugreports.qt-project.org/browse/QTBUG-42161
+  # https://bugreports.qt.io/browse/QTBUG-42161
+  # https://bugreports.qt.io/browse/QTBUG-43456
 
   depends_on OracleHomeVar if build.with? "oci"
-
-  deprecated_option "qtdbus" => "with-d-bus"
 
   def install
     ENV.universal_binary if build.universal?
@@ -84,12 +86,13 @@ class Qt5 < Formula
       args << "-plugin-sql-oci"
     end
 
-    args << "-developer-build" if build.include? "developer"
+    args << "-developer-build" if build.with? "developer"
 
     system "./configure", *args
     system "make"
     ENV.j1
-    system "make install"
+    system "make", "install"
+
     if build.with? "docs"
       system "make", "docs"
       system "make", "install_docs"


### PR DESCRIPTION
### Commit 1

qt: move to new qt url

Bunch of strict audit fixes as well.

### Commit 2

qt5: move to new qt url

Strict audit fixes as well. Also moves the bug reports to the new URL, because the old one won’t redirect due to the broken Qt SSL cert on the old website now, so people just run into awful looking cert failures.