### PR TITLE
Add python3 module testing back. It seems to be inadvertantly deleted.

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require 'set'
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :rbx, :ruby
+    :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :rbx, :ruby
   ].freeze
 
   CACHE = {}


### PR DESCRIPTION
Signed-off-by: Tanachat Nilanon <gor-tanachat@users.noreply.github.com>

In the file `language_module_dependency.rb`, `:python3` module testing is supported in line 31:
```ruby
when :python3 then %W{/usr/bin/env python3 -c import\ #{@import_name}}
```

But in `dependency_collector.rb`, `:python3` is missing from `LANGUAGE_MODULES`:
```ruby
LANGUAGE_MODULES = Set[
  :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :rbx, :ruby
].freeze
```
```ruby
def parse_string_spec(spec, tags)
  if tags.empty?
    Dependency.new(spec, tags)
  elsif (tag = tags.first) && LANGUAGE_MODULES.include?(tag)
    LanguageModuleDependency.new(tag, spec, tags[1])
  elsif HOMEBREW_TAP_FORMULA_REGEX === spec
    TapDependency.new(spec, tags)
  else
    Dependency.new(spec, tags)
  end
end
```

Is this intentional? Is the support for `:python3` going to be dropped?
Otherwise, I believe line 21 in `dependency_collector.rb` needs to be changed to
```ruby
  :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :rbx, :ruby
```