### PR TITLE
dcd 0.5.1 (new formula)

### DIFF
--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -12,21 +12,21 @@ class Dcd < Formula
   
   test do
     begin
-      #spawn a server, using a non-default port to avoid
-      #clashes with pre-existing dcd-server instances
+      # spawn a server, using a non-default port to avoid
+      # clashes with pre-existing dcd-server instances
       puts "==> dcd-server -p9167"
       server = spawn "dcd-server -p9167" 
       Process.detach server
-      #Give it generous time to load
+      # Give it generous time to load
       sleep 0.5
-      #query the server from a client
-      client = system "dcd-client", "-q", "-p9167"
+      # query the server from a client
+      system "dcd-client", "-q", "-p9167"
     rescue
-      #clean up the server process
+      # clean up the server process
       Process.kill "TERM", server
       raise
     end
-    #Ditto
+    # Ditto
     Process.kill "TERM", server
   end
 end

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -12,14 +12,15 @@ class Dcd < Formula
   
   test do
     begin
-      #spawn a server
-      puts "==> dcd-server"
-      server = spawn "dcd-server" 
+      #spawn a server, using a non-default port to avoid
+      #clashes with pre-existing dcd-server instances
+      puts "==> dcd-server -p9167"
+      server = spawn "dcd-server -p9167" 
       Process.detach server
       #Give it generous time to load
       sleep 0.5
       #query the server from a client
-      client = system "dcd-client", "-q"
+      client = system "dcd-client", "-q", "-p9167"
     rescue
       #clean up the server process
       Process.kill "TERM", server

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -1,0 +1,13 @@
+require "formula"
+
+class Dcd < Formula
+  homepage "https://github.com/Hackerpilot/DCD"
+  url "https://github.com/Hackerpilot/DCD.git", :using => :git, :tag => "v0.5.1"
+
+  depends_on "dmd" => :build
+
+  def install
+    system "make"
+    bin.install "bin/dcd-client", "bin/dcd-server"
+  end
+end

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -1,6 +1,7 @@
 class Dcd < Formula
   homepage "https://github.com/Hackerpilot/DCD"
-  url "https://github.com/Hackerpilot/DCD.git", :tag => "v0.5.1"
+  url "https://github.com/Hackerpilot/DCD.git", :tag => "v0.5.1",
+    :revision => "351bf2ee2d5f1c4986c2c5957f542dda17b1d085"
 
   depends_on "dmd" => :build
 

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -16,8 +16,10 @@ class Dcd < Formula
       # spawn a server, using a non-default port to avoid
       # clashes with pre-existing dcd-server instances
       puts "==> dcd-server -p9167"
-      server = spawn "dcd-server -p9167"
-      Process.detach server
+      # would use spawn, can't on M-L as ruby 1.8
+      server = fork do
+        exec "dcd-server", "-p9167"
+      end
       # Give it generous time to load
       sleep 0.5
       # query the server from a client

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -4,6 +4,9 @@ class Dcd < Formula
       :tag => "v0.5.1",
       :revision => "351bf2ee2d5f1c4986c2c5957f542dda17b1d085"
 
+  bottle do
+  end
+
   depends_on "dmd" => :build
 
   def install

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -1,8 +1,6 @@
-require "formula"
-
 class Dcd < Formula
   homepage "https://github.com/Hackerpilot/DCD"
-  url "https://github.com/Hackerpilot/DCD.git", :using => :git, :tag => "v0.5.1"
+  url "https://github.com/Hackerpilot/DCD.git", :tag => "v0.5.1"
 
   depends_on "dmd" => :build
 

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -1,12 +1,31 @@
 class Dcd < Formula
   homepage "https://github.com/Hackerpilot/DCD"
   url "https://github.com/Hackerpilot/DCD.git", :tag => "v0.5.1",
-    :revision => "351bf2ee2d5f1c4986c2c5957f542dda17b1d085"
-
+      :revision => "351bf2ee2d5f1c4986c2c5957f542dda17b1d085"
+  
   depends_on "dmd" => :build
-
+  
   def install
     system "make"
     bin.install "bin/dcd-client", "bin/dcd-server"
+  end
+  
+  test do
+    begin
+      #spawn a server
+      puts "==> dcd-server"
+      server = spawn "dcd-server" 
+      Process.detach server
+      #Give it generous time to load
+      sleep 0.5
+      #query the server from a client
+      client = system "dcd-client", "-q"
+    rescue
+      #clean up the server process
+      Process.kill "TERM", server
+      raise
+    end
+    #Ditto
+    Process.kill "TERM", server
   end
 end

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -23,8 +23,9 @@ class Dcd < Formula
       # query the server from a client
       system "dcd-client", "-q", "-p9167"
     rescue
-      # clean up the server process
-      Process.kill "TERM", server
+      if server
+        # clean up the server process
+        Process.kill "TERM", server
       raise
     end
     # Ditto

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -26,6 +26,7 @@ class Dcd < Formula
       if server
         # clean up the server process
         Process.kill "TERM", server
+      end
       raise
     end
     # Ditto

--- a/Library/Formula/dcd.rb
+++ b/Library/Formula/dcd.rb
@@ -1,21 +1,22 @@
 class Dcd < Formula
   homepage "https://github.com/Hackerpilot/DCD"
-  url "https://github.com/Hackerpilot/DCD.git", :tag => "v0.5.1",
+  url "https://github.com/Hackerpilot/DCD.git",
+      :tag => "v0.5.1",
       :revision => "351bf2ee2d5f1c4986c2c5957f542dda17b1d085"
-  
+
   depends_on "dmd" => :build
-  
+
   def install
     system "make"
     bin.install "bin/dcd-client", "bin/dcd-server"
   end
-  
+
   test do
     begin
       # spawn a server, using a non-default port to avoid
       # clashes with pre-existing dcd-server instances
       puts "==> dcd-server -p9167"
-      server = spawn "dcd-server -p9167" 
+      server = spawn "dcd-server -p9167"
       Process.detach server
       # Give it generous time to load
       sleep 0.5


### PR DESCRIPTION
dcd is an auto-completion daemon for D source code. Support exists for emacs, vim, KTextEditor (e.g. Kate), Sublime, textadept and zeus (and probably others I'm not aware of).

As a system-wide tool used by a number of other programs, Homebrew seems a logical place for it.