### PR TITLE
Update MacVim head URL

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -8,7 +8,7 @@ class Macvim < Formula
   sha1 'b87e37fecb305a99bc268becca39f8854e3ff9f0'
   revision 1
 
-  head 'https://github.com/b4winckler/macvim.git'
+  head 'https://github.com/douglasdrumond/macvim.git'
 
   option "custom-icons", "Try to generate custom document icons"
   option "override-system-vim", "Override system vim"


### PR DESCRIPTION
The project has recently changed maintainer. See https://groups.google.com/forum/#!topic/vim_mac/-bd5RKGs8qw
In this pull request I have updated the HEAD (git) to the new project repository. A new snapshot-74 release was recently made but a few problems have been reported and it has now been marked as RC status. As such, I did not update the release source URL.