### PR TITLE
nghttp2: install c++ asio libraries by default

### DIFF
--- a/Library/Formula/nghttp2.rb
+++ b/Library/Formula/nghttp2.rb
@@ -82,6 +82,7 @@ class Nghttp2 < Formula
       --disable-threads
       --enable-app
       --with-boost=#{Formula["boost"].opt_prefix}
+      --enable-asio-lib
       --disable-python-bindings
     ]
 


### PR DESCRIPTION
This installs the C++ libraries by default as the include files for the C++ interface are included by default.
