### PR TITLE
libidn 1.30

### DIFF
--- a/Library/Formula/libidn.rb
+++ b/Library/Formula/libidn.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Libidn < Formula
-  homepage "http://www.gnu.org/software/libidn/"
-  url "http://ftpmirror.gnu.org/libidn/libidn-1.29.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libidn/libidn-1.29.tar.gz"
-  sha256 "fb82747dbbf9b36f703ed27293317d818d7e851d4f5773dedf3efa4db32a7c7c"
+  homepage "https://www.gnu.org/software/libidn/"
+  url "http://ftpmirror.gnu.org/libidn/libidn-1.30.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libidn/libidn-1.30.tar.gz"
+  sha256 "39b9fc94d74081c185757b12e0891ce5a22db55268e7d1bb24533ff4432eb053"
 
   bottle do
     cellar :any
@@ -23,7 +21,7 @@ class Libidn < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-csharp"
-    system "make install"
+    system "make", "install"
   end
 
   test do

--- a/Library/Formula/libidn.rb
+++ b/Library/Formula/libidn.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class Libidn < Formula
   homepage "https://www.gnu.org/software/libidn/"
   url "http://ftpmirror.gnu.org/libidn/libidn-1.30.tar.gz"
@@ -25,6 +26,7 @@ class Libidn < Formula
   end
 
   test do
-    system "#{bin}/idn", "--version"
+    ENV["CHARSET"] = "UTF-8"
+    system "#{bin}/idn", "räksmörgås.se", "blåbærgrød.no"
   end
 end


### PR DESCRIPTION
Update to latest stable release, change format of `make` command, use HTTPS on homepage and mirror URLs.