### PR TITLE
cppcheck: Fix --with-gui option

### DIFF
--- a/Library/Formula/cppcheck.rb
+++ b/Library/Formula/cppcheck.rb
@@ -19,6 +19,12 @@ class Cppcheck < Formula
   depends_on "pcre" if build.with? "rules"
   depends_on "qt" if build.with? "gui"
 
+  # Upstream patches for OS X + Clang compilation
+  patch do
+    url "https://github.com/danmar/cppcheck/commit/141a071.diff"
+    sha1 "4ccc8d814709d0e221c533a5556da4b1aa5fbead"
+  end 
+
   def install
     # Man pages aren't installed as they require docbook schemas.
 
@@ -36,18 +42,14 @@ class Cppcheck < Formula
 
     if build.with? "gui"
       cd "gui" do
-        # fix make not finding cfg directory:
-        # https://github.com/Homebrew/homebrew/issues/27756
-        inreplace "gui.qrc", "../cfg/", "#{prefix}/cfg/"
-
         if build.with? "rules"
-          system "qmake"
+          system "qmake", "HAVE_RULES=yes"
         else
           system "qmake", "HAVE_RULES=no"
         end
 
         system "make"
-        bin.install "cppcheck-gui.app"
+        prefix.install "cppcheck-gui.app"
       end
     end
   end


### PR DESCRIPTION
- In 1.68, gui.qrc no longer references a cfg dir, so removed the
  previously-required inreplace.
- The QT build now requires HAVE_RULES to be explicitly enabled, so
  added that to the qmake invocation.
- Fixed a clang compile error caused by ambiguous closing template angle
  brackets.  This fix is already in upstream’s master branch.
- Made sure QT project builds in C++11 mode when using clang.  This fix
  is taken from upstream’s master branch.
- Caused .app to be installed directly in the prefix dir, not the bin
  dir - that was stopping ‘brew linkapps’ from working.