### PR TITLE
gptfdisk 1.0.0

### DIFF
--- a/Library/Formula/gptfdisk.rb
+++ b/Library/Formula/gptfdisk.rb
@@ -1,10 +1,7 @@
-require "formula"
-
 class Gptfdisk < Formula
   homepage "http://www.rodsbooks.com/gdisk/"
-  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/0.8.10/gptfdisk-0.8.10.tar.gz"
-  sha1 "1708e232220236b6bdf299b315e9bc2205c01ba5"
-  revision 2
+  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
+  sha256 "5b66956743a799fc0471cdb032665c1391e82f9c5b3f1d7d726d29fe2ba01d6c"
 
   bottle do
     cellar :any
@@ -17,7 +14,7 @@ class Gptfdisk < Formula
   depends_on "icu4c"
 
   def install
-    system "make -f Makefile.mac"
+    system "make", "-f", "Makefile.mac"
     sbin.install "gdisk", "cgdisk", "sgdisk", "fixparts"
     man8.install Dir["*.8"]
   end


### PR DESCRIPTION
GPT fdisk updated on March 17, 2015 to 1.0.0.
(See: http://www.rodsbooks.com/gdisk/revisions.html )
This commit makes the appropriate changes to update brew's version.

Additionally, this commit brings the formula up to current style standards.
(That is, `brew audit --strict gptfdisk` gives an all-clear.)