### PR TITLE
gst-plugins-bad: add openssl depends for head build

### DIFF
--- a/Library/Formula/gst-plugins-bad.rb
+++ b/Library/Formula/gst-plugins-bad.rb
@@ -18,6 +18,7 @@ class GstPluginsBad < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    depends_on "openssl"
   end
 
   depends_on 'pkg-config' => :build


### PR DESCRIPTION
This is for solving build error for head build.
A few days ago, dtls plugins are merged to upstream and it refers openssl.
And It caused build error.

gstdtlsconnection.c:591:3: error: use of undeclared identifier 'SRTP_PROTECTION_PROFILE'
  SRTP_PROTECTION_PROFILE *profile;
  ^
gstdtlsconnection.c:591:28: error: use of undeclared identifier 'profile'
  SRTP_PROTECTION_PROFILE *profile;
                           ^
gstdtlsconnection.c:607:3: error: use of undeclared identifier 'profile'
  profile = SSL_get_selected_srtp_profile (self->priv->ssl);
  ^
gstdtlsconnection.c:609:58: error: use of undeclared identifier 'profile'
  GST_INFO_OBJECT (self, "keys received, profile is %s", profile->name);
                                                         ^
/usr/local/Cellar/gstreamer/HEAD/include/gstreamer-1.0/gst/gstinfo.h:860:95: note: expanded from macro 'GST_INFO_OBJECT'
#define GST_INFO_OBJECT(obj,...)        GST_CAT_LEVEL_LOG (GST_CAT_DEFAULT, GST_LEVEL_INFO,    obj,  __VA_ARGS__)
                                                                                                     ^
/usr/local/Cellar/gstreamer/HEAD/include/gstreamer-1.0/gst/gstinfo.h:541:31: note: expanded from macro 'GST_CAT_LEVEL_LOG'
        (GObject *) (object), __VA_ARGS__);                             \
                              ^
gstdtlsconnection.c:611:11: error: use of undeclared identifier 'profile'
  switch (profile->id) {
          ^
5 errors generated.
make[3]: *** [libgstdtls_la-gstdtlsconnection.lo] Error 1