### PR TITLE
checksums: switch to sha256 for bottles and new formulae

### DIFF
--- a/Library/Contributions/example-formula.rb
+++ b/Library/Contributions/example-formula.rb
@@ -29,17 +29,17 @@ class ExampleFormula < Formula
   # version is seldom needed, because it's usually autodetected from the URL/tag.
   version "1.2-final"
 
-  # For integrity and security, we verify the hash (`openssl dgst -sha1 <FILE>`)
-  # You may also use sha256 if the software uses sha256 on their homepage. Do not use md5.
+  # For integrity and security, we verify the hash (`openssl dgst -sha256 <FILE>`)
+  # You should use SHA256. Never use md5.
   # Either generate the sha locally or leave it empty & `brew install` will tell you the expected.
-  sha1 "cafebabe78901234567890123456789012345678"
+  sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"
 
   # Stable-only dependencies should be nested inside a `stable` block rather than
   # using a conditional. It is preferrable to also pull the URL and checksum into
   # the block if one is necessary.
   stable do
     url "https://example.com/foo-1.0.tar.gz"
-    sha1 "cafebabe78901234567890123456789012345678"
+    sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"
 
     depends_on "libxml2"
     depends_on "libffi"
@@ -65,7 +65,7 @@ class ExampleFormula < Formula
   # Use this to specify a not-yet-released version of a software.
   devel do
     url "https://example.com/archive-2.0-beta.tar.gz"
-    sha1 "1234567890123456789012345678901234567890"
+    sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"
 
     depends_on "cairo"
     depends_on "pixman"
@@ -97,9 +97,9 @@ class ExampleFormula < Formula
     prefix "/opt/homebrew" # Optional HOMEBREW_PREFIX in which the bottles were built.
     cellar "/opt/homebrew/Cellar" # Optional HOMEBREW_CELLAR in which the bottles were built.
     revision 1 # Making the old bottle outdated without bumping the version of the formula.
-    sha1 "d3d13fe6f42416765207503a946db01378131d7b" => :yosemite
-    sha1 "cdc48e79de2dee796bb4ba1ad987f6b35ce1c1ee" => :mavericks
-    sha1 "a19b544c8c645d7daad1d39a070a0eb86dfe9b9c" => :mountain_lion
+    sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7" => :yosemite
+    sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7" => :mavericks
+    sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7" => :mountain_lion
   end
 
   def pour_bottle?
@@ -204,7 +204,7 @@ class ExampleFormula < Formula
   # head block. This mechanism replaces ad-hoc "subformula" classes.
   resource "additional_files" do
     url "https://example.com/additional-stuff.tar.gz"
-    sha1 "deadbeef7890123456789012345678901234567890"
+    sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
   end
 
 
@@ -213,14 +213,14 @@ class ExampleFormula < Formula
   # External patches can be declared using resource-style blocks.
   patch do
     url "https://example.com/example_patch.diff"
-    sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
   end
 
   # A strip level of -p1 is assumed. It can be overridden using a symbol
   # argument:
   patch :p0 do
     url "https://example.com/example_patch.diff"
-    sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
   end
 
   # Patches can be declared in stable, devel, and head blocks. This form is
@@ -228,7 +228,7 @@ class ExampleFormula < Formula
   stable do
     patch do
       url "https://example.com/example_patch.diff"
-      sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+      sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
     end
   end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -838,9 +838,15 @@ class ResourceAuditor
 
     case checksum.hash_type
     when :md5
-      problem "MD5 checksums are deprecated, please use SHA1 or SHA256"
+      problem "MD5 checksums are deprecated, please use SHA256"
       return
-    when :sha1   then len = 40
+    when :sha1
+      if ARGV.include? "--strict"
+        problem "SHA1 checksums are deprecated, please use SHA256"
+        return
+      else
+        len = 40
+      end
     when :sha256 then len = 64
     end
 

--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -202,7 +202,7 @@ module Homebrew
     bottle.prefix prefix
     bottle.cellar relocatable ? :any : cellar
     bottle.revision bottle_revision
-    bottle.sha1 bottle_path.sha1 => bottle_tag
+    bottle.sha256 bottle_path.sha256 => bottle_tag
 
     output = bottle_output bottle
 

--- a/Library/Homebrew/cmd/create.rb
+++ b/Library/Homebrew/cmd/create.rb
@@ -73,7 +73,7 @@ module Homebrew
 end
 
 class FormulaCreator
