### PR TITLE
build pngcheck utilities using the provided Makefile.

### DIFF
--- a/Library/Formula/pngcheck.rb
+++ b/Library/Formula/pngcheck.rb
@@ -4,9 +4,10 @@ class Pngcheck < Formula
   homepage 'http://www.libpng.org/pub/png/apps/pngcheck.html'
   url 'https://downloads.sourceforge.net/project/png-mng/pngcheck/2.3.0/pngcheck-2.3.0.tar.gz'
   sha1 'e7f1535abbf2f809e036a9a43c759eeac5e39350'
+  revision 1
 
   def install
-    system 'make pngcheck'
-    bin.install 'pngcheck'
+    system 'make -f Makefile.unx ZINC= ZLIB=-lz'
+    bin.install %w[pngcheck pngsplit png-fix-IDAT-windowsize]
   end
 end


### PR DESCRIPTION
Previous formula used `make` command to compile without Makefile,
as described at http://stackoverflow.com/q/15745241