### PR TITLE
audit: fix to enforce https for apache homepage

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -301,7 +301,7 @@ class FormulaAuditor
       problem "Github Pages links should be https:// (URL is #{homepage})."
     end
 
-    if homepage =~ %r[^http://[^/]*\.apache\.org/]
+    if homepage =~ %r[^http://[^/]*\.apache\.org]
       problem "Apache homepages should be https:// links (URL is #{homepage})."
     end
 


### PR DESCRIPTION
It was failing to recognize the URL without an ending slash.