### PR TITLE
Fix git-fixup

### DIFF
--- a/Library/Formula/git-fixup.rb
+++ b/Library/Formula/git-fixup.rb
@@ -1,7 +1,7 @@
 class GitFixup < Formula
   homepage "https://github.com/keis/git-fixup"
-  url "https://github.com/keis/git-fixup/archive/v1.0.0.tar.gz"
-  sha1 "836613c7b9d1ccafaa5f5250b6ff2e125fabf974"
+  url "https://github.com/keis/git-fixup/archive/v1.0.1.tar.gz"
+  sha1 "0c2f2dd1f6543e537291c0f9e0e06905725b0ccc"
 
   head "https://github.com/keis/git-fixup.git", :branch => "master"
 

--- a/Library/Formula/git-fixup.rb
+++ b/Library/Formula/git-fixup.rb
@@ -13,7 +13,7 @@ class GitFixup < Formula
   end
 
   def install
-    system "make", "prefix=#{prefix}", "install"
+    system "make", "PREFIX=#{prefix}", "install"
     zsh_completion.install "completion.zsh" => "_git-fixup"
   end
 

--- a/Library/Formula/git-fixup.rb
+++ b/Library/Formula/git-fixup.rb
@@ -13,7 +13,7 @@ class GitFixup < Formula
   end
 
   def install
-    system "make", "PREFIX=#{prefix}", "install"
+    bin.install "git-fixup"
     zsh_completion.install "completion.zsh" => "_git-fixup"
   end
 

--- a/Library/Formula/git-fixup.rb
+++ b/Library/Formula/git-fixup.rb
@@ -13,7 +13,7 @@ class GitFixup < Formula
   end
 
   def install
-    bin.install "git-fixup"
+    system "make", "PREFIX=#{prefix}", "install"
     zsh_completion.install "completion.zsh" => "_git-fixup"
   end
 


### PR DESCRIPTION
TLDR: only the zsh-completion was getting installed, not the actual script.

```none
$ brew install git-fixup
==> Downloading https://homebrew.bintray.com/bottles/git-fixup-1.0.0.yosemite.bo
Already downloaded: /Library/Caches/Homebrew/git-fixup-1.0.0.yosemite.bottle.tar.gz
==> Pouring git-fixup-1.0.0.yosemite.bottle.tar.gz
==> Caveats
zsh completion has been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/git-fixup/1.0.0: 4 files, 16K
$ brew ls git-fixup
/usr/local/Cellar/git-fixup/1.0.0/share/zsh/site-functions/_git-fixup
```

There were two problems with the current formula.

1. The line
   ```ruby
   system "make", "prefix=#{prefix}", "install"
   ```
   should read
   ```ruby
   system "make", "PREFIX=#{prefix}", "install"
   ```
   The consequence of this mistake is that the actual `git-fixup` script is installed to `/usr/local/bin/git-fixup` instead of `/usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup` since [`/usr/local` is the default value of `PREFIX`](https://github.com/keis/git-fixup/blob/628f13abc8f1dceff540053d833c642342524626/Makefile#L1).

2. **But** even if you change `prefix=#{prefix}` to `PREFIX=#{prefix}`, the installation will then *fail* because the necessary directories don't exist.
   ```none
   $ brew install git-fixup --interactive
   ==> Downloading https://github.com/keis/git-fixup/archive/v1.0.0.tar.gz
   Already downloaded: /Library/Caches/Homebrew/git-fixup-1.0.0.tar.gz
   ==> Entering interactive mode
   Type `exit' to return and finalize the installation
   Install to this prefix: /usr/local/Cellar/git-fixup/1.0.0
   bash-3.2$ make PREFIX=/usr/local/Cellar/git-fixup/1.0.0 install
   install -m755 git-fixup /usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup
   install: /usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup: No such file or directory
   make: *** [install] Error 71
   bash-3.2$ mkdir -p /usr/local/Cellar/git-fixup/1.0.0
   bash-3.2$ make PREFIX=/usr/local/Cellar/git-fixup/1.0.0 install
   install -m755 git-fixup /usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup
   install: /usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup: No such file or directory
   make: *** [install] Error 71
   bash-3.2$ mkdir -p /usr/local/Cellar/git-fixup/1.0.0/bin
   bash-3.2$ make PREFIX=/usr/local/Cellar/git-fixup/1.0.0 install
   install -m755 git-fixup /usr/local/Cellar/git-fixup/1.0.0/bin/git-fixup
   bash-3.2$ printf "$?\n"
   0 
```