### PR TITLE
Run autogen.sh while building from HEAD.

### DIFF
--- a/Library/Formula/lnav.rb
+++ b/Library/Formula/lnav.rb
@@ -5,7 +5,6 @@ class Lnav < Formula
   url 'https://github.com/tstack/lnav/releases/download/v0.7.2/lnav-0.7.2.tar.gz'
   sha1 'f679a5a3b52a05edf6ab2446182e085d1953c1fc'
 
-  head 'https://github.com/tstack/lnav.git'
 
   bottle do
     sha256 "8c178133d92e3fe244d60aef590f17943ae494a12a5b0be40bad789dc6646de2" => :yosemite
@@ -13,10 +12,18 @@ class Lnav < Formula
     sha256 "26892fd713417b2b84a6615a63d9492a683f53a7fb497dd2b4a681d7267cc2a5" => :mountain_lion
   end
 
+  head do
+      url 'https://github.com/tstack/lnav.git'
+
+      depends_on "autoconf" => :build
+      depends_on "automake" => :build
+  end
+
   depends_on 'readline'
   depends_on 'pcre'
 
   def install
+    system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-readline=#{Formula["readline"].opt_prefix}"

--- a/Library/Formula/lnav.rb
+++ b/Library/Formula/lnav.rb
@@ -13,10 +13,10 @@ class Lnav < Formula
   end
 
   head do
-      url 'https://github.com/tstack/lnav.git'
+    url "https://github.com/tstack/lnav.git"
 
-      depends_on "autoconf" => :build
-      depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
   end
 
   depends_on 'readline'


### PR DESCRIPTION
The autotools generated scripts might be out of date with the actual
build files while installing from head. Run 'autogen.sh' to rebuild the
build scripts.