### PR TITLE
update pigz version to 2.3.3

### DIFF
--- a/Library/Formula/pigz.rb
+++ b/Library/Formula/pigz.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Pigz < Formula
   homepage 'http://www.zlib.net/pigz/'
-  url 'http://www.zlib.net/pigz/pigz-2.2.4.tar.gz'
-  md5 '9df2a3c742524446fa4e797c17e8fd85'
+  url 'http://www.zlib.net/pigz/pigz-2.3.3.tar.gz'
+  sha1 '11252d38fe2a7b8d7a712dff22bbb7630287d00b'
 
   def install
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"


### PR DESCRIPTION
This PR fixes the following error:

```
 brew install pigz
==> Downloading http://www.zlib.net/pigz/pigz-2.3.1.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "pigz"
Download failed: http://www.zlib.net/pigz/pigz-2.3.1.tar.gz
```