### PR TITLE
Update AWS SDK dependency of S3DownloadStrategy

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -405,7 +405,7 @@ class S3DownloadStrategy < CurlDownloadStrategy
     # a dependency of S3 users, not all Homebrew users
     require 'rubygems'
     begin
-      require 'aws-sdk'
+      require 'aws-sdk-v1'
     rescue LoadError
       onoe "Install the aws-sdk gem into the gem repo used by brew."
       raise


### PR DESCRIPTION
In Feb (2015), Amazon bumped the major version of their Ruby SDK from 1 to 2.  In this upgrade, they decided there was some "value add" in renaming their top-level module to Aws from AWS, which breaks the S3DownloadStrategy.

This patch to S3DownloadStrategy fixes this breakage, by tying the S3DownloadStrategy to the newly-defined aws-sdk-v1 gem, which presumably will be immune from future "value adding" renaminings Amazon may pursue in the future.