### PR TITLE
centre-im: fix system openssl linkage

### DIFF
--- a/Library/Formula/center-im.rb
+++ b/Library/Formula/center-im.rb
@@ -1,13 +1,13 @@
-require 'formula'
-
 class CenterIm < Formula
-  homepage 'http://www.centerim.org/index.php/Main_Page'
-  url 'http://www.centerim.org/download/releases/centerim-4.22.10.tar.gz'
-  sha1 '46fbac7a55f33b0d4f42568cca21ed83770650e5'
+  homepage "http://www.centerim.org/index.php/Main_Page"
+  url "http://www.centerim.org/download/releases/centerim-4.22.10.tar.gz"
+  sha1 "46fbac7a55f33b0d4f42568cca21ed83770650e5"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gettext'
-  depends_on 'jpeg' => :optional
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "openssl"
+  depends_on "jpeg" => :optional
 
   # Fix build with clang; 4.22.10 is an outdated release and 5.0 is a rewrite,
   # so this is not reported upstream
@@ -21,7 +21,14 @@ class CenterIm < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-msn"
-    system "make install"
+    system "make", "install"
+
+    # /bin/gawk does not exist on OS X
+    inreplace bin/"cimformathistory", "/bin/gawk", "/usr/bin/awk"
+  end
+
+  test do
+    assert_match /trillian/, shell_output("#{bin}/cimconv")
   end
 end
 


### PR DESCRIPTION
Primary: Fixes the hooking into the system OpenSSL.
Secondary: Style nits. New inreplace for a prior unnoticed/unfixed error. A simple test as the primary command just insta-fires up the terminal graphical interface.