### PR TITLE
node: force-bump npm

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -4,6 +4,7 @@ class Node < Formula
   url "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz"
   sha256 "9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32"
   head "https://github.com/joyent/node.git", :branch => "v0.12"
+  revision 1
 
   bottle do
     revision 1
@@ -31,8 +32,8 @@ class Node < Formula
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.5.1.tgz"
-    sha1 "23e4b0fdd1ffced7d835780e692a9e5a0125bb02"
+    url "https://registry.npmjs.org/npm/-/npm-2.7.1.tgz"
+    sha256 "dda316a9abe1881c220e7db3b04e240e6f44179825d3c143b72e4734d2ac1046"
   end
 
   def install


### PR DESCRIPTION
Both 2.6.1 and the consequent 2.7.0 ended up being really quite major npm releases, with some nifty new features, not least:

*drumroll*: the problem where doing `npm update -g` would completely murder your entire npm installation has been significantly reduced. Not completely, but significantly.

Other stuff:

* New documentation pertaining to the above. If you’re super-interested in running wild with the `npm update -g` command, give the new docs a glance over first.
* A change to the handling of node-gyp which could make handling iojs in Homebrew a less painful situation for everyone involved in the near future.
* Minor internal deps updates.

Revision for the whole making it much harder to kill off your own npm installation with the `npm update -g` command :cake: :tada: :birthday: :gift: 