### PR TITLE
cmake: build with ssl support

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -66,6 +66,9 @@ class Cmake < Formula
       --datadir=/share/cmake
       --docdir=/share/doc/cmake
       --mandir=/share/man
+      --system-curl
+      --system-zlib
+      --system-bzip2
     ]
 
     if build.with? "docs"


### PR DESCRIPTION
Without ssl support, CMake will not be able to download assets from
GitHub and other sites that host them via https.