### PR TITLE
gnupg2 2.0.27

### DIFF
--- a/Library/Formula/gnupg2.rb
+++ b/Library/Formula/gnupg2.rb
@@ -1,13 +1,11 @@
 class Gnupg2 < Formula
   homepage "https://www.gnupg.org/"
-  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.26.tar.bz2"
-  mirror "ftp://ftp.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.26.tar.bz2"
-  mirror "ftp://mirror.tje.me.uk/pub/mirrors/ftp.gnupg.org/gnupg/gnupg-2.0.26.tar.bz2"
-  sha1 "3ff5b38152c919724fd09cf2f17df704272ba192"
-  revision 1
+  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.27.tar.bz2"
+  mirror "ftp://ftp.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.27.tar.bz2"
+  mirror "http://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.27.tar.bz2"
+  sha1 "d065be185f5bac8ea07b210ab7756e79b83b63d4"
 
   bottle do
-    revision 2
     sha1 "ccbafc88773f15b92e7ab931ec1be83fb27b58c2" => :yosemite
     sha1 "1735c876de43f9635e191e6b1f1ed3f1ae04068d" => :mavericks
     sha1 "ad0e8129ffbaf615f8b43aa93b89eb1cdc517f1f" => :mountain_lion
@@ -69,7 +67,7 @@ class Gnupg2 < Formula
 
     # Conflicts with a manpage from the 1.x formula, and
     # gpg-zip isn't installed by this formula anyway
-    rm man1/"gpg-zip.1"
+    rm_f man1/"gpg-zip.1"
   end
 
   test do


### PR DESCRIPTION
Version bump.

Not on the website yet, but it is an official, announced, stable release, see: https://lists.gnupg.org/pipermail/gnupg-announce/2015q1/000362.html