### PR TITLE
gexiv2 0.10.2 (new formula)

### DIFF
--- a/Library/Formula/gexiv2.rb
+++ b/Library/Formula/gexiv2.rb
@@ -31,7 +31,7 @@ class Gexiv2 < Formula
       "-lgexiv2",
     ]
 
-    system ENV.cc, "test.c", *flags, "-o", "test"
+    system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/gexiv2.rb
+++ b/Library/Formula/gexiv2.rb
@@ -1,0 +1,17 @@
+class Gexiv2 < Formula
+  homepage "https://wiki.gnome.org/Projects/gexiv2"
+  url "https://download.gnome.org/sources/gexiv2/0.10/gexiv2-0.10.2.tar.xz"
+  sha256 "2fd21f0ed5125e51d02226e7f41be751cfa8ae411a8ed1a651e16b06d79047b2"
+
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "exiv2"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end

--- a/Library/Formula/gexiv2.rb
+++ b/Library/Formula/gexiv2.rb
@@ -16,7 +16,7 @@ class Gexiv2 < Formula
   end
 
   test do
-    (testpath/'test.c').write <<-EOS.undent
+    (testpath/"test.c").write <<-EOS.undent
       #include <gexiv2/gexiv2.h>
       int main() {
         GExiv2Metadata *metadata = gexiv2_metadata_new();
@@ -28,7 +28,7 @@ class Gexiv2 < Formula
       "-I#{HOMEBREW_PREFIX}/include/glib-2.0",
       "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include",
       "-L#{lib}",
-      "-lgexiv2"
+      "-lgexiv2",
     ]
 
     system ENV.cc, "test.c", *flags, "-o", "test"

--- a/Library/Formula/gexiv2.rb
+++ b/Library/Formula/gexiv2.rb
@@ -14,4 +14,24 @@ class Gexiv2 < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
   end
+
+  test do
+    (testpath/'test.c').write <<-EOS.undent
+      #include <gexiv2/gexiv2.h>
+      int main() {
+        GExiv2Metadata *metadata = gexiv2_metadata_new();
+        return 0;
+      }
+    EOS
+
+    flags = [
+      "-I#{HOMEBREW_PREFIX}/include/glib-2.0",
+      "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include",
+      "-L#{lib}",
+      "-lgexiv2"
+    ]
+
+    system ENV.cc, "test.c", *flags, "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
gexiv2 is a GObject wrapper around the Exiv2 photo metadata library. It allows for GNOME applications to easily inspect and update EXIF, IPTC, and XMP metadata in photo files of various formats.

A dependency of Shotwell and others.