### PR TITLE
vnu 15.3.28

### DIFF
--- a/Library/Formula/vnu.rb
+++ b/Library/Formula/vnu.rb
@@ -1,8 +1,8 @@
 class Vnu < Formula
   homepage "https://validator.github.io/validator/"
-  url "https://github.com/validator/validator/releases/download/20150216/vnu-20150216.jar.zip"
-  sha1 "76806240e7f07d210e23e0dd96a06f6f2c5f0162"
-  version "20150216"
+  url "https://github.com/validator/validator/releases/download/15.3.28/vnu.jar_15.3.28.zip"
+  sha256 "5b7d17fca4900253d30d0b367afa1b7afc3b8f09f3cfa4e4e656e679b21d7841"
+  version "20150328"
 
   def install
     libexec.install "vnu.jar"
@@ -10,8 +10,7 @@ class Vnu < Formula
   end
 
   test do
-    path = testpath/"index.html"
-    path.write <<-EOS.undent
+    (testpath/"index.html").write <<-EOS.undent
       <!DOCTYPE html>
       <html>
       <head>
@@ -21,7 +20,6 @@ class Vnu < Formula
       </body>
       </html>
     EOS
-
-    system bin/"vnu", path
+    system bin/"vnu", testpath/"index.html"
   end
 end


### PR DESCRIPTION
There's a problem with this update: the versioning schema was changed from 20150328 to 15.3.28, so Homebrew won't upgrade (since it thinks the new version is actually older).  Should we just continue using the old schema, or is there another solution?