### PR TITLE
trafficserver: SPDY support and misc fixes

### DIFF
--- a/Library/Formula/trafficserver.rb
+++ b/Library/Formula/trafficserver.rb
@@ -1,8 +1,17 @@
 class Trafficserver < Formula
-  homepage "http://trafficserver.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-5.2.0.tar.bz2"
+  homepage "https://trafficserver.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-5.2.0.tar.bz2"
   mirror "https://archive.apache.org/dist/trafficserver/trafficserver-5.2.0.tar.bz2"
-  sha1 "a32ae5a0ea6d734a955fa56f3e446a66c08be21f"
+  sha256 "e3a265dd3188edaa7b8ad2bb54b0030c23588b48abb02890363db1374aac68d3"
+  revision 1
+
+  head do
+    url "https://github.com/apache/trafficserver.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool"  => :build
+  end
 
   bottle do
     sha256 "60ca4def066dd106a5f71706b3b07d7ee8d093f95926d341f4d98bd88c3b4d2d" => :yosemite
@@ -10,21 +19,36 @@ class Trafficserver < Formula
     sha256 "4920a708ef78452027f9a258f50b7802b3f0bdc68aca92337d2468d9abe88415" => :mountain_lion
   end
 
+  option "with-spdy", "Build with SPDY protocol support"
+
   depends_on "openssl"
   depends_on "pcre"
+  if build.with? "spdy"
+    depends_on "spdylay"
+    depends_on "pkg-config" => :build
+  end
 
-  # remove some amd64 compiler options that fail on Snow Leopard
-  patch :DATA if MacOS.version == :snow_leopard
+  # patch openssl 1.0.2 tls1.h detection, remove on 5.3.0 (upstream bug TS-3443)
+  patch :DATA if build.stable?
 
   def install
     # Needed for correct ./configure detections.
     ENV.enable_warnings
     # Needed for OpenSSL headers on Lion.
     ENV.append_to_cflags "-Wno-deprecated-declarations"
-    system "./configure", "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--with-user=#{ENV["USER"]}",
-                          "--with-group=admin"
+    system "autoreconf", "-fvi" if build.head?
+    args = [
+      "--prefix=#{prefix}",
+      "--mandir=#{man}",
+      "--with-openssl=#{Formula["openssl"].opt_prefix}",
+      "--with-user=#{ENV["USER"]}",
+      "--with-group=admin"
+    ]
+    args << "--enable-spdy" if build.with? "spdy"
+    system "./configure", *args
+    # Fix wrong username in the generated startup script for bottles.
+    inreplace "rc/trafficserver.in", "@pkgsysuser@", '$USER'
+    system "make" if build.head?
     system "make", "install"
   end
 
@@ -34,109 +58,37 @@ class Trafficserver < Formula
 end
 
 __END__
