### PR TITLE
hugo 0.13

### DIFF
--- a/Library/Formula/hugo.rb
+++ b/Library/Formula/hugo.rb
@@ -1,8 +1,8 @@
 class Hugo < Formula
-  homepage "http://hugo.spf13.com/"
+  homepage "http://gohugo.io/"
   head "https://github.com/spf13/hugo.git"
-  url "https://github.com/spf13/hugo/archive/v0.12.tar.gz"
-  sha1 "f0537942cde9645ee2d98aaaf927a80c79070e99"
+  url "https://github.com/spf13/hugo/archive/v0.13.tar.gz"
+  sha1 "a821fcde92b03baf49a45970d0ae6b781a3b12c1"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Running `hugo version` gives `Hugo Static Site Generator v0.14-DEV BuildDate: 2015-02-21T23:47:42-08:00`, but I think that's an issue with the Go build system; `hugo version` on the 0.12 bottle gives `Hugo Static Site Generator v0.13-DEV buildDate: 2015-01-16T00:28:45-08:00` so ¯\\\_(ツ)\_/¯ 