### PR TITLE
sysbench: test added, homepage link fixed

### DIFF
--- a/Library/Formula/sysbench.rb
+++ b/Library/Formula/sysbench.rb
@@ -1,12 +1,12 @@
-require "formula"
-
 class Sysbench < Formula
-  homepage "http://sysbench.sourceforge.net/"
+  homepage "https://launchpad.net/sysbench"
   url "http://ftp.de.debian.org/debian/pool/main/s/sysbench/sysbench_0.4.12.orig.tar.gz"
   sha1 "3f346e8b29b738711546970b027bbb7359d4672a"
+  revision 1
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "openssl"
   depends_on :mysql => :recommended
   depends_on :postgresql => :optional
 
@@ -24,5 +24,9 @@ class Sysbench < Formula
 
     system "./configure", *args
     system "make", "install"
+  end
+
+  test do
+    system "#{bin}/sysbench", "--test=cpu", "--cpu-max-prime=1", "run"
   end
 end


### PR DESCRIPTION
Sysbench [has been removed from SourceForge](http://sourceforge.net/p/forge/site-support/7738/), the homepage link gives a 404 error. I added an `openssl` dependency to fix an `audit` warning.