### PR TITLE
Upgrade liblinear to 1.96

### DIFF
--- a/Library/Formula/liblinear.rb
+++ b/Library/Formula/liblinear.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Liblinear < Formula
   homepage 'http://www.csie.ntu.edu.tw/~cjlin/liblinear/'
-  url 'http://www.csie.ntu.edu.tw/~cjlin/liblinear/oldfiles/liblinear-1.94.tar.gz'
-  sha1 '19678355e6c933b7ec133e07fef77796e50df0d5'
+  url 'http://www.csie.ntu.edu.tw/~cjlin/liblinear/oldfiles/liblinear-1.96.tar.gz'
+  sha1 '54de76b5e37cc3f200857e7a4cee0da21f0eefbc'
 
   bottle do
     cellar :any


### PR DESCRIPTION
In this pull request, I'd like to upgrade liblinear to version 1.96.