### PR TITLE
libxslt: link against libxml2 opt_prefix.

### DIFF
--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -5,6 +5,7 @@ class Libxslt < Formula
   url 'ftp://xmlsoft.org/libxml2/libxslt-1.1.28.tar.gz'
   mirror 'http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz'
   sha1 '4df177de629b2653db322bfb891afa3c0d1fa221'
+  revision 1
 
   bottle do
     revision 1
@@ -36,7 +37,7 @@ class Libxslt < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-libxml-prefix=#{Formula["libxml2"].prefix}"
+                          "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"
     system "make install"
   end


### PR DESCRIPTION
When installing (on Yosemite, I didn't check others), and the bottle is used, it appears that the bottle was compiled against libxml2 2.9.1, so it's compiled to reference `/usr/local/Cellar/libxml2/2.9.1/lib` which doesn't exist on any system that got libxml2 2.9.2 installed, which is the latest.

This change links the compilation against the `/usr/local/opt/libxml2` path instead which is pointing to the latest version always.

The side effects of the bug are this when installing from the bottle:

```
$ /usr/local/Cellar/libxslt/1.1.28/bin/xslt-config --libs
/usr/local/Cellar/libxslt/1.1.28/bin/xslt-config: line 94: /usr/local/Cellar/libxml2/2.9.1/bin/xml2-config: No such file or directory
-L/usr/local/Cellar/libxslt/1.1.28/lib -L/usr/local/Cellar/libxml2/2.9.1/lib -lxslt -lxml2 -lz -lpthread -liconv -lm
```

`xslt-config` can't find the corresponding `xml2-config` because it's looking in the wrong place. :anguished: 