### PR TITLE
Add GRC colorization to head/tail.

### DIFF
--- a/Library/Formula/grc.rb
+++ b/Library/Formula/grc.rb
@@ -35,6 +35,8 @@ class Grc < Formula
         alias netstat='colourify netstat'
         alias ping='colourify ping'
         alias traceroute='colourify /usr/sbin/traceroute'
+        alias head='colourify head'
+        alias tail='colourify tail'
     fi
     EOS
   end


### PR DESCRIPTION
This adds GRC colorization to head and tail for viewing log files, etc. when the user adds ``source "`brew --prefix`/etc/grc.bashrc"`` to their profile.