### PR TITLE
libssh2 1.5.0

### DIFF
--- a/Library/Formula/libssh2.rb
+++ b/Library/Formula/libssh2.rb
@@ -1,10 +1,7 @@
-require "formula"
-
 class Libssh2 < Formula
   homepage "http://www.libssh2.org/"
-  url "http://www.libssh2.org/download/libssh2-1.4.3.tar.gz"
-  sha1 "c27ca83e1ffeeac03be98b6eef54448701e044b0"
-  revision 1
+  url "http://www.libssh2.org/download/libssh2-1.5.0.tar.gz"
+  sha256 "83196badd6868f5b926bdac8017a6f90fb8a90b16652d3bf02df0330d573d0fc"
 
   option "with-libressl", "build with LibreSSL instead of OpenSSL"
 
@@ -18,7 +15,6 @@ class Libssh2 < Formula
 
   bottle do
     cellar :any
-    revision 2
     sha1 "6e9fd52d513692ea5db968de524dbe2b81e2f018" => :yosemite
     sha1 "bbe16ac0d85f7aed7794ba5f2220aa3a533298aa" => :mavericks
     sha1 "6de15a0a9400554c51858092e0276bb9ddd15c42" => :mountain_lion
@@ -28,11 +24,14 @@ class Libssh2 < Formula
   depends_on "libressl" => :optional
 
   def install
-    args = [ "--prefix=#{prefix}",
-             "--disable-debug",
-             "--disable-dependency-tracking",
-             "--with-openssl",
-             "--with-libz"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --disable-examples-build
+      --with-openssl
+      --with-libz
     ]
 
     if build.with? "libressl"
@@ -44,5 +43,20 @@ class Libssh2 < Formula
     system "./buildconf" if build.head?
     system "./configure", *args
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+     #include <libssh2.h>
+
+     int main(void)
+     {
+      libssh2_exit();
+      return 0;
+     }
+    EOS
+
+    system ENV.cc, "test.c", "-L#{lib}", "-lssh2", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
Release to fix [CVE-2015-1782](http://www.libssh2.org/adv_20150311.html), amongst a hoard of less important bug fixes.

Added a test. It works okay, and the documentation suggests it’s right, but my hatred of C is well known so I’m not attempting to vouch as to whether this test sucks or not.