### PR TITLE
mobiledevice 2.0.0 (new formula)

### DIFF
--- a/Library/Formula/mobiledevice.rb
+++ b/Library/Formula/mobiledevice.rb
@@ -8,7 +8,9 @@ class Mobiledevice < Formula
   end
 
   test do
-    has_version = shell_output("#{bin}/mobiledevice version").strip
-    assert_match "#{version}", has_version
+    cur_version = shell_output("#{bin}/mobiledevice version").strip
+    assert_match "#{version}", cur_version
+    `#{bin}/mobiledevice list_devices`
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Library/Formula/mobiledevice.rb
+++ b/Library/Formula/mobiledevice.rb
@@ -10,7 +10,6 @@ class Mobiledevice < Formula
   test do
     cur_version = shell_output("#{bin}/mobiledevice version").strip
     assert_match "#{version}", cur_version
-    `#{bin}/mobiledevice list_devices`
-    assert_equal 0, $?.exitstatus
+    system("#{bin}/mobiledevice list_devices")
   end
 end

--- a/Library/Formula/mobiledevice.rb
+++ b/Library/Formula/mobiledevice.rb
@@ -1,0 +1,14 @@
+class Mobiledevice < Formula
+  homepage "https://github.com/imkira/mobiledevice"
+  url "https://github.com/imkira/mobiledevice/archive/v2.0.0.tar.gz"
+  sha256 "07b167f6103175c5eba726fd590266bf6461b18244d34ef6d05a51fc4871e424"
+
+  def install
+    system "make", "install", "CC=#{ENV.cc}", "PREFIX=#{prefix}"
+  end
+
+  test do
+    has_version = shell_output("#{bin}/mobiledevice version").strip
+    assert_match "#{version}", has_version
+  end
+end


### PR DESCRIPTION
mobiledevice is a command line utility for interacting with Apple's
Private Mobile Device Framework. It can be used for automating several
tasks like installing and uninstalling apps on your iPhone/iPad without
having to manually do it via Xcode or iTunes. And you don't need a
jailbroken device!