### PR TITLE
seafile-client 4.2.8: new formula

### DIFF
--- a/Library/Formula/ccnet.rb
+++ b/Library/Formula/ccnet.rb
@@ -1,0 +1,72 @@
+class Ccnet < Formula
+  desc "A framework for writing networked applications in C"
+  homepage "http://www.seafile.com/"
+  url "https://github.com/haiwen/ccnet/archive/v4.2.8.tar.gz"
+  sha256 "a5ae0b9f4ddd07bdb3702f69da94e9a3a1c28feaa18a8b9a792aae42cec413b2"
+
+  head "https://github.com/haiwen/ccnet.git"
+
+  # FIX for homebrew autotools path
+  patch :DATA
+
+  # FIX for openssl build
+  patch :p1 do
+    url "https://github.com/Chilledheart/ccnet/commit/4bede362.diff"
+    sha1 "e6c540344dfa4d4650cf3e370f2421d897319ab6"
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libtool" => :build
+  depends_on "vala" => :build
+  depends_on "glib"
+  depends_on "jansson"
+  depends_on "libevent"
+  depends_on "openssl"
+  depends_on "libsearpc"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --enable-client
+      --disable-server
+      --disable-compile-demo
+    ]
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    mkdir_p testpath/"conf"
+    (testpath/"conf/ccnet.conf").write <<-EOS.undent
+      [General]
+      USER_NAME = test
+      ID = fa69e633a6bb4b08c27727d53db0450295258e52
+      NAME = test@test.com
+
+      [Network]
+      PORT = 10001
+
+      [Client]
+      PORT = 13419
+    EOS
+    system "#{bin}/ccnet", "-c", testpath/"conf", "-d"
+  end
+end
+
+__END__
+diff --git a/autogen.sh b/autogen.sh
+index cb0bbaa..df71a1c 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -63,7 +63,7 @@ aclocalinclude="$aclocalinclude -I m4"
+ if test x"$MSYSTEM" = x"MINGW32"; then
+     aclocalinclude="$aclocalinclude -I /local/share/aclocal"
+ elif test "$(uname)" = "Darwin"; then
+-    aclocalinclude="$aclocalinclude -I /opt/local/share/aclocal"
++    aclocalinclude="$aclocalinclude -I /usr/local/share/aclocal"
+ fi

--- a/Library/Formula/libsearpc.rb
+++ b/Library/Formula/libsearpc.rb
@@ -1,0 +1,66 @@
+class Libsearpc < Formula
+  desc "A simple and easy-to-use C language RPC framework"
+  homepage "http://www.seafile.com/"
+  url "https://github.com/haiwen/libsearpc/archive/v3.0-latest.tar.gz"
+  version "3.0"
+  sha256 "56313771e0ad7dc075c4590b6a75daeb3939937b21716d82c91be2612133b8cd"
+
+  head "https://github.com/haiwen/libsearpc.git"
+
+  # FIX for homebrew autotools path
+  patch :DATA
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libtool" => :build
+  depends_on "jansson"
+  depends_on "glib"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}", "--disable-compile-demo"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <searpc.h>
+      #include <stdio.h>
+      char *printer(void *arg, const gchar *fcall_str, size_t fcall_len,
+                    size_t *ret_len) {
+        fprintf(stdout, "%s", fcall_str);
+        *ret_len = 0;
+        return NULL;
+      }
+
+      int main() {
+        SearpcClient *client = searpc_client_new();
+        client->send = printer;
+        searpc_client_call__int(client, "test", NULL, 0, NULL);
+        searpc_client_free(client);
+        return 0;
+      }
+    EOS
+    args = "-I#{HOMEBREW_PREFIX}/include/glib-2.0 -I#{Formula["glib"].opt_prefix}/lib/glib-2.0/include -I#{Formula["gettext"].opt_prefix}/include -I#{include} -L#{lib} -lsearpc -lglib-2.0 -L#{Formula["gettext"].opt_prefix}/lib -lintl -ljansson".split
+    args += %w[test.c -o test]
+    system ENV.cc, *args
+    system "./test"
+  end
+end
+
+__END__
+diff --git a/autogen.sh b/autogen.sh
+index b6a7d24..af0d8d7 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -60,7 +60,7 @@ fi
+ if test x"$MSYSTEM" = x"MINGW32"; then
+     autoreconf --install -I/local/share/aclocal
+ elif test "$(uname -s)" = "Darwin"; then
+-    autoreconf --install -I/opt/local/share/aclocal
++    autoreconf --install -I/usr/local/share/aclocal
+ else
+     autoreconf --install
+ fi

