### PR TITLE
tor 0.2.5.11

### DIFF
--- a/Library/Formula/tor.rb
+++ b/Library/Formula/tor.rb
@@ -1,9 +1,8 @@
 class Tor < Formula
   homepage "https://www.torproject.org/"
-  url "https://dist.torproject.org/tor-0.2.5.10.tar.gz"
-  mirror "https://tor.eff.org/dist/tor-0.2.5.10.tar.gz"
-  sha256 "b3dd02a5dcd2ffe14d9a37956f92779d4427edf7905c0bba9b1e3901b9c5a83b"
-  revision 2
+  url "https://dist.torproject.org/tor-0.2.5.11.tar.gz"
+  mirror "https://tor.eff.org/dist/tor-0.2.5.11.tar.gz"
+  sha256 "aee0faee9c3f1bb265ee8e94b4bb93967413f3c56e65f954db16b09451546769"
 
   bottle do
     sha1 "0a17052c81afa7dfdb9d6988cfa84839d3f7e8f8" => :yosemite


### PR DESCRIPTION
Version bump.

Bug fixes, including fixes for two security issues.