### PR TITLE
Closure-Compiler v20150126

### DIFF
--- a/Library/Formula/closure-compiler.rb
+++ b/Library/Formula/closure-compiler.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class ClosureCompiler < Formula
   homepage "https://github.com/google/closure-compiler"
-  url "https://github.com/google/closure-compiler/archive/maven-release-v20141023.tar.gz"
-  sha1 "4551a74f0ccfd7e1de325d495b5f71f71a3b24c8"
+  url "https://github.com/google/closure-compiler/archive/maven-release-v20150126.tar.gz"
+  sha1 "2d21bd4faf8a982346d390391d7f6d0e60fe571b"
 
   head "https://github.com/google/closure-compiler.git"
 
@@ -15,7 +13,7 @@ class ClosureCompiler < Formula
   end
 
   depends_on :ant => :build
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
 
   def install
     system "ant", "clean"

--- a/Library/Formula/closure-compiler.rb
+++ b/Library/Formula/closure-compiler.rb
@@ -1,7 +1,7 @@
 class ClosureCompiler < Formula
   homepage "https://github.com/google/closure-compiler"
   url "https://github.com/google/closure-compiler/archive/maven-release-v20150126.tar.gz"
-  sha1 "2d21bd4faf8a982346d390391d7f6d0e60fe571b"
+  sha256 "cedd1746f2e47bad781aaba9c80e5409906d09af309f05c03832dea05497e375"
 
   head "https://github.com/google/closure-compiler.git"
 
@@ -21,5 +21,18 @@ class ClosureCompiler < Formula
 
     libexec.install Dir["*"]
     bin.write_jar_script libexec/"build/compiler.jar", "closure-compiler"
+  end
+
+  test do
+    (testpath/"test.js").write <<-EOS.undent
+      (function(){
+        var count = true;
+        return count;
+      })();
+    EOS
+    system bin/"closure-compiler",
+           "--js", testpath/"test.js",
+           "--js_output_file", testpath/"out.js"
+    assert_equal (testpath/"out.js").read.chomp, "(function(){return!0})();"
   end
 end


### PR DESCRIPTION
Update to latest stable release, change dependency to allow versions of Java higher than 1.7, remove `require "formula"`.