### PR TITLE
dmd: Install the correct dmd.conf even when upgrading via bottle.

### DIFF
--- a/Library/Formula/dmd.rb
+++ b/Library/Formula/dmd.rb
@@ -72,13 +72,11 @@ class Dmd < Formula
   # post_install() if the user is running `brew install --build-from-source`.
   def install_new_dmd_conf
     conf = etc/"dmd.conf"
-    # Iff the new file differs from conf, etc.install drops it here:
-    new_conf = etc/"dmd.conf.default"
 
-    if !new_conf.exist?
-      # Nothing to do. Our conf is already the newest version
-      return
-    end
+    # If the new file differs from conf, etc.install drops it here:
+    new_conf = etc/"dmd.conf.default"
+    # Else, we're already using the latest version:
+    return unless new_conf.exist?
 
     backup = etc/"dmd.conf.old"
     opoo "An old dmd.conf was found and will be moved to #{backup}."

--- a/Library/Formula/dmd.rb
+++ b/Library/Formula/dmd.rb
@@ -68,9 +68,9 @@ class Dmd < Formula
   # Previous versions of this formula may have left in place an incorrect
   # dmd.conf.  If it differs from the newly generated one, move it out of place
   # and warn the user.
-  # This must be idempotent because it may run from both install() and 
+  # This must be idempotent because it may run from both install() and
   # post_install() if the user is running `brew install --build-from-source`.
-  def install_new_dmd_conf    
+  def install_new_dmd_conf
     conf = etc/"dmd.conf"
     # Iff the new file differs from conf, etc.install drops it here:
     new_conf = etc/"dmd.conf.default"
@@ -82,8 +82,8 @@ class Dmd < Formula
 
     backup = etc/"dmd.conf.old"
     opoo "An old dmd.conf was found and will be moved to #{backup}."
-    FileUtils.mv conf, backup
-    FileUtils.mv new_conf, conf    
+    mv conf, backup
+    mv new_conf, conf
   end
 
   def post_install


### PR DESCRIPTION
dmd.conf hard-codes a path to DMD library files, which includes the keg
version in the path. Upgrades via bottle would leave the old dmd.conf in
place, which would result in a broken dmd.

This change moves some logic from install into a new fix_dmd_conf method,
which now gets called both during install and in post_install so that it
works for bottle installs/upgrades too.

Testing
---------

* With an old version of dmd.rb, edit /usr/local/etc/dmd.conf and change one of the paths to be wrong.   (This simulates having an old path from a previous version of dmd.)
* run `brew test dmd` and see that it's broken. 
* `brew uninstall dmd;` `brew install dmd;` 
* run `brew test dmd` again to see that it's still broken.

With the fix, the install will fix up the dmd.conf to point to the correct paths.