### PR TITLE
rtags 1.2 (new formula)

### DIFF
--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -1,0 +1,41 @@
+class Rtags < Formula
+  homepage "https://github.com/Andersbakken/rtags"
+
+  stable do
+    url "https://github.com/Andersbakken/rtags/archive/v1.2.tar.gz"
+    sha256 "11e5b12f2601c638b73c23f84b0c8e269036269b25a15e631dff714cd248db78"
+
+    resource "rct" do
+      url "https://github.com/Andersbakken/rct.git", :revision => "10700c615179f07d4832d459e6453eed736cfaef"
+    end
+  end
+
+  head "https://github.com/Andersbakken/rtags.git"
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => "with-clang"
+  depends_on "openssl"
+
+  def install
+    unless build.head?
+      (buildpath/"src/rct").install resource("rct")
+    end
+
+    # we use brew's LLVM instead of the macosx llvm because the macosx one
+    # doesn't include libclang.
+    ENV.prepend_path "PATH", "#{opt_libexec}/llvm/bin"
+
+    mkdir "build" do
+      args = std_cmake_args
+      args << ".."
+
+      system "cmake", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "sh", "-c", "rc >/dev/null --help  ; test $? == 1"
+  end
+end


### PR DESCRIPTION
rtags is a ctags-like source code cross-referencer with a clang frontend.

from rtags README:

RTags is a client/server application that indexes C/C++ code and keeps a persistent in-memory database of references, declarations, definitions, symbolnames etc. There’s also limited support for ObjC/ObjC++. It allows you to find symbols by name (including class and namespace scope). Most importantly we give you proper follow-symbol and find-references support. We also have neat little things like rename-symbol, integration with clang’s “fixits” (http://clang.llvm.org/diagnostics.html). We also integrate with flymake using clang’s vastly superior errors and warnings. Since RTags constantly will reindex “dirty” files you get live updating of compiler errors and warnings. Since we already know how to compile your sources we have a way to quickly bring up the preprocessed output of the current source file in a buffer.

While existing taggers like gnu global, cscope, etags, ctags etc do a good job for C they often fall a little bit short for C++. With its incredible lexical complexity, parsing C++ is an incredibly hard task and we make no bones about the fact that the only reason we are able to improve on the current tools is because of clang (http://clang.llvm.org/). RTags is named RTags in recognition of Roberto Raggi on whose C++ parser we intended to base this project but he assured us clang was the way to go. The name stuck though.