### PR TITLE
py3cairo: restore to core

### DIFF
--- a/Library/Formula/py3cairo.rb
+++ b/Library/Formula/py3cairo.rb
@@ -1,0 +1,20 @@
+class Py3cairo < Formula
+  homepage "http://cairographics.org/pycairo/"
+  url "http://cairographics.org/releases/pycairo-1.10.0.tar.bz2"
+  sha256 "9aa4078e7eb5be583aeabbe8d87172797717f95e8c4338f0d4a17b683a7253be"
+
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on :python3
+
+  def install
+    ENV["PYTHON"] = "python3"
+    system "./waf", "configure", "--prefix=#{prefix}"
+    system "./waf", "build"
+    system "./waf", "install"
+  end
+
+  test do
+    system "python3", "-c", "import cairo; print(cairo.version)"
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -130,7 +130,6 @@ TAP_MIGRATIONS = {
   "pocl" => "homebrew/science",
   "prooftree" => "homebrew/x11",
   "pulse" => "homebrew/boneyard",
-  "py3cairo" => "homebrew/x11",
   "pyenv-pip-rehash" => "homebrew/boneyard",
   "pyxplot" => "homebrew/x11",
   "qfits" => "homebrew/boneyard",


### PR DESCRIPTION
py3cairo doesn't really have an :x11 dependency and should live with py2cairo.