### PR TITLE
Switch to a more useful serialization of tap info

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -25,9 +25,8 @@ module Homebrew
         all_versions << version
         older_version = f.version <= version
 
-        tap = Tab.for_keg(keg).tapped_from
-        same_or_path_url_tap = f.tap == tap || tap == HOMEBREW_PATH_URL_TAP
-        if same_or_path_url_tap || older_version
+        tap = Tab.for_keg(keg).tap
+        if tap.nil? || f.tap == tap || older_version
           older_or_same_tap_versions << version
         end
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -539,8 +539,6 @@ class Formula
       "#$1/#$2"
     elsif core_formula?
       "Homebrew/homebrew"
-    else
-      HOMEBREW_PATH_URL_TAP
     end
   end
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -17,13 +17,13 @@ class Tab < OpenStruct
       "tabfile" => formula.prefix.join(FILENAME),
       "built_as_bottle" => build.bottle?,
       "poured_from_bottle" => false,
-      "tapped_from" => formula.tap,
       "time" => Time.now.to_i,
       "HEAD" => Homebrew.git_head,
       "compiler" => compiler,
       "stdlib" => stdlib,
       "source" => {
         "path" => formula.path.to_s,
+        "tap" => formula.tap,
       },
     }
 
@@ -33,6 +33,13 @@ class Tab < OpenStruct
   def self.from_file path
     attributes = Utils::JSON.load(File.read(path))
     attributes["tabfile"] = path
+    attributes["source"] ||= {}
+
+    tapped_from = attributes["tapped_from"]
+    unless tapped_from.nil? || tapped_from == "path or URL"
+      attributes["source"]["tap"] = attributes.delete("tapped_from")
+    end
+
     new(attributes)
   end
 
@@ -86,7 +93,7 @@ class Tab < OpenStruct
     else
       tab = empty
       tab.unused_options = f.options.as_flags
-      tab.source = { "path" => f.path.to_s }
+      tab.source = { "path" => f.path.to_s, "tap" => f.tap }
     end
 
     tab
@@ -98,13 +105,13 @@ class Tab < OpenStruct
       "unused_options" => [],
       "built_as_bottle" => false,
       "poured_from_bottle" => false,
-      "tapped_from" => "",
       "time" => nil,
       "HEAD" => nil,
       "stdlib" => nil,
       "compiler" => "clang",
       "source" => {
         "path" => nil,
+        "tap" => nil,
       },
     }
 
@@ -159,18 +166,21 @@ class Tab < OpenStruct
     built_as_bottle
   end
 
+  def tap
+    source["tap"]
+  end
+
   def to_json
     attributes = {
       "used_options" => used_options.as_flags,
       "unused_options" => unused_options.as_flags,
       "built_as_bottle" => built_as_bottle,
       "poured_from_bottle" => poured_from_bottle,
-      "tapped_from" => tapped_from,
       "time" => time,
       "HEAD" => self.HEAD,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
-      "source" => source || {},
+      "source" => source,
     }
 
     Utils::JSON.dump(attributes)

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -8,5 +8,3 @@ HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
 # match the default brew-cask tap e.g. Caskroom/cask
 HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^(Caskroom)/(cask)/([\w+-.]+)$}
-# the tap name used for formulae installed from paths or URLs
-HOMEBREW_PATH_URL_TAP = "path or URL"

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -12,12 +12,14 @@ class TabTests < Homebrew::TestCase
       "unused_options"     => @unused.as_flags,
       "built_as_bottle"    => false,
       "poured_from_bottle" => true,
-      "tapped_from"        => "Homebrew/homebrew",
       "time"               => nil,
       "HEAD"               => TEST_SHA1,
       "compiler"           => "clang",
       "stdlib"             => "libcxx",
-      "source"             => { "path" => nil },
+      "source"             => {
+        "tap" => "Homebrew/homebrew",
+        "path" => nil,
+      },
     })
   end
 
@@ -27,7 +29,7 @@ class TabTests < Homebrew::TestCase
     assert_empty tab.used_options
     refute_predicate tab, :built_as_bottle
     refute_predicate tab, :poured_from_bottle
-    assert_empty tab.tapped_from
+    assert_nil tab.tap
     assert_nil tab.time
     assert_nil tab.HEAD
     assert_equal MacOS.default_compiler, tab.cxxstdlib.compiler
@@ -58,7 +60,7 @@ class TabTests < Homebrew::TestCase
 
   def test_other_attributes
     assert_equal TEST_SHA1, @tab.HEAD
-    assert_equal "Homebrew/homebrew", @tab.tapped_from
+    assert_equal "Homebrew/homebrew", @tab.tap
     assert_nil @tab.time
     refute_predicate @tab, :built_as_bottle
     assert_predicate @tab, :poured_from_bottle
@@ -72,7 +74,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
-    assert_equal "Homebrew/homebrew", tab.tapped_from
+    assert_equal "Homebrew/homebrew", tab.tap
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD
     assert_equal :clang, tab.cxxstdlib.compiler
@@ -85,7 +87,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.unused_options.sort, tab.unused_options.sort
     assert_equal @tab.built_as_bottle, tab.built_as_bottle
     assert_equal @tab.poured_from_bottle, tab.poured_from_bottle
-    assert_equal @tab.tapped_from, tab.tapped_from
+    assert_equal @tab.tap, tab.tap
     assert_equal @tab.time, tab.time
     assert_equal @tab.HEAD, tab.HEAD
     assert_equal @tab.compiler, tab.compiler


### PR DESCRIPTION
Currently we are writing out the literal string "path or URL" as the tap in the install receipt for formulae that do not originate in core or in a tap. This isn't very useful; we have to special case this string in several places.

Now that we are saving the path, let's write out nil for the tap instead.