### PR TITLE
add cycript formula

### DIFF
--- a/Library/Formula/cycript.rb
+++ b/Library/Formula/cycript.rb
@@ -1,0 +1,20 @@
+class Cycript < Formula
+  homepage "http://www.cycript.org"
+  url "git://git.saurik.com/cycript.git",
+    :tag => "v0.9.502",
+    :revision => "bb99d698a27487af679f8c04c334d4ea840aea7a"
+  head "git://git.saurik.com/cycript.git"
+
+  def install
+    ENV.deparallelize
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    assert_match /20/, pipe_output("#{bin}/cycript", "10 + 10")
+  end
+end


### PR DESCRIPTION
I'm not 100% sure if this formula belongs in this repo of one of the taps, apologies if this is the wrong place.

While the formula is head-only, the reason for this is that cycript releases are only packaged as compiled binaries. Releases are tagged in the git repo, but snapshots are disabled on the [gitweb interface](http://gitweb.saurik.com/cycript.git).

Given the unusual nature of cycript's distribution I wasn't sure how to proceed, so I am sending this PR hoping for an authoritative decision.