### PR TITLE
fontforge 20150330

### DIFF
--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -1,7 +1,7 @@
 class Fontforge < Formula
   homepage "https://fontforge.github.io"
-  url "https://github.com/fontforge/fontforge/archive/20150228.tar.gz"
-  sha256 "5b4e66159856da0e231488f8e6d508ec158ba9cc6892ec34a491f469debedc20"
+  url "https://github.com/fontforge/fontforge/archive/20150330.tar.gz"
+  sha256 "b2cfdf254697d630f8f16913bafeb6eccb305fcddf7232e6a104318139e64f40"
   head "https://github.com/fontforge/fontforge.git"
 
   bottle do
@@ -24,7 +24,6 @@ class Fontforge < Formula
   depends_on "pango"
   depends_on "zeromq"
   depends_on "czmq"
-  depends_on "fontconfig"
   depends_on "cairo"
   depends_on "libpng" => :recommended
   depends_on "jpeg" => :recommended
@@ -34,16 +33,28 @@ class Fontforge < Formula
   depends_on :x11 => :optional
   depends_on :python if MacOS.version <= :snow_leopard
 
+  # This may be causing font-display glitches and needs further isolation & fixing.
+  # https://github.com/fontforge/fontforge/issues/2083
+  # https://github.com/Homebrew/homebrew/issues/37803
+  depends_on "fontconfig"
+
   fails_with :llvm do
     build 2336
     cause "Compiling cvexportdlg.c fails with error: initializer element is not constant"
   end
 
   def install
+    if MacOS.version <= :snow_leopard || !build.bottle?
+      pydir = "#{%x(python-config --prefix).chomp}"
+    else
+      pydir = "#{%x(/usr/bin/python-config --prefix).chomp}"
+    end
+
     args = %W[
       --prefix=#{prefix}
       --disable-silent-rules
       --disable-dependency-tracking
+      --with-pythonbinary=#{pydir}/bin/python2.7
     ]
 
     if build.with? "x11"
@@ -58,15 +69,16 @@ class Fontforge < Formula
     args << "--without-giflib" if build.without? "giflib"
     args << "--without-libspiro" if build.without? "libspiro"
 
-    # Fix linker error; see: http://trac.macports.org/ticket/25012
+    # Fix linker error; see: https://trac.macports.org/ticket/25012
     ENV.append "LDFLAGS", "-lintl"
-
-    # And finding Homebrew's Python
-    ENV.append_path "PKG_CONFIG_PATH", "#{HOMEBREW_PREFIX}/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig/"
-    ENV.prepend "LDFLAGS", "-L#{%x(python-config --prefix).chomp}/lib"
 
     # Reset ARCHFLAGS to match how we build
     ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
+
+    # And for finding the correct Python, not always Homebrew's.
+    ENV.prepend "CFLAGS", "-I#{pydir}/include"
+    ENV.prepend "LDFLAGS", "-L#{pydir}/lib"
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{pydir}/lib/pkgconfig"
 
     # Bootstrap in every build: https://github.com/fontforge/fontforge/issues/1806
     system "./bootstrap"


### PR DESCRIPTION
Version bump.

Should also fix #38144 by removing the LDFLAG usage and allowing Fontforge to use any Python in the $PATH, rather than the system’s by default.