### PR TITLE
Bump requests to 2.6.0

### DIFF
--- a/Library/Formula/deis.rb
+++ b/Library/Formula/deis.rb
@@ -1,7 +1,7 @@
 class Deis < Formula
   homepage "http://deis.io"
-  url "https://github.com/deis/deis/archive/v1.4.0.tar.gz"
-  sha1 "96bb7bb71bfe32cfb5e148ccb9deabd621ddbcd4"
+  url "https://github.com/deis/deis/archive/v1.4.1.tar.gz"
+  sha256 "d24333b6b7674916b416871ca909c8e24bbbbae3d894056728e176ec2b6769bd"
 
   bottle do
     cellar :any
@@ -29,8 +29,8 @@ class Deis < Formula
   end
 
   resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.5.1.tar.gz"
-    sha1 "f906c441be2f0e7a834cbf701a72788d3ac3d144"
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.6.0.tar.gz"
+    sha256 "1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75"
   end
 
   resource "termcolor" do
@@ -53,6 +53,9 @@ class Deis < Formula
     end
 
     cd "client" do
+      # unpin requests
+      inreplace "setup.py", /'requests==.*?'/, "'requests'"
+
       ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
       system "python", *Language::Python.setup_install_args(libexec)
     end

--- a/Library/Formula/fig.rb
+++ b/Library/Formula/fig.rb
@@ -2,6 +2,7 @@ class Fig < Formula
   homepage "https://docs.docker.com/compose/"
   url "https://github.com/docker/compose/archive/1.1.0.tar.gz"
   sha1 "175066934c19f455606b16f1b4e4b9f26fc3f599"
+  revision 1
 
   bottle do
     revision 1
@@ -49,8 +50,8 @@ class Fig < Formula
   end
 
   resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.4.3.tar.gz"
-    sha1 "411f1bfa44556f7dd0f34cd822047c31baa7d741"
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.6.0.tar.gz"
+    sha256 "1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75"
   end
 
   resource "websocket-client" do
@@ -65,6 +66,11 @@ class Fig < Formula
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
+
+    # unpin requests
+    inreplace Dir[libexec/"vendor/lib/python2.7/site-packages/docker_py-*.egg-info/requires.txt"],
+              /requests.*$/, "requests"
+    inreplace "setup.py", /'requests.*?'/, "'requests'"
 
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
     system "python", *Language::Python.setup_install_args(libexec)

--- a/Library/Formula/internetarchive.rb
+++ b/Library/Formula/internetarchive.rb
@@ -4,6 +4,7 @@ class Internetarchive < Formula
   homepage "https://github.com/jjjake/ia-wrapper"
   url "https://pypi.python.org/packages/source/i/internetarchive/internetarchive-0.7.9.tar.gz"
   sha1 "f52fd6cdece11da62bb8b32664da9271be3eaa91"
+  revision 1
 
   bottle do
     cellar :any
@@ -38,8 +39,8 @@ class Internetarchive < Formula
   end
 
   resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.3.0.tar.gz"
-    sha1 "f57bc125d35ec01a81afe89f97dc75913a927e65"
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.6.0.tar.gz"
+    sha256 "1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75"
   end
 
   resource "py" do
@@ -64,6 +65,9 @@ class Internetarchive < Formula
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
+
+    # unpin requests
+    inreplace "setup.py", /'requests.*?'/, "'requests'"
 
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
     system "python", *Language::Python.setup_install_args(libexec)


### PR DESCRIPTION
Unpin requests in internetarchive, fig, and deis so we can upgrade them to 2.6.0.