### PR TITLE
task requires C++11 compatiblity

### DIFF
--- a/Library/Formula/task.rb
+++ b/Library/Formula/task.rb
@@ -14,6 +14,8 @@ class Task < Formula
   depends_on "cmake" => :build
   depends_on "gnutls" => :optional
 
+  needs :cxx11
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
Building in Linuxbrew fails because of taskwarrior requiring C++11. [Was told to add this over here](https://github.com/Homebrew/linuxbrew/pull/294#issuecomment-76634163), as it is a general requirement.