### PR TITLE
flvstreamer: basic test added

### DIFF
--- a/Library/Formula/flvstreamer.rb
+++ b/Library/Formula/flvstreamer.rb
@@ -1,12 +1,14 @@
-require 'formula'
-
 class Flvstreamer < Formula
-  homepage 'http://www.nongnu.org/flvstreamer/'
-  url 'http://download.savannah.gnu.org/releases-noredirect/flvstreamer/source/flvstreamer-2.1c1.tar.gz'
-  sha1 '07fac3dea65d8de8afbcc3c892d7830a90b66f10'
+  homepage "http://www.nongnu.org/flvstreamer/"
+  url "http://download.savannah.gnu.org/releases-noredirect/flvstreamer/source/flvstreamer-2.1c1.tar.gz"
+  sha256 "e90e24e13a48c57b1be01e41c9a7ec41f59953cdb862b50cf3e667429394d1ee"
 
   def install
-    system "make posix"
-    bin.install 'flvstreamer', 'rtmpsrv', 'rtmpsuck', 'streams'
+    system "make", "posix"
+    bin.install "flvstreamer", "rtmpsrv", "rtmpsuck", "streams"
+  end
+
+  test do
+    system "#{bin}/flvstreamer", "-h"
   end
 end


### PR DESCRIPTION
We can’t really add a better test since `flvstreamer` needs a remote RTMP server.