### PR TITLE
audit: fix FormulaText match

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -69,6 +69,14 @@ class FormulaText
   def has_trailing_newline?
     /\Z\n/ =~ @text
   end
+
+  def =~ regex
+    regex =~ @text
+  end
+
+  def !~ regex
+    regex !~ @text
+  end
 end
 
 class FormulaAuditor


### PR DESCRIPTION
It's used in `audit_text`.

I found this when implementing `audit_java_home`.