### PR TITLE
aws-elasticbeanstalk: Remove unneeded caveats. Add alias.

### DIFF
--- a/Library/Aliases/awsebcli
+++ b/Library/Aliases/awsebcli
@@ -1,0 +1,1 @@
+../Formula/aws-elasticbeanstalk.rb

--- a/Library/Formula/aws-elasticbeanstalk.rb
+++ b/Library/Formula/aws-elasticbeanstalk.rb
@@ -52,14 +52,6 @@ class AwsElasticbeanstalk < Formula
     bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
-  def caveats; <<-EOS.undent
-      Before you can use these tools you must export some variables to your $SHELL.
-        export AWS_ACCESS_KEY="<Your AWS Access ID>"
-        export AWS_SECRET_KEY="<Your AWS Secret Key>"
-        export AWS_CREDENTIAL_FILE="<Path to the credentials file>"
-    EOS
-  end
-
   test do
     system "#{bin}/eb", "--version"
   end


### PR DESCRIPTION
Caveats in aws-elasticbeanstalk are not needed and not recommended. 
Added alias awsebcli to be inline with pip package name.