### PR TITLE
software_spec: check if bottles are compatible.

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -62,7 +62,8 @@ class SoftwareSpec
   end
 
   def bottled?
-    bottle_specification.tag?(bottle_tag)
+    bottle_specification.tag?(bottle_tag) && \
+      bottle_specification.compatible_cellar?
   end
 
   def bottle &block
@@ -220,6 +221,7 @@ class Bottle
     @name = formula.name
     @resource = Resource.new
     @resource.owner = formula
+    @spec = spec
 
     checksum, tag = spec.checksum_for(bottle_tag)
 
@@ -234,7 +236,7 @@ class Bottle
   end
 
   def compatible_cellar?
-    cellar == :any || cellar == HOMEBREW_CELLAR.to_s
+    @spec.compatible_cellar?
   end
 
   def stage
@@ -263,6 +265,10 @@ class BottleSpecification
     @cellar = DEFAULT_CELLAR
     @root_url = DEFAULT_ROOT_URL
     @collector = BottleCollector.new
+  end
+
+  def compatible_cellar?
+    cellar == :any || cellar == HOMEBREW_CELLAR.to_s
   end
 
   def tag?(tag)


### PR DESCRIPTION
The `bottled?` method makes more sense when it also checks for compatibility.

This is particularly useful for the case in `brew info` so it prints out `(bottled)` correctly depending on the `Cellar`.

CC @jacknagel for thoughts.