-  attr_reader :url, :sha1
+  attr_reader :url, :sha256
   attr_accessor :name, :version, :path, :mode
 
   def url= url
@@ -112,7 +112,7 @@ class FormulaCreator
       r.url(url)
       r.version(version)
       r.owner = self
-      @sha1 = r.fetch.sha1 if r.download_strategy == CurlDownloadStrategy
+      @sha256 = r.fetch.sha256 if r.download_strategy == CurlDownloadStrategy
     end
 
     path.write ERB.new(template, nil, '>').result(binding)
@@ -129,7 +129,7 @@ class FormulaCreator
     <% unless version.nil? or version.detected_from_url? %>
       version "#{version}"
     <% end %>
-      sha1 "#{sha1}"
+      sha256 "#{sha256}"
 
     <% if mode == :cmake %>
       depends_on "cmake" => :build

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -122,7 +122,7 @@ class Resource
   rescue ChecksumMissingError
     opoo "Cannot verify integrity of #{fn.basename}"
     puts "A checksum was not provided for this resource"
-    puts "For your reference the SHA1 is: #{fn.sha1}"
+    puts "For your reference the SHA256 is: #{fn.sha256}"
   end
 
   Checksum::TYPES.each do |type|

--- a/Library/Homebrew/test/test_resource.rb
+++ b/Library/Homebrew/test/test_resource.rb
@@ -113,7 +113,7 @@ class ResourceTests < Homebrew::TestCase
 
     fn.stubs(:file? => true)
     fn.expects(:verify_checksum).raises(ChecksumMissingError)
-    fn.expects(:sha1)
+    fn.expects(:sha256)
 
     shutup { @resource.verify_download_integrity(fn) }
   end

--- a/share/doc/homebrew/Bottles.md
+++ b/share/doc/homebrew/Bottles.md
@@ -23,9 +23,9 @@ Bottles have a DSL to be used in formulae which is contained in the `bottle do .
 A simple (and typical) example:
 ```ruby
 bottle do
-  sha1 "23ef6a81af2f37166d7d7423b88f7716bf9b0629" => :yosemite
-  sha1 "fdc919d750012fbfeeec8b3f95d07000adc3c946" => :mavericks
-  sha1 "0d08b3ca611f47a25a922b2d942f157f1d6268c1" => :mountain_lion
+  sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :yosemite
+  sha256 "c71db15326ee9196cd98602e38d0b7fb2b818cdd48eede4ee8eb827d809e09ba" => :mavericks
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7" => :mountain_lion
 end
 ```
 
@@ -36,9 +36,9 @@ bottle do
   prefix "/opt/homebrew"
   cellar "/opt/homebrew/Cellar"
   revision 4
-  sha1 "23ef6a81af2f37166d7d7423b88f7716bf9b0629" => :yosemite
-  sha1 "fdc919d750012fbfeeec8b3f95d07000adc3c946" => :mavericks
-  sha1 "0d08b3ca611f47a25a922b2d942f157f1d6268c1" => :mountain_lion
+  sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :yosemite
+  sha256 "c71db15326ee9196cd98602e38d0b7fb2b818cdd48eede4ee8eb827d809e09ba" => :mavericks
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7" => :mountain_lion
 end
 ```
 
@@ -58,8 +58,8 @@ See description of `cellar`. When `cellar` is `:any` prefix should be omitted.
 Optionally contains the revision of the bottle.
 Sometimes bottles may need be updated without bumping the version of the formula e.g. a new patch was applied. In that case the revision will have a value of 1 or more.
 
-### `sha1`
-Contains the SHA-1 of bottle for a particular version of OS X.
+### `sha256`
+Contains the SHA-256 of bottle for a particular version of OS X.
 
 ## Formula DSL
 Additionally there is a method available in the formula DSL.

--- a/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
+++ b/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
@@ -19,7 +19,7 @@ To pull and bottle a pull request with `brew pull`:
 
 1. Ensure the job has already completed successfully.
 2. Run `brew pull --bottle 12345` where `12345` is the pull request number (or URL). If it complains about a missing URL with `BrewTestBot` in it then the bottles have not finished uploading yet; wait and try again later.
-3. Run `brew fetch --force-bottle $FORMULAE` to check the SHA-1 in the bottled formulae match the uploaded files.
+3. Run `brew fetch --force-bottle $FORMULAE` to check the SHA-256 in the bottled formulae match the uploaded files.
 4. Run `git push` to push the commits.
 
 To bottle a test build or pull request without `brew pull`:
