### PR TITLE
Use 'formulae' instead of 'brews' everywhere

### DIFF
--- a/Library/Contributions/brew_fish_completion.fish
+++ b/Library/Contributions/brew_fish_completion.fish
@@ -94,7 +94,7 @@ complete -c brew --arguments '(__fish_brew_formula_arguments)'
 complete -c brew -x -a "$commands" -n '__fish_complete_brew_no_command'
 complete -c brew -x -a '(__fish_complete_brew_argument)' -n '__fish_complete_brew_has_command'
 
-complete -c brew -s f -l force -n '__fish_complete_brew_command cleanup' -d "Remove out-of-date keg-only brews"
+complete -c brew -s f -l force -n '__fish_complete_brew_command cleanup' -d "Remove out-of-date keg-only formulae"
 complete -c brew -s n -l dry-run -n '__fish_complete_brew_command cleanup' -d "Show what would be removed, but don't do anything"
 complete -c brew -s s -n '__fish_complete_brew_command cleanup' -d "Remove all downloads"
 
@@ -144,7 +144,7 @@ complete -c brew -l compact -n '__fish_complete_brew_command options' -d "Show o
 complete -c brew -l all -n '__fish_complete_brew_command options' -f -d "Show options for all formulae"
 complete -c brew -l installed -n '__fish_complete_brew_command options' -f -d "Show options for all installed formulae"
 
-complete -c brew -l quiet -n '__fish_complete_brew_command outdated' -d "Do not print names of outdated brews"
+complete -c brew -l quiet -n '__fish_complete_brew_command outdated' -d "Do not print names of outdated formulae"
 
 complete -c brew -s f -l force -n '__fish_complete_brew_command uninstall rm remove' -d "Delete all installed versions"
 

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -122,7 +122,7 @@ end
 class Formula
   def can_cleanup?
     # It used to be the case that keg-only kegs could not be cleaned up, because
-    # older brews were built against the full path to the keg-only keg. Then we
+    # older formulae were built against the full path to the keg-only keg. Then we
     # introduced the opt symlink, and built against that instead. So provided
     # no brew exists that was built against an old-style keg-only keg, we can
     # remove it.

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -503,7 +503,7 @@ def check_homebrew_prefix
   unless HOMEBREW_PREFIX.to_s == '/usr/local'
     <<-EOS.undent
       Your Homebrew is not installed to /usr/local
-      You can install Homebrew anywhere you want, but some brews may only build
+      You can install Homebrew anywhere you want, but some formulae may only build
       correctly if you install in /usr/local. Sorry!
     EOS
   end
@@ -651,7 +651,7 @@ def check_for_gettext
 
   return if @found.empty?
 
-  # Our gettext formula will be caught by check_linked_keg_only_brews
+  # Our gettext formula will be caught by check_for_linked_keg_only_brews
   f = Formulary.factory("gettext") rescue nil
   return if f and f.linked_keg.directory? and @found.all? do |path|
     Pathname.new(path).realpath.to_s.start_with? "#{HOMEBREW_CELLAR}/gettext"
@@ -788,7 +788,7 @@ def check_for_multiple_volumes
   unless where_cellar == where_temp then <<-EOS.undent
     Your Cellar and TEMP directories are on different volumes.
     OS X won't move relative symlinks across volumes unless the target file already
-    exists. Brews known to be affected by this are Git and Narwhal.
+    exists. Formulae known to be affected by this are Git and Narwhal.
 
     You should set the "HOMEBREW_TEMP" environmental variable to a suitable
     directory on the same volume as your Cellar.
@@ -945,7 +945,7 @@ def check_for_linked_keg_only_brews
     Binaries provided by keg-only formulae may override system binaries
     with other strange results.
 
-    You may wish to `brew unlink` these brews:
+    You may wish to `brew unlink` these formulae:
 
     EOS
     warnings.each_key { |f| s << "    #{f}\n" }
@@ -1144,7 +1144,7 @@ def check_for_unlinked_but_not_keg_only
 
   if not unlinked.empty? then <<-EOS.undent
     You have unlinked kegs in your Cellar
-    Leaving kegs unlinked can lead to build-trouble and cause brews that depend on
+    Leaving kegs unlinked can lead to build-trouble and cause formulae that depend on
     those kegs to fail to run properly once built. Run `brew link` on these:
 
         #{unlinked * "\n        "}

--- a/Library/Homebrew/cmd/edit.rb
+++ b/Library/Homebrew/cmd/edit.rb
@@ -10,7 +10,7 @@ module Homebrew
         EOS
     end
 
-    # If no brews are listed, open the project root in an editor.
+    # If no formulae are listed, open the project root in an editor.
     if ARGV.named.empty?
       editor = File.basename which_editor
       if editor == "mate" or editor == "subl"

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -41,7 +41,7 @@ end
 HOMEBREW_CACHE = cache
 undef cache
 
