### PR TITLE
Avidemux: fix build, fix SDL, and adjust dependencies

### DIFF
--- a/Library/Formula/avidemux.rb
+++ b/Library/Formula/avidemux.rb
@@ -1,4 +1,3 @@
-# Help! Wanted: someone who can get Avidemux working with SDL.
 class Avidemux < Formula
   homepage "http://fixounet.free.fr/avidemux/"
 
@@ -48,6 +47,13 @@ class Avidemux < Formula
   depends_on "jack" => :optional
   depends_on "two-lame" => :optional
   depends_on "fribidi" => :optional
+  depends_on "sdl2" => :optional
+
+  # fix compilation against SDL
+  patch do
+    url "https://gist.githubusercontent.com/Noctem/2c03f24daf6705964347/raw/dd6d27374e5ed44678f25b84da159ea57a9d8857/avidemux-sdl.patch"
+    sha256 "17cb0181fbe503e84ad9b2762eb182ad4ec3ef8df8a90741e4f3c0e4d0a8f1ff"
+  end if build.with? "sdl2"
 
   def install
     ENV["REV"] = version.to_s
@@ -65,9 +71,7 @@ class Avidemux < Formula
       args = std_cmake_args
       args << "-DAVIDEMUX_SOURCE_DIR=#{buildpath}"
       args << "-DGETTEXT_INCLUDE_DIR=#{Formula["gettext"].opt_include}"
-      # TODO: We could depend on SDL and then remove the `-DSDL=OFF` arguments
-      # but I got build errors about NSview.
-      args << "-DSDL=OFF"
+      args << "-DSDL=OFF" if build.without? "sdl2"
 
       if build.with? "debug"
         ENV.O2
@@ -98,7 +102,7 @@ class Avidemux < Formula
         args = std_cmake_args
         args << "-DAVIDEMUX_SOURCE_DIR=#{buildpath}"
         args << "-DAVIDEMUX_LIB_DIR=#{lib}"
-        args << "-DSDL=OFF"
+        args << "-DSDL=OFF" if build.without? "sdl2"
         args << "../avidemux/#{interface}"
         system "cmake", *args
         system "make"

--- a/Library/Formula/avidemux.rb
+++ b/Library/Formula/avidemux.rb
@@ -1,14 +1,23 @@
 # Help! Wanted: someone who can get Avidemux working with SDL.
 class Avidemux < Formula
   homepage "http://fixounet.free.fr/avidemux/"
-  url "https://downloads.sourceforge.net/avidemux/avidemux_2.6.8.tar.gz"
-  sha256 "02998c235a89894d184d745c94cac37b78bc20e9eb44b318ee2bb83f2507e682"
-  revision 1
+
+  stable do
+    url "https://downloads.sourceforge.net/avidemux/avidemux_2.6.8.tar.gz"
+    sha256 "02998c235a89894d184d745c94cac37b78bc20e9eb44b318ee2bb83f2507e682"
+
+    # remove ffmpeg binary from targets (fixed upstream)
+    # https://github.com/mean00/avidemux2/commit/bf018562bc6cff300edb1e59ee060a10df902bdc
+    # http://avidemux.org/smuf/index.php/topic,16379.15.html
+    patch :DATA
+  end
 
   head do
     url "https://github.com/mean00/avidemux2.git"
     depends_on "x265"
   end
+
+  revision 1
 
   bottle do
     sha256 "35f7e570a81d8b1fbeb406e04de695952eccb353ee2fad49ff1cf523b7fc86ac" => :yosemite
@@ -154,3 +163,16 @@ class Avidemux < Formula
     system "#{bin}/avidemux_cli", "--help"
   end
 end
+
+__END__
+diff -u a/cmake/admFFmpegBuild.cmake b/cmake/admFFmpegBuild.cmake
+--- a/cmake/admFFmpegBuild.cmake	2014-03-12 00:15:23 -0600
++++ b/cmake/admFFmpegBuild.cmake	2015-03-25 01:39:33 -0600
+@@ -282,7 +282,6 @@
+ 						"${FFMPEG_BINARY_DIR}/libavutil/${LIBAVUTIL_LIB}"
+ 						"${FFMPEG_BINARY_DIR}/libpostproc/${LIBPOSTPROC_LIB}"
+ 						"${FFMPEG_BINARY_DIR}/libswscale/${LIBSWSCALE_LIB}"
+-						"${FFMPEG_BINARY_DIR}/ffmpeg${CMAKE_EXECUTABLE_SUFFIX}"
+ 				   COMMAND ${BASH_EXECUTABLE} ffmpeg_make.sh WORKING_DIRECTORY "${FFMPEG_BINARY_DIR}")
+ 
+ # Add and install libraries

--- a/Library/Formula/avidemux.rb
+++ b/Library/Formula/avidemux.rb
@@ -6,9 +6,11 @@ class Avidemux < Formula
     sha256 "02998c235a89894d184d745c94cac37b78bc20e9eb44b318ee2bb83f2507e682"
 
     # remove ffmpeg binary from targets (fixed upstream)
-    # https://github.com/mean00/avidemux2/commit/bf018562bc6cff300edb1e59ee060a10df902bdc
     # http://avidemux.org/smuf/index.php/topic,16379.15.html
