### PR TITLE
Linuxbrew: Remove hyphen from BOTTLE_EXTNAME_RX

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -7,7 +7,7 @@ require 'metafiles'
 class Pathname
   include MachO
 
-  BOTTLE_EXTNAME_RX = /(\.[-a-z0-9_]+\.bottle\.(\d+\.)?tar\.gz)$/
+  BOTTLE_EXTNAME_RX = /(\.[a-z0-9_]+\.bottle\.(\d+\.)?tar\.gz)$/
 
   def install *sources
     sources.each do |src|


### PR DESCRIPTION
A hyphen is not a valid character in a Ruby symbol, and the bottle
tag should be a valid Ruby symbol for its use in the bottle stanza.