### PR TITLE
mesos: install python bindings

### DIFF
--- a/Library/Formula/mesos.rb
+++ b/Library/Formula/mesos.rb
@@ -139,6 +139,11 @@ class Mesos < Formula
     Process.kill("TERM", master)
     Process.kill("TERM", slave)
     assert File.exist?("#{testpath}/executed")
+
+    user_site = Language::Python.user_site_packages("python")
+    mkdir_p user_site
+    pth_contents = "import site; site.addsitedir('#{Language::Python.homebrew_site_packages}')\n"
+    (user_site/"homebrew.pth").atomic_write pth_contents
     system "python", "-c", "import mesos.native"
   end
 end

--- a/Library/Formula/mesos.rb
+++ b/Library/Formula/mesos.rb
@@ -15,22 +15,70 @@ class Mesos < Formula
   depends_on :apr => :build
   depends_on "subversion"
 
+  resource "boto" do
+    url "https://pypi.python.org/packages/source/b/boto/boto-2.36.0.tar.gz"
+    sha1 "f230ff9b041d3b43244086e38b7b6029450898be"
+  end
+
+  resource "protobuf" do
+    url "https://pypi.python.org/packages/source/p/protobuf/protobuf-2.6.1.tar.gz"
+    sha1 "3dff24d019729060eff569d7a718bdbb10db13a3"
+  end
+
+# build dependencies for protobuf
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    sha1 "d168e6d01f0900875c6ecebc97da72d0fda31129"
+  end
+
+  resource "python-dateutil" do
+    url "https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.0.tar.gz"
+    sha1 "159081a4c5b3602ab440a7db305f987c00ee8c6d"
+  end
+
+  resource "pytz" do
+    url "https://pypi.python.org/packages/source/p/pytz/pytz-2014.10.tar.bz2"
+    sha1 "74a1869c804dd422afbc49cb92206a0ca1529ddc"
+  end
+
+  resource "python-gflags" do
+    url "https://pypi.python.org/packages/source/p/python-gflags/python-gflags-2.0.tar.gz"
+    sha1 "1529a1102da2fc671f2a9a5e387ebabd1ceacbbf"
+  end
+
+  resource "google-apputils" do
+    url "https://pypi.python.org/packages/source/g/google-apputils/google-apputils-0.4.2.tar.gz"
+    sha1 "6f82069efd1a2cbc168dfb814d077df2fca4cff1"
+  end
 
   needs :cxx11
 
   def install
+    boto_path = libexec/"boto/lib/python2.7/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", boto_path
+    resource("boto").stage do
+      system "python", *Language::Python.setup_install_args(libexec/"boto")
+    end
+    (lib/"python2.7/site-packages").mkpath
+    (lib/"python2.7/site-packages/homebrew-mesos-boto.pth").atomic_write boto_path + "\n"
+
     # work around distutils abusing CC instead of using CXX
     # https://issues.apache.org/jira/browse/MESOS-799
     # https://github.com/Homebrew/homebrew/pull/37087
+    native_patch = <<-EOS.undent
+      import os
+      os.environ["CC"] = "#{ENV.cxx}"
+      os.environ["LDFLAGS"] = "@LIBS@"
+      \\0
+    EOS
     inreplace "src/python/native/setup.py.in",
               "import ext_modules",
-              "import os; os.environ['CC'] = '#{ENV.cxx}'\n\\0"
+              native_patch
 
     args = ["--prefix=#{prefix}",
             "--disable-debug",
             "--disable-dependency-tracking",
             "--disable-silent-rules",
-            "--without-python",
             "--with-svn=#{Formula["subversion"].opt_prefix}"
            ]
 
@@ -40,9 +88,35 @@ class Mesos < Formula
 
     ENV.cxx11
 
-    system "./configure", *args
+    system "./configure", *(args + ["--disable-python"])
     system "make"
     system "make", "install"
