### PR TITLE
libpointing: fix homepage URL

### DIFF
--- a/Library/Formula/libpointing.rb
+++ b/Library/Formula/libpointing.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Libpointing < Formula
-  homepage "http://pointing.org"
+  homepage "http://libpointing.org"
   url "http://libpointing.org/homebrew/libpointing-0.92.tar.gz"
   sha1 "a7f20c405e87a4b6fae369f977c0615a621ab143"
 


### PR DESCRIPTION
The homepage URL was previously http://pointing.org, which is a parking page; this changes it to http://libpointing.org.