### PR TITLE
autoconf-archive 2015.02.24

### DIFF
--- a/Library/Formula/autoconf-archive.rb
+++ b/Library/Formula/autoconf-archive.rb
@@ -1,13 +1,33 @@
-require "formula"
-
 class AutoconfArchive < Formula
   homepage "http://savannah.gnu.org/projects/autoconf-archive/"
-  url "http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2014.10.15.tar.xz"
-  mirror "http://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2014.10.15.tar.xz"
-  sha1 "7efcefd29a67da2a7243ea2b30e353027d70b460"
+  url "http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2015.02.24.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2015.02.24.tar.xz"
+  sha1 "3b85294775df75acce4b89d99ad268a6e7219d9c"
+
+  # autoconf-archive is useless without autoconf
+  depends_on "autoconf" => :run
 
   def install
     system "./configure", "--prefix=#{prefix}"
-    system 'make install'
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.m4").write <<-EOS.undent
+      AC_INIT(myconfig, version-0.1)
+      AC_MSG_NOTICE([Hello, world.])
+
+      m4_include([#{share}/aclocal/ax_have_select.m4])
+
+      # from http://www.gnu.org/software/autoconf-archive/ax_have_select.html
+      AX_HAVE_SELECT(
+        [AX_CONFIG_FEATURE_ENABLE(select)],
+        [AX_CONFIG_FEATURE_DISABLE(select)])
+      AX_CONFIG_FEATURE(
+        [select], [This platform supports select(7)],
+        [HAVE_SELECT], [This platform supports select(7).])
+    EOS
+
+    system "#{Formula["autoconf"].bin}/autoconf", "test.m4"
   end
 end


### PR DESCRIPTION
I added a run dependency on `autoconf` even if `autoconf-archive` can't run. It's just a collection of files but it's unusable without `autoconf`.

I also don’t know anything about `autoconf`, if someone has a better test feel free to suggest it here.