### PR TITLE
pbzip2 1.1.12

### DIFF
--- a/Library/Formula/pbzip2.rb
+++ b/Library/Formula/pbzip2.rb
@@ -1,17 +1,13 @@
-require 'formula'
-
 class Pbzip2 < Formula
-  homepage 'http://compression.ca/pbzip2/'
-  url 'http://compression.ca/pbzip2/pbzip2-1.1.8.tar.gz'
-  sha1 '6957483690f00c33ffeabbe0e9e6475098820cd5'
+  homepage "http://compression.ca/pbzip2/"
+  url "https://launchpad.net/pbzip2/1.1/1.1.12/+download/pbzip2-1.1.12.tar.gz"
+  sha256 "573bb358a5a7d3bf5f42f881af324cedf960c786e8d66dd03d448ddd8a0166ee"
 
   fails_with :llvm do
     build 2334
   end
 
   def install
-    inreplace "Makefile", "$(PREFIX)/man", "$(PREFIX)/share/man"
-
     system "make", "PREFIX=#{prefix}",
                    "CC=#{ENV.cxx}",
                    "CFLAGS=#{ENV.cflags}",


### PR DESCRIPTION
Update to latest stable release, remove obsolete `inreplace`, modernize formula.