### PR TITLE
v8 4.1.0.27

### DIFF
--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -1,12 +1,11 @@
-# When trunk is 3.x, then 3.x is devel and 3.(x-1)
-# is stable.
-# https://code.google.com/p/v8/issues/detail?id=2545
-# http://omahaproxy.appspot.com/
+# Track Chrome stable.
+# https://github.com/v8/v8-git-mirror/commits/901b67916
+# https://omahaproxy.appspot.com/
 
 class V8 < Formula
   homepage "https://code.google.com/p/v8/"
-  url "https://github.com/v8/v8-git-mirror/archive/3.30.33.16.tar.gz"
-  sha1 "c7456744cec231ae63ccf3f4f209509e40fc386d"
+  url "https://github.com/v8/v8-git-mirror/archive/4.1.0.27.tar.gz"
+  sha256 "88bafa0bf80154f8f00e9808acd90a9233c0589c5da46ac4ebe3489ce914b87a"
 
   bottle do
     cellar :any
@@ -15,28 +14,30 @@ class V8 < Formula
     sha1 "fd905b5c2d8d8e2948bcec54af33b21fea902951" => :mountain_lion
   end
 
-  option 'with-readline', 'Use readline instead of libedit'
+  option "with-readline", "Use readline instead of libedit"
 
   # not building on Snow Leopard:
   # https://github.com/Homebrew/homebrew/issues/21426
   depends_on :macos => :lion
 
   depends_on :python => :build # gyp doesn't run under 2.6 or lower
-  depends_on 'readline' => :optional
+  depends_on "readline" => :optional
 
-  resource 'gyp' do
-    url 'http://gyp.googlecode.com/svn/trunk', :revision => 1831
-    version '1831'
+  # Update from "DEPS" file in tarball.
+  resource "gyp" do
+    url "https://chromium.googlesource.com/external/gyp.git",
+        :revision => "fe00999dfaee449d3465a9316778434884da4fa7"
+    version "2010"
   end
 
   resource "gmock" do
-    url "http://googlemock.googlecode.com/svn/trunk", :revision => 485
-    version "485"
+    url "http://googlemock.googlecode.com/svn/trunk", :revision => 501
+    version "501"
   end
 
   resource "gtest" do
-    url "http://googletest.googlecode.com/svn/trunk", :revision => 692
-    version "692"
+    url "http://googletest.googlecode.com/svn/trunk", :revision => 700
+    version "700"
   end
 
   def install
@@ -52,17 +53,15 @@ class V8 < Formula
     (buildpath/"testing/gmock").install resource("gmock")
     (buildpath/"testing/gtest").install resource("gtest")
 
-    system "make", "native",
-                   "library=shared",
-                   "snapshot=on",
-                   "console=readline",
-                   "i18nsupport=off"
+    system "make", "native", "library=shared", "snapshot=on",
+                   "console=readline", "i18nsupport=off"
 
-    prefix.install 'include'
-    cd 'out/native' do
+    prefix.install "include"
+
+    cd "out/native" do
       rm ["libgmock.a", "libgtest.a"]
-      lib.install Dir['lib*']
-      bin.install "d8", "lineprocessor", "mksnapshot", "process", "shell" => "v8"
+      lib.install Dir["lib*"]
+      bin.install "d8", "mksnapshot", "process", "shell" => "v8"
     end
   end
 end


### PR DESCRIPTION
The V8 Formula update process is fairly confusing, which is why I haven’t proposed an update to it in months even after the 4.1.x branch landed stable. But I guess a PR is more welcome than an issue, wherever the discussion ends up.

I don’t know what current policy is here, but I guess I’m proposing that we track Chrome Stable in future. It’d make it easier for people to understand what gets updated and why - Further to that, nothing in the core has a firm dep on V8, there’s only one optional dep, so we don’t particularly have to worry about protecting other formulae from breaking.

Jack and Adam have historically been the main editors to this formulae, so I happily defer to them on what we do and why.