-# Where brews installed via URL are cached
+# Where formulae installed via URL are cached
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"
 
 if not defined? HOMEBREW_BREW_FILE

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -55,11 +55,11 @@ Note that these flags should only appear after a command.
 
   * `cleanup [--force] [-ns]` [<formulae>]:
     For all installed or specific formulae, remove any older versions from the
-    cellar. By default, does not remove out-of-date keg-only brews, as other
+    cellar. By default, does not remove out-of-date keg-only formulae, as other
     software may link directly to specific versions. In addition old downloads from
     the Homebrew download-cache are deleted.
 
-    If `--force` is passed, remove out-of-date keg-only brews as well.
+    If `--force` is passed, remove out-of-date keg-only formulae as well.
 
     If `-n` is passed, show what would be removed, but do not actually remove anything.
 
@@ -272,7 +272,7 @@ Note that these flags should only appear after a command.
   * `missing` [<formulae>]:
     Check the given <formulae> for missing dependencies.
 
-    If no <formulae> are given, check all installed brews.
+    If no <formulae> are given, check all installed formulae.
 
   * `options [--compact] [--all] [--installed]` <formula>:
     Display install options specific to <formula>.
@@ -290,7 +290,7 @@ Note that these flags should only appear after a command.
     By default, version information is displayed in interactive shells, and
     suppressed otherwise.
 
-    If `--quiet` is passed, list only the names of outdated brews (takes
+    If `--quiet` is passed, list only the names of outdated formulae (takes
     precedence over `--verbose`).
 
     If `--verbose` is passed, display detailed version information.
@@ -389,11 +389,11 @@ Note that these flags should only appear after a command.
     If `--rebase` is specified then `git pull --rebase` is used.
 
   * `upgrade [install-options]` [<formulae>]:
-    Upgrade outdated, unpinned brews.
+    Upgrade outdated, unpinned formulae.
 
     Options for the `install` command are also valid here.
 
-    If <formulae> are given, upgrade only the specified brews (but do so even
+    If <formulae> are given, upgrade only the specified formulae (but do so even
     if they are pinned; see `pin`, `unpin`).
 
   * `uses [--installed] [--recursive] [--skip-build] [--skip-optional] [--devel|--HEAD]` <formulae>:

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "February 2015" "Homebrew" "brew"
+.TH "BREW" "1" "March 2015" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for OS X
@@ -62,10 +62,10 @@ Display the source to \fIformula\fR\.
 .
 .TP
 \fBcleanup [\-\-force] [\-ns]\fR [\fIformulae\fR]
-For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only brews, as other software may link directly to specific versions\. In addition old downloads from the Homebrew download\-cache are deleted\.
+For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only formulae, as other software may link directly to specific versions\. In addition old downloads from the Homebrew download\-cache are deleted\.
 .
 .IP
-If \fB\-\-force\fR is passed, remove out\-of\-date keg\-only brews as well\.
+If \fB\-\-force\fR is passed, remove out\-of\-date keg\-only formulae as well\.
 .
 .IP
 If \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
@@ -288,7 +288,7 @@ Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recogni
 Check the given \fIformulae\fR for missing dependencies\.
 .
 .IP
-If no \fIformulae\fR are given, check all installed brews\.
+If no \fIformulae\fR are given, check all installed formulae\.
 .
 .TP
 \fBoptions [\-\-compact] [\-\-all] [\-\-installed]\fR \fIformula\fR
@@ -311,7 +311,7 @@ Show formulae that have an updated version available\.
 By default, version information is displayed in interactive shells, and suppressed otherwise\.
 .
 .IP
-If \fB\-\-quiet\fR is passed, list only the names of outdated brews (takes precedence over \fB\-\-verbose\fR)\.
+If \fB\-\-quiet\fR is passed, list only the names of outdated formulae (takes precedence over \fB\-\-verbose\fR)\.
 .
 .IP
 If \fB\-\-verbose\fR is passed, display detailed version information\.
@@ -413,13 +413,13 @@ If \fB\-\-rebase\fR is specified then \fBgit pull \-\-rebase\fR is used\.
 .
 .TP
 \fBupgrade [install\-options]\fR [\fIformulae\fR]
-Upgrade outdated, unpinned brews\.
+Upgrade outdated, unpinned formulae\.
 .
 .IP
 Options for the \fBinstall\fR command are also valid here\.
 .
 .IP
-If \fIformulae\fR are given, upgrade only the specified brews (but do so even if they are pinned; see \fBpin\fR, \fBunpin\fR)\.
+If \fIformulae\fR are given, upgrade only the specified formulae (but do so even if they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
 .TP
 \fBuses [\-\-installed] [\-\-recursive] [\-\-skip\-build] [\-\-skip\-optional] [\-\-devel|\-\-HEAD]\fR \fIformulae\fR


### PR DESCRIPTION
From what I understand, “brews” is the old way to speak of “formulae”. This PR only changes the wording in text and comments, not in the code (I didn’t rename `outdated_brews` nor `check_for_linked_keg_only_brews`. Should I?).