### PR TITLE
test_fixtures: copy in testpath if called during testing

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -652,7 +652,13 @@ class Formula
   end
 
   def test_fixtures(file)
-    HOMEBREW_LIBRARY.join("Homebrew", "test", "fixtures", file)
+    path = HOMEBREW_LIBRARY.join("Homebrew", "test", "fixtures", file)
+    unless @testpath.nil?
+      oldpath = path
+      path = @testpath/file
+      cp oldpath, path
+    end
+    path
   end
 
   def install


### PR DESCRIPTION
I noticed when writing a test for `aacgain` (#37079) that when a test uses a fixture Homebrew doesn’t restore it to its pristine state at the end. This PR fixes that by copying test fixtures in `@testpath` if it’s defined (i.e. we’re running a test).