### PR TITLE
Update vnstat formula

### DIFF
--- a/Library/Formula/vnstat.rb
+++ b/Library/Formula/vnstat.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Vnstat < Formula
   homepage 'http://humdi.net/vnstat/'
-  url 'http://humdi.net/vnstat/vnstat-1.11.tar.gz'
-  sha1 '92494f38a752dcf60053af2a6d8977737da7e616'
+  url 'http://humdi.net/vnstat/vnstat-1.13.tar.gz'
+  sha256 '6f4e2599ebb195b25f499d3e2e865aa14da336dfc9cc03a79181aa71f7ed99cd'
 
   depends_on 'gd'
 
@@ -15,16 +15,28 @@ class Vnstat < Formula
       s.gsub! '/var/lib/vnstat', "#{var}/db/vnstat"
     end
 
+    inreplace "man/vnstatd.1" do |s|
+      s.gsub! '/etc/vnstat.conf', "#{etc}/vnstat.conf"
+      s.gsub! '/var/lib/vnstat', "#{var}/db/vnstat"
+      s.gsub! '/var/log/vnstat.log', "#{var}/log/vnstat/vnstat.log"
+      s.gsub! '/var/run/vnstat.pid', "#{var}/run/vnstat/vnstat.pid"
+    end
+
+    inreplace "man/vnstati.1" do |s|
+      s.gsub! '/etc/vnstat.conf', "#{etc}/vnstat.conf"
+      s.gsub! '/var/lib/vnstat', "#{var}/db/vnstat"
+    end
+
     inreplace "man/vnstat.conf.5", '/etc/vnstat.conf', "#{etc}/vnstat.conf"
 
     inreplace "cfg/vnstat.conf" do |c|
+      c.gsub! 'Interface "eth0"', %Q{Interface "en0"}
       c.gsub! 'DatabaseDir "/var/lib/vnstat"', %Q{DatabaseDir "#{var}/db/vnstat"}
-      c.gsub! 'LogFile "/var/log/vnstat.log"', %Q{LogFile "#{var}/log/vnstat.log"}
-      c.gsub! 'PidFile "/var/run/vnstat.pid"', %Q{PidFile "#{var}/run/vnstat.pid"}
+      c.gsub! 'LogFile "/var/log/vnstat/vnstat.log"', %Q{LogFile "#{var}/log/vnstat/vnstat.log"}
+      c.gsub! 'PidFile "/var/run/vnstat/vnstat.pid"', %Q{PidFile "#{var}/run/vnstat/vnstat.pid"}
     end
 
     (var+'db/vnstat').mkpath
-    (var+'spool/vnstat').mkpath
 
     system "make", "all", "-C", "src", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"
     (prefix+'etc').install "cfg/vnstat.conf"
@@ -33,14 +45,41 @@ class Vnstat < Formula
     man5.install "man/vnstat.conf.5"
   end
 
+  plist_options :startup => true
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/vnstatd</string>
+          <string>--nodaemon</string>
+          <string>--config</string>
+          <string>#{etc}/vnstat.conf</string>
+        </array>
+        <key>KeepAlive</key>
+        <true/>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>UserName</key>
+        <string>#{`whoami`.chomp}</string>
+        <key>GroupName</key>
+        <string>staff</string>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>ProcessType</key>
+        <string>Background</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
   def caveats; <<-EOS.undent
-    To setup vnstat, run `vnstat -u -i en0' (replace en0 with the network
-    interface you wish to monitor).
-
-    You must then create a cron job to update the vnstat database.
-
-    Run `crontab -e' and add the following:
-    0-55/5 * * * * if [ -x #{bin}/vnstat ] && [ `ls #{var}/db/vnstat/ | wc -l` -ge 1 ]; then #{bin}/vnstat -u; fi
+    To monitor interfaces other than "en0" edit #{etc}/vnstat.conf
     EOS
   end
 end


### PR DESCRIPTION
* Upgrades version to 1.13
* Fixes some paths in man files to point to Homebrew locations
* Fixes default interface name in vnstat.conf
* Use launchd to collect stats instead of cron
* Removes unused spool directory