### PR TITLE
freeradius-server --devel 3.0.7

### DIFF
--- a/Library/Formula/freeradius-server.rb
+++ b/Library/Formula/freeradius-server.rb
@@ -12,8 +12,8 @@ class FreeradiusServer < Formula
   end
 
   devel do
-    url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.6.tar.bz2"
-    sha1 "37c5a38f74a8b228abe9682db9f3184a9c7d9639"
+    url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.7.tar.bz2"
+    sha1 "d3fda2c4baa79fa72942fc77a33aa30e308d31a9"
     depends_on "talloc" => :build
   end
 


### PR DESCRIPTION
Version bump for [FreeRadius][1] for developer version 3.0.7 released on [19 Feb 2015][2].

* Tested on OS X 10.10.2.
* SHA-1 calculated using sha1sum (GNU coreutils) 8.21.
* Signature verified with key E402497D (Alan T. DeKok <aland@freeradius.org>).
* Successfully ran:
  * `brew install --verbose --devel --debug --verbose freeradius-server`
  * `brew test --verbose --devel --debug freeradius-server`
  * `brew audit freeradius-server`

Thank you for maintaining such a great project! :smile: 

[1]: http://freeradius.org/
[2]: http://freeradius.org/version3.html