### PR TITLE
task-spooler: upgrade to 0.7.5

### DIFF
--- a/Library/Formula/task-spooler.rb
+++ b/Library/Formula/task-spooler.rb
@@ -5,6 +5,8 @@ class TaskSpooler < Formula
   url 'http://vicerveza.homeunix.net/~viric/soft/ts/ts-0.7.4.tar.gz'
   sha1 '92813a3b0eedfe1d4a177727122e6d08695f6bc8'
 
+  patch :DATA
+
   conflicts_with 'moreutils',
     :because => "both install a 'ts' executable."
 
@@ -12,3 +14,17 @@ class TaskSpooler < Formula
     system "make", "install", "PREFIX=#{prefix}"
   end
 end
+__END__
+diff --git a/server.c b/server.c
+index a58ad87..aec0c70 100644
+--- a/server.c
++++ b/server.c
+@@ -179,7 +179,8 @@ void server_main(int notify_fd, char *_path)
+     path = _path;
+
+     /* Move the server to the socket directory */
+-    dirpath = strdup(path);
++    dirpath = malloc(strlen(path)+1);
++    strcpy(dirpath, path);
+     chdir(dirname(dirpath));
+     free(dirpath);

--- a/Library/Formula/task-spooler.rb
+++ b/Library/Formula/task-spooler.rb
@@ -2,10 +2,8 @@ require 'formula'
 
 class TaskSpooler < Formula
   homepage 'http://vicerveza.homeunix.net/~viric/soft/ts/'
-  url 'http://vicerveza.homeunix.net/~viric/soft/ts/ts-0.7.4.tar.gz'
-  sha1 '92813a3b0eedfe1d4a177727122e6d08695f6bc8'
-
-  patch :DATA
+  url 'http://vicerveza.homeunix.net/~viric/soft/ts/ts-0.7.5.tar.gz'
+  sha1 'c2a81abbc3bcec14629a3a288a06e1f0c57f175c'
 
   conflicts_with 'moreutils',
     :because => "both install a 'ts' executable."
@@ -14,17 +12,3 @@ class TaskSpooler < Formula
     system "make", "install", "PREFIX=#{prefix}"
   end
 end
-__END__
-diff --git a/server.c b/server.c
-index a58ad87..aec0c70 100644
---- a/server.c
-+++ b/server.c
-@@ -179,7 +179,8 @@ void server_main(int notify_fd, char *_path)
-     path = _path;
-
-     /* Move the server to the socket directory */
--    dirpath = strdup(path);
-+    dirpath = malloc(strlen(path)+1);
-+    strcpy(dirpath, path);
-     chdir(dirname(dirpath));
-     free(dirpath);


### PR DESCRIPTION
Task-spooler wouldn’t start on my Mac running Yosemite.  It would simply fail with “The server didn’t come up.”  I traced it to the strdup call in server.c  I don’t understand why it caused a problem, but replacing it with a malloc/strcpy fixed the issue.  I have seen other reports of the same problem online.

I contacted the author of task-spooler, and he responded promptly stating he would release a new version of task-spooler within the next few days.  You may wish to reject this pull request in favour of waiting for an upstream fix.