### PR TITLE
Add Formula for Google's Bazel (http://bazel.io)

### DIFF
--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -5,8 +5,9 @@ class Bazel < Formula
 
   head "https://github.com/google/bazel.git"
 
-  depends_on "protobuf" => :build
   depends_on "libarchive"
+  depends_on "protobuf" => :build
+  depends_on :java => "1.8+"
 
   def install
     if build.stable?
@@ -20,6 +21,7 @@ class Bazel < Formula
   end
 
   test do
-    #TODO: tests; see https://github.com/Homebrew/homebrew/pull/38061#discussion-diff-27137134
+    system "git", "clone", "https://github.com/google/bazel.git"
+    system "./bootstrap_test.sh", "test"
   end
 end

--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -1,59 +1,21 @@
-#
-# Brew Formula for Google's Bazel
-# written by Felix Klein <me@felixklein.at>
-#
-
 class Bazel < Formula
   homepage "http://bazel.io/"
 
-  #
-  # Version: Bazel 0.0.2 (latest tag from GitHub)
-  # This version is quite old, however there are no newer tags available on GitHub.
-  #
-  url "https://github.com/google/bazel/archive/0.0.2.tar.gz"
+  head "https://github.com/google/bazel.git"
+
+  url "https://github.com/google/bazel.git", :tag => "0.0.2"
   sha256 "5865356e74622c248248174acd09f38c07f3983867d7e687fa5932f2216e84c0"
-  version "0.0.2"
 
-  #
-  # Use userpaths, otherwise the build script doesn't find the libarchive library
-  #
-  env :userpaths
-
-  #
-  # Dependencies
-  #
   depends_on "protobuf" => :build
   depends_on "libarchive"
 
-  #
-  # Install the latest version from GitHub, if the user passes the --HEAD argument
-  #
-  head do
-    url "https://github.com/google/bazel.git", :using => :git
-  end
-
-  #
-  # Set flags for optimization, and build with supplied build scripts
-  # Install the bazel binary
-  #
   def install
-    ENV.append_to_cflags "-Ofast -march=native -flto"
+    inreplace "compile.sh" do |s|
+      s.gsub! "$(brew --prefix 2>/dev/null)/Cellar/libarchive/*/include/archive.h 2>/dev/null | head -n1",
+              "#{Formula["libarchive"].opt_include}/archive.h | head -n1"
+    end
+
     system "./compile.sh"
-    system "./output/bazel help"
-    bin.install "./output/bazel"
-  end
 
-  #
-  # Warn the user that this is potentially unstable software
-  #
-  def caveats
-    "This software is still in Alpha, visit http://bazel.io/ for more information."
-  end
-
-  #
-  # Runn the supplied test script
-  #
-  test do
-    system "./bootstrap_test.sh test"
   end
 end

--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -20,6 +20,6 @@ class Bazel < Formula
   end
 
   test do
-    #TODO: tests
+    #TODO: tests; see https://github.com/Homebrew/homebrew/pull/38061#discussion-diff-27137134
   end
 end

--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -1,21 +1,25 @@
 class Bazel < Formula
   homepage "http://bazel.io/"
-
-  head "https://github.com/google/bazel.git"
-
   url "https://github.com/google/bazel.git", :tag => "0.0.2"
   sha256 "5865356e74622c248248174acd09f38c07f3983867d7e687fa5932f2216e84c0"
+
+  head "https://github.com/google/bazel.git"
 
   depends_on "protobuf" => :build
   depends_on "libarchive"
 
   def install
-    inreplace "compile.sh" do |s|
-      s.gsub! "$(brew --prefix 2>/dev/null)/Cellar/libarchive/*/include/archive.h 2>/dev/null | head -n1",
-              "#{Formula["libarchive"].opt_include}/archive.h | head -n1"
+    if build.stable?
+      inreplace "compile.sh", "$(brew --prefix 2>/dev/null)/Cellar/libarchive/*/include/archive.h", "#{Formula["libarchive"].opt_include}/archive.h"
+    else
+      inreplace "compile.sh", "$(brew --prefix libarchive 2>/dev/null)/include/archive.h", "#{Formula["libarchive"].opt_include}/archive.h"
     end
 
     system "./compile.sh"
+    bin.install "./output/bazel"
+  end
 
+  test do
+    #TODO: tests
   end
 end

--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -1,0 +1,59 @@
+#
+# Brew Formula for Google's Bazel
+# written by Felix Klein <me@felixklein.at>
+#
+
+class Bazel < Formula
+  homepage "http://bazel.io/"
+
+  #
+  # Version: Bazel 0.0.2 (latest tag from GitHub)
+  # This version is quite old, however there are no newer tags available on GitHub.
+  #
+  url "https://github.com/google/bazel/archive/0.0.2.tar.gz"
+  sha256 "5865356e74622c248248174acd09f38c07f3983867d7e687fa5932f2216e84c0"
+  version "0.0.2"
+
+  #
+  # Use userpaths, otherwise the build script doesn't find the libarchive library
+  #
+  env :userpaths
+
+  #
+  # Dependencies
+  #
+  depends_on "protobuf" => :build
+  depends_on "libarchive"
+
+  #
+  # Install the latest version from GitHub, if the user passes the --HEAD argument
+  #
+  head do
+    url "https://github.com/google/bazel.git", :using => :git
+  end
+
+  #
+  # Set flags for optimization, and build with supplied build scripts
+  # Install the bazel binary
+  #
+  def install
+    ENV.append_to_cflags "-Ofast -march=native -flto"
+    system "./compile.sh"
+    system "./output/bazel help"
+    bin.install "./output/bazel"
+  end
+
+  #
+  # Warn the user that this is potentially unstable software
+  #
+  def caveats
+    "This software is still in Alpha, visit http://bazel.io/ for more information."
+  end
+
+  #
+  # Runn the supplied test script
+  #
+  test do
+    system "./bootstrap_test.sh test"
+  end
+end


### PR DESCRIPTION
Hello there,

After playing around with Bazel (http://bazel.io/) and discovering there is no Homebrew Formula available  yet, I decided to create one.

Installing works fine, however the version is quite old, due to v0.0.2 being the latest tagged version - to get the newest version users need to install with the --HEAD option.
I hope new releases get tagged more often in the future.