### PR TITLE
Upgrade sbt from 0.13.7 to 0.13.8

### DIFF
--- a/Library/Formula/sbt.rb
+++ b/Library/Formula/sbt.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Sbt < Formula
   homepage "http://www.scala-sbt.org"
-  url "https://dl.bintray.com/sbt/native-packages/sbt/0.13.7/sbt-0.13.7.tgz"
-  sha1 "0ee4df9a5bd6dc478f9007ebdb24bacd1cf2731c"
+  url "https://dl.bintray.com/sbt/native-packages/sbt/0.13.8/sbt-0.13.8.tgz"
+  sha1 "155d6ff3bc178745ad4f951b74792b257ed14105"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This PR upgrades sbt from 0.13.7 to 0.13.8

I think I've done this right - install fails when trying to get with bottle but the way I read CONTRIBUTING.md, this is normal?

```
==> Downloading https://homebrew.bintray.com/bottles/sbt-0.13.8.yosemite.bottle.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "sbt"
Download failed: https://homebrew.bintray.com/bottles/sbt-0.13.8.yosemite.bottle.tar.gz
Warning: Bottle installation failed: building from source.
==> Downloading https://dl.bintray.com/sbt/native-packages/sbt/0.13.8/sbt-0.13.8.tgz
Already downloaded: /Library/Caches/Homebrew/sbt-0.13.8.tgz
```