### PR TITLE
audit: Clarify GNU url warning message

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -311,7 +311,7 @@ class FormulaAuditor
 
     # Check GNU urls; doesn't apply to mirrors
     urls.grep(%r[^(?:https?|ftp)://(?!alpha).+/gnu/]) do |u|
-      problem "\"ftpmirror.gnu.org\" is preferred for GNU software (url is #{u})."
+      problem "\"http://ftpmirror.gnu.org\" is preferred for GNU software (url is #{u})."
     end
 
     # the rest of the checks apply to mirrors as well.


### PR DESCRIPTION
"ftpmirror.gnu.org" must have a protocol prefix of "http", not "https", so tell the user this.

Otherwise, the message is confusing.  See e.g., the comments in  ~~https://github.com/Homebrew/homebrew-dupes/#436.~~~
https://github.com/Homebrew/homebrew-dupes/pull/436