### PR TITLE
percona-toolkit v2.2.13 security update

### DIFF
--- a/Library/Formula/percona-toolkit.rb
+++ b/Library/Formula/percona-toolkit.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class PerconaToolkit < Formula
   homepage "http://www.percona.com/software/percona-toolkit/"
-  url "http://www.percona.com/redir/downloads/percona-toolkit/2.2.12/tarball/percona-toolkit-2.2.12.tar.gz"
-  sha1 "83757aca2e04b0c55e682316d9e09f405d4a0180"
+  url "http://www.percona.com/redir/downloads/percona-toolkit/2.2.13/tarball/percona-toolkit-2.2.13.tar.gz"
+  sha1 "f3e0e59e6036bfabbd5db881848022e1e4881ab9"
 
   bottle do
     sha1 "cf2163192bcf6f6c12e8de0fdee7e707d7dd0860" => :yosemite


### PR DESCRIPTION
The current Homebrew version of percona-toolkit is 2.2.12 and it's affected by the issue officially reported [here](http://www.percona.com/forums/questions-discussions/percona-toolkit/26690-pt-online-schema-change-in-version-2-2-12-doesn-t-honour-ask-pass-anymore). 

The Percona team already fixed the problem and this PR provides the latest, fixed version.