### PR TITLE
cmake: use vendored rather than system libraries.

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -1,23 +1,3 @@
-class NoExpatFramework < Requirement
-  def expat_framework
-    "/Library/Frameworks/expat.framework"
-  end
-
-  satisfy :build_env => false do
-    !File.exist? expat_framework
-  end
-
-  def message; <<-EOS.undent
-    Detected #{expat_framework}
-
-    This will be picked up by CMake's build system and likely cause the
-    build to fail, trying to link to a 32-bit version of expat.
-
-    You may need to move this file out of the way to compile CMake.
-    EOS
-  end
-end
-
 class Cmake < Formula
   homepage "http://www.cmake.org/"
   url "http://www.cmake.org/files/v3.2/cmake-3.2.1.tar.gz"
@@ -34,7 +14,6 @@ class Cmake < Formula
   option "without-docs", "Don't build man pages"
 
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
-  depends_on "xz" # For LZMA
 
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
@@ -65,8 +44,6 @@ class Cmake < Formula
     sha1 "cd5c22acf6dd69046d6cb6a3920d84ea66bdf62a"
   end
 
-  depends_on NoExpatFramework
-
   def install
     if build.with? "docs"
       ENV.prepend_create_path "PYTHONPATH", buildpath+"sphinx/lib/python2.7/site-packages"
@@ -83,10 +60,8 @@ class Cmake < Formula
 
     args = %W[
       --prefix=#{prefix}
-      --system-libs
+      --no-system-libs
       --parallel=#{ENV.make_jobs}
-      --no-system-libarchive
-      --no-system-jsoncpp
       --datadir=/share/cmake
       --docdir=/share/doc/cmake
       --mandir=/share/man


### PR DESCRIPTION
Can cause hard-to-debug errors and I'm not sure what the advantage is of using our own versions, really.

Closes #37770.