--- a/Library/Formula/seafile-client.rb
+++ b/Library/Formula/seafile-client.rb
@@ -1,0 +1,58 @@
+class SeafileClient < Formula
+  desc "Open source cloud storage application"
+  homepage "http://www.seafile.com/"
+  url "https://github.com/haiwen/seafile-client/archive/v4.2.8.tar.gz"
+  sha256 "d245f74fb4fd95c2639de248347efdab2968f1533eabda9889e336ace346fbd8"
+
+  head "https://github.com/haiwen/seafile-client.git"
+
+  option "without-app", "Build without app bundle"
+
+  # Seafile Client doesn't support OS X older than lion since version 4.0.
+  # It uses some features that don't come along with OS X 10.6.
+  depends_on MinimumMacOSRequirement => :lion
+
+  depends_on :xcode => :build
+  depends_on "cmake" => :build
+  depends_on "glib"
+  depends_on "jansson"
+  depends_on "qt5"
+  depends_on "openssl"
+  depends_on "libsearpc"
+  depends_on "ccnet"
+  depends_on "seafile"
+
+  def install
+    ENV.cxx11
+    cmake_args = std_cmake_args
+    if build.with? "app"
+      # use the build script to generate app bundle
+      cmake_args << "-G" << "Xcode" << "-DCMAKE_BUILD_TYPE=Release"
+      system "cmake", ".", *cmake_args
+      xcodebuild "-target", "ALL_BUILD", "-configuration", "Release", "SYMROOT=."
+
+      File.rename "Release/seafile-applet.app", "Seafile Client.app"
+
+      # Install app bundle
+      prefix.install "Seafile Client.app"
+
+      # Create necessary symbol links which are used by Seafile Client
+      resources_directory = prefix/"Seafile Client.app/Contents/Resources"
+      mkdir_p resources_directory
+      resources_directory.install_symlink "#{Formula["ccnet"].opt_prefix}/bin/ccnet"
+      resources_directory.install_symlink "#{Formula["seafile"].opt_prefix}/bin/seaf-daemon"
+
+      # Create symbol links to be executed from the console
+      bin.install_symlink prefix/"Seafile Client.app/Contents/MacOS/seafile-applet"
+    else
+      system "cmake", ".", *cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    # this command will connect the running seaf-daemon and ask it to quit
+    system "#{bin}/seafile-applet", "-K"
+  end
+end

--- a/Library/Formula/seafile.rb
+++ b/Library/Formula/seafile.rb
@@ -1,0 +1,108 @@
+class Seafile < Formula
+  desc "A daemon program used in seafile-client"
+  homepage "http://www.seafile.com/"
+  url "https://github.com/haiwen/seafile/archive/v4.2.8.tar.gz"
+  sha256 "d9e3ed479fdc997df1b767133a065f2ceaa5a5a5f51184fe5964d01abc7c8cb2"
+
+  head "https://github.com/haiwen/seafile.git"
+
+  # FIX for homebrew autotools path
+  # FIX use system zlib
+  patch :DATA
+
+  # [FIX] fix openssl build
+  patch :p1 do
+    url "https://github.com/Chilledheart/seafile/commit/79fc942d.diff"
+    sha1 "a4c81dbf6e131502b2c229b9cab2f324e8c51e5d"
+  end
+
+  depends_on MinimumMacOSRequirement => :snow_leopard
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libtool" => :build
+  depends_on "vala" => :build
+  depends_on "glib"
+  depends_on "jansson"
+  depends_on "libevent"
+  depends_on "openssl"
+
+  depends_on "libsearpc"
+  depends_on "ccnet"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --enable-client
+      --disable-server
+      --disable-fuse
+    ]
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    mkdir_p testpath/"conf"
+    mkdir_p testpath/"data"
+    (testpath/"conf/ccnet.conf").write <<-EOS.undent
+      [General]
+      USER_NAME = test
+      ID = fa69e633a6bb4b08c27727d53db0450295258e52
+      NAME = test@test.com
+
+      [Network]
+      PORT = 10001
+
+      [Client]
+      PORT = 13419
+    EOS
+    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python2.7/site-packages"
+    system "#{bin}/seaf-cli", "init", "-c", testpath/"conf", "-d", testpath/"data"
+  end
+end
+
+__END__
+diff --git a/autogen.sh b/autogen.sh
+index ec1d2c2..2390b65 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -98,7 +98,7 @@ aclocalinclude="$aclocalinclude -I m4"
+ if test x"$MSYSTEM" = x"MINGW32"; then
+     aclocalinclude="$aclocalinclude -I /local/share/aclocal"
+ elif test "$(uname)" = "Darwin"; then
+-    aclocalinclude="$aclocalinclude -I /opt/local/share/aclocal"
++    aclocalinclude="$aclocalinclude -I /usr/local/share/aclocal"
+ fi
+
+
+diff --git a/configure.ac b/configure.ac
+index ccb356d..9ab3ffa 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -156,6 +156,8 @@ if test "$bwin32" != true; then
+   if test "$bmac" = true; then
+   AC_CHECK_LIB(c, uuid_generate, [echo "found library uuid"],
+           AC_MSG_ERROR([*** Unable to find uuid_generate in libc]), )
++  AC_CHECK_LIB(z, inflate, [echo "found library zlib"],
++          AC_MSG_ERROR([*** Unable to find inflate in zlib]), )
+   else
+   AC_CHECK_LIB(uuid, uuid_generate, [echo "found library uuid"],
+           AC_MSG_ERROR([*** Unable to find uuid library]), )
+@@ -270,7 +272,12 @@ PKG_CHECK_MODULES(LIBEVENT, [libevent >= $LIBEVENT_REQUIRED])
+ AC_SUBST(LIBEVENT_CFLAGS)
+ AC_SUBST(LIBEVENT_LIBS)
+ 
+-PKG_CHECK_MODULES(ZLIB, [zlib >= $ZLIB_REQUIRED])
++if test "$bmac" = true; then
++  ZLIB_CFLAGS=
++  ZLIB_LIBS=-lz
++else
++  PKG_CHECK_MODULES(ZLIB, [zlib >= $ZLIB_REQUIRED])
++fi
+ AC_SUBST(ZLIB_CFLAGS)
+ AC_SUBST(ZLIB_LIBS)
+ 


### PR DESCRIPTION
Add seafile-client formula and its three dependencies, namely, libsearpc, ccnet and seafile.

These four formulas have been host at
http://github.com/Chilledheart/homebrew-seafile for months and work fine.
> it is documented in the [seafile's official guide](http://manual.seafile.com/build_seafile/osx.html) as well.

By submiting these formula to the upstream I hope it can benefit more people.