### PR TITLE
bullet: fix style and some audit checks

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,30 +1,34 @@
-require 'formula'
-
 class Bullet < Formula
-  homepage 'http://bulletphysics.org/wordpress/'
-  url 'https://bullet.googlecode.com/files/bullet-2.82-r2704.tgz'
-  version '2.82'
-  sha1 'a0867257b9b18e9829bbeb4c6c5872a5b29d1d33'
-  head 'http://bullet.googlecode.com/svn/trunk/'
+  homepage "http://bulletphysics.org/wordpress/"
+  url "https://bullet.googlecode.com/files/bullet-2.82-r2704.tgz"
+  version "2.82"
+  sha256 "67e4c9eb76f7adf99501d726d8ad5e9b525dfd0843fbce9ca73aaca4ba9eced2"
+  head "https://github.com/bulletphysics/bullet3.git"
 
-  depends_on 'cmake' => :build
+  depends_on "cmake" => :build
+
+  deprecated_option "framework" => "with-framework"
+  deprecated_option "shared" => "with-shared"
+  deprecated_option "build-demo" => "with-demo"
+  deprecated_option "build-extra" => "with-extra"
+  deprecated_option "double-precision" => "with-double-precision"
 
   option :universal
-  option 'framework',        'Build Frameworks'
-  option 'shared',           'Build shared libraries'
-  option 'build-demo',       'Build demo applications'
-  option 'build-extra',      'Build extra library'
-  option 'double-precision', 'Use double precision'
+  option "with-framework",        "Build Frameworks"
+  option "with-shared",           "Build shared libraries"
+  option "with-demo",             "Build demo applications"
+  option "with-extra",            "Build extra library"
+  option "with-double-precision", "Use double precision"
 
   def install
     args = []
 
-    if build.include? "framework"
+    if build.with? "framework"
       args << "-DBUILD_SHARED_LIBS=ON" << "-DFRAMEWORK=ON"
       args << "-DCMAKE_INSTALL_PREFIX=#{frameworks}"
       args << "-DCMAKE_INSTALL_NAME_DIR=#{frameworks}"
     else
-      args << "-DBUILD_SHARED_LIBS=ON" if build.include? "shared"
+      args << "-DBUILD_SHARED_LIBS=ON" if build.with? "shared"
       args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
     end
 
@@ -33,13 +37,13 @@ class Bullet < Formula
       args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
     end
 
-    args << "-DUSE_DOUBLE_PRECISION=ON" if build.include? "double-precision"
+    args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
-    args << "-DBUILD_DEMOS=OFF" unless build.include? "build-demo"
+    args << "-DBUILD_DEMOS=OFF" if build.without? "demo"
 
     # Demos require extras, see:
     # https://code.google.com/p/bullet/issues/detail?id=767&thanks=767&ts=1384333052
-    if build.include? "build-extra" or build.include? "build-demo"
+    if build.with?("extra") || build.with?("demo")
       args << "-DINSTALL_EXTRA_LIBS=ON"
     else
       args << "-DBUILD_EXTRAS=OFF"
@@ -47,9 +51,23 @@ class Bullet < Formula
 
     system "cmake", *args
     system "make"
-    system "make install"
+    system "make", "install"
 
-    prefix.install 'Demos' if build.include? "build-demo"
-    prefix.install 'Extras' if build.include? "build-extra"
+    prefix.install "Demos" if build.with? "demo"
+    prefix.install "Extras" if build.with? "extra"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include "bullet/LinearMath/btPolarDecomposition.h"
+      int main() {
+        btMatrix3x3 I = btMatrix3x3::getIdentity();
+        btMatrix3x3 u, h;
+        polarDecompose(I, u, h);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lLinearMath", "-lc++", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
Replaced all single quotes with double quotes
Removed require formula
Use sha256
"make install" -> "make", "install"
Use || instead of or

FYI: this project is now on github, but I'm waiting on the upstream developer to create tags for previous google code releases (https://github.com/bulletphysics/bullet3/issues/339) so we can stop pointing to google code. At that time, I was planning to point `head` to github as well.

There are still a few complaints from `brew audit --strict`, but I was going to save them for another day.
~~~
bullet:
 * A `test do` test block should be added
 * Options should begin with with/without. Migrate '--framework' with `deprecated_option`.
 * Options should begin with with/without. Migrate '--shared' with `deprecated_option`.
 * Options should begin with with/without. Migrate '--build-demo' with `deprecated_option`.
 * Options should begin with with/without. Migrate '--build-extra' with `deprecated_option`.
 * Options should begin with with/without. Migrate '--double-precision' with `deprecated_option`.
~~~