### PR TITLE
markdown: note conflicts with markdown and multimarkdown recipes

### DIFF
--- a/Library/Formula/markdown.rb
+++ b/Library/Formula/markdown.rb
@@ -7,6 +7,7 @@ class Markdown < Formula
 
   conflicts_with 'discount',
     :because => 'both markdown and discount ship a `markdown` executable.'
+  conflicts_with 'markdown', :because => 'both install `markdown` binaries'
 
   def install
     bin.install 'Markdown.pl' => 'markdown'

--- a/Library/Formula/multimarkdown.rb
+++ b/Library/Formula/multimarkdown.rb
@@ -15,6 +15,7 @@ class Multimarkdown < Formula
   end
 
   conflicts_with 'mtools', :because => 'both install `mmd` binaries'
+  conflicts_with 'multimarkdown', :because => 'both install `markdown` binaries'
 
   def install
     ENV.append 'CFLAGS', '-g -O3 -include GLibFacade.h'


### PR DESCRIPTION
I'm not sure this is the right way to solve the problem, but at least this will error properly when attempting to install as opposed to during the install.  The `markdown` program in the `multimarkdown` recipe runs the `multimarkdown` program in a compatibility mode.