### PR TITLE
h2o 1.0.0

### DIFF
--- a/Library/Formula/h2o.rb
+++ b/Library/Formula/h2o.rb
@@ -1,7 +1,7 @@
 class H2o < Formula
   homepage "https://github.com/h2o/h2o/"
-  url "https://github.com/h2o/h2o/archive/v0.9.2.tar.gz"
-  sha1 "001f5aefcd829467ed64b328ff0d35b736593dec"
+  url "https://github.com/h2o/h2o/archive/v1.0.0.tar.gz"
+  sha1 "9215eb3ec6b7455ce20b3dc3d322c327d0e56dad"
   head "https://github.com/h2o/h2o.git"
 
   bottle do
@@ -16,6 +16,7 @@ class H2o < Formula
   depends_on "libyaml"
   depends_on "openssl"
   depends_on "libuv" => :optional
+  depends_on "wslay" => :optional
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Version bump.

Note: Due to the added “wslay” optional dep, this is dependent on #36836 being accepted. If maintainers don’t want to accept #36836 I’ll remove the optional dep here prior to merge, Let me know :).