### PR TITLE
Migrate gnome-icon-theme to adwaita-icon-theme

### DIFF
--- a/Library/Aliases/gnome-icon-theme
+++ b/Library/Aliases/gnome-icon-theme
@@ -1,0 +1,1 @@
+../Formula/adwaita-icon-theme.rb

--- a/Library/Formula/adwaita-icon-theme.rb
+++ b/Library/Formula/adwaita-icon-theme.rb
@@ -1,17 +1,7 @@
-require "formula"
-
-class GnomeIconTheme < Formula
+class AdwaitaIconTheme < Formula
   homepage "https://developer.gnome.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gnome-icon-theme/3.12/gnome-icon-theme-3.12.0.tar.xz"
-  sha1 "cc0f0dc55db3c4ca7f2f34564402f712807f1342"
-  revision 1
-
-  bottle do
-    cellar :any
-    sha1 "e9329d81e8c615e78f0c96e62b91008dbc4a74e5" => :mavericks
-    sha1 "84c1e818410a0c5b8b33c6b07932b8a547f69ede" => :mountain_lion
-    sha1 "3bbeb7cee6c7bd1e1b070cc0be276502eee3cc6b" => :lion
-  end
+  url "http://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.14/adwaita-icon-theme-3.14.1.tar.xz"
+  sha1 "e1d603d9cc4e4b7f83f749ba20934832d4321dd2"
 
   depends_on "pkg-config" => :build
   depends_on "gettext" => :build
@@ -21,6 +11,7 @@ class GnomeIconTheme < Formula
 
   def install
     system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--enable-icon-mapping",
                           "GTK_UPDATE_ICON_CACHE=#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache"

--- a/Library/Formula/stoken.rb
+++ b/Library/Formula/stoken.rb
@@ -14,7 +14,7 @@ class Stoken < Formula
 
   depends_on "gtk+3" => :optional
   if build.with? "gtk+3"
-    depends_on "gnome-icon-theme"
+    depends_on "adwaita-icon-theme"
     depends_on "hicolor-icon-theme"
   end
   depends_on "pkg-config" => :build

--- a/Library/Formula/wireshark.rb
+++ b/Library/Formula/wireshark.rb
@@ -58,7 +58,7 @@ class Wireshark < Formula
   depends_on "qt" => :optional
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
-  depends_on "gnome-icon-theme" if build.with? "gtk+3"
+  depends_on "adwaita-icon-theme" if build.with? "gtk+3"
 
   def install
     args = ["--disable-dependency-tracking",


### PR DESCRIPTION
The GNOME Project merged gnome-icon-theme and gnome-icon-theme-symbolic into adwaita-icon-theme in the 3.14 release. (See the mailing list [archives](https://mail.gnome.org/archives/desktop-devel-list/2014-April/msg00086.html).) The reason for the merge was to simplify packaging, as many packagers (like Homebrew) did not include the symbolic icons, which are no longer optional. 

Notably, without the symbolic icons, programs using brewed GTK+3 did not properly display icons like the HeaderBar's minimize/maximize/close icons. (See images below.)

This pull request keeps the package current with upstream, and fixes the lack of symbolic icons in Homebrew's packages.

The current state of things:
![symbolic-icons-missing](https://cloud.githubusercontent.com/assets/7482008/6430114/36a75f48-bfb1-11e4-82df-acc8a0490d6d.png)
With the changes in this pull request:
![symbolic-icons-available](https://cloud.githubusercontent.com/assets/7482008/6430115/36b0571a-bfb1-11e4-8e17-2be36e9cf6fc.png)