### PR TITLE
global: Use opt_prefix in install config file.

### DIFF
--- a/Library/Formula/global.rb
+++ b/Library/Formula/global.rb
@@ -56,6 +56,7 @@ class Global < Formula
       bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
     end
 
+    inreplace "gtags.conf", prefix, opt_prefix
     etc.install "gtags.conf"
 
     # we copy these in already


### PR DESCRIPTION
The installed configuration file (`/usr/local/etc/gtags.conf`) should not contain prefix paths (i.e. `/usr/local/Cellar/global/6.3.4/lib/gtags/exuberant-ctags.la`) since they will break when updating to a newer version instead op_prefix paths shoul be used (`/usr/local/opt/global/lib/gtags/exuberant-ctags.la`).