### PR TITLE
Update website for figtoipe

### DIFF
--- a/Library/Formula/figtoipe.rb
+++ b/Library/Formula/figtoipe.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Figtoipe < Formula
   homepage 'http://ipe7.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/ipe7/tools/figtoipe-20091205.tar.gz'
+  url 'http://hg.mrzv.org/IpePresenter/archive/f29d75686e95.tar.gz'
   sha1 'b81f2f0cc568e165bdedb618ced9384ebfcb19a3'
 
   def install


### PR DESCRIPTION
The current website for the figtoipe download is outdated; updated file includes new website (I manually verified it to contain the same contents.)