### PR TITLE
Lua (sha256, linuxbrew)

### DIFF
--- a/Library/Formula/lua.rb
+++ b/Library/Formula/lua.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Lua < Formula
   homepage "http://www.lua.org/"
   url "http://www.lua.org/ftp/lua-5.2.3.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/l/lua5.2/lua5.2_5.2.3.orig.tar.gz"
-  sha1 "926b7907bc8d274e063d42804666b40a3f3c124c"
+  sha256 "13c2fb97961381f7d06d5b5cea55b743c163800896fd5c5e2356201d3619002d"
   bottle do
     sha1 "febde5bb25ed1a6d7cdf2b1a9ed798f29587f7f4" => :yosemite
     sha1 "10d2bc30697656e6deb6fde98a8fafbd1385681c" => :mavericks
@@ -21,6 +19,8 @@ class Lua < Formula
   option :universal
   option "with-completion", "Enables advanced readline support"
   option "without-sigaction", "Revert to ANSI signal instead of improved POSIX sigaction"
+
+  depends_on "readline" unless OS.mac?
 
   # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
   # See: https://github.com/Homebrew/homebrew/pull/5043


### PR DESCRIPTION
1) Use sha256 instead sha1; 2)Added extra dependecy which is required
to compile lua on Linuxbrew.