### PR TITLE
Update Gratipay badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Code is under the [BSD 2 Clause (NetBSD) license](https://github.com/Homebrew/ho
 ## Donations
 We accept tips through [Gratipay](https://gratipay.com/Homebrew/).
 
-[![Gratipay](https://img.shields.io/gratipay/Homebrew.svg?style=flat)](https://www.gittip.com/Homebrew/)
+[![Gratipay](https://img.shields.io/gratipay/Homebrew.svg?style=flat)](https://gratipay.com/Homebrew/)


### PR DESCRIPTION
Since gittip.com redirects to gratipay.com, this changes the README badge to link directly to Gratipay.