### PR TITLE
Fixed 404 error when attempting to install activemq

### DIFF
--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Activemq < Formula
   homepage "http://activemq.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=/activemq/5.10.1/apache-activemq-5.10.1-bin.tar.gz"
-  sha1 "5e62deb1ccd103ec1765f836756a7889f6131ab0"
+  url "http://www.apache.org/dyn/closer.cgi?path=/activemq/5.10.2/apache-activemq-5.10.2-bin.tar.gz"
+  sha1 "7b5d797abf6d6767d2f5a17935d8cac829d230cd"
 
   def install
     rm_rf Dir["bin/linux-x86-*"]


### PR DESCRIPTION
* Changed the path for the ActiveMQ tar ball to point to the new version that exists on the mirror servers.

* Changed the sha1 value the the value pulled from Apache’s website.