### PR TITLE
Fixed Mozilla bug #1142646

### DIFF
--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -12,6 +12,13 @@ class Nspr < Formula
     sha1 "ceb1c3a8693af7726f5e9dceb3697dfcb9f616be" => :mountain_lion
   end
 
+  keg_only <<-EOF
+Having this library symlinked makes Firefox pick it up instead of built-in,
+so it then randomly crashes without meaningful explanation.
+
+Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOF
+
   def install
     ENV.deparallelize
     cd "nspr" do

--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -12,12 +12,12 @@ class Nspr < Formula
     sha1 "ceb1c3a8693af7726f5e9dceb3697dfcb9f616be" => :mountain_lion
   end
 
-  keg_only <<-EOF
-Having this library symlinked makes Firefox pick it up instead of built-in,
-so it then randomly crashes without meaningful explanation.
+  keg_only <<-EOS.undent
+    Having this library symlinked makes Firefox pick it up instead of built-in,
+    so it then randomly crashes without meaningful explanation.
 
-Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
-  EOF
+    Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOS
 
   def install
     ENV.deparallelize

--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -4,6 +4,7 @@ class Nspr < Formula
   homepage "https://developer.mozilla.org/docs/Mozilla/Projects/NSPR"
   url "https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.10.8/src/nspr-4.10.8.tar.gz"
   sha256 "507ea57c525c0c524dae4857a642b4ef5c9d795518754c7f83422d22fe544a15"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/nss.rb
+++ b/Library/Formula/nss.rb
@@ -4,7 +4,7 @@ class Nss < Formula
   homepage "https://developer.mozilla.org/docs/NSS"
   url "https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_17_4_RTM/src/nss-3.17.4.tar.gz"
   sha256 "1d98ad1881a4237ec98cbe472fc851480f0b0e954dfe224d047811fb96ff9d79"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/nss.rb
+++ b/Library/Formula/nss.rb
@@ -13,12 +13,12 @@ class Nss < Formula
     sha1 "83a0cf6db62ff865b07347c4a94361869715e6b0" => :mountain_lion
   end
 
-  keg_only <<-EOF
-Having this library symlinked makes Firefox pick it up instead of built-in,
-so it then randomly crashes without meaningful explanation.
+  keg_only <<-EOS.undent
+    Having this library symlinked makes Firefox pick it up instead of built-in,
+    so it then randomly crashes without meaningful explanation.
 
-Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
-  EOF
+    Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOS
   depends_on "nspr"
 
   def install
@@ -28,8 +28,8 @@ Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
     args = [
       "BUILD_OPT=1",
       "NSS_USE_SYSTEM_SQLITE=1",
-      "NSPR_INCLUDE_DIR=#{Formula["nspr"].include}/nspr",
-      "NSPR_LIB_DIR=#{Formula["nspr"].lib}"
+      "NSPR_INCLUDE_DIR=#{Formula["nspr"].opt_include}/nspr",
+      "NSPR_LIB_DIR=#{Formula["nspr"].opt_lib}"
     ]
     args << "USE_64=1" if MacOS.prefer_64_bit?
 

--- a/Library/Formula/nss.rb
+++ b/Library/Formula/nss.rb
@@ -13,6 +13,12 @@ class Nss < Formula
     sha1 "83a0cf6db62ff865b07347c4a94361869715e6b0" => :mountain_lion
   end
 
+  keg_only <<-EOF
+Having this library symlinked makes Firefox pick it up instead of built-in,
+so it then randomly crashes without meaningful explanation.
+
+Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1142646 for details.
+  EOF
   depends_on "nspr"
 
   def install
@@ -22,8 +28,8 @@ class Nss < Formula
     args = [
       "BUILD_OPT=1",
       "NSS_USE_SYSTEM_SQLITE=1",
-      "NSPR_INCLUDE_DIR=#{HOMEBREW_PREFIX}/include/nspr",
-      "NSPR_LIB_DIR=#{HOMEBREW_PREFIX}/lib"
+      "NSPR_INCLUDE_DIR=#{Formula["nspr"].include}/nspr",
+      "NSPR_LIB_DIR=#{Formula["nspr"].lib}"
     ]
     args << "USE_64=1" if MacOS.prefer_64_bit?
 

