### PR TITLE
libmagic: install the static library

### DIFF
--- a/Library/Formula/libmagic.rb
+++ b/Library/Formula/libmagic.rb
@@ -22,7 +22,8 @@ class Libmagic < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-fsect-man5"
+                          "--enable-fsect-man5",
+                          "--enable-static"
     system "make", "install"
 
     if build.with? "python"


### PR DESCRIPTION
The static library is required by homebrew/science/sratoolkit