### PR TITLE
ensure metafiles being installed to prefix rather than libexec

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -140,6 +140,7 @@ class Build
 
         # Find and link metafiles
         formula.prefix.install_metafiles Pathname.pwd
+        formula.prefix.install_metafiles formula.libexec if formula.libexec.exist?
       end
     end
   end


### PR DESCRIPTION
This is a follow-up of #37734. I think we should treat `install_metafiles` as
a general issue rather than a formula-specific one.