### PR TITLE
Updated Newlisp to 10.6.2 (10.6.3 development)

### DIFF
--- a/Library/Formula/newlisp.rb
+++ b/Library/Formula/newlisp.rb
@@ -2,12 +2,12 @@ require "formula"
 
 class Newlisp < Formula
   homepage "http://www.newlisp.org/"
-  url "http://www.newlisp.org/downloads/newlisp-10.6.0.tgz"
-  sha1 "0f5ce581d070ff171cbef504308e578885aa5e72"
+  url "http://www.newlisp.org/downloads/newlisp-10.6.2.tgz"
+  sha1 "8ea722f2ed415548a0904ef15bafd259d8b07e01"
 
   devel do
-    url "http://www.newlisp.org/downloads/development/newlisp-10.6.1.tgz"
-    sha1 "6f7d06df961022f4319b0ea7227480847e221cb0"
+    url "http://www.newlisp.org/downloads/development/inprogress/newlisp-10.6.3.tgz"
+    sha1 "15fff9bff3eb4bb2118b1941ffd34255b9a9a5b5"
   end
 
   depends_on "readline"


### PR DESCRIPTION
Since Newlisp doesn't have a download for 10.6.0 at the URL in the formula, this updates it to 10.6.2 and the development version to 10.6.3.