### PR TITLE
Fish 2.1.2

### DIFF
--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -1,7 +1,10 @@
 class Fish < Formula
   homepage "http://fishshell.com"
-  url "https://github.com/fish-shell/fish-shell/releases/download/2.1.1/fish-2.1.1.tar.gz"
-  sha1 "8f97f39b92ea7dfef1f464b18e304045bf37546d"
+  url "https://github.com/fish-shell/fish-shell/archive/2.1.2.tar.gz"
+  sha1 "fd40ed8de7497bf1578f50df6674b2d0464395fe"
+
+  depends_on "autoconf" => :build
+  depends_on "doxygen" => :build
 
   bottle do
     sha1 "61736de475346ff8aba971429d217b827730bc65" => :mavericks
@@ -11,16 +14,12 @@ class Fish < Formula
 
   head do
     url "https://github.com/fish-shell/fish-shell.git", :shallow => false
-
-    depends_on "autoconf" => :build
-    # Indeed, the head build always builds documentation
-    depends_on "doxygen" => :build
   end
 
   skip_clean "share/doc"
 
   def install
-    system "autoconf" if build.head?
+    system "autoconf"
     # In Homebrew's 'superenv' sed's path will be incompatible, so
     # the correct path is passed into configure here.
     system "./configure", "--prefix=#{prefix}", "SED=/usr/bin/sed"

--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -40,6 +40,12 @@ class Fish < Formula
     to /etc/shells. Run:
       chsh -s #{HOMEBREW_PREFIX}/bin/fish
     to make fish your default shell.
+
+    To set your colors, run 'fish_config'
+    To scan your man pages for completions, run 'fish_update_completions'
+    To autocomplete command suggestions press Ctrl + F or right arrow key.
+
+    Have fun!
     EOS
   end
 end

--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -45,12 +45,6 @@ class Fish < Formula
     to /etc/shells. Run:
       chsh -s #{HOMEBREW_PREFIX}/bin/fish
     to make fish your default shell.
-
-    To set your colors, run 'fish_config'
-    To scan your man pages for completions, run 'fish_update_completions'
-    To autocomplete command suggestions press Ctrl + F or right arrow key.
-
-    Have fun!
     EOS
   end
 end

--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -3,11 +3,6 @@ class Fish < Formula
   url "https://github.com/fish-shell/fish-shell/archive/2.1.2.tar.gz"
   sha1 "fd40ed8de7497bf1578f50df6674b2d0464395fe"
 
-  # This pair of dependencies should be revisited upon fish's next release.
-  # (they're normally only necessary for HEAD builds)
-  depends_on "autoconf" => :build
-  depends_on "doxygen" => :build
-
   bottle do
     sha1 "61736de475346ff8aba971429d217b827730bc65" => :mavericks
     sha1 "1d8d3f5656a4a9ec53d22b908581109eecfc9769" => :mountain_lion
@@ -17,6 +12,11 @@ class Fish < Formula
   head do
     url "https://github.com/fish-shell/fish-shell.git", :shallow => false
   end
+
+  # This pair of dependencies should be revisited upon fish's next release.
+  # (they're normally only necessary for HEAD builds)
+  depends_on "autoconf" => :build
+  depends_on "doxygen" => :build
 
   skip_clean "share/doc"
 

--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -3,6 +3,8 @@ class Fish < Formula
   url "https://github.com/fish-shell/fish-shell/archive/2.1.2.tar.gz"
   sha1 "fd40ed8de7497bf1578f50df6674b2d0464395fe"
 
+  # This pair of dependencies should be revisited upon fish's next release.
+  # (they're normally only necessary for HEAD builds)
   depends_on "autoconf" => :build
   depends_on "doxygen" => :build
 
@@ -19,6 +21,9 @@ class Fish < Formula
   skip_clean "share/doc"
 
   def install
+    # As described above, needing autoconf on a release is temporary; once
+    # fish has another major release, we can probably restore the
+    # `if build.head?` statement modifier.
     system "autoconf"
     # In Homebrew's 'superenv' sed's path will be incompatible, so
     # the correct path is passed into configure here.


### PR DESCRIPTION
I had to move the `autoconf` and `doxygen` dependencies out of `head` since version 2.1.2 [is "just" a tag](https://github.com/fish-shell/fish-shell/releases/tag/2.1.2).