### PR TITLE
juju-quickstart 2.0.0

### DIFF
--- a/Library/Formula/juju-quickstart.rb
+++ b/Library/Formula/juju-quickstart.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class JujuQuickstart < Formula
   homepage "https://launchpad.net/juju-quickstart"
-  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-1.6.0.tar.gz"
-  sha1 "6631c560bc26b88c85e281df4fe4b5199884ae5a"
+  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-2.0.0.tar.gz"
+  sha1 "5ae0f94b87b03405a09413a55317f42ed112f725"
 
   bottle do
     cellar :any


### PR DESCRIPTION
  * Update the way bundles can be specified on the command line. 
    The new simplified jujucharms.com syntax is used, 
    e.g. "juju-quickstart mediawiki-single".
    The old "bundle:mediawiki/single" form is still supported but deprecated.
  * When deploying bundles, specifying a directory is no longer supported.
    Local files are still supported but must have a ".yaml" or ".json" 
    extension. For more details, see "juju-quickstart --help".
  * Add support for new Juju WebSocket API endpoints. 
    Connect to a specific environment using its unique identifier.
  * External API refactoring: implement the Juju reference model 
    (charm and bundle URLs). 
    Improve support for bundles as first class entities.
  * Retrieve bundles from the new charm store API v4.
  * Improve the testing infrastructure: exercize Quickstart with all the 
    supported dependency versions. 
    Also introduce functional tests against a real Juju environment.
