### PR TITLE
keg: explicitly create cmake folder under lib

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -278,6 +278,8 @@ class Keg
       when 'charset.alias' then :skip_file
       # pkg-config database gets explicitly created
       when 'pkgconfig' then :mkpath
+      # cmake database gets explicitly created
+      when 'cmake' then :mkpath
       # lib/language folders also get explicitly created
       when 'dtrace' then :mkpath
       when /^gdk-pixbuf/ then :mkpath

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -207,6 +207,13 @@ class LinkTests < Homebrew::TestCase
     assert_predicate link.lstat, :directory?
   end
 
+  def test_cmake_is_mkpathed
+    link = HOMEBREW_PREFIX.join("lib", "cmake")
+    @keg.join("lib", "cmake").mkpath
+    @keg.link
+    assert_predicate link.lstat, :directory?
+  end
+
   def test_symlinks_are_linked_directly
     link = HOMEBREW_PREFIX.join("lib", "pkgconfig")
 


### PR DESCRIPTION
Packages supporting CMake may install configuration files for use with CMake's `find_package` command. One location recommended by CMake for installing these is `<prefix>/lib/cmake` which is not unique across packages. This may cause issues for Formulae using this location if more than one Keg tries to create links under this location.

As with pkg-config, this fix explicitly creates the `lib/cmake` folder when linking a Keg that has installed folders/files under this location.

I haven't added a test for this in `test_keg.rb` like `test_pkgconfig_is_mkpathed` as other created folders aren't tested. However, I'll add this if it's required.