### PR TITLE
plist: create var paths

### DIFF
--- a/Library/Formula/beanstalk.rb
+++ b/Library/Formula/beanstalk.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Beanstalk < Formula
-  homepage "http://kr.github.io/beanstalkd/"
+  homepage "https://kr.github.io/beanstalkd/"
   url "https://github.com/kr/beanstalkd/archive/v1.10.tar.gz"
-  sha1 "bfc0ccf99e15b15eac03ec1d8a57a3aaff143237"
+  sha256 "923b1e195e168c2a91adcc75371231c26dcf23868ed3e0403cd4b1d662a52d59"
 
   bottle do
     sha1 "054320dc87c106976408f6bf195a87244635bb05" => :mavericks
@@ -12,6 +10,7 @@ class Beanstalk < Formula
   end
 
   def install
+    mkdir_p var/"log"
     system "make", "install", "PREFIX=#{prefix}"
   end
 

--- a/Library/Formula/cayley.rb
+++ b/Library/Formula/cayley.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Cayley < Formula
   homepage "https://github.com/google/cayley"
   url "https://github.com/google/cayley/archive/v0.4.0.tar.gz"
-  sha1 "100c1e057fb140b35e1ecdd4824541436e6cb741"
+  sha256 "b4eaed9006a1b615b8d5f4a7fe6075eb9cf3555e04fb7d02eaa07bf1f5d67e51"
   head "https://github.com/google/cayley.git"
 
   bottle do
@@ -72,6 +70,7 @@ class Cayley < Formula
   end
 
   def post_install
+    (var/"log").mkpath
     unless File.exist? "#{var}/cayley"
       # Create data directory
       (var/"cayley").mkpath

--- a/Library/Formula/chromedriver.rb
+++ b/Library/Formula/chromedriver.rb
@@ -1,13 +1,12 @@
-require 'formula'
-
 class Chromedriver < Formula
-  homepage 'https://sites.google.com/a/chromium.org/chromedriver/'
-  url 'http://chromedriver.storage.googleapis.com/2.14/chromedriver_mac32.zip'
-  sha256 '33ee96ea17b00dd8e14e15ca6fe1b1fd4ae7a71f86d8785e562e88d839299d2e'
-  version '2.14'
+  homepage "https://sites.google.com/a/chromium.org/chromedriver/"
+  url "https://chromedriver.storage.googleapis.com/2.14/chromedriver_mac32.zip"
+  sha256 "33ee96ea17b00dd8e14e15ca6fe1b1fd4ae7a71f86d8785e562e88d839299d2e"
+  version "2.14"
 
   def install
-    bin.install 'chromedriver'
+    mkdir_p var/"log"
+    bin.install "chromedriver"
   end
 
   def plist; <<-EOS.undent

--- a/Library/Formula/collectd.rb
+++ b/Library/Formula/collectd.rb
@@ -10,8 +10,11 @@ class Collectd < Formula
   end
 
   # Will fail against Java 1.7
-  option "java", "Enable Java 1.6 support"
-  option "debug", "Enable debug support"
+  option "with-java", "Enable Java 1.6 support"
+  option "with-debug", "Enable debug support"
+
+  deprecated_option "java" => "with-java"
+  deprecated_option "debug" => "with-debug"
 
   head do
     url "git://git.verplant.org/collectd.git"
@@ -41,12 +44,13 @@ class Collectd < Formula
     ]
 
     args << "--disable-embedded-perl" if MacOS.version <= :leopard
-    args << "--disable-java" unless build.include? "java"
-    args << "--enable-debug" if build.include? "debug"
+    args << "--disable-java" if build.without? "java"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./build.sh" if build.head?
     system "./configure", *args
     system "make", "install"
+    mkdir_p var/"log"
   end
 
   def plist; <<-EOS.undent
@@ -68,9 +72,9 @@ class Collectd < Formula
         <key>RunAtLoad</key>
         <true/>
         <key>StandardErrorPath</key>
-        <string>/usr/local/var/log/collectd.log</string>
+        <string>#{var}/log/collectd.log</string>
         <key>StandardOutPath</key>
-        <string>/usr/local/var/log/collectd.log</string>
+        <string>#{var}/log/collectd.log</string>
       </dict>
     </plist>
     EOS

