### PR TITLE
cppcheck: Fix head build

### DIFF
--- a/Library/Formula/cppcheck.rb
+++ b/Library/Formula/cppcheck.rb
@@ -1,7 +1,16 @@
 class Cppcheck < Formula
   homepage "http://sourceforge.net/apps/mediawiki/cppcheck/index.php?title=Main_Page"
-  url "https://github.com/danmar/cppcheck/archive/1.68.tar.gz"
-  sha1 "f08ef07f750f92fafe4f960166072e9d1088d74e"
+
+  stable do
+    url "https://github.com/danmar/cppcheck/archive/1.68.tar.gz"
+    sha1 "f08ef07f750f92fafe4f960166072e9d1088d74e"
+
+    # Upstream patches for OS X + Clang compilation
+    patch do
+      url "https://github.com/danmar/cppcheck/commit/141a071.diff"
+      sha1 "4ccc8d814709d0e221c533a5556da4b1aa5fbead"
+    end
+  end
 
   head "https://github.com/danmar/cppcheck.git"
 
@@ -19,11 +28,6 @@ class Cppcheck < Formula
   depends_on "pcre" if build.with? "rules"
   depends_on "qt" if build.with? "gui"
 
-  # Upstream patches for OS X + Clang compilation
-  patch do
-    url "https://github.com/danmar/cppcheck/commit/141a071.diff"
-    sha1 "4ccc8d814709d0e221c533a5556da4b1aa5fbead"
-  end
 
   def install
     # Man pages aren't installed as they require docbook schemas.


### PR DESCRIPTION
Sorry, I forgot to fix the HEAD build with my previous PR.

The OSX patch is already in upstream and so is only required for cppcheck 1.68.  This commit ensures the patch is only applied to the ‘stable’ build.

