### PR TITLE
git-ftp 1.0.2 and altered curl dependency

### DIFF
--- a/Library/Formula/git-ftp.rb
+++ b/Library/Formula/git-ftp.rb
@@ -1,11 +1,9 @@
-require 'formula'
-
 class GitFtp < Formula
-  homepage 'http://git-ftp.github.io/git-ftp'
-  url 'https://github.com/git-ftp/git-ftp/archive/1.0.1.tar.gz'
-  sha1 'ee0ff7525a88aafffe7e09b6cb95d6dde6bacf93'
+  homepage "https://git-ftp.github.io/git-ftp"
+  url "https://github.com/git-ftp/git-ftp/archive/1.0.2.tar.gz"
+  sha256 "f488c39bf7784923201c61ece41f40f8e18682e18b13918b0730ad196a11f1f7"
 
-  head 'https://github.com/git-ftp/git-ftp.git', :branch => 'develop'
+  head "https://github.com/git-ftp/git-ftp.git", :branch => "develop"
 
   bottle do
     cellar :any
@@ -16,7 +14,7 @@ class GitFtp < Formula
 
   option "with-manpage", "build and install the manpage (depends on pandoc)"
 
-  depends_on "curl" => [:optional, "with-libssh2"]
+  depends_on "curl" => "with-libssh2"
   depends_on "pandoc" => :build if build.with? "manpage"
 
   def install
@@ -25,5 +23,15 @@ class GitFtp < Formula
       system "make", "-C", "man", "man"
       man1.install "man/man1/git-ftp.1"
     end
+    libexec.install bin/"git-ftp"
+    (bin/"git-ftp").write <<-EOS.undent
+      #!/bin/sh
+      PATH=#{Formula["curl"].opt_bin}:$PATH
+      #{libexec}/git-ftp "$@"
+    EOS
+  end
+
+  test do
+    system bin/"git-ftp", "--help"
   end
 end


### PR DESCRIPTION
- ` 60bde2b` is a version bump with audit fixes
- `a07ba83` changes the curl dependency from optional to recommended, and adds a wrapper script to prepend the keg-only curl to PATH. git-ftp requires a version of curl with sftp support (git-ftp/git-ftp#91), which the system curl doesn't have, so maybe this should just be a hard dependency.