### PR TITLE
enhanced permissions fix command

### DIFF
--- a/share/doc/homebrew/Troubleshooting.md
+++ b/share/doc/homebrew/Troubleshooting.md
@@ -21,7 +21,7 @@ Thank you!
 * Read through the [Common Issues](Common-Issues.md) page.
 * If you’re installing something Java-related, maybe you need the [Java Developer Update][] or [JDK 7][]?
 * Check that **Command Line Tools for Xcode (CLT)** and/or **Xcode** are up to date.
-* If things fail with permissions errors, check the permissions in `/usr/local`. If you’re unsure what to do, you can `sudo chown -R $(whoami) /usr/local`.
+* If things fail with permissions errors, check the permissions in `/usr/local`. If you’re unsure what to do, you can `sudo chown -R $(whoami):admin $(brew --prefix)`.
 
 #### Listen to Dr. Brew
 


### PR DESCRIPTION
The previous "permissions fixer" command was 
```bash
sudo chown -R $(whoami) /usr/local
```
However, this is incomplete in two respects. First, it doesn't include the group (i.e., ```chown user:group```). Secondly, it assumes that the ```HOMEBREW_PREFIX``` is always ```/usr/local```, whereas, in rare cases, users choose a custom ```HOMEBREW_PREFIX```, such as ```/opt```, ```/opt/brew``` or whatever. 

Now, I suggest 
```bash
sudo chown -R $(whoami):admin $(brew --prefix)
```
to fix both problems. According to [the homebrew install script](https://raw.githubusercontent.com/Homebrew/install/master/install), the group should be ```admin```. This alias sets it to ```$USER:admin```. Secondly, just in case the user has a custom ```HOMEBREW_PREFIX```, this alias will fix permissions in the correct homebrew directory in all cases. 

If you have questions, please let me know. :-)