@@ -29,5 +29,5 @@ To bottle a test build or pull request without `brew pull`:
 3. Run `git fetch --tags https://github.com/BrewTestBot/homebrew.git`
 4. For testing builds run `git merge testing-123` (where `123` is the testing job number). For pull requests builds run `git merge pr-45678` (where `45678` is the pull request number).
 5. Run `git rebase origin/master` to get rid of any nasty merge commits.
-6. Run `brew fetch --force-bottle $FORMULAE` to check the SHA-1 in the bottled formulae match the uploaded files.
+6. Run `brew fetch --force-bottle $FORMULAE` to check the SHA-256 in the bottled formulae match the uploaded files.
 7. Run `git push` to push the commits.

--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -99,7 +99,7 @@ And opens it in your `$EDITOR`. It'll look like:
 class Foo < Formula
   url "http://example.com/foo-0.1.tar.gz"
   homepage ""
-  sha1 "1234567890ABCDEF1234567890ABCDEF"
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
 
   # depends_on "cmake" => :build
 
@@ -257,7 +257,7 @@ If you're installing an application then please locally vendor all the language-
 class Foo < Formula
   resource "pycrypto" do
     url "https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.tar.gz"
-    sha1 "c17e41a80b3fbf2ee4e8f2d8bb9e28c5d08bbb84"
+    sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
   end
 
   def install
@@ -476,7 +476,7 @@ External patches can be declared using resource-style blocks:
 ```rb
 patch do
   url "https://example.com/example_patch.diff"
-  sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
 end
 ```
 
@@ -485,7 +485,7 @@ A strip level of -p1 is assumed. It can be overridden using a symbol argument:
 ```rb
 patch :p0 do
   url "https://example.com/example_patch.diff"
-  sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
 end
 ```
 
@@ -497,7 +497,7 @@ stable do
 
   patch do
     url "https://example.com/example_patch.diff"
-    sha1 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
   end
 end
 ```
@@ -583,7 +583,7 @@ The "devel" spec (activated by passing `--devel`) is used for a project’s unst
 ```ruby
 devel do
   url "https://foo.com/foo-0.1.tar.gz"
-  sha1 "deadbeefdeadbeefdeadbeafdeadbeefdeadbeef"
+  sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
 end
 ```
 
@@ -895,7 +895,7 @@ Homebrew provides two Formula methods for launchd plist files. `plist_name` will
 
 ## Updating formulae
 
-Eventually a new version of the software will be released. In this case you should update the `url` and `sha1`/`sha256`. Please leave the `bottle do ... end`  block as-is; our CI system will update it when we pull your change.
+Eventually a new version of the software will be released. In this case you should update the `url` and `sha256`. Please leave the `bottle do ... end`  block as-is; our CI system will update it when we pull your change.
 
 Check if the formula you are updating is a dependency for any other formulae by running `brew uses UPDATED_FORMULA`. If it is a dependency please `brew reinstall` all the dependencies after it is installed and verify they work correctly.
 


### PR DESCRIPTION
As far as I can see, the SHA1 check on this was first introduced at least as far back as the middle of 2012, when a very low number of formulae had SHA256 checksums.

Circle forwards to 2015 and we have ~210 formulae using SHA256 checksums, with (hopefully) more to follow in the coming months/years/etc.

This has resulted in an odd discrepancy where Homebrew effectively downgrades the SHA check on formula with SHA256 checksums from SHA256 via source to SHA1 via bottle.

Consequently, I’d like to propose that we start generating bottles with SHA256 hashes. I contemplated examining the formula file for the checksum it was using, and then adopting that SHA1/SHA256 and passing either ` bottle.sha256 bottle_path.sha256 ` or ` bottle.sha1 bottle_path.sha1 ` to the bottle mechanism depending on what the response was, but I’m not entirely sure what the complexity would gain Homebrew, to be honest.

None of the machines that we currently support building bottles for have any significant computational delay generating SHA256sums, and all are capable of generating those SHA256sums, so there wouldn’t be a user-appreciable gain in performance in only supporting SHA1, or rather a user-appreciable loss of performance in supporting SHA256 if you prefer it phrased that way around.

Just pondering on this really. I think given the slow move away from SHA1, this wouldn’t be a bad place to start, as it’d only impact formula authors and/or maintainers and is a tiny change. It also doesn't break the status quo as far as my testing goes. Bottles with SHA1 are still accepted, you just can't generate bottles with SHA1 anymore.

Thoughts?