### PR TITLE
pcre2 10.10

### DIFF
--- a/Library/Formula/pcre2.rb
+++ b/Library/Formula/pcre2.rb
@@ -1,8 +1,7 @@
 class Pcre2 < Formula
   homepage "http://www.pcre.org/"
-  url "https://downloads.sourceforge.net/pcre/pcre2/10.00/pcre2-10.00.tar.bz2"
-  mirror "http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.00.tar.bz2"
-  sha256 "487e605cf6ea273b416ad86fb8f2746c36f9959dcc730a6f49a4beca7c73888b"
+  url "http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.10.tar.bz2"
+  sha256 "5f45e5550a8c055a8a02b20c50060b16e71bec8440e5c86013c6b272c242ff42"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Deleted sf.net mirror; it's not updated yet and its https doesn't work anyway.