### PR TITLE
utils: support curl env

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -162,7 +162,12 @@ def quiet_system cmd, *args
 end
 
 def curl *args
-  curl = Pathname.new '/usr/bin/curl'
+  if ENV["HOMEBREW_CURL"]
+    curl = Pathname.new(ENV["HOMEBREW_CURL"])
+  else
+    curl = Pathname.new "/usr/bin/curl"
+  end
+
   raise "#{curl} is not executable" unless curl.exist? and curl.executable?
 
   flags = HOMEBREW_CURL_ARGS


### PR DESCRIPTION
Self-explanatory request. Have wanted to do this for a while, but I don’t know how the maintainers feel. The general feeling towards screwing with the download mechanism too much has seemed a little reluctant, for understandable reasons, but limiting it to using a cURL means nothing else would need to change, and would be fairly predictable.

Open to outright rejection, but I live in hope.