### PR TITLE
fixed cimg - bump to 1.6.1

### DIFF
--- a/Library/Formula/cimg.rb
+++ b/Library/Formula/cimg.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Cimg < Formula
   homepage "http://cimg.sourceforge.net/"
-  url "https://downloads.sourceforge.net/cimg/CImg-1.5.9.zip"
-  sha1 "bcad203e1836db4882c73923f810cdd69906c896"
+  url "http://freefr.dl.sourceforge.net/project/cimg/CImg_1.6.1.zip"
+  sha1 "b5bac348c4eeaef6b68d17e2314f42642994005a"
 
   def install
     include.install "CImg.h"
@@ -11,6 +11,6 @@ class Cimg < Formula
     doc.install %w(
       README.txt
       Licence_CeCILL-C_V1-en.txt Licence_CeCILL_V2-en.txt
-      html examples)
+      examples)
   end
 end


### PR DESCRIPTION
The version `1.5.9` doesn't work, because link [cimg-1.5.9](https://downloads.sourceforge.net/cimg/CImg-1.5.9.zip) is broken.
I bumped to `1.6.1`.