### PR TITLE
Bugfix for ctags: Don't strcpy overlapping buffers

### DIFF
--- a/Library/Formula/ctags.rb
+++ b/Library/Formula/ctags.rb
@@ -2,6 +2,7 @@ class Ctags < Formula
   homepage "http://ctags.sourceforge.net/"
   url "https://downloads.sourceforge.net/ctags/ctags-5.8.tar.gz"
   sha1 "482da1ecd182ab39bbdc09f2f02c9fba8cd20030"
+  revision 1
 
   bottle do
     cellar :any
@@ -102,3 +103,27 @@ diff -ur a/ctags-5.8/read.h b/ctags-5.8/read.h
  
  /*
  *   FUNCTION PROTOTYPES
+
+
+Bugfix: Don't use strcpy on overlapping buffers
+Upstream commit (not in release yet): http://sourceforge.net/p/ctags/code/782/
+Homebrew PR: https://github.com/Homebrew/homebrew/pull/37521
+diff -ur a/ctags-5.8/routines.c b/ctags-5.8/routines.c
+--- a/ctags-5.8/routines.c	2007-06-07 00:35:21.000000000 -0400
++++ b/ctags-5.8/routines.c	2015-03-07 20:38:58.000000000 -0500
+@@ -757,13 +757,13 @@
+ 				else if (cp [0] != PATH_SEPARATOR)
+ 					cp = slashp;
+ #endif
+-				strcpy (cp, slashp + 3);
++				memmove (cp, slashp + 3, strlen (slashp + 3) + 1);
+ 				slashp = cp;
+ 				continue;
+ 			}
+ 			else if (slashp [2] == PATH_SEPARATOR  ||  slashp [2] == '\0')
+ 			{
+-				strcpy (slashp, slashp + 2);
++				memmove (slashp, slashp + 2, strlen (slashp + 2) + 1);
+ 				continue;
+ 			}
+ 		}


### PR DESCRIPTION
Upstream committed this patch in 2012, but it hasn't made it into a release yet (last release was in 2009).

Using --tag-relative, with relative paths to both the output tagfile and the files to tag, with sufficiently long pathnames, produces bad filenames in the output tagfile.
To reproduce bug with unpatched build (MacOS 10.10.2):
```
mkdir bugcheck                                                  
echo 'int a;' > bugcheck/bugcheck.c                             
ctags --tag-relative -o ./tags ./bugcheck/../bugcheck/bugcheck.c
grep bugcheck tags                                              
```
Filename (second field) in the tags file should be `bugcheck/bugcheck.c`, but it comes out mangled.