### PR TITLE
Updates selenium-server-standalone to 2.45.0

### DIFF
--- a/Library/Formula/selenium-server-standalone.rb
+++ b/Library/Formula/selenium-server-standalone.rb
@@ -1,7 +1,7 @@
 class SeleniumServerStandalone < Formula
   homepage "http://seleniumhq.org/"
-  url "http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar"
-  sha1 "deb2a8d4f6b5da90fd38d1915459ced2e53eb201"
+  url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
+  sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"
 
   def install
     libexec.install "selenium-server-standalone-#{version}.jar"


### PR DESCRIPTION
2.45.0 is the current latest stable version of selenium server. It was released about a week ago.