### PR TITLE
typos fixed & empty lines removed in the brew manpage

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -327,7 +327,7 @@ Note that these flags should only appear after a command.
   * `sh [--env=std]`:
     Instantiate a Homebrew build environment. Uses our years-battle-hardened
     Homebrew build logic to help your `./configure && make && make install`
-    or even your `gem install` succeeed. Especially handy if you run Homebrew
+    or even your `gem install` succeed. Especially handy if you run Homebrew
     in a Xcode-only configuration since it adds tools like make to your PATH
     which otherwise build-systems would not find.
 
@@ -337,9 +337,8 @@ Note that these flags should only appear after a command.
     <tap> is of the form <user>/<repo>, e.g. `brew tap homebrew/dupes`.
 
   * `tap --repair`:
-
-    Ensures all tapped formula are symlinked into Library/Formula and prunes dead
-    formula from Library/Formula.
+    Ensure all tapped formulae are symlinked into Library/Formula and prune dead
+    formulae from Library/Formula.
 
   * `test` [--devel|--HEAD] [--debug] <formula>:
     A few formulae provide a test method. `brew test <formula>` runs this
@@ -366,7 +365,6 @@ Note that these flags should only appear after a command.
     If no <formulae> are provided, all linked app will be removed.
 
   * `unpack [--git|--patch] [--destdir=<path>]` <formulae>:
-
     Unpack the source files for <formulae> into subdirectories of the current
     working directory. If `--destdir=<path>` is given, the subdirectories will
     be created in the directory named by `<path>` instead.

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -349,7 +349,7 @@ Search for \fItext\fR in the given package manager\'s list\.
 .
 .TP
 \fBsh [\-\-env=std]\fR
-Instantiate a Homebrew build environment\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeeed\. Especially handy if you run Homebrew in a Xcode\-only configuration since it adds tools like make to your PATH which otherwise build\-systems would not find\.
+Instantiate a Homebrew build environment\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeed\. Especially handy if you run Homebrew in a Xcode\-only configuration since it adds tools like make to your PATH which otherwise build\-systems would not find\.
 .
 .TP
 \fBtap\fR [\fItap\fR]
@@ -359,10 +359,8 @@ Tap a new formula repository from GitHub, or list existing taps\.
 \fItap\fR is of the form \fIuser\fR/\fIrepo\fR, e\.g\. \fBbrew tap homebrew/dupes\fR\.
 .
 .TP
-\fBtap \-\-repair\fR:
-.
-.IP
-Ensures all tapped formula are symlinked into Library/Formula and prunes dead formula from Library/Formula\.
+\fBtap \-\-repair\fR
+Ensure all tapped formulae are symlinked into Library/Formula and prune dead formulae from Library/Formula\.
 .
 .TP
 \fBtest\fR [\-\-devel|\-\-HEAD] [\-\-debug] \fIformula\fR
@@ -389,9 +387,7 @@ Removes links created by \fBbrew linkapps\fR\.
 If no \fIformulae\fR are provided, all linked app will be removed\.
 .
 .TP
-\fBunpack [\-\-git|\-\-patch] [\-\-destdir=<path>]\fR \fIformulae\fR:
-.
-.IP
+\fBunpack [\-\-git|\-\-patch] [\-\-destdir=<path>]\fR \fIformulae\fR
 Unpack the source files for \fIformulae\fR into subdirectories of the current working directory\. If \fB\-\-destdir=<path>\fR is given, the subdirectories will be created in the directory named by \fB<path>\fR instead\.
 .
 .IP


### PR DESCRIPTION
These lines break the manpage formatting for the two commands, e.g.:

![manpage screenshot](https://cloud.githubusercontent.com/assets/1334295/6335423/c458a942-bb9b-11e4-874a-7df94ff5cc28.png)

I also fixed a couple typos I found when reviewing this PR ~~before hitting the submit button~~.