### PR TITLE
brew pull: add automatic tap repair

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -183,6 +183,8 @@ module Homebrew
       ohai 'Patch changed:'
       safe_system "git", "diff-tree", "-r", "--stat", revision, "HEAD"
 
+      safe_system "brew", "tap", "--repair" if tap_name
+
       if ARGV.include? '--install'
         changed_formulae.each do |f|
           ohai "Installing #{f.name}"


### PR DESCRIPTION
At the moment, every time I pull a new formulae from a tap, I have to fetch it with the fully qualified name, `brew fetch homebrew/versions/duck123 `, which is fine, but then I also have to install, test, and audit it in the same way, which isn’t fixed until I tap repair, which gets a bit onerous. (I'm not *actually* installing and auditing things manually after ` brew pull `, but I checked and the problem is there too).

This just adds a step to `brew pull` where it does the tap repair automatically, unless you ask it not to bother.