### PR TITLE
fixes x264 --with-10bit flag

### DIFF
--- a/Library/Formula/x264.rb
+++ b/Library/Formula/x264.rb
@@ -43,7 +43,7 @@ class X264 < Formula
     elsif Formula["gpac"].installed?
       args << "--disable-lsmash"
     end
-    args << "--bit-depth=10" if build.include? "10-bit"
+    args << "--bit-depth=10" if build.include? "with-10-bit"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
The configure flag was still  triggered with __--10-bit__ but it was depreciated so __--with-10-bit__ never added the __--bit-depth=10__ argument.