### PR TITLE
Fix installing lnav from HEAD.

### DIFF
--- a/Library/Formula/lnav.rb
+++ b/Library/Formula/lnav.rb
@@ -18,7 +18,8 @@ class Lnav < Formula
 
   def install
     system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-readline=#{Formula["readline"].opt_prefix}"
     system "make", "install"
   end
 end


### PR DESCRIPTION
Installing lnav from HEAD is currently broken. Currently the Formula
specifies 'readline' as a dependency. However, readline formula is
keg-only because 'OS X provides the BSD libedit library, which shadows
libreadline.'

With the latest changes in lnav build scripts, it detects and rejects
building with 'editline'. This change explicitly passes in the prefix to
readline during 'configure' stage to get around the problem.