### PR TITLE
java_home_env: dont override JAVA_HOME if already set

### DIFF
--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -2,7 +2,8 @@ module Language
   module Java
     def self.java_home_env(version=nil)
       version_flag = " --version #{version}" if version
-      { :JAVA_HOME => "$(/usr/libexec/java_home#{version_flag})" }
+      java_home = "$(/usr/libexec/java_home#{version_flag})"
+      { :JAVA_HOME => "$(if [ -z \"$JAVA_HOME\" ]; then echo \"#{java_home}\"; else echo \"$JAVA_HOME\"; fi)" }
     end
   end
 end


### PR DESCRIPTION
Discussion on: https://github.com/Homebrew/homebrew/pull/37439

This PR adds a guard to protect the java_home_env value so it will not override JAVA_HOME if its already set.