### PR TITLE
macvim: add python framework to (c|ld)flags

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -67,6 +67,15 @@ class Macvim < Formula
     elsif build.with? "python"
       ENV.prepend "LDFLAGS", `python-config --ldflags`.chomp
       ENV.prepend "CFLAGS", `python-config --cflags`.chomp
+      framework_script = <<-EOS.undent
+        import distutils.sysconfig
+        print distutils.sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
+      EOS
+      framework_prefix = `python -c '#{framework_script}'`.chuzzle
+      if framework_prefix
+        ENV.prepend "LDFLAGS", "-F#{framework_prefix}"
+        ENV.prepend "CFLAGS", "-F#{framework_prefix}"
+      end
       args << "--enable-pythoninterp"
     end
 

--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -1,8 +1,6 @@
-require 'formula'
-
 # Reference: https://github.com/b4winckler/macvim/wiki/building
 class Macvim < Formula
-  homepage 'http://code.google.com/p/macvim/'
+  homepage 'https://code.google.com/p/macvim/'
   url 'https://github.com/b4winckler/macvim/archive/snapshot-73.tar.gz'
   version '7.4-73'
   sha1 'b87e37fecb305a99bc268becca39f8854e3ff9f0'

--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -72,7 +72,7 @@ class Macvim < Formula
         print distutils.sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
       EOS
       framework_prefix = `python -c '#{framework_script}'`.chuzzle
-      if framework_prefix
+      if framework_prefix && framework_prefix != "/System/Library/Frameworks"
         ENV.prepend "LDFLAGS", "-F#{framework_prefix}"
         ENV.prepend "CFLAGS", "-F#{framework_prefix}"
       end


### PR DESCRIPTION
MacVim assumes that it's building against a framework python and that
the framework is in the compiler's and linker's framework search paths.
This change means that #include \<Python/Python.h\> (which only works
against a framework) and -framework Python can find a python other than
the system python, avoiding header mixing-and-matching and avoiding the
confusing double linkage in otool output.

Leaving the existing python-config calls in place means that the python
linkage will probably continue to work if macvim is built against a
non-framework Python, though it will continue to pull in parts from the
system framework.

Incidentally avoids problems with pathological configurations like #37492 where system Python is absent.