### PR TITLE
scriptcs 0.13.3 (new formula)

### DIFF
--- a/Library/Formula/scriptcs.rb
+++ b/Library/Formula/scriptcs.rb
@@ -1,0 +1,25 @@
+require "formula"
+
+class Scriptcs < Formula
+  homepage "https://github.com/scriptcs/scriptcs"
+  url "https://github.com/scriptcs/scriptcs.git", :tag => "v0.13.3"
+  depends_on "mono" => :recommended
+
+  def install
+    script_file = "scriptcs.sh"
+    system "./build.sh"
+    libexec.install Dir["src/ScriptCs/bin/Release/*"]
+    (libexec/script_file).write <<-EOS.undent
+    #!/usr/bin/env bash
+    mono /usr/local/opt/scriptcs/libexec/scriptcs.exe $@
+    EOS
+    (libexec/script_file).chmod 0755
+    bin.install_symlink libexec/script_file => "scriptcs"
+  end
+
+  test do
+    test_file = "tests.csx"
+    (testpath/test_file).write('Console.WriteLine("{0}, {1}!", "Hello", "world");')
+    assert_equal "Hello, world!", `scriptcs #{test_file}`.strip
+  end
+end

--- a/Library/Formula/scriptcs.rb
+++ b/Library/Formula/scriptcs.rb
@@ -1,8 +1,8 @@
-require "formula"
-
 class Scriptcs < Formula
   homepage "https://github.com/scriptcs/scriptcs"
-  url "https://github.com/scriptcs/scriptcs.git", :tag => "v0.13.3"
+  url "https://github.com/scriptcs/scriptcs/archive/v0.13.3.tar.gz"
+  sha256 "08cf6f2fc14b334ec8d18367a47e5210e99928c3c1cd3d16f2e94d596c8ab44a"
+
   depends_on "mono" => :recommended
 
   def install
@@ -11,7 +11,7 @@ class Scriptcs < Formula
     libexec.install Dir["src/ScriptCs/bin/Release/*"]
     (libexec/script_file).write <<-EOS.undent
     #!/usr/bin/env bash
-    mono /usr/local/opt/scriptcs/libexec/scriptcs.exe $@
+    mono #{libexec}/scriptcs.exe $@
     EOS
     (libexec/script_file).chmod 0755
     bin.install_symlink libexec/script_file => "scriptcs"


### PR DESCRIPTION
> Write C# apps with a text editor, nuget and the power of Roslyn!

http://scriptcs.net

__What is it?__

scriptcs makes it easy to write and execute C# with a simple text editor.

While Visual Studio, and other IDEs, are powerful tools, they can sometimes hinder productivity more than they promote it. You don’t always need, or want, the overhead of a creating a new solution or project. Sometimes you want to just type away in your favorite text editor.

scriptcs frees you from Visual Studio, without sacrificing the advantages of a strongly-typed language.
Write C# in your favorite text editor.
* Use NuGet to manage your dependencies.
* The relaxed C# scripting syntax means you can write and execute an application with only one line of code.
* Script Packs allow you to bootstrap the environment for new scripts, further reduces the amount of code necessary to take advantage of your favorite C# frameworks.

__This PR?__

Adds scriptcs v0.13.3 (current stable version) to Homebrew.