### PR TITLE
juju-quickstart 2.0.1

### DIFF
--- a/Library/Formula/juju-quickstart.rb
+++ b/Library/Formula/juju-quickstart.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class JujuQuickstart < Formula
   homepage "https://launchpad.net/juju-quickstart"
-  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-2.0.0.tar.gz"
-  sha1 "5ae0f94b87b03405a09413a55317f42ed112f725"
+  url "https://pypi.python.org/packages/source/j/juju-quickstart/juju-quickstart-2.0.1.tar.gz"
+  sha1 "603cf03a47e91d83f3d6032b99e0e7fdf07ecfcd"
 
   bottle do
     cellar :any


### PR DESCRIPTION
  * Fix a regression in bundle deployments when using the legacy bundle syntax.
    The bundle was not found in the case the original legacy YAML only included
    a single bundle name at top level.
  * Always run apt-get update before installing new packages, even when the
    distro-only flag is enabled.
  * Improve charm store API client code organization.