### PR TITLE
stunnel 5.13

### DIFF
--- a/Library/Formula/stunnel.rb
+++ b/Library/Formula/stunnel.rb
@@ -1,8 +1,8 @@
 class Stunnel < Formula
   homepage "https://www.stunnel.org/"
-  url "https://www.stunnel.org/downloads/stunnel-5.12.tar.gz"
-  mirror "http://www.usenix.org.uk/mirrors/stunnel/stunnel-5.12.tar.gz"
-  sha256 "80c3d350c9b3e4438143fcc77c915026ae338f8174bb730ff117ca438ba84847"
+  url "https://www.stunnel.org/downloads/stunnel-5.13.tar.gz"
+  mirror "http://www.usenix.org.uk/mirrors/stunnel/stunnel-5.13.tar.gz"
+  sha256 "71b4efb3814ec298124ec78386d756ee2cba9c999e7f9571bb8abcef317f04b5"
 
   bottle do
     sha256 "ad8866b0532d2618e85b61165d9ac060ea4489d0430a13a3c7fdbe1bfdaa484c" => :yosemite


### PR DESCRIPTION
Another new release; was a bug in yesterday’s release on some platforms apparently. Didn’t affect OS X, but bumping to the latest version given the dev kills the old versions from the server is necessary.