--- a/Library/Formula/dynamodb-local.rb
+++ b/Library/Formula/dynamodb-local.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class DynamodbLocal < Formula
-  homepage 'https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html'
-  url 'http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_2015-01-27.tar.gz'
-  version '2015-01-27'
-  sha1 '3e2fdead8763e35bc449665837834b949e26230f'
+  homepage "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html"
+  url "http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_2015-01-27.tar.gz"
+  version "2015-01-27"
+  sha256 "d53b43cfe06da99b37a2e246b311096b032e92fad62786fec08c446a258939d6"
 
   def data_path
-    var/'data/dynamodb-local'
+    var/"data/dynamodb-local"
   end
 
   def log_path
-    var/'log/dynamodb-local.log'
+    var/"log/dynamodb-local.log"
   end
 
   def bin_wrapper; <<-EOS.undent
@@ -21,9 +19,11 @@ class DynamodbLocal < Formula
   end
 
   def install
+    mkdir_p var/"log"
+
     prefix.install %w[LICENSE.txt README.txt third_party_licenses]
     libexec.install %w[DynamoDBLocal_lib DynamoDBLocal.jar]
-    (bin/'dynamodb-local').write(bin_wrapper)
+    (bin/"dynamodb-local").write(bin_wrapper)
   end
 
   def post_install

--- a/Library/Formula/ngircd.rb
+++ b/Library/Formula/ngircd.rb
@@ -37,13 +37,14 @@ class Ngircd < Formula
 
     system "./configure", *args
     system "make", "install"
+    mkdir_p var/"log"
 
     prefix.install "contrib/MacOSX/de.barton.ngircd.plist.tmpl" => "de.barton.ngircd.plist"
     (prefix+"de.barton.ngircd.plist").chmod 0644
 
     inreplace prefix+"de.barton.ngircd.plist" do |s|
       s.gsub! ":SBINDIR:", sbin
-      s.gsub! "/Library/Logs/ngIRCd.log", var/"Logs/ngIRCd.log"
+      s.gsub! "/Library/Logs/ngIRCd.log", var/"log/ngIRCd.log"
     end
   end
 

--- a/Library/Formula/pincaster.rb
+++ b/Library/Formula/pincaster.rb
@@ -1,13 +1,12 @@
-require 'formula'
-
 class Pincaster < Formula
-  homepage 'https://github.com/jedisct1/Pincaster'
-  url 'http://download.pureftpd.org/pincaster/releases/pincaster-0.6.tar.bz2'
-  sha1 'ad3799ce3207480979355f30d6f534dad6229ae2'
+  homepage "https://github.com/jedisct1/Pincaster"
+  url "http://download.pureftpd.org/pincaster/releases/pincaster-0.6.tar.bz2"
+  sha256 "c88be055ecf357b50b965afe70b5fc15dff295fbe2b6f0c473cf7e4a795a9f97"
 
   def install
+    mkdir_p var/"log"
     system "./configure", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
 
     inreplace "pincaster.conf" do |s|
       s.gsub! "/var/db/pincaster/pincaster.db", "#{var}/db/pincaster/pincaster.db"

--- a/Library/Formula/pure-ftpd.rb
+++ b/Library/Formula/pure-ftpd.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class PureFtpd < Formula
-  homepage 'http://www.pureftpd.org/'
-  url 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.35.tar.gz'
-  sha1 'fed26bb1f36d71819a08873d94bbda52522ff96a'
+  homepage "http://www.pureftpd.org/"
+  url "http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.37.tar.gz"
+  sha256 "a9c10b0b8b5772fbf2212bc46fece86f9d4bcc07e58dfd83b58e42a1b2acb76c"
 
   def install
     args = ["--disable-dependency-tracking",
@@ -24,14 +22,15 @@ class PureFtpd < Formula
             "--with-tls",
             "--with-bonjour"]
 
-    args << "--with-pgsql" if which 'pg_config'
-    args << "--with-mysql" if which 'mysql'
+    args << "--with-pgsql" if which "pg_config"
+    args << "--with-mysql" if which "mysql"
 
+    mkdir_p var/"log"
     system "./configure", *args
-    system "make install"
+    system "make", "install"
   end
 
-  plist_options :manual => 'pure-ftpd'
+  plist_options :manual => "pure-ftpd"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Library/Formula/selenium-server-standalone.rb
+++ b/Library/Formula/selenium-server-standalone.rb
@@ -1,9 +1,10 @@
 class SeleniumServerStandalone < Formula
   homepage "http://seleniumhq.org/"
