### PR TITLE
Symlinked `nss` and `nspr` make Firefox crash.

### DIFF
--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -15,10 +15,10 @@ class Nspr < Formula
   keg_only <<-EOF
 Having this library symlinked makes Firefox pick it up instead of built-in,
 so it then randomly crashes without meaningful explanation.
-    
+
 Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
   EOF
-  
+
   def install
     ENV.deparallelize
     cd "nspr" do

--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -12,6 +12,13 @@ class Nspr < Formula
     sha1 "ceb1c3a8693af7726f5e9dceb3697dfcb9f616be" => :mountain_lion
   end
 
+  keg_only <<-EOF
+Having this library symlinked makes Firefox pick it up instead of built-in,
+so it then randomly crashes without meaningful explanation.
+    
+Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOF
+  
   def install
     ENV.deparallelize
     cd "nspr" do

--- a/Library/Formula/nss.rb
+++ b/Library/Formula/nss.rb
@@ -13,6 +13,12 @@ class Nss < Formula
     sha1 "83a0cf6db62ff865b07347c4a94361869715e6b0" => :mountain_lion
   end
 
+  keg_only <<-EOF
+Having this library symlinked makes Firefox pick it up instead of built-in,
+so it then randomly crashes without meaningful explanation.
+    
+Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOF
   depends_on "nspr"
 
   def install

--- a/Library/Formula/nss.rb
+++ b/Library/Formula/nss.rb
@@ -16,7 +16,7 @@ class Nss < Formula
   keg_only <<-EOF
 Having this library symlinked makes Firefox pick it up instead of built-in,
 so it then randomly crashes without meaningful explanation.
-    
+
 Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
   EOF
   depends_on "nspr"
@@ -28,8 +28,8 @@ Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
     args = [
       "BUILD_OPT=1",
       "NSS_USE_SYSTEM_SQLITE=1",
-      "NSPR_INCLUDE_DIR=#{HOMEBREW_PREFIX}/include/nspr",
-      "NSPR_LIB_DIR=#{HOMEBREW_PREFIX}/lib"
+      "NSPR_INCLUDE_DIR=#{include}/nspr",
+      "NSPR_LIB_DIR=#{lib}"
     ]
     args << "USE_64=1" if MacOS.prefer_64_bit?
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.