### PR TITLE
jsdoc3 3.3.0-beta3 devel

### DIFF
--- a/Library/Formula/jsdoc3.rb
+++ b/Library/Formula/jsdoc3.rb
@@ -2,11 +2,11 @@ class Jsdoc3 < Formula
   homepage "http://usejsdoc.org/"
   head "https://github.com/jsdoc3/jsdoc.git"
   url "https://github.com/jsdoc3/jsdoc/archive/v3.2.2.tar.gz"
-  sha1 "69d284a65a9b2b06c6e6454acb30976b41dea7b6"
+  sha256 "c101896d2cf08be636332a5eaaf38fe318ae7f639c37735abd1643b1b973254b"
 
   devel do
-    url "https://github.com/jsdoc3/jsdoc/archive/v3.3.0-alpha13.tar.gz"
-    sha1 "7f0d094c8e61bbc0fbbf965209e8fe1d903352d4"
+    url "https://github.com/jsdoc3/jsdoc/archive/3.3.0-beta3.tar.gz"
+    sha256 "de32d538a5eb1835fdafbb686cdab7ea80ad64b3651a0b85904766c2f5e94b44"
     version "3.3.0-alpha13"
   end
 


### PR DESCRIPTION
Update to latest development release, use SHA256.