### PR TITLE
add plist, conform to 'brew style', add simple test

### DIFF
--- a/Library/Formula/riemann.rb
+++ b/Library/Formula/riemann.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Riemann < Formula
-  homepage 'http://riemann.io'
-  url 'http://aphyr.com/riemann/riemann-0.2.8.tar.bz2'
-  sha1 'f77769345691f7276a58feb6be4ba3857753cf86'
+  homepage "http://riemann.io"
+  url "http://aphyr.com/riemann/riemann-0.2.8.tar.bz2"
+  sha256 "f5bb666acb878e144471f8c6d7f622193840d127aea96924fd8575e1fb6c57dc"
 
   def shim_script
     <<-EOS.undent
@@ -19,16 +17,16 @@ class Riemann < Formula
   end
 
   def install
-    if (etc/'riemann.config').exist?
-      (prefix/'etc').install 'etc/riemann.config' => 'riemann.config.guide'
+    if (etc/"riemann.config").exist?
+      (prefix/"etc").install "etc/riemann.config" => "riemann.config.guide"
     else
-      etc.install 'etc/riemann.config'
+      etc.install
     end
 
     # Install jars in libexec to avoid conflicts
-    libexec.install Dir['*']
+    libexec.install Dir["*"]
 
-    (bin+'riemann').write shim_script
+    (bin+"riemann").write shim_script
   end
 
   def caveats; <<-EOS.undent
@@ -37,5 +35,35 @@ class Riemann < Formula
       riemann-tools
       riemann-dash
     EOS
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/riemann</string>
+          <string>#{etc}/riemann.config</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/riemann.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/riemann.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/riemann", "-help", "0"
   end
 end

--- a/Library/Formula/riemann.rb
+++ b/Library/Formula/riemann.rb
@@ -17,11 +17,7 @@ class Riemann < Formula
   end
 
   def install
-    if (etc/"riemann.config").exist?
-      (prefix/"etc").install "etc/riemann.config" => "riemann.config.guide"
-    else
-      etc.install
-    end
+    (prefix/"etc").install "etc/riemann.config" => "riemann.config.guide"
 
     # Install jars in libexec to avoid conflicts
     libexec.install Dir["*"]

--- a/Library/Formula/riemann.rb
+++ b/Library/Formula/riemann.rb
@@ -17,7 +17,7 @@ class Riemann < Formula
   end
 
   def install
-    (prefix/"etc").install "etc/riemann.config" => "riemann.config.guide"
+    etc.install "etc/riemann.config" => "riemann.config.guide"
 
     # Install jars in libexec to avoid conflicts
     libexec.install Dir["*"]


### PR DESCRIPTION
The riemann binary doesn't allow (afaik) for a test beyond actually testing the java binary.

Add a plist for brew services, LaunchRocket etc
Style fixes from brew style riemann. Had to add my own sha256, someone please confirm this SHA.
Add a test block
Tested uninstall, install, etc.

Passes brew audit --strict riemann

==> brew style riemann
1 file inspected, no offenses detected