-  url "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
-  sha1 "9bc872d1f364a3104257b1f8e055a342228259c3"
+  url "https://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar"
+  sha256 "1172dfa2d94b43bcbcd9e85c824fd714f2d1ed411b6919a22e7338879fad757b"
 
   def install
+    mkdir_p var/"log"
     libexec.install "selenium-server-standalone-#{version}.jar"
     bin.write_jar_script libexec/"selenium-server-standalone-#{version}.jar", "selenium-server"
   end

--- a/Library/Formula/sshguard.rb
+++ b/Library/Formula/sshguard.rb
@@ -1,24 +1,23 @@
-require 'formula'
-
 class Sshguard < Formula
-  homepage 'http://www.sshguard.net/'
-  url 'https://downloads.sourceforge.net/project/sshguard/sshguard/sshguard-1.5/sshguard-1.5.tar.bz2'
-  sha1 'f8f713bfb3f5c9877b34f6821426a22a7eec8df3'
+  homepage "http://www.sshguard.net/"
+  url "https://downloads.sourceforge.net/project/sshguard/sshguard/sshguard-1.5/sshguard-1.5.tar.bz2"
+  sha256 "b537f8765455fdf8424f87d4bd695e5b675b88e5d164865452137947093e7e19"
 
   # Fix blacklist flag (-b) so that it doesn't abort on first usage.
   # Upstream bug report:
   # http://sourceforge.net/tracker/?func=detail&aid=3252151&group_id=188282&atid=924685
   patch do
     url "http://sourceforge.net/p/sshguard/bugs/_discuss/thread/3d94b7ef/c062/attachment/sshguard.c.diff"
-    sha1 "68cd0910d310e4d23e7752dee1b077ccfe715c0b"
+    sha256 "1bdf1db9e0bd730cfc6926dde683fcf5cd7b420ae003f9ec44dce083fe8eb54b"
   end
 
   def install
+    mkdir_p var/"log"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-firewall=#{firewall}"
-    system "make install"
+    system "make", "install"
   end
 
   def firewall

--- a/Library/Formula/syncthing.rb
+++ b/Library/Formula/syncthing.rb
@@ -26,6 +26,7 @@ class Syncthing < Formula
 
     system "./build.sh", "noupgrade"
     bin.install "syncthing"
+    mkdir_p var/"log"
   end
 
   def plist; <<-EOS.undent

--- a/Library/Formula/uwsgi.rb
+++ b/Library/Formula/uwsgi.rb
@@ -1,12 +1,10 @@
-require "formula"
-
 class Uwsgi < Formula
   homepage "https://uwsgi-docs.readthedocs.org/en/latest/"
   head "https://github.com/unbit/uwsgi.git"
 
   stable do
     url "http://projects.unbit.it/downloads/uwsgi-2.0.9.tar.gz"
-    sha1 "318d1d6d4bb57eb48b58361201cdc1cc7feedcbb"
+    sha256 "fe0489bca0a8b95653908be2297e35699fb9e992f728e382224587ee6b918295"
   end
 
   bottle do
@@ -120,6 +118,7 @@ class Uwsgi < Formula
     end
 
     bin.install "uwsgi"
+    mkdir_p var/"log"
   end
 
   plist_options :manual => "uwsgi"

--- a/Library/Formula/znc.rb
+++ b/Library/Formula/znc.rb
@@ -1,7 +1,7 @@
 class Znc < Formula
   homepage "http://wiki.znc.in/ZNC"
   url "http://znc.in/releases/archive/znc-1.6.0.tar.gz"
-  sha1 "548d31fa63d50494bdf4b1d3c0f43a8ceda66849"
+  sha256 "df622aeae34d26193c738dff6499e56ad669ec654484e19623738d84cc80aba7"
 
   head do
     url "https://github.com/znc/znc.git"
@@ -31,6 +31,7 @@ class Znc < Formula
     args = ["--prefix=#{prefix}"]
     args << "--enable-debug" if build.with? "debug"
 
+    mkdir_p var/"log"
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Ensure the ` var ` paths are created in-formulae, rather than allowing ` launchctl ` to create the paths once loaded. This should prevent a few of the occasions where the ` var ` path is created with ` root ` ownership rather than ` $USER `.