### PR TITLE
ghc: make gmp a build-time dependency.

### DIFF
--- a/Library/Formula/ghc.rb
+++ b/Library/Formula/ghc.rb
@@ -58,6 +58,13 @@ class Ghc < Formula
     end
   end
 
+  fails_with :llvm do
+    cause <<-EOS.undent
+      cc1: error: unrecognized command line option "-Wno-invalid-pp-token"
+      cc1: error: unrecognized command line option "-Wno-unicode"
+    EOS
+  end
+
   if build.build_32_bit? || !MacOS.prefer_64_bit? || MacOS.version < :mavericks
     fails_with :clang do
       cause <<-EOS.undent


### PR DESCRIPTION
Link against the static libraries instead.

CC @adamv in case you can remember why this was added in 7153db0a9e0f1f7057548cc7defd3f8a2ac753af.