### PR TITLE
Patch for boost 1.57.

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -183,6 +183,7 @@ index 966fd03..1bad30a 100644
  
  #else
  
++// unnamed namespace to avoid multiple declarations (#138)
 +namespace {
  using ::boost::bind;
  boost::arg<1> _1;

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -36,6 +36,10 @@ class Boost < Formula
     cause "Dropped arguments to functions when linking with boost"
   end
 
+  # Patch for odeint. Can (hopefully) be removed with the next release of Boost (1.58).
+  # See https://github.com/headmyshoulder/odeint-v2/issues/138
+  patch :DATA
+
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
     if build.with? "mpi" and build.with? "single"
@@ -165,3 +169,25 @@ class Boost < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/boost/numeric/odeint/util/bind.hpp b/boost/numeric/odeint/util/bind.hpp
+index 966fd03..1bad30a 100644
+--- a/boost/numeric/odeint/util/bind.hpp
++++ b/boost/numeric/odeint/util/bind.hpp
+@@ -41,12 +41,14 @@ using namespace ::std::placeholders;
+ 
+ #else
+ 
++namespace {
+ using ::boost::bind;
+ boost::arg<1> _1;
+ boost::arg<2> _2;
+ // using ::boost::bind;
+ // using ::_1;
+ // using ::_2;
++}
+ 
+ #endif
+ 
+

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -179,7 +179,7 @@ diff --git a/boost/numeric/odeint/util/bind.hpp b/boost/numeric/odeint/util/bind
 index 966fd03..1bad30a 100644
 --- a/boost/numeric/odeint/util/bind.hpp
 +++ b/boost/numeric/odeint/util/bind.hpp
-@@ -41,12 +41,14 @@ using namespace ::std::placeholders;
+@@ -41,12 +41,15 @@ using namespace ::std::placeholders;
  
  #else
  

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -36,8 +36,12 @@ class Boost < Formula
     cause "Dropped arguments to functions when linking with boost"
   end
 
-  # Patch for odeint. Can (hopefully) be removed with the next release of Boost (1.58).
-  # See https://github.com/headmyshoulder/odeint-v2/issues/138
+  # Patch for odeint. Can be removed with the next release of Boost (1.58).
+  # See the issue here:
+  # https://github.com/headmyshoulder/odeint-v2/issues/138
+  # The fix has been merged into the Boost project here:
+  # https://github.com/boostorg/odeint/commit/0ca187cd6e83ddbaa5eedaa5d0d570986f351263
+  # It is needed to compile OMPL (http://ompl.kavrakilab.org/).
   patch :DATA
 
   def install

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -2,6 +2,7 @@ class Boost < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.tar.bz2"
   sha1 "e151557ae47afd1b43dc3fac46f8b04a8fe51c12"
+  revision 1
 
   head "https://github.com/boostorg/boost.git"
 

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -43,7 +43,10 @@ class Boost < Formula
   # The fix has been merged into the Boost project here:
   # https://github.com/boostorg/odeint/commit/0ca187cd6e83ddbaa5eedaa5d0d570986f351263
   # It is needed to compile OMPL (http://ompl.kavrakilab.org/).
-  patch :DATA
+  patch :p2 do
+	url "https://github.com/boostorg/odeint/commit/0ca187.diff"
+	sha256 "4d78d7d56a8292de71c702ac286114d6e33f260d4ad8471d98ae4f2bf5de1d65"
+  end
 
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
@@ -174,26 +177,4 @@ class Boost < Formula
     system "./test"
   end
 end
-
-__END__
-diff --git a/boost/numeric/odeint/util/bind.hpp b/boost/numeric/odeint/util/bind.hpp
-index 966fd03..1bad30a 100644
---- a/boost/numeric/odeint/util/bind.hpp
-+++ b/boost/numeric/odeint/util/bind.hpp
-@@ -41,12 +41,15 @@ using namespace ::std::placeholders;
- 
- #else
- 
-+// unnamed namespace to avoid multiple declarations (#138)
-+namespace {
- using ::boost::bind;
- boost::arg<1> _1;
- boost::arg<2> _2;
- // using ::boost::bind;
- // using ::_1;
- // using ::_2;
-+}
- 
- #endif
- 
 


### PR DESCRIPTION
Fix for an issue in odeint which is fixed upstream. Can be likely be
removed with the next boost release. See
https://github.com/headmyshoulder/odeint-v2/issues/138