### PR TITLE
Add --termtruecolor option to vim formula

### DIFF
--- a/Library/Formula/vim.rb
+++ b/Library/Formula/vim.rb
@@ -15,6 +15,7 @@ class Vim < Formula
   option "override-system-vi", "Override system vi"
   option "disable-nls", "Build vim without National Language Support (translated messages, keymaps)"
   option "with-client-server", "Enable client/server mode"
+  option "with-termtruecolor", "Build vim with support for 24-bit colors in compatible terminals"
 
   LANGUAGES_OPTIONAL = %w(lua mzscheme python3 tcl)
   LANGUAGES_DEFAULT  = %w(perl python ruby)
@@ -35,6 +36,13 @@ class Vim < Formula
 
   conflicts_with "ex-vi",
     :because => "vim and ex-vi both install bin/ex and bin/view"
+
+  # Patch to add 24-bit color support to vim in compatible terminals
+  # https://groups.google.com/forum/#!topic/vim_dev/ed0GTyYrSYg
+  patch do
+    url "https://gist.githubusercontent.com/sebroeder/e91f155917c9cae697b6/raw/2aa83d91fa227a6e56ed6ccdbd0a8068a3dbfc6f/vim-termtruecolor.diff"
+    sha256 "6f52d599745389f0d8ed400a7410be3ffa0a1f16d26722795b81c339b51a33f7"
+  end if build.with? "termtruecolor"
 
   def install
     ENV["LUA_PREFIX"] = HOMEBREW_PREFIX if build.with?("lua") || build.with?("luajit")
@@ -68,6 +76,10 @@ class Vim < Formula
     if build.with? "luajit"
       opts << "--with-luajit"
       opts << "--enable-luainterp"
+    end
+
+    if build.with? "termtruecolor"
+      opts << "--enable-termtruecolor"
     end
 
     # XXX: Please do not submit a pull request that hardcodes the path


### PR DESCRIPTION
Apply a patch from ZyX that enables support for 24 bit colors (true
color) in vim when run inside a terminal that supports ISO-8613-3. This
makes it possible to use the same colorscheme in a terminal version of
vim as in the GUI version.

The patch is provided and discussed on the vim-dev mailing list:
https://groups.google.com/forum/#!topic/vim_dev/ed0GTyYrSYg

The patch is only applied when the --termtruecolor option is provided by
the user and does not affect users that are not interested in this
feature. I hope this makes it OK to add this feature to the offical vim formula,
even if it is a little experimental. I can imagine that many vim users would
like to try it out before it gets eventually merged upstream.

There is a tap with an alternative version of the vim formula at
https://github.com/choppsv1/homebrew-term24 but I wanted to deverge as little as
possible from the offical formula.

I am not 100% happy that I have to host the patch as a Gist but I failed to get
a curl-able URL directly from the Google Groups mailing list attachment. I also
failed to get a (set of relevant) patches from https://bitbucket.org/ZyX_I/vim.

Let me know if I can improve this PR in any way.