### PR TITLE
mpich: Update to 3.1.4 and fix testing

### DIFF
--- a/Library/Formula/mpich2.rb
+++ b/Library/Formula/mpich2.rb
@@ -2,10 +2,9 @@
 # formula renames, see homebrew issue #14374.
 class Mpich2 < Formula
   homepage "http://www.mpich.org/"
-  url "http://www.mpich.org/static/downloads/3.1.3/mpich-3.1.3.tar.gz"
-  mirror "https://fossies.org/linux/misc/mpich-3.1.3.tar.gz"
-  sha1 "aa9907891ef4a4a584ab2f90a86775f29ca0dec0"
-  revision 1
+  url "http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz"
+  mirror "https://fossies.org/linux/misc/mpich-3.1.4.tar.gz"
+  sha1 "af4f563e2772d610e57e17420c9dcc5c3c9fec4e"
 
   bottle do
     sha1 "9cb9688f9c881de7e4874f670ad007710dc90483" => :yosemite
@@ -51,7 +50,7 @@ class Mpich2 < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "testing"
+    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
A recent commit changes the formula to use `make testing`. That's not
the right way to test the installation and will make the entire process
take forever. Instead, just use `make check` as a basic sanity check.