### PR TITLE
pidgin: fix finch dependencies

### DIFF
--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -1,7 +1,7 @@
 class Pidgin < Formula
   homepage "https://pidgin.im/"
   url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.10.11/pidgin-2.10.11.tar.bz2"
-  sha1 "5e0062b81bdb01300804e12bc0b6a04a91984631"
+  sha256 "f2ae211341fc77efb9945d40e9932aa535cdf3a6c8993fe7919fca8cc1c04007"
 
   bottle do
     sha1 "7b54cf4adf86babc1ad1cb6ef4984bc1320f58e4" => :yosemite
@@ -9,22 +9,26 @@ class Pidgin < Formula
     sha1 "613a6eba69a416c37595d34452a75ecd465a7a86" => :mountain_lion
   end
 
-  deprecated_option "perl" => "with-perl"
-
   option "with-perl", "Build Pidgin with Perl support"
-  option "without-GUI", "Build Finch instead of Pidgin"
+  option "without-gui", "Build Finch instead of Pidgin"
 
-  depends_on :x11 => :optional
+  deprecated_option "perl" => "with-perl"
+  deprecated_option "without-GUI" => "without-gui"
+
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext"
-  depends_on "gtk+"
   depends_on "gsasl" => :optional
   depends_on "gnutls"
   depends_on "libgcrypt"
-  depends_on "libotr"
 
-  if build.without? "GUI"
+  if build.with? "gui"
+    depends_on :x11 => :optional
+    depends_on "gtk+"
+    depends_on "cairo"
+    depends_on "pango"
+    depends_on "libotr"
+  else
     depends_on "glib"
     depends_on "libidn"
   end
@@ -33,7 +37,7 @@ class Pidgin < Formula
   # If you want to fix this and create a PR on Homebrew please do so.
   resource "pidgin-otr" do
     url "https://otr.cypherpunks.ca/pidgin-otr-4.0.1.tar.gz"
-    sha1 "e231a2dc72c960f2aa70d8c9d4b05abc6d123085"
+    sha256 "1b781f48c27bcc9de3136c0674810df23f7d6b44c727dbf4dfb24067909bf30a"
   end
 
   def install
@@ -49,28 +53,29 @@ class Pidgin < Formula
       --disable-gstreamer
       --disable-gstreamer-interfaces
       --disable-gtkspell
-      --disable-idn
       --disable-meanwhile
       --disable-vv
     ]
 
-    args << "--with-x" if build.with? "GUI"
     args << "--disable-perl" if build.without? "perl"
     args << "--enable-cyrus-sasl" if build.with? "gsasl"
 
-    if build.without? "GUI"
+    if build.without? "gui"
       args << "--with-tclconfig=#{MacOS.sdk_path}/usr/lib"
       args << "--with-tkconfig=#{MacOS.sdk_path}/usr/lib"
       args << "--without-x"
       args << "--disable-gtkui"
+    else
+      args << "--with-x"
+      args << "--disable-idn"
     end
 
     system "./configure", *args
     system "make", "install"
 
-    if build.with? "GUI"
+    if build.with? "gui"
       resource("pidgin-otr").stage do
-        ENV.prepend "CFLAGS", "-I#{HOMEBREW_PREFIX}/opt/libotr/include/libotr"
+        ENV.prepend "CFLAGS", "-I#{Formula["libotr"].opt_include}"
         ENV.append_path "PKG_CONFIG_PATH", "#{lib}/pkgconfig"
         system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
         system "make", "install"


### PR DESCRIPTION
Closes #37919.

Changes:

* Bump to SHA256
* Lowercase the GUI option to match our standard formatting.
* Move the X11-using deps which aren’t necessary for Finch compile out of the main deps block and into a gui deps block.
* Fixes libidn finch usage.
* Moves the CFLAG to an opt CFLAG rather than a HOMEBREW_PREFIX CFLAG - Not sure why I used the latter in the first place.