+
+    system "./configure", *(args + ["--enable-python"])
+    ["native", "interface", ""].each do |p|
+      cd "src/python/#{p}" do
+        system "python", *Language::Python.setup_install_args(prefix)
+      end
+    end
+
+    # stage protobuf build dependencies
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"protobuf/lib/python2.7/site-packages"
+    %w[six python-dateutil pytz python-gflags google-apputils].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(buildpath/"protobuf")
+      end
+    end
+
+    protobuf_path = libexec/"protobuf/lib/python2.7/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", protobuf_path
+    resource("protobuf").stage do
+      ln_s buildpath/"protobuf/lib/python2.7/site-packages/google/apputils", "google/apputils"
+      system "python", *Language::Python.setup_install_args(libexec/"protobuf")
+    end
+    pth_contents = "import site; site.addsitedir('#{protobuf_path}')\n"
+    (lib/"python2.7/site-packages/homebrew-mesos-protobuf.pth").atomic_write pth_contents
+
+    (share/"mesos").install "ec2"
   end
 
   test do
@@ -65,5 +139,6 @@ class Mesos < Formula
     Process.kill("TERM", master)
     Process.kill("TERM", slave)
     assert File.exist?("#{testpath}/executed")
+    system "python", "-c", "import mesos.native"
   end
 end

--- a/Library/Formula/mesos.rb
+++ b/Library/Formula/mesos.rb
@@ -1,5 +1,5 @@
 class Mesos < Formula
-  homepage "http://mesos.apache.org"
+  homepage "https://mesos.apache.org"
   url "http://mirror.cogentco.com/pub/apache/mesos/0.21.1/mesos-0.21.1.tar.gz"
   sha1 "275d211364699f2861c108fa80764785178f3eeb"
 
@@ -60,7 +60,7 @@ class Mesos < Formula
       system "python", *Language::Python.setup_install_args(libexec/"boto")
     end
     (lib/"python2.7/site-packages").mkpath
-    (lib/"python2.7/site-packages/homebrew-mesos-boto.pth").atomic_write boto_path + "\n"
+    (lib/"python2.7/site-packages/homebrew-mesos-boto.pth").write "#{boto_path}\n"
 
     # work around distutils abusing CC instead of using CXX
     # https://issues.apache.org/jira/browse/MESOS-799
@@ -88,11 +88,11 @@ class Mesos < Formula
 
     ENV.cxx11
 
-    system "./configure", *(args + ["--disable-python"])
+    system "./configure", "--disable-python", *args
     system "make"
     system "make", "install"
 
-    system "./configure", *(args + ["--enable-python"])
+    system "./configure", "--enable-python", *args
     ["native", "interface", ""].each do |p|
       cd "src/python/#{p}" do
         system "python", *Language::Python.setup_install_args(prefix)
@@ -114,7 +114,7 @@ class Mesos < Formula
       system "python", *Language::Python.setup_install_args(libexec/"protobuf")
     end
     pth_contents = "import site; site.addsitedir('#{protobuf_path}')\n"
-    (lib/"python2.7/site-packages/homebrew-mesos-protobuf.pth").atomic_write pth_contents
+    (lib/"python2.7/site-packages/homebrew-mesos-protobuf.pth").write pth_contents
 
     (share/"mesos").install "ec2"
   end
@@ -143,7 +143,7 @@ class Mesos < Formula
     user_site = Language::Python.user_site_packages("python")
     mkdir_p user_site
     pth_contents = "import site; site.addsitedir('#{Language::Python.homebrew_site_packages}')\n"
-    (user_site/"homebrew.pth").atomic_write pth_contents
+    (user_site/"homebrew.pth").write pth_contents
     system "python", "-c", "import mesos.native"
   end
 end


### PR DESCRIPTION
* installs python bindings and dependencies
* installs ec2 scripts into share/mesos/ec2

The mesos build scripts should build these but they work in an idiosyncratic way and don't seem to produce correct results.

Previously: https://github.com/Homebrew/homebrew/pull/37087#issuecomment-77114099