### PR TITLE
taktuk 3.7.5

### DIFF
--- a/Library/Formula/taktuk.rb
+++ b/Library/Formula/taktuk.rb
@@ -1,14 +1,16 @@
-require "formula"
-
 class Taktuk < Formula
   homepage "http://taktuk.gforge.inria.fr/"
-  url "http://gforge.inria.fr/frs/download.php/30903/taktuk-3.7.4.tar.gz"
+  url "http://gforge.inria.fr/frs/download.php/30903/taktuk-3.7.5.tar.gz"
   sha1 "947de1e9810316142815df3077e3f629680de564"
 
   def install
     system "./configure", "--prefix=#{prefix}"
-    system "make",
+    system "make"
     ENV.j1
     system "make", "install"
+  end
+
+  test do
+    system "#{bin}/taktuk", "quit"
   end
 end


### PR DESCRIPTION
This also fixes the build which was broken by one single character in the formula: a trailing slash after `system "make"`:

```rb
system "make",
ENV.j1
```

is equivalent to:

```rb
system "make", ENV.j1
```

And because `ENV.j1` returns an empty string it was causing this error:

```
make: *** empty string invalid as file name.  Stop.
```