### PR TITLE
lemur 4.11

### DIFF
--- a/Library/Formula/lemur.rb
+++ b/Library/Formula/lemur.rb
@@ -18,11 +18,7 @@ class Lemur < Formula
     system "#{bin}/GenL2Norm"
     system "#{bin}/GenerateQueryModel"
     system "#{bin}/GenerateSmoothSupport"
-    system "#{bin}/IndriBuildIndex"
-    system "#{bin}/IndriDaemon"
-    system "#{bin}/IndriRunQuery"
     system "#{bin}/ModifyFields"
-    system "#{bin}/PDictManager"
     system "#{bin}/ParseInQueryOp"
     system "#{bin}/ParseQuery"
     system "#{bin}/ParseToFile"
@@ -34,11 +30,5 @@ class Lemur < Formula
     system "#{bin}/StructQueryEval"
     system "#{bin}/TwoStageRetEval"
     system "#{bin}/XlingRetEval"
-    system "#{bin}/dumpDoc"
-    system "#{bin}/dumpTerm"
-    system "#{bin}/dumpindex"
-    system "#{bin}/harvestlinks"
-    system "#{bin}/makeprior"
-    system "#{bin}/pagerank"
   end
 end

--- a/Library/Formula/lemur.rb
+++ b/Library/Formula/lemur.rb
@@ -1,0 +1,44 @@
+class Lemur < Formula
+  homepage "http://www.lemurproject.org/lemur.php"
+  url "https://github.com/fsqcds/lemur-4.11.git"
+
+  def install
+    ENV.deparallelize
+    ENV.no_optimization
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/BuildDocMgr"
+    system "#{bin}/BuildIndex"
+    system "#{bin}/BuildPropIndex"
+    system "#{bin}/EstimateDirPrior"
+    system "#{bin}/GenL2Norm"
+    system "#{bin}/GenerateQueryModel"
+    system "#{bin}/GenerateSmoothSupport"
+    system "#{bin}/IndriBuildIndex"
+    system "#{bin}/IndriDaemon"
+    system "#{bin}/IndriRunQuery"
+    system "#{bin}/ModifyFields"
+    system "#{bin}/PDictManager"
+    system "#{bin}/ParseInQueryOp"
+    system "#{bin}/ParseQuery"
+    system "#{bin}/ParseToFile"
+    system "#{bin}/QueryClarity"
+    system "#{bin}/QueryModelEval"
+    system "#{bin}/RelFBEval"
+    system "#{bin}/RetEval"
+    system "#{bin}/RetQueryClarity"
+    system "#{bin}/StructQueryEval"
+    system "#{bin}/TwoStageRetEval"
+    system "#{bin}/XlingRetEval"
+    system "#{bin}/dumpDoc"
+    system "#{bin}/dumpTerm"
+    system "#{bin}/dumpindex"
+    system "#{bin}/harvestlinks"
+    system "#{bin}/makeprior"
+    system "#{bin}/pagerank"
+  end
+end


### PR DESCRIPTION
I patched old but still popular IR toolkit for successful compilation on OS X. This is formula for it. Lemur 4.12 was transition to indri and is not widely used version. There will be another formula for indri.