### PR TITLE
automoc4: use https homepage

### DIFF
--- a/Library/Formula/automoc4.rb
+++ b/Library/Formula/automoc4.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Automoc4 < Formula
-  homepage 'http://techbase.kde.org/Development/Tools/Automoc4'
+  homepage 'https://techbase.kde.org/Development/Tools/Automoc4'
   url 'http://download.kde.org/stable/automoc4/0.9.88/automoc4-0.9.88.tar.bz2'
   sha1 'd864c3dda99d8b5f625b9267acfa1d88ff617e3a'
 


### PR DESCRIPTION
`*.kde.org` does support SSL/TLS.
It appears that the `download.kde.org` subdomain doesn't serve the same files in SSL/TLS mode as in plaintext, thus leaving `url` as is.