### PR TITLE
Uninstall build deps

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -29,12 +29,24 @@ module Homebrew
   end
 
   def deps_for_formula(f, recursive=false)
+    ignores = []
+    ignores << "build?" if ARGV.include? "--skip-build"
+    ignores << "optional?" if ARGV.include? "--skip-optional"
+
     if recursive
-      deps = f.recursive_dependencies
-      reqs = f.recursive_requirements
+      deps = f.recursive_dependencies.reject do |dep|
+        ignores.any? { |ignore| dep.send(ignore) }
+      end
+      reqs = f.recursive_requirements.reject do |req|
+        ignores.any? { |ignore| req.send(ignore) }
+      end
     else
-      deps = f.deps.default
-      reqs = f.requirements
+      deps = f.deps.reject do |dep|
+              ignores.any? { |ignore| dep.send(ignore) }
+      end
+      reqs = f.requirements.reject do |req|
+        ignores.any? { |ignore| req.send(ignore) }
+      end
     end
 
     deps + reqs.select(&:default_formula?).map(&:to_dependency)

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -3,18 +3,18 @@
 # Usage: brew test-bot [options...] <pull-request|formula>
 #
 # Options:
-# --keep-logs:    Write and keep log files under ./brewbot/
-# --cleanup:      Clean the Homebrew directory. Very dangerous. Use with care.
-# --clean-cache:  Remove all cached downloads. Use with care.
-# --skip-setup:   Don't check the local system is setup correctly.
-# --junit:        Generate a JUnit XML test results file.
-# --email:        Generate an email subject file.
-# --no-bottle:    Run brew install without --build-bottle
-# --HEAD:         Run brew install with --HEAD
-# --local:        Ask Homebrew to write verbose logs under ./logs/ and set HOME to ./home/
-# --tap=<tap>:    Use the git repository of the given tap
-# --dry-run:      Just print commands, don't run them.
-# --fail-fast:    Immediately exit on a failing step.
+# --keep-logs:     Write and keep log files under ./brewbot/
+# --cleanup:       Clean the Homebrew directory. Very dangerous. Use with care.
+# --clean-cache:   Remove all cached downloads. Use with care.
+# --skip-setup:    Don't check the local system is setup correctly.
+# --junit:         Generate a JUnit XML test results file.
+# --email:         Generate an email subject file.
+# --no-bottle:     Run brew install without --build-bottle
+# --HEAD:          Run brew install with --HEAD
+# --local:         Ask Homebrew to write verbose logs under ./logs/ and set HOME to ./home/
+# --tap=<tap>:     Use the git repository of the given tap
+# --dry-run:       Just print commands, don't run them.
+# --fail-fast:     Immediately exit on a failing step.
 #
 # --ci-master:           Shortcut for Homebrew master branch CI options.
 # --ci-pr:               Shortcut for Homebrew pull request CI options.

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -7,6 +7,7 @@
 # --cleanup:       Clean the Homebrew directory. Very dangerous. Use with care.
 # --clean-cache:   Remove all cached downloads. Use with care.
 # --skip-setup:    Don't check the local system is setup correctly.
+# --skip-homebrew: Don't check Homebrew's files and tests are all valid.
 # --junit:         Generate a JUnit XML test results file.
 # --email:         Generate an email subject file.
 # --no-bottle:     Run brew install without --build-bottle
@@ -504,6 +505,7 @@ module Homebrew
 
     def homebrew
       @category = __method__
+      return if ARGV.include? "--skip-homebrew"
       test "brew", "tests"
       readall_args = []
       readall_args << "--syntax" if MacOS.version >= :mavericks


### PR DESCRIPTION
Add support to `brew deps` and `brew test-bot` so the latter uninstalls build dependencies before testing bottles.

Hopefully this should resolve the situation where build deps are marked incorrectly.

CC @Homebrew/owners for review.