### PR TITLE
libressl 2.1.4

### DIFF
--- a/Library/Formula/libressl.rb
+++ b/Library/Formula/libressl.rb
@@ -1,8 +1,8 @@
 class Libressl < Formula
   homepage "http://www.libressl.org/"
-  url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.3.tar.gz"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/LibreSSL/libressl-2.1.3.tar.gz"
-  sha256 "eb2f370971408fb10af6453e556465c8eee728ac333bf1eb47ec1a5112304f7c"
+  url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.4.tar.gz"
+  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/LibreSSL/libressl-2.1.4.tar.gz"
+  sha256 "e8e08535928774119a979412ee8e307444b7a1a42c8c47ac06ee09423ca9a04e"
 
   option "without-libtls", "Build without libtls"
 
@@ -64,7 +64,7 @@ class Libressl < Formula
   test do
     (testpath/"testfile.txt").write("This is a test file")
     expected_checksum = "91b7b0b1e27bfbf7bc646946f35fa972c47c2d32"
-    system "#{bin}/openssl", "dgst", "-sha1", "-out", "checksum.txt", "testfile.txt"
+    system bin/"openssl", "dgst", "-sha1", "-out", "checksum.txt", "testfile.txt"
     open("checksum.txt") do |f|
       checksum = f.read(100).split("=").last.strip
       assert_equal checksum, expected_checksum

--- a/Library/Formula/ucspi-tools.rb
+++ b/Library/Formula/ucspi-tools.rb
@@ -1,7 +1,8 @@
 class UcspiTools < Formula
   homepage "https://github.com/younix/ucspi/blob/master/README.md"
   url "https://github.com/younix/ucspi/archive/v1.2.tar.gz"
-  sha1 "38a708efd6d72e0d9d077efb15477763bdea39b0"
+  sha256 "38cd0ae9113324602a600a6234d60ec9c3a8c13c8591e9b730f91ffb77e5412a"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,6 +14,14 @@ class UcspiTools < Formula
   depends_on "pkg-config" => :build
   depends_on "ucspi-tcp"
   depends_on "libressl"
+
+  # LibreSSL renamed a function between the 2.1.3 and 2.1.4 release which ucspi uses.
+  # https://github.com/younix/ucspi/issues/2
+  # http://www.freshbsd.org/commit/openbsd/2b22762d1139c74c743195f46b41fea0b9459ecd
+  patch do
+    url "https://github.com/younix/ucspi/pull/3.diff"
+    sha256 "932aa6fcde21dc4eb3ad4474a6cd5f413f4da076b1de1491360a60584e0e514e"
+  end
 
   def install
     system "make", "PREFIX=#{prefix}", "install"


### PR DESCRIPTION
Bump.

Lib version numbers have moved again, so recompile your stuff as necessary (This only impacts, optionally, curl wget and libssh2 in Homebrew/homebrew).

Edit - It also impacts ` ucspi-tools ` apparently. I wasn't aware we had any mandatory ` libressl ` deps at this point. Colour me pleasantly surprised :smile_cat:. Will bump revision.