### PR TITLE
go-app-engine 1.9.18

### DIFF
--- a/Library/Formula/go-app-engine-32.rb
+++ b/Library/Formula/go-app-engine-32.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class GoAppEngine32 < Formula
-  homepage "https://code.google.com/appengine/docs/go/overview.html"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.17.zip"
-  sha1 "1798e2d3366d9a7e05620e8174f92597e14e1723"
+  homepage "https://cloud.google.com/appengine/docs/go/"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.18.zip"
+  sha1 "5f74eba1b77dddca9122ba355e6348e8cc833031"
 
   def install
     cd ".."

--- a/Library/Formula/go-app-engine-64.rb
+++ b/Library/Formula/go-app-engine-64.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class GoAppEngine64 < Formula
-  homepage "https://code.google.com/appengine/docs/go/overview.html"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.17.zip"
-  sha1 "c88aa3e50f56f8c1b3d27cdaee68d2c17ac4ed22"
+  homepage "https://cloud.google.com/appengine/docs/go/"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.18.zip"
+  sha1 "21721945d0fee2f523d3997205164e7e9888297c"
 
   def install
     cd ".."


### PR DESCRIPTION
Update go-app-engine-32 & go-app-engine-64 to 1.9.18.
Updated URLs for homepage.