### PR TITLE
jack: remove dead celt dep

### DIFF
--- a/Library/Formula/jack.rb
+++ b/Library/Formula/jack.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 # This now builds a version of JACKv1 which matches the current API
 # for JACKv2. JACKv2 is not buildable on a number of Mac OS X
 # distributions, and the JACK team instead suggests installation of
@@ -8,7 +6,7 @@ require 'formula'
 # operate fine.
 # Please see https://github.com/Homebrew/homebrew/pull/22043 for more info
 class Jack < Formula
-  homepage 'http://jackaudio.org'
+  homepage "http://jackaudio.org"
   url "http://jackaudio.org/downloads/jack-audio-connection-kit-0.124.1.tar.gz"
   sha1 "e9ba4a4c754ec95fbe653dcf7344edd6cc47cd60"
 
@@ -19,10 +17,10 @@ class Jack < Formula
     sha1 "01f34e585df06210bfc2f06d07d1ef7058d17f67" => :mountain_lion
   end
 
-  depends_on 'berkeley-db'
-  depends_on 'celt'
-  depends_on 'libsndfile'
-  depends_on 'libsamplerate'
+  depends_on "pkg-config" => :build
+  depends_on "berkeley-db"
+  depends_on "libsndfile"
+  depends_on "libsamplerate"
 
   # Change pThread header include from CarbonCore
   patch :p0, :DATA if MacOS.version >= :mountain_lion
@@ -54,9 +52,9 @@ class Jack < Formula
   end
 
   def install
-    ENV['LINKFLAGS'] = ENV.ldflags
+    ENV["LINKFLAGS"] = ENV.ldflags
     system "./configure", "--prefix=#{prefix}"
-    system "make","install"
+    system "make", "install"
   end
 end
 


### PR DESCRIPTION
Removed Celt in https://github.com/Homebrew/homebrew/commit/45f47a5e73ab8f506231c30e42a753a0cb841832 which upset Jack. I ran a `brew uses` beforehand but apparently missed the one-formula reply because I was particularly stupid at the time.

It builds and works fine without it. Celt at best should have been a recommended or optional dep, I suspect. Opus has indeed replaced Celt, but because they merged it into Opus and ditched the Celt name, Jack doesn’t know how to find it under the new name. Either upstream hasn’t done anything about the change, or it hasn’t been reported, I guess.

Filed a bug report incase: https://github.com/jackaudio/jack1/issues/19

Closes #37134