### PR TITLE
dhcping: homepage fixed

### DIFF
--- a/Library/Formula/dhcping.rb
+++ b/Library/Formula/dhcping.rb
@@ -1,12 +1,10 @@
-require 'formula'
-
 class Dhcping < Formula
-  homepage 'http://www.mavetju.org'
-  url 'http://www.mavetju.org/download/dhcping-1.2.tar.gz'
-  sha1 '97927886adc1e5b3a67c55f9010a918e2e880f1e'
+  homepage "http://www.mavetju.org/unix/general.php"
+  url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
-    system "make install"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
We can’t write any test because it needs to be ran as `root` and doesn’t provide any `--help`/`--version` option.