### PR TITLE
Add a fomula for librdkafka.

### DIFF
--- a/Library/Formula/librdkafka.rb
+++ b/Library/Formula/librdkafka.rb
@@ -1,0 +1,10 @@
+class Librdkafka < Formula
+  homepage "https://github.com/edenhill/librdkafka"
+  url "http://github.com/edenhill/librdkafka/archive/0.8.6.tar.gz"
+  sha256 "184080e3898b80b3f7c1398c50787f8edb326b8271017a5f8000ef9a660e1a4f"
+
+  def install
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
The Apache Kafka C/C++ library.

Only 1 error from audit and I'm not sure what it means? 
Only thing I can think of is 0.8.4 is a version below the latest but the latest version 0.8.5 doesn't compile on OS X.

```
[add_librdkafka][/usr/local]$ brew audit librdkafka
librdkafka:
 * Stable: version 0.8.4 is redundant with version scanned from URL

Error: 1 problems in 1 formulae
``