### PR TITLE
cassandra 2.1.4

### DIFF
--- a/Library/Formula/cassandra.rb
+++ b/Library/Formula/cassandra.rb
@@ -1,21 +1,60 @@
-require 'formula'
-
 class Cassandra < Formula
-  homepage 'http://cassandra.apache.org'
-  url 'http://www.apache.org/dyn/closer.cgi?path=/cassandra/2.1.2/apache-cassandra-2.1.2-bin.tar.gz'
-  sha1 '93d89de9aadc50acfee84b502daa3f96c9eca782'
+  homepage "https://cassandra.apache.org"
+  url "https://www.apache.org/dyn/closer.cgi?path=/cassandra/2.1.4/apache-cassandra-2.1.4-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/cassandra/2.1.4/apache-cassandra-2.1.4-bin.tar.gz"
+  sha256 "fb5debada72905f169866ca43c21ade4782f9c036b160894e42b9072190cb7f1"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  # Only Yosemite has new enough setuptools for successful compile of the below deps.
+  resource "setuptools" do
+    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-12.0.5.tar.gz"
+    sha256 "bda326cad34921060a45004b0dd81f828d471695346e303f4ca53b8ba6f4547f"
+  end
+
+  resource "thrift" do
+    url "https://pypi.python.org/packages/source/t/thrift/thrift-0.9.2.tar.gz"
+    sha256 "08f665e4b033c9d2d0b6174d869273104362c80e77ee4c01054a74141e378afa"
+  end
+
+  resource "futures" do
+    url "https://pypi.python.org/packages/source/f/futures/futures-2.2.0.tar.gz"
+    sha256 "151c057173474a3a40f897165951c0e33ad04f37de65b6de547ddef107fd0ed3"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
+  end
+
+  resource "cql" do
+    url "https://pypi.python.org/packages/source/c/cql/cql-1.4.0.tar.gz"
+    sha256 "7857c16d8aab7b736ab677d1016ef8513dedb64097214ad3a50a6c550cb7d6e0"
+  end
+
+  resource "cassandra-driver" do
+    url "https://pypi.python.org/packages/source/c/cassandra-driver/cassandra-driver-2.5.0.tar.gz"
+    sha256 "b9751efab561dbddc4da97f4d05db7ea6c1c4cdefb2d767f55ca3dd151eaa090"
+  end
 
   def install
     (var+"lib/cassandra").mkpath
     (var+"log/cassandra").mkpath
-    (etc+"cassandra").mkpath
+
+    pypath = libexec/"vendor/lib/python2.7/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", pypath
+    %w[setuptools thrift futures six cql cassandra-driver].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
 
     inreplace "conf/cassandra.yaml", "/var/lib/cassandra", "#{var}/lib/cassandra"
     inreplace "conf/cassandra-env.sh", "/lib/", "/"
 
     inreplace "bin/cassandra", "-Dcassandra.logdir\=$CASSANDRA_HOME/logs", "-Dcassandra.logdir\=#{var}/log/cassandra"
     inreplace "bin/cassandra.in.sh" do |s|
-      s.gsub! "CASSANDRA_HOME=\"`dirname \"$0\"`/..\"", "CASSANDRA_HOME=\"#{prefix}\""
+      s.gsub! "CASSANDRA_HOME=\"`dirname \"$0\"`/..\"", "CASSANDRA_HOME=\"#{libexec}\""
       # Store configs in etc, outside of keg
       s.gsub! "CASSANDRA_CONF=\"$CASSANDRA_HOME/conf\"", "CASSANDRA_CONF=\"#{etc}/cassandra\""
       # Jars installed to prefix, no longer in a lib folder
@@ -28,23 +67,21 @@ class Cassandra < Formula
 
     rm Dir["bin/*.bat", "bin/*.ps1"]
 
+    # This breaks on `brew uninstall cassandra && brew install cassandra`
+    # https://github.com/Homebrew/homebrew/pull/38309
     (etc+"cassandra").install Dir["conf/*"]
-    prefix.install Dir["*.txt", "{bin,interface,javadoc,pylib,lib/licenses}"]
-    prefix.install Dir["lib/*.jar"]
 
-    share.install [bin+'cassandra.in.sh', bin+'stop-server']
-    inreplace Dir["#{bin}/cassandra*", "#{bin}/debug-cql", "#{bin}/nodetool", "#{bin}/sstable*"],
+    libexec.install Dir["*.txt", "{bin,interface,javadoc,pylib,lib/licenses}"]
+    libexec.install Dir["lib/*.jar"]
+
+    share.install [libexec+"bin/cassandra.in.sh", libexec+"bin/stop-server"]
+    inreplace Dir["#{libexec}/bin/cassandra*", "#{libexec}/bin/debug-cql", "#{libexec}/bin/nodetool", "#{libexec}/bin/sstable*"],
               /`dirname "?\$0"?`\/cassandra.in.sh/,
               "#{share}/cassandra.in.sh"
-  end
 
-  def caveats; <<-EOS.undent
-    If you plan to use the CQL shell (cqlsh), you will need the Python CQL library
-    installed. Since Homebrew prefers using pip for Python packages, you can
-    install that using:
-
-      pip install cql
-    EOS
+    bin.write_exec_script Dir["#{libexec}/bin/*"]
+    rm bin/"cqlsh" # Remove existing exec script
+    (bin/"cqlsh").write_env_script libexec/"bin/cqlsh", :PYTHONPATH => pypath
   end
 
   def plist; <<-EOS.undent
@@ -54,19 +91,15 @@ class Cassandra < Formula
       <dict>
         <key>KeepAlive</key>
         <true/>
-
         <key>Label</key>
         <string>#{plist_name}</string>
-
         <key>ProgramArguments</key>
         <array>
             <string>#{opt_bin}/cassandra</string>
             <string>-f</string>
         </array>
-
         <key>RunAtLoad</key>
         <true/>
-
         <key>WorkingDirectory</key>
         <string>#{var}/lib/cassandra</string>
       </dict>


### PR DESCRIPTION
Fixes CVE-2015-022.

This was intended to just be a bump to fix the CVE, but then I noticed the caveats and thought we could do better than just shoving users onto pip. That might have been a bad idea, since it led to me rewriting a good chunk of the formula. I’ll ping Tim for some review of the Python changes, whether he thinks it’s worthwhile, etc.

The other maintainers may know why the etc/“cassandra” directory .write method is misbehaving.