### PR TITLE
Update gnome-icon-theme to 3.14.1 and alias adwaita-icon-theme

### DIFF
--- a/Library/Aliases/adwaita-icon-theme
+++ b/Library/Aliases/adwaita-icon-theme
@@ -1,0 +1,1 @@
+Library/Formula/gnome-icon-theme.rb

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -15,7 +15,7 @@ class GnomeIconTheme < Formula
   depends_on "gtk+3" => :build # for gtk3-update-icon-cache
   depends_on "icon-naming-utils" => :build
   depends_on "intltool" => :build
-  depends_on "librsvg" => :build
+  depends_on "librsvg"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -29,14 +29,7 @@ class GnomeIconTheme < Formula
     # and that a file created late in the install process exists.
     # Someone who understands GTK+3 could probably write better tests that
     # check if GTK+3 can find the icons.
-    (testpath/"test.sh").write <<-EOS.undent
-    #!/usr/bin/env bash
-    if [ -r "#{share}/icons/Adwaita/96x96/status/weather-storm-symbolic.symbolic.png" ] && [ -r "#{share}/icons/Adwaita/index.theme" ]; then
-        exit 0;
-    else
-        exit 1;
-    fi
-    EOS
-    system "bash", "./test.sh"
+    assert (share/"icons/Adwaita/96x96/status/weather-storm-symbolic.symbolic.png").exist?
+    assert (share/"icons/Adwaita/index.theme").exist?
   end
 end

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -15,6 +15,7 @@ class GnomeIconTheme < Formula
   depends_on "gtk+3" => :build # for gtk3-update-icon-cache
   depends_on "icon-naming-utils" => :build
   depends_on "intltool" => :build
+  depends_on "librsvg" => :build
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -1,10 +1,7 @@
-require "formula"
-
 class GnomeIconTheme < Formula
   homepage "https://developer.gnome.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gnome-icon-theme/3.12/gnome-icon-theme-3.12.0.tar.xz"
-  sha1 "cc0f0dc55db3c4ca7f2f34564402f712807f1342"
-  revision 1
+  url "http://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.14/adwaita-icon-theme-3.14.1.tar.xz"
+  sha1 "e1d603d9cc4e4b7f83f749ba20934832d4321dd2"
 
   bottle do
     cellar :any
@@ -22,8 +19,23 @@ class GnomeIconTheme < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-icon-mapping",
                           "GTK_UPDATE_ICON_CACHE=#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache"
     system "make", "install"
+  end
+
+  test do
+    # This checks that a -symbolic png file generated from svg exists
+    # and that a file created late in the install process exists.
+    # Someone who understands GTK+3 could probably write better tests that
+    # check if GTK+3 can find the icons.
+    (testpath/"test.sh").write <<-EOS.undent
+    #!/usr/bin/env bash
+    if [ -r "#{share}/icons/Adwaita/96x96/status/weather-storm-symbolic.symbolic.png" ] && [ -r "#{share}/icons/Adwaita/index.theme" ]; then
+        exit 0;
+    else
+        exit 1;
+    fi
+    EOS
+    system "bash", "./test.sh"
   end
 end


### PR DESCRIPTION
In GNOME 3.14, gnome-icon-theme and gnome-icon-theme-symbolic were merged into adwaita-icon-theme, because the symbolic icons are no longer considered optional. (See the mailing list [archives](https://mail.gnome.org/archives/desktop-devel-list/2014-April/msg00086.html).)

Moving to the latest stable version of this package fixes the lack of symbolic icons for GTK+3 in Homebrew. (See images below.)

The tests I've written are simple sanity checks that ensure certain files were created in the install process.
Someone with GTK+3 knowledge could probably write better ones that check if GTK+ properly detects the icon files.

(This PR also makes gnome-icon-theme depend on librsvg, since the symbolic icons are converted svg to png during the `make install` step, and SVGs are subsequently used by GTK+.)

The current state of things:
![symbolic-icons-missing](https://cloud.githubusercontent.com/assets/7482008/6430114/36a75f48-bfb1-11e4-82df-acc8a0490d6d.png)
With the changes in this pull request:
![symbolic-icons-available](https://cloud.githubusercontent.com/assets/7482008/6430115/36b0571a-bfb1-11e4-8e17-2be36e9cf6fc.png)