### PR TITLE
brew style: --fix flag added to auto-correct issues

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -8,8 +8,16 @@ module Homebrew
 
     Homebrew.install_gem_setup_path! "rubocop"
 
-    system "rubocop", "--format", "simple", "--config",
-                      "#{HOMEBREW_LIBRARY}/.rubocop.yml", *target
+    args = [
+      "--format", "simple", "--config",
+      "#{HOMEBREW_LIBRARY}/.rubocop.yml"
+    ]
+
+    args << "--auto-correct" if ARGV.homebrew_developer? && ARGV.flag?("--fix")
+
+    args += target
+
+    system "rubocop", *args
     Homebrew.failed = !$?.success?
   end
 end


### PR DESCRIPTION
This should be useful for Homebrew maintainers/contributors. The first thing I do when I edit a formula is to fix quotes and other common style warnings.

It changes the workflow from this:

1. run `brew style --strict <formula>` to check it
2. open the formula
3. fix the warnings
4. make changes (e.g. bump version)
5. …

To that:

1. run `brew style --strict --fix <formula>` to check it and fix common mistakes
2. open the formula
3. make changes (e.g. bump version)
4. …

It won’t correct all mistakes ([the list is here](https://github.com/bbatsov/rubocop/wiki/Automatic-Corrections)), but it’s still useful. I’m open to suggestions for the flag name.

---
Update: sample output:

```
$ brew style --strict --fix qtfaststart
== Library/Formula/qtfaststart.rb ==
C:  1:  9: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  4: 12: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  5:  7: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  6:  8: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  9: 20: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  9: 26: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C:  9: 48: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 10: 17: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.

1 file inspected, 8 offenses detected, 8 offenses corrected
```

Update 2: changed for `--fix` and updated the text above.