### PR TITLE
MongoDB: increase open files limit

### DIFF
--- a/Library/Formula/mongodb.rb
+++ b/Library/Formula/mongodb.rb
@@ -114,12 +114,12 @@ class Mongodb < Formula
       <key>HardResourceLimits</key>
       <dict>
         <key>NumberOfFiles</key>
-        <integer>1024</integer>
+        <integer>65536</integer>
       </dict>
       <key>SoftResourceLimits</key>
       <dict>
         <key>NumberOfFiles</key>
-        <integer>1024</integer>
+        <integer>65536</integer>
       </dict>
     </dict>
     </plist>


### PR DESCRIPTION
With the release of MongoDB 3.0 and the WiredTiger storage engine, the number of open files limit specified in the MongoDB launchctl script is set too low.

WiredTiger puts each collection in its own file, and each index in its own file as well. This means that the number of open files limit currently specified in the launchctl script (1024) is easy to run into. The mongod process crashes with an assertion failure when this takes place.

This change increases the hard and soft limit of the number of open files in the launchctl script from 1024 to 65536.