### PR TITLE
newsbeuter: install scripts

### DIFF
--- a/Library/Formula/newsbeuter.rb
+++ b/Library/Formula/newsbeuter.rb
@@ -24,6 +24,9 @@ class Newsbeuter < Formula
     ENV.cxx11
     system "make"
     system "make", "install", "prefix=#{prefix}"
+
+    share.install "contrib"
+    (doc/"examples").install "doc/example-bookmark-plugin.sh"
   end
 
   test do


### PR DESCRIPTION
`make install` creates the `doc/"examples"` directory, but it doesn't install the sample bookmark script or any of the files in `contrib` (colorschemes, scripts for sending articles to Pinboard, Pocket, etc.).