### PR TITLE
xplanetfx update and dependency change

### DIFF
--- a/Library/Formula/xplanetfx.rb
+++ b/Library/Formula/xplanetfx.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Xplanetfx < Formula
   homepage "http://mein-neues-blog.de/xplanetFX/"
-  url "http://repository.mein-neues-blog.de:9000/archive/xplanetfx-2.6.2_all.tar.gz"
-  sha1 "9718a94186a524562b26a18ae91f1cad720ba1b2"
-  version "2.6.2"
+  url "http://repository.mein-neues-blog.de:9000/archive/xplanetfx-2.6.4_all.tar.gz"
+  sha1 "289b5581350f0b153e74cd57b0ac7eee1e165e66"
+  version "2.6.4"
 
   bottle do
     cellar :any
@@ -13,7 +13,6 @@ class Xplanetfx < Formula
     sha1 "71ddd365d9100e42e00989c6414e98838765abd0" => :mountain_lion
   end
 
-  option "without-perlmagick", "Build without PerlMagick support - used to check cloud map downloads"
   option "without-gui", "Build to run xplanetFX from the command-line only"
   option "with-gnu-sed", "Build to use GNU sed instead of OS X sed"
 
@@ -22,7 +21,6 @@ class Xplanetfx < Formula
   depends_on "wget"
   depends_on "coreutils"
   depends_on "gnu-sed" => :optional
-  depends_on "perlmagick" => :recommended
 
   if build.with? "gui"
     depends_on "librsvg"
@@ -38,15 +36,11 @@ class Xplanetfx < Formula
 
     path = "#{Formula["coreutils"].opt_libexec}/gnubin"
     path += ":#{Formula["gnu-sed"].opt_libexec}/gnubin" if build.with?("gnu-sed")
-    if build.with?("perlmagick")
-      perl_version = `/usr/bin/perl -e 'printf "%vd", $^V;'`
-      ENV.prepend_create_path "PERL5LIB", "#{HOMEBREW_PREFIX}/lib/perl5/site_perl/#{perl_version}"
-    end
     if build.with?("gui")
       ENV.prepend_create_path "PYTHONPATH", "#{HOMEBREW_PREFIX}/lib/python2.7/site-packages/gtk-2.0"
       ENV.prepend_create_path "GDK_PIXBUF_MODULEDIR", "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
     end
-    bin.env_script_all_files(libexec+'bin', :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :PERL5LIB => ENV["PERL5LIB"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"])
+    bin.env_script_all_files(libexec+'bin', :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"])
   end
 
   def post_install


### PR DESCRIPTION
Updating to xplanetFX 2.6.4.  New version no longer requires PerlMagick
to check the status of the cloud image download.  It now uses native
functions found in ImageMagick.  Removed all dependencies to PerlMagick
and tested to work fine.