### PR TITLE
ffmpeg: use texi2html on all Mac OS X versions

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -35,7 +35,7 @@ class Ffmpeg < Formula
   depends_on "pkg-config" => :build
 
   # manpages won't be built without texi2html
-  depends_on "texi2html" => :build if MacOS.version >= :mountain_lion
+  depends_on "texi2html" => :build
   depends_on "yasm" => :build
 
   depends_on "x264" => :recommended


### PR DESCRIPTION
ffmpeg 2.6 requires a newer version of `texi2html` than is available on Mac OS X 10.7. See the error bellow.

```
Unknown open() mode ':encoding(utf-8-strict)' at /usr/bin/texi2html line 11111.
Unknown open() mode ':encoding(utf-8-strict)' at /usr/bin/texi2html line 11111.
make: *** [doc/ffprobe.html] Error 255
make: *** Waiting for unfinished jobs....
make: *** [doc/ffmpeg.html] Error 255
```