### PR TITLE
nzbget 0.14.2: Add testing build and optional LaunchAgent

### DIFF
--- a/Library/Formula/nzbget.rb
+++ b/Library/Formula/nzbget.rb
@@ -3,6 +3,12 @@ class Nzbget < Formula
   url "https://downloads.sourceforge.net/project/nzbget/nzbget-stable/14.2/nzbget-14.2.tar.gz"
   sha1 "25adf5565d228cf1cbb8fa305732f61a6f869aa0"
 
+  devel do
+    url "https://downloads.sourceforge.net/project/nzbget/nzbget-testing/15.0-r1207/nzbget-15.0-testing-r1207.tar.gz"
+    sha1 "37f9d069df4bab4a78a1999434a2152aae6c2577"
+    version "15.0-r1207"
+  end
+
   head "https://nzbget.svn.sourceforge.net/svnroot/nzbget/trunk"
 
   bottle do
@@ -45,6 +51,31 @@ class Nzbget < Formula
     ENV.j1
     system "make", "install"
     etc.install "nzbget.conf"
+  end
+
+  plist_options :manual => "nzbget"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/nzbget</string>
+        <string>-s</string>
+        <string>-o</string>
+        <string>OutputMode=Log</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
   end
 
   test do


### PR DESCRIPTION
Added an optional ```devel``` build for those following the more frequently updated ```testing``` branch and
a ```LaunchAgent``` plist for those using the web interface.