### PR TITLE
protobuf: fix python handling

### DIFF
--- a/Library/Formula/protobuf.rb
+++ b/Library/Formula/protobuf.rb
@@ -71,7 +71,7 @@ class Protobuf < Formula
                           "--prefix=#{prefix}",
                           "--with-zlib"
     system "make"
-    system "make", "check" if build.with? "check"
+    system "make", "check" if build.with? "check" || build.bottle?
     system "make", "install"
 
     # Install editor support and examples

--- a/Library/Formula/protobuf.rb
+++ b/Library/Formula/protobuf.rb
@@ -1,39 +1,3 @@
-require "formula"
-
-class OldOrNoDateutilUnlessGoogleApputils < Requirement
-  # https://github.com/Homebrew/homebrew/issues/32571
-  # https://code.google.com/p/google-apputils-python/issues/detail?id=6
-  fatal true
-
-  satisfy(:build_env => false) {
-    if can_import("dateutil") && !can_import("google.apputils")
-      dateutil_version < Version.new("2.0")
-    else
-      true
-    end
-  }
-
-  def message; <<-EOS.undent
-    The protobuf Python bindings depend on the google-apputils Python library,
-    which requires a version of python-dateutil less than 2.0.
-
-    You have python-dateutil version #{dateutil_version} installed in:
-      #{Pathname.new(`python -c "import dateutil; print(dateutil.__file__)"`.chomp).dirname}
-
-    Please run:
-      pip uninstall python-dateutil && pip install "python-dateutil<2"
-    EOS
-  end
-
-  def can_import pymodule
-    quiet_system "python", "-c", "import #{pymodule}"
-  end
-
-  def dateutil_version
-    Version.new(`python -c "import dateutil; print(dateutil.__version__)"`.chomp)
-  end
-end
-
 class Protobuf < Formula
   homepage "https://github.com/google/protobuf/"
   url 'https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2'
@@ -42,7 +6,6 @@ class Protobuf < Formula
   devel do
     url "https://github.com/google/protobuf/archive/v3.0.0-alpha-2.tar.gz"
     sha256 "46df8649e2a0ce736e37f8f347f92b32a9b8b54d672bf60bd8f6f4d24d283390"
-
     version "3.0.0-alpha-2"
 
     depends_on "autoconf" => :build
@@ -65,10 +28,34 @@ class Protobuf < Formula
   option :cxx11
 
   depends_on :python => :optional
-  depends_on OldOrNoDateutilUnlessGoogleApputils if build.with? "python"
 
   fails_with :llvm do
     build 2334
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
+  end
+
+  resource "python-dateutil" do
+    url "https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.1.tar.gz"
+    sha256 "23fd0a7c228d9c298c562245290a3f82999586c87aae71250f95f9894cb22c7c"
+  end
+
+  resource "pytz" do
+    url "https://pypi.python.org/packages/source/p/pytz/pytz-2014.10.tar.bz2"
+    sha256 "387f968fde793b142865802916561839f5591d8b4b14c941125eb0fca7e4e58d"
+  end
+
+  resource "python-gflags" do
+    url "https://pypi.python.org/packages/source/p/python-gflags/python-gflags-2.0.tar.gz"
+    sha256 "0dff6360423f3ec08cbe3bfaf37b339461a54a21d13be0dd5d9c9999ce531078"
+  end
+
+  resource "google-apputils" do
+    url "https://pypi.python.org/packages/source/g/google-apputils/google-apputils-0.4.2.tar.gz"
+    sha256 "47959d0651c32102c10ad919b8a0ffe0ae85f44b8457ddcf2bdc0358fb03dc29"
   end
 
   def install
@@ -88,15 +75,25 @@ class Protobuf < Formula
     system "make", "install"
 
     # Install editor support and examples
-    doc.install %w( editors examples )
+    doc.install "editors", "examples"
 
     if build.with? "python"
+      # google-apputils is a build-time dependency
+      ENV.prepend_create_path "PYTHONPATH", buildpath/"homebrew/lib/python2.7/site-packages"
+      %w[six python-dateutil pytz python-gflags google-apputils].each do |package|
+        resource(package).stage do
+          system "python", *Language::Python.setup_install_args(buildpath/"homebrew")
+        end
+      end
+      # google is a namespace package and .pth files aren't processed from
+      # PYTHONPATH
+      touch buildpath/"homebrew/lib/python2.7/site-packages/google/__init__.py"
       chdir "python" do
         ENV.append_to_cflags "-I#{include}"
         ENV.append_to_cflags "-L#{lib}"
-        system "python", "setup.py", "build"
-        system "python", "setup.py", "install", "--cpp_implementation", "--prefix=#{prefix}",
-               "--single-version-externally-managed", "--record=installed.txt"
+        args = Language::Python.setup_install_args prefix
+        args << "--cpp_implementation"
+        system "python", *args
       end
     end
   end
@@ -125,7 +122,7 @@ class Protobuf < Formula
         EOS
     end
     (testpath/"test.proto").write(testdata)
-    system "protoc", "test.proto", "--cpp_out=."
+    system bin/"protoc", "test.proto", "--cpp_out=."
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
protobuf: fix python handling
    Install protobuf's setup_requires (moral equivalent of :build deps) to
    buildpath before running setup.py. Routes around the problem we used to
    have with python-dateutil, which was obsoleted by a new google-apputils
    release anyway.

Closes #37296.

I'd be really tempted to try and bottle the python bindings but I think we'll run into linking conflicts for people who have already installed protobuf with pip, which is a bummer. python3 support should be easy to add someday, too.