### PR TITLE
apr-util now builds with berkeley-db support

### DIFF
--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -15,6 +15,7 @@ class AprUtil < Formula
 
   depends_on "apr"
   depends_on "openssl"
+  depends_on "berkeley-db"
   depends_on "postgresql" => :optional
 
   def install
@@ -25,6 +26,8 @@ class AprUtil < Formula
       --prefix=#{libexec}
       --with-apr=#{Formula["apr"].opt_prefix}
       --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-berkeley-db=#{Formula["berkeley-db"].opt_prefix}
+      --with-dbm=db#{Formula["berkeley-db"].version.to_str.gsub(/(\d+)\.(\d+).*/, '\1\2')}
     ]
 
     args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"

--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -1,6 +1,7 @@
 class AprUtil < Formula
   homepage "https://apr.apache.org/"
   url "http://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
+  mirror "https://archive.apache.org/dist/apr/apr-util-1.5.4.tar.bz2"
   sha1 "b00038b5081472ed094ced28bcbf2b5bb56c589d"
 
   bottle do


### PR DESCRIPTION
This means the httpd22 package now supports "dbm:db" files by default, and you see support in httxt2dbm (below). I didn't put this behind an option because it is very basic support that should be default.

```
$ httxt2dbm
httxt2dbm -- Program to Create DBM Files for use by RewriteMap
Usage: httxt2dbm [-v] [-f format] -i SOURCE_TXT -o OUTPUT_DBM

Options:
 -v    More verbose output

 -i    Source Text File. If '-', use stdin.

 -o    Output DBM.

 -f    DBM Format.  If not specified, will use the APR Default.
           GDBM for GDBM files (unavailable)
           SDBM for SDBM files (available)
           DB   for berkeley DB files (available)   <-- was unavailable before
           NDBM for NDBM files (unavailable)
           default for the default DBM type
```