-    patch :DATA
+    patch do
+      url "https://github.com/mean00/avidemux2/commit/bf0185.diff"
+      sha256 "3ca5b4f1b5b3ec407a3daa5c811862ea6ed7ef6cdaaf187045e6e1c77c193800"
+    end
   end
 
   head do
@@ -49,11 +51,14 @@ class Avidemux < Formula
   depends_on "fribidi" => :optional
   depends_on "sdl2" => :optional
 
-  # fix compilation against SDL
-  patch do
-    url "https://gist.githubusercontent.com/Noctem/2c03f24daf6705964347/raw/dd6d27374e5ed44678f25b84da159ea57a9d8857/avidemux-sdl.patch"
-    sha256 "17cb0181fbe503e84ad9b2762eb182ad4ec3ef8df8a90741e4f3c0e4d0a8f1ff"
-  end if build.with? "sdl2"
+  if build.with? "sdl2"
+    # fix compilation against SDL, change deprecated NSQuickDrawView to NSView
+    # (submitted patch to developer via email)
+    patch do
+      url "https://gist.githubusercontent.com/Noctem/2c03f24daf6705964347/raw/dd6d27374e5ed44678f25b84da159ea57a9d8857/avidemux-sdl.patch"
+      sha256 "17cb0181fbe503e84ad9b2762eb182ad4ec3ef8df8a90741e4f3c0e4d0a8f1ff"
+    end
+  end
 
   def install
     ENV["REV"] = version.to_s
@@ -162,16 +167,3 @@ class Avidemux < Formula
     system "#{bin}/avidemux_cli", "--help"
   end
 end
-
-__END__
-diff -u a/cmake/admFFmpegBuild.cmake b/cmake/admFFmpegBuild.cmake
---- a/cmake/admFFmpegBuild.cmake	2014-03-12 00:15:23 -0600
-+++ b/cmake/admFFmpegBuild.cmake	2015-03-25 01:39:33 -0600
-@@ -282,7 +282,6 @@
- 						"${FFMPEG_BINARY_DIR}/libavutil/${LIBAVUTIL_LIB}"
- 						"${FFMPEG_BINARY_DIR}/libpostproc/${LIBPOSTPROC_LIB}"
- 						"${FFMPEG_BINARY_DIR}/libswscale/${LIBSWSCALE_LIB}"
--						"${FFMPEG_BINARY_DIR}/ffmpeg${CMAKE_EXECUTABLE_SUFFIX}"
- 				   COMMAND ${BASH_EXECUTABLE} ffmpeg_make.sh WORKING_DIRECTORY "${FFMPEG_BINARY_DIR}")
- 
- # Add and install libraries

--- a/Library/Formula/avidemux.rb
+++ b/Library/Formula/avidemux.rb
@@ -30,29 +30,24 @@ class Avidemux < Formula
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "yasm" => :build
+  depends_on "xvid" => [:build, :recommended]
+  depends_on "libvpx" => [:build, :recommended]
+  depends_on "libass" => [:build, :recommended]
   depends_on "fontconfig"
   depends_on "gettext"
   depends_on "x264" => :recommended
   depends_on "faac" => :recommended
   depends_on "faad2" => :recommended
   depends_on "lame" => :recommended
-  depends_on "xvid" => :recommended
   depends_on "freetype" => :recommended
-  depends_on "theora" => :recommended
   depends_on "libvorbis" => :recommended
-  depends_on "libvpx" => :recommended
-  depends_on "rtmpdump" => :recommended
   depends_on "opencore-amr" => :recommended
-  depends_on "libvo-aacenc" => :recommended
-  depends_on "libass" => :recommended
-  depends_on "openjpeg" => :recommended
-  depends_on "speex" => :recommended
-  depends_on "schroedinger" => :recommended
-  depends_on "fdk-aac" => :recommended
-  depends_on "opus" => :recommended
-  depends_on "frei0r" => :recommended
-  depends_on "libcaca" => :recommended
+  depends_on "aften" => :recommended
+  depends_on "libdca" => :recommended
   depends_on "qt" => :recommended
+  depends_on "jack" => :optional
+  depends_on "two-lame" => :optional
+  depends_on "fribidi" => :optional
 
   def install
     ENV["REV"] = version.to_s


### PR DESCRIPTION
- Add upstream patch to remove `ffmpeg` cmake target since `ffmpeg` binary building is disabled. (fixes #37915)
- adjust dependencies
  - Remove unused dependencies: `theora`, `rtmpdump`, `libvo-aacenc`, `openjpeg`, `speex`, `schroedinger`, `fdk-aac`, `opus`, `frei0r`, and `libcaca`.
    - None of these appear in the list of libraries from `otool -L` for any of `avidemux`'s files, and they don't appear to have any effect on the build.
  - Specify that `xvid`, `libvpx`, and `libass` are only `:build` dependencies as they are statically linked.
    - None of these are dynamically linked either, but they are discovered during the build process and they do affect the final product.
  - Add `aften` and `libdca` as recommended dependencies.
  - Add `SDL2` as an optional dependency.
    - Add a patch to fix compilation with it.
  - Add `jack`, `two-lame`, and `fribidi` as optional dependencies.

 