### PR TITLE
erlang-versions: bottle regex fix

### DIFF
--- a/Library/Homebrew/bottle_version.rb
+++ b/Library/Homebrew/bottle_version.rb
@@ -7,6 +7,10 @@ class BottleVersion < Version
     m = /-([\d\.]+-x86(_64)?)/.match(stem)
     return m.captures.first unless m.nil?
 
+    # e.g. R14B04 from erlang-r14-R14B04.yosemite.bottle.tar.gz
+    m = /erlang-r\d+-(R\d+B\d+(-\d)?)/.match(stem)
+    return m.captures.first unless m.nil?
+
     # e.g. x264-r2197.4.mavericks.bottle.tar.gz
     # e.g. lz4-r114.mavericks.bottle.tar.gz
     m = /-(r\d+\.?\d*)/.match(stem)

--- a/Library/Homebrew/test/test_bottle_versions.rb
+++ b/Library/Homebrew/test/test_bottle_versions.rb
@@ -56,6 +56,11 @@ class BottleVersionParsingTests < Homebrew::TestCase
       'erlang-R16B03-1.mavericks.bottle.2.tar.gz'
   end
 
+  def test_erlang_versions_style
+    assert_version_detected 'R14B04',
+      'erlang-r14-R14B04.yosemite.bottle.tar.gz'
+  end
+
   def test_libpano_style
     assert_version_detected '13-2.9.19',
       'libpano-13-2.9.19_1.yosemite.bottle.tar.gz'


### PR DESCRIPTION
Note: This isn’t a fix yet. It’s still detecting just the R14 part and ignoring the latter.

Mike just asked me to push to a remote branch so he can giggle at how bad my regexes are/help me get it solved :).