### PR TITLE
iojs 1.5.1

### DIFF
--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -1,7 +1,7 @@
 class Iojs < Formula
   homepage "https://iojs.org/"
-  url "https://iojs.org/dist/v1.4.3/iojs-v1.4.3.tar.xz"
-  sha256 "ffcd739c59c7d4c1f4cbdbe288b9db2d8a7ea4605540701f28a32757bbe6dd28"
+  url "https://iojs.org/dist/v1.5.1/iojs-v1.5.1.tar.xz"
+  sha256 "edf7fe994b72f70cc2c8e6d971ad94f576cdb36b2be008471e5b0d3af61a77fc"
 
   bottle do
     sha1 "df191613915a1fcedc0042414762e5ad9ada4bdf" => :yosemite


### PR DESCRIPTION
Version bump, and moving from keg_only to conflicts with. We can’t quite go the whole hog and roll with #36369 yet because `npm`’s codebase still needs patching for gyp, *but* with the 2.7.0 release we *can* vendor in an alternative gyp which supports iojs and install that, and then instruct users to use the new `npm` feature `--node-gyp=#{HOMEBREW_PREFIX}/bin/pangyp`.

Have verified this works on a few things. It removes the need for Homebrew to patch anything itself, and it means we can keep our npm-tarball preferred method in place. It’s not a perfect situation, but thought it may merit discussion until we can roll discussion forwards on #36369 in future.

It's a middle ground between having to the current iojs/node situation and #36369. Open for discussion.