### PR TITLE
hevea: Bump to 2.23, use better URL

### DIFF
--- a/Library/Formula/hevea.rb
+++ b/Library/Formula/hevea.rb
@@ -1,7 +1,7 @@
 class Hevea < Formula
   homepage "http://hevea.inria.fr/"
-  url "http://hevea.inria.fr/distri/hevea-2.22.tar.gz"
-  sha1 "16ddc99402940fe06b89723f7c4e5cb0c646d55f"
+  url "http://hevea.inria.fr/old/hevea-2.23.tar.gz"
+  sha256 "db8ec1459cace8f008387dbcf745ba56917d44ff62c7bdba843da250109137b9"
 
   bottle do
     sha1 "bfac35ec39ad56dc6ff8d4c5d64ce9491dfc7baa" => :yosemite


### PR DESCRIPTION
Every time hevea pushes a new version, the `url` for the previous version becomes bad.  This means that sometimes when one needs hevea, one can't brew it because nobody's updated the formula yet and one gets an irritating 404.

However, they keep both older versions of hevea *and* whatever one is currently current under this prefix: http://hevea.inria.fr/old

Hence I changed the formula `url` to use that prefix; this way one can still brew hevea even if nobody has noticed the version bump yet.  In this respect, brewing hevea is like brewing nearly every other formula.