### PR TITLE
hackrf: v2014.08.1

### DIFF
--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -6,7 +6,6 @@ class Hackrf < Formula
 
   depends_on "cmake" => :build
   depends_on "libusb"
-  depends_on "pkgconfig"
 
   def install
     cd "host" do
@@ -16,6 +15,6 @@ class Hackrf < Formula
   end
 
   test do
-    system "pkg-config libhackrf --cflags"
+    shell_output("hackrf_transfer", 1)
   end
 end

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Hackrf < Formula
   homepage "https://github.com/mossmann/hackrf"
   url "https://github.com/mossmann/hackrf/archive/v2014.08.1.tar.gz"

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -15,6 +15,6 @@ class Hackrf < Formula
   end
 
   test do
-    system "hackrf_info"
+    system "pkg-config libhackrf --cflags"
   end
 end

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -1,7 +1,6 @@
 class Hackrf < Formula
   homepage "https://github.com/mossmann/hackrf"
   url "https://github.com/mossmann/hackrf/archive/v2014.08.1.tar.gz"
-  version "2014.08.1"
   sha256 "5ab1641a9af766c476e04bfe2f7cbe3d7edd22c324453c22e58e3f0ef51082eb"
 
   depends_on "cmake" => :build

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -1,0 +1,22 @@
+require "formula"
+
+class Hackrf < Formula
+  homepage "https://github.com/mossmann/hackrf"
+  url "https://github.com/mossmann/hackrf/archive/v2014.08.1.tar.gz"
+  version "2014.08.1"
+  sha256 "5ab1641a9af766c476e04bfe2f7cbe3d7edd22c324453c22e58e3f0ef51082eb"
+
+  depends_on "cmake" => :build
+  depends_on "libusb"
+
+  def install
+    cd "host" do
+      system "cmake", ".", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "hackrf_info"
+  end
+end

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -6,6 +6,7 @@ class Hackrf < Formula
 
   depends_on "cmake" => :build
   depends_on "libusb"
+  depends_on "pkgconfig"
 
   def install
     cd "host" do

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -5,6 +5,7 @@ class Hackrf < Formula
   sha256 "5ab1641a9af766c476e04bfe2f7cbe3d7edd22c324453c22e58e3f0ef51082eb"
 
   depends_on "cmake" => :build
+  depends_on "pkgconfig"
   depends_on "libusb"
 
   def install

--- a/Library/Formula/hackrf.rb
+++ b/Library/Formula/hackrf.rb
@@ -4,7 +4,7 @@ class Hackrf < Formula
   sha256 "5ab1641a9af766c476e04bfe2f7cbe3d7edd22c324453c22e58e3f0ef51082eb"
 
   depends_on "cmake" => :build
-  depends_on "pkgconfig"
+  depends_on "pkg-config" => :build
   depends_on "libusb"
 
   def install


### PR DESCRIPTION
I propose adding the HackRF library to Homebrew. These are the drivers and libraries for the HackRF device, a low-cast general-purpose software-defined radio.

An issue is that the test code executes `hackrf_info`, which fails if you don't have a HackRF device connected. All of the other installed programs have the same issue. Should I use a different test for this?

