### PR TITLE
Fix the --include-related option for 10.9

### DIFF
--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -43,6 +43,10 @@ class Mu < Formula
     # shipped by default with Mac OS X is too old.
     ENV["EMACS"] = "no" if build.without? "emacs"
 
+    # Make --related work on 10.9
+    # https://github.com/djcb/mu/issues/380
+    ENV.O0 if MacOS.version >= :mavericks && ENV.compiler == :clang
+
     # I dunno.
     # https://github.com/djcb/mu/issues/332
     # https://github.com/Homebrew/homebrew/issues/25524
@@ -53,7 +57,6 @@ class Mu < Formula
                           "--prefix=#{prefix}",
                           "--with-gui=none"
     system "make"
-    system "make test"
     system "make install"
   end
 
@@ -62,5 +65,41 @@ class Mu < Formula
 
       mu index --rebuild
     EOS
+  end
+
+  test do
+    mkdir (testpath/"cur")
+
+    (testpath/"cur/1234567890.11111_1.host1!2,S").write <<-EOS.undent
+      From: "Road Runner" <fasterthanyou@example.com>
+      To: "Wile E. Coyote" <wile@example.com>
+      Date: Mon, 4 Aug 2008 11:40:49 +0200
+      Message-id: <1111111111@example.com>
+
+      Beep beep!
+    EOS
+
+    (testpath/"cur/0987654321.22222_2.host2!2,S").write <<-EOS.undent
+      From: "Wile E. Coyote" <wile@example.com>
+      To: "Road Runner" <fasterthanyou@example.com>
+      Date: Mon, 4 Aug 2008 12:40:49 +0200
+      Message-id: <2222222222@example.com>
+      References: <1111111111@example.com>
+
+      This used to happen outdoors. It was more fun then.
+    EOS
+
+    system "#{bin}/mu", "index",
+                        "--muhome",
+                        testpath,
+                        "--maildir=#{testpath}"
+
+    mu_find = "#{bin}/mu find --muhome #{testpath} "
+    find_message = "#{mu_find} msgid:2222222222@example.com"
+    find_message_and_related = "#{mu_find} --include-related msgid:2222222222@example.com"
+
+    assert_equal 1, shell_output(find_message).lines.count
+    assert_equal 2, shell_output(find_message_and_related).lines.count,
+                 "You tripped over https://github.com/djcb/mu/issues/380\n\t--related doesn't work. Everything else should"
   end
 end

--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -43,14 +43,9 @@ class Mu < Formula
     # shipped by default with Mac OS X is too old.
     ENV["EMACS"] = "no" if build.without? "emacs"
 
-    # Make --related work on 10.9
     # https://github.com/djcb/mu/issues/380
-    ENV.O0 if MacOS.version >= :mavericks && ENV.compiler == :clang
-
-    # I dunno.
     # https://github.com/djcb/mu/issues/332
-    # https://github.com/Homebrew/homebrew/issues/25524
-    ENV.delete "MACOSX_DEPLOYMENT_TARGET"
+    ENV.O0 if MacOS.version >= :mavericks && ENV.compiler == :clang
 
     system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
CXXFLAGS='-std=c++11' need to be set for xapian to be happy, it seems.

Fix from: https://github.com/djcb/mu/issues/380