### PR TITLE
nginx: Enable stub status module

### DIFF
--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -59,6 +59,7 @@ class Nginx < Formula
             "--http-log-path=#{var}/log/nginx/access.log",
             "--error-log-path=#{var}/log/nginx/error.log",
             "--with-http_gzip_static_module",
+            "--with-http_stub_status_module"
            ]
 
     if build.with? "passenger"


### PR DESCRIPTION
This allows to enable a status page that can be used to monitor several
nginx stats. The module still needs to be enabled from the configuration
with the stub_status directive so it's safe to enable it by default.

More info: http://nginx.org/en/docs/http/ngx_http_stub_status_module.html