### PR TITLE
Add a test for mu

### DIFF
--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -53,7 +53,6 @@ class Mu < Formula
                           "--prefix=#{prefix}",
                           "--with-gui=none"
     system "make"
-    system "make test"
     system "make install"
   end
 
@@ -62,5 +61,34 @@ class Mu < Formula
 
       mu index --rebuild
     EOS
+  end
+
+  test do
+    mkdir (testpath/"cur")
+
+    (testpath/"cur/1234567890.11111_1.host1!2,S").write <<-EOS.undent
+      From: "Road Runner" <fasterthanyou@example.com>
+      To: "Wile E. Coyote" <wile@example.com>
+      Date: Mon, 4 Aug 2008 11:40:49 +0200
+      Message-id: <1111111111@example.com>
+
+      Beep beep!
+    EOS
+
+    (testpath/"cur/0987654321.22222_2.host2!2,S").write <<-EOS.undent
+      From: "Wile E. Coyote" <wile@example.com>
+      To: "Road Runner" <fasterthanyou@example.com>
+      Date: Mon, 4 Aug 2008 12:40:49 +0200
+      Message-id: <2222222222@example.com>
+      References: <1111111111@example.com>
+
+      This used to happen outdoors. It was more fun then.
+    EOS
+
+    system "#{bin}/mu index --muhome #{testpath} --maildir=#{testpath}"
+
+    assert_equal "1", `#{bin}/mu find --muhome #{testpath} msgid:2222222222@example.com | wc -l`.strip
+    assert_equal "2", `#{bin}/mu find --muhome #{testpath} --include-related msgid:2222222222@example.com | wc -l`.strip,
+                 "You tripped over https://github.com/djcb/mu/issues/380\n\t--related doesn't work. Everything else should"
   end
 end


### PR DESCRIPTION
The expectation is that mavericks and yosemite will fail this test.

https://github.com/djcb/mu/issues/380 is a tricky one too fix, it seems.

I also removed the `make test` - the brew test is more verbose and explains the error better.