### PR TITLE
bind 9.10.2

### DIFF
--- a/Library/Formula/bind.rb
+++ b/Library/Formula/bind.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Bind < Formula
   homepage "http://www.isc.org/software/bind/"
-  url "http://ftp.isc.org/isc/bind9/9.10.1-P2/bind-9.10.1-P2.tar.gz"
-  sha1 "4a7475b4f2c1d257001ad40653379af52f090666"
-  version "9.10.1-P2"
+  url "http://ftp.isc.org/isc/bind9/9.10.2/bind-9.10.2.tar.gz"
+  sha1 "4ddb2670976c06af7e86352616383958d82c51ce"
+  version "9.10.2"
 
   bottle do
     sha1 "2fd8dc7775ff6f1ef5f237f8f4a8fd3a40e296cf" => :yosemite


### PR DESCRIPTION
"BIND 9.10.2 is now available"
https://lists.isc.org/pipermail/bind-announce/2015-February/000945.html