### PR TITLE
show what arch and os is currently building for go

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -58,6 +58,7 @@ class Go < Formula
           ENV["GOOS"]         = os
           ENV["GOARCH"]       = arch
           ENV["CGO_ENABLED"]  = cgo_enabled
+          ohai "Building go for #{arch}-#{os}"
           system "./make.bash", "--no-clean"
         end
       end


### PR DESCRIPTION
right now the installer looks like this when building for many arch and os's:

```
==> Upgrading go
==> Downloading https://storage.googleapis.com/golang/go1.4.2.src.tar.gz
######################################################################## 100.0%
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
==> ./make.bash --no-clean
```

since this takes a while, I figured it would be better to show the user what they're actually compiling under:

```
☸ /u/local:(go-ux!) brew install go --with-cc-all                           #130
==> Downloading https://storage.googleapis.com/golang/go1.4.2.src.tar.gz
Already downloaded: /Library/Caches/Homebrew/go-1.4.2.tar.gz
==> Building go for 386-linux
==> ./make.bash --no-clean
==> Building go for amd64-linux
==> ./make.bash --no-clean
==> Building go for arm-linux
==> ./make.bash --no-clean
==> Building go for 386-freebsd
==> ./make.bash --no-clean
==> Building go for amd64-freebsd
==> ./make.bash --no-clean
==> Building go for arm-freebsd
==> ./make.bash --no-clean
==> Building go for 386-netbsd
==> ./make.bash --no-clean
==> Building go for amd64-netbsd
==> ./make.bash --no-clean
==> Building go for arm-netbsd
==> ./make.bash --no-clean
==> Building go for 386-openbsd
==> ./make.bash --no-clean
==> Building go for amd64-openbsd
==> ./make.bash --no-clean
==> Building go for 386-windows
==> ./make.bash --no-clean
==> Building go for amd64-windows
==> ./make.bash --no-clean
==> Building go for 386-dragonfly
==> ./make.bash --no-clean
==> Building go for amd64-dragonfly
==> ./make.bash --no-clean
==> Building go for 386-plan9
==> ./make.bash --no-clean
==> Building go for amd64-plan9
==> ./make.bash --no-clean
==> Building go for amd64-solaris
==> ./make.bash --no-clean
==> Building go for 386-darwin
==> ./make.bash --no-clean
==> Building go for amd64-darwin
==> ./make.bash --no-clean
```