--- a/Library/Formula/spidermonkey.rb
+++ b/Library/Formula/spidermonkey.rb
@@ -33,6 +33,7 @@ class Spidermonkey < Formula
                                     "--enable-readline",
                                     "--enable-threadsafe",
                                     "--with-system-nspr",
+                                    "--with-nspr-prefix=#{Formula["nspr"].opt_prefix}",
                                     "--enable-macos-target=#{MacOS.version}"
 
       inreplace "js-config", /JS_CONFIG_LIBS=.*?$/, "JS_CONFIG_LIBS=''"

--- a/Library/Formula/spidermonkey.rb
+++ b/Library/Formula/spidermonkey.rb
@@ -5,6 +5,7 @@ class Spidermonkey < Formula
   url 'http://ftp.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz'
   version '1.8.5'
   sha1 '52a01449c48d7a117b35f213d3e4263578d846d6'
+  revision 1
 
   head 'https://hg.mozilla.org/tracemonkey/archive/tip.tar.gz'
 


### PR DESCRIPTION
I've changed `nss` and `nspr` to be keg-only, because when symlinked globally, they cause obscure Firefox crashes due to [Mozilla bug #1142646] (https://bugzilla.mozilla.org/show_bug.cgi?id=1142646).

Steps to reproduce:

1. have OS X running — tested with `10.9.5`;
2. `brew install nss` — tested with `stable 3.17.4 (bottled)`;
3. `brew install nspr` — tested with `stable 4.10.8 (bottled)`;
4. launch fresh Firefox instance with separate profile (`-no-remote -profile ./tempdir`) — tested with regular release Firefox `36.0.1` and debug build of `Nightly eab4a81e4457`;
5. install Adblock Plus addon — tested with `2.6.8`;
6. visit "http://half-life3.com";

**What is expected:** domain parking page with some ads to be shown;
**What actually happens:** Firefox crashes from `EXC_BAD_ACCESS` to address `0x0000000000000010` somewhere in the depths of `libplds4.dylib`;

To confirm homebrew is to blame, `brew unlink nss nspr`, then restart Firefox from scratch and try to visit offending page again. It won't crash.

Also, one can confirm homebrew libraries load where they shouldn't, by doing the following:

    $ /Applications/Firefox.app/Contents/MacOS/firefox-bin -no-remote -profile ./tempdir & FFPID=$!
    $ lldb --attach-pid $FFPID
    (lldb) process continue
    Now open "http://half-life3.com" in the browser.
    (lldb) target modules list
    ...
    [152] BC2BB0EE-CBE1-3D22-B784-6BEDBC3043FD 0x0000000100500000 /Applications/Firefox.app/Contents/MacOS/libnss3.dylib
    ...
    [275] E6AAE75C-3AAE-3799-A100-8AB530D6E13A 0x000000012c400000 /usr/local/lib/libnss3.dylib
    [276] 0FAE6F64-39D7-38A5-AEEA-71CD1BD95C90 0x0000000121a36000 /usr/local/Cellar/nss/3.17.4_1/lib/libnssutil3.dylib
    [277] 51263767-1C6A-3A63-81ED-271A59EF2F60 0x00000001203b6000 /usr/local/lib/libplc4.dylib
    [278] 18FE1E13-0A06-37C1-995F-6FD243A262D3 0x00000001203bc000 /usr/local/lib/libplds4.dylib
    [279] 311DBE19-4E0C-31EC-BE25-8F37EC540E85 0x0000000121fc8000 /usr/local/lib/libnspr4.dylib 
    ...

Those guys from `/usr/local/` shouldn't be there.