### PR TITLE
audit: exclude dyn from apache checks

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -326,6 +326,7 @@ class FormulaAuditor
     urls.each do |p|
       # Skip the main url link, as it can't be made SSL/TLS yet.
       next if p =~ %r[/ftpmirror\.gnu\.org]
+      next if p =~ %r[/apache\.org/dyn]
 
       case p
       when %r[^http://ftp\.gnu\.org/]


### PR DESCRIPTION
Although it is possible to use SSL/TLS on the dyn/closer links, It’s fairly misleading because Apache will always downgrade the SSL/TLS connection back to plaintext once its passed to the mirror, so we should probably exclude it for now.