### PR TITLE
cmake: adjust standard built type

### DIFF
--- a/Library/Formula/libgit2.rb
+++ b/Library/Formula/libgit2.rb
@@ -2,8 +2,8 @@ class Libgit2 < Formula
   homepage "https://libgit2.github.com/"
   url "https://github.com/libgit2/libgit2/archive/v0.22.0.tar.gz"
   sha1 "a37dc29511422eec9828e129ad057e77ca962c5e"
-
   head "https://github.com/libgit2/libgit2.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -466,8 +466,6 @@ class Formula
   end
 
   # Standard parameters for CMake builds.
-  # Using Build Type "None" tells cmake to use our CFLAGS,etc. settings.
-  # Setting it to Release would ignore our flags.
   # Setting CMAKE_FIND_FRAMEWORK to "LAST" tells CMake to search for our
   # libraries before trying to utilize Frameworks, many of which will be from
   # 3rd party installs.
@@ -475,8 +473,10 @@ class Formula
   # less consistent and the standard parameters are more memorable.
   def std_cmake_args
     %W[
+      -DCMAKE_C_FLAGS_RELEASE=
+      -DCMAKE_CXX_FLAGS_RELEASE=
       -DCMAKE_INSTALL_PREFIX=#{prefix}
-      -DCMAKE_BUILD_TYPE=None
+      -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_FIND_FRAMEWORK=LAST
       -DCMAKE_VERBOSE_MAKEFILE=ON
       -Wno-dev


### PR DESCRIPTION
Moves from None to Release, but comments out the standard release CFLAGS so we can continue using our own.

Bumped Libgit2 as an example/test to play with.

Closes #37332, hopefully.