### PR TITLE
audit: enforce https for apache.org

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -300,6 +300,7 @@ class FormulaAuditor
     if homepage =~ %r[^http://[^/]*github\.io/]
       problem "Github Pages links should be https:// (URL is #{homepage})."
     end
+
     if homepage =~ %r[^http://[^/]*\.apache\.org/]
       problem "Apache homepages should be https:// links (URL is #{homepage})."
     end

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -300,6 +300,9 @@ class FormulaAuditor
     if homepage =~ %r[^http://[^/]*github\.io/]
       problem "Github Pages links should be https:// (URL is #{homepage})."
     end
+    if homepage =~ %r[^http://[^/]*\.apache\.org/]
+      problem "Apache homepages should be https:// links (URL is #{homepage})."
+    end
 
     # There's an auto-redirect here, but this mistake is incredibly common too.
     # Only applies to the homepage and subdomains for now, not the FTP links.
@@ -326,8 +329,8 @@ class FormulaAuditor
       case p
       when %r[^http://ftp\.gnu\.org/]
         problem "ftp.gnu.org urls should be https://, not http:// (url is #{p})."
-      when %r[^http://archive\.apache\.org/]
-        problem "archive.apache.org urls should be https://, not http (url is #{p})."
+      when %r[^http://[^/]*\.apache\.org/]
+        problem "Apache urls should be https://, not http (url is #{p})."
       when %r[^http://code\.google\.com/]
         problem "code.google.com urls should be https://, not http (url is #{p})."
       when %r[^http://fossies\.org/]


### PR DESCRIPTION
- including all apache.org subdomains
- for `homepage` as well