### PR TITLE
libmusicbrainz 5.1.0

### DIFF
--- a/Library/Formula/libmusicbrainz.rb
+++ b/Library/Formula/libmusicbrainz.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Libmusicbrainz < Formula
-  homepage 'http://musicbrainz.org/doc/libmusicbrainz'
-  url 'https://github.com/downloads/metabrainz/libmusicbrainz/libmusicbrainz-5.0.1.tar.gz'
-  sha1 'd4823beeca3faf114756370dc7dd6e3cd01d7e4f'
+  homepage "https://musicbrainz.org/doc/libmusicbrainz"
+  url "https://github.com/metabrainz/libmusicbrainz/releases/download/release-5.1.0/libmusicbrainz-5.1.0.tar.gz"
+  sha1 "1576b474c777bb9c4ff906853ef1d3bb14915f50"
 
   bottle do
     cellar :any
@@ -13,14 +11,14 @@ class Libmusicbrainz < Formula
     sha1 "869651234ba41e4a878402de4fbb7cacce190aab" => :mountain_lion
   end
 
-  depends_on 'cmake' => :build
-  depends_on 'neon'
+  depends_on "cmake" => :build
+  depends_on "neon"
 
   def install
     neon = Formula["neon"]
     neon_args = %W[-DNEON_LIBRARIES:FILEPATH=#{neon.lib}/libneon.dylib
-                 -DNEON_INCLUDE_DIR:PATH=#{neon.include}/neon]
+                   -DNEON_INCLUDE_DIR:PATH=#{neon.include}/neon]
     system "cmake", ".", *(std_cmake_args + neon_args)
-    system "make install"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
Update to latest stable release, use HTTPS homepage URL, reformat `make` command, change single quotes to double, align elements of multi-line array literal, remove `require 'formula'`.