### PR TITLE
Updated broken URL from v1.5 to v1.7.

### DIFF
--- a/Library/Formula/grc.rb
+++ b/Library/Formula/grc.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Grc < Formula
   homepage 'http://korpus.juls.savba.sk/~garabik/software/grc.html'
-  url 'http://korpus.juls.savba.sk/~garabik/software/grc/grc_1.5.tar.gz'
-  sha1 'bcbe45992d2c4cb1d33e76aac6aa79b448124ce2'
+  url 'http://korpus.juls.savba.sk/~garabik/software/grc/grc_1.7.orig.tar.gz'
+  sha1 'df9a6a303823500e315d83e1982e4ca1b42d9e77'
 
   conflicts_with 'cc65', :because => 'both install `grc` binaries'
 


### PR DESCRIPTION
Updated the broken URL from grc_1.5.tar.gz to grc_1.7.orig.tar.gz as well as the new sha1 hash.
Verified that 'brew install grc' successfully installs version 1.7 of Generic Colouriser (grc).