### PR TITLE
Check revisions for Git tags

### DIFF
--- a/Library/Formula/boot2docker.rb
+++ b/Library/Formula/boot2docker.rb
@@ -2,7 +2,8 @@ class Boot2docker < Formula
   homepage "https://github.com/boot2docker/boot2docker-cli"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
-  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.5.0"
+  url "https://github.com/boot2docker/boot2docker-cli.git", :tag => "v1.5.0",
+    :revision => "ccd9032caf251ca63edaf3a0808456fa5d5f9057"
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
   bottle do

--- a/Library/Formula/docker.rb
+++ b/Library/Formula/docker.rb
@@ -2,7 +2,8 @@ class Docker < Formula
   homepage "https://www.docker.com/"
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of boot2docker too
-  url "https://github.com/docker/docker.git", :tag => "v1.5.0"
+  url "https://github.com/docker/docker.git", :tag => "v1.5.0",
+    :revision => "a8a31eff10544860d2188dddabdee4d727545796"
 
   bottle do
     cellar :any

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -872,6 +872,14 @@ class ResourceAuditor
       problem "Use of the #{$&} scheme is deprecated, pass `:using => :#{$1}` instead"
     end
 
+    url_strategy = DownloadStrategyDetector.detect(url)
+
+    if using == :git || url_strategy == GitDownloadStrategy
+      if specs[:tag] && !specs[:revision]
+        problem "Git should specify :revision when a :tag is specified."
+      end
+    end
+
     return unless using
 
     if using == :ssl3 || using == CurlSSL3DownloadStrategy
@@ -898,7 +906,6 @@ class ResourceAuditor
       end
     end
 
-    url_strategy   = DownloadStrategyDetector.detect(url)
     using_strategy = DownloadStrategyDetector.detect('', using)
 
     if url_strategy == using_strategy


### PR DESCRIPTION
It's always bothered me a bit that we use checksums so heavily but when we check out a Git tag we're effectively just relying on a string match. Instead, let's nudge people into adding a `:revision` when they specify a `:tag` and then verify the two match. This should give us the same level of protection for Git tags as we do for their tarball equivalents.

CC @Homebrew/owners @DomT4