### PR TITLE
sstp-client: fix placement of runtime dir

### DIFF
--- a/Library/Formula/sstp-client.rb
+++ b/Library/Formula/sstp-client.rb
@@ -2,6 +2,7 @@ class SstpClient < Formula
   homepage "http://sstp-client.sourceforge.net"
   url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/1.0.9/sstp-client-1.0.9.tar.gz"
   sha1 "b56c60fc6ecd8b1686d6c319a8adb3f988bcabbd"
+  revision 1
 
   bottle do
     sha1 "e94c6a28d0e72b8bc9e28de00e2bd7a58238fd7f" => :yosemite
@@ -16,11 +17,13 @@ class SstpClient < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--disable-ppp-plugin",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-runtime-dir=#{var}/run/sstpc"
+
     system "make", "install"
 
     # Create a directory needed by sstpc for privilege separation
-    mkdir_p "var/run/sstpc"
+    mkdir_p var/"run/sstpc"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
This commit fixes the placement of the privilege separation directory for `sstp-client`.

`sstp-client` chdirs to a special privilege separation directory, chroots into it and drops root privileges when it is safe to do so. By default, `sstp-client` assumes that the privilege separation directory is in `#{prefix}/var/run/sstpc`. However, `#{var}` in Homebrew refers to `#{HOMEBREW_PREFIX}/var` so we must tell `sstp-client` at configure time to use that one instead of the default.

I wasn't sure what to do with the SHA1 hashes of the bottles but I assume that @BrewTestBot will sort these out.