### PR TITLE
cmd/info: show time of last commit to formula

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -118,7 +118,17 @@ module Homebrew
     end
 
     history = github_info(f)
-    puts "From: #{history}" if history
+    if history
+      if f.core_formula?
+        git_dir = "#{HOMEBREW_REPOSITORY}/.git"
+        formula_path = f.path
+      else
+        git_dir = "#{f.path.dirname}/.git"
+        formula_path = f.path.basename
+      end
+      local_commit_time = `git --git-dir=#{git_dir} log -n 1 --pretty=format:%cd --date=local -- #{formula_path}`
+      puts "From: #{history} (Last modified #{local_commit_time})"
+    end
 
     unless f.deps.empty?
       ohai "Dependencies"


### PR DESCRIPTION
This is (imo) a nice way to check how likely it is that a formula is up-to-date.  It does have a noticeable impact on speed on formulae that haven't been updated in a while, though, so I get if that's a deal-breaker.