-diff --git a/configure b/configure
-index 49add2a..e478b34 100755
---- a/configure
-+++ b/configure
-@@ -24109,48 +24109,6 @@ $as_echo "yes" >&6; }
-
- else
-
--
--  if test "x$CXXFLAGS" = "x"; then
--    test "x$verbose" = "xyes" && echo "  setting CXXFLAGS to \"-mcx16\""
--    CXXFLAGS="-mcx16"
--  else
--    ats_addto_bugger="-mcx16"
--    for i in $ats_addto_bugger; do
--      ats_addto_duplicate="0"
--      for j in $CXXFLAGS; do
--        if test "x$i" = "x$j"; then
--          ats_addto_duplicate="1"
--          break
--        fi
--      done
--      if test $ats_addto_duplicate = "0"; then
--        test "x$verbose" = "xyes" && echo "  adding \"$i\" to CXXFLAGS"
--        CXXFLAGS="$CXXFLAGS $i"
--      fi
--    done
--  fi
--
--
--  if test "x$CFLAGS" = "x"; then
--    test "x$verbose" = "xyes" && echo "  setting CFLAGS to \"-mcx16\""
--    CFLAGS="-mcx16"
--  else
--    ats_addto_bugger="-mcx16"
--    for i in $ats_addto_bugger; do
--      ats_addto_duplicate="0"
--      for j in $CFLAGS; do
--        if test "x$i" = "x$j"; then
--          ats_addto_duplicate="1"
--          break
--        fi
--      done
--      if test $ats_addto_duplicate = "0"; then
--        test "x$verbose" = "xyes" && echo "  adding \"$i\" to CFLAGS"
--        CFLAGS="$CFLAGS $i"
--      fi
--    done
--  fi
--
-     ats_save_CFLAGS=$CFLAGS
-  CFLAGS="$CFLAGS $CFLAGS_WARN"
-  if test "$ac_cv_c_compiler_gnu" = "yes"; then
-@@ -24204,52 +24162,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
-
--if test "x$has_128bit_cas" = "x1"; then :
--
--
--  if test "x$CFLAGS" = "x"; then
--    test "x$verbose" = "xyes" && echo "  setting CFLAGS to \"-mcx16\""
--    CFLAGS="-mcx16"
--  else
--    ats_addto_bugger="-mcx16"
--    for i in $ats_addto_bugger; do
--      ats_addto_duplicate="0"
--      for j in $CFLAGS; do
--        if test "x$i" = "x$j"; then
--          ats_addto_duplicate="1"
--          break
--        fi
--      done
--      if test $ats_addto_duplicate = "0"; then
--        test "x$verbose" = "xyes" && echo "  adding \"$i\" to CFLAGS"
--        CFLAGS="$CFLAGS $i"
--      fi
--    done
--  fi
--
--
--  if test "x$CXXFLAGS" = "x"; then
--    test "x$verbose" = "xyes" && echo "  setting CXXFLAGS to \"-mcx16\""
--    CXXFLAGS="-mcx16"
--  else
--    ats_addto_bugger="-mcx16"
--    for i in $ats_addto_bugger; do
--      ats_addto_duplicate="0"
--      for j in $CXXFLAGS; do
--        if test "x$i" = "x$j"; then
--          ats_addto_duplicate="1"
--          break
--        fi
--      done
--      if test $ats_addto_duplicate = "0"; then
--        test "x$verbose" = "xyes" && echo "  adding \"$i\" to CXXFLAGS"
--        CXXFLAGS="$CXXFLAGS $i"
--      fi
--    done
--  fi
--
--
--fi
-
- # Check for POSIX capabilities library.
- # If we don't find it, disable checking for header.
+--- a/configure	2015-03-15 05:01:02.000000000 +0100
++++ b/configure	2015-03-15 05:08:09.000000000 +0100
+@@ -22608,7 +22608,7 @@
+     done
+   fi
+ 
+-  for ac_header in openssl/tls1.h openssl/ssl.h openssl/ts.h
++  for ac_header in openssl/ssl.h openssl/ts.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+@@ -22621,6 +22621,22 @@
+ 
+ done
+ 
++  for ac_header in openssl/tls1.h
++do :
++  ac_fn_c_check_header_compile "$LINENO" "openssl/tls1.h" "ac_cv_header_openssl_tls1_h" " #if HAVE_OPENSSL_SSL_H
++#include <openssl/ssl.h>
++#include <openssl/tls1.h>
++#endif
++"
++if test "x$ac_cv_header_openssl_tls1_h" = xyes; then :
++  cat >>confdefs.h <<_ACEOF
++#define HAVE_OPENSSL_TLS1_H 1
++_ACEOF
++
++fi
++
++done
++
+   # We are looking for SSL_CTX_set_tlsext_servername_callback, but it's a
+   # macro, so AC_CHECK_FUNCS is not going to do the business.
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSL_CTX_set_tlsext_servername_callback" >&5


### PR DESCRIPTION
* Add optional SPDY protocol support
* Allow building with brewed libcurl
* Add HEAD support
* Remove obsolete Snow Leopard patch (verified on 10.6.8 / Xcode 4.2)
* Add patch for tls1.h detection on openssl 1.0.2+ ([upstream bug TS-3443](https://issues.apache.org/jira/browse/TS-3443))
* Fix compilation not using brewed openssl (missing configure switch)
* Fix wrong username *brew* in `trafficserver` script for bottles (caused by compile time user name)