### PR TITLE
chapel 1.11.0

### DIFF
--- a/Library/Formula/chapel.rb
+++ b/Library/Formula/chapel.rb
@@ -1,7 +1,7 @@
 class Chapel < Formula
   homepage "http://chapel.cray.com/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.10.0/chapel-1.10.0.tar.gz"
-  sha1 "9c05c48f9309a7f685390df37753c086d1637c96"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.11.0/chapel-1.11.0.tar.gz"
+  sha256 "307b156d9cf0968bad90a2f7225366d90f6a5d948eb42be1d33f0efc6979949b"
   head "https://github.com/chapel-lang/chapel.git"
 
   bottle do
@@ -11,9 +11,6 @@ class Chapel < Formula
   end
 
   def install
-    # Remove the deparallelize with the 1.11.0 release, circa April 2015.
-    ENV.deparallelize
-
     libexec.install Dir["*"]
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
@@ -22,12 +19,15 @@ class Chapel < Formula
     # https://gist.github.com/DomT4/90dbcabcc15e5d4f786d
     # https://github.com/Homebrew/homebrew/pull/35166
     cd libexec do
-      system "make", "all"
+      system "make"
+      system "make", "chpldoc"
     end
 
     prefix.install_metafiles
 
-    (bin/"chpl").write_env_script libexec/"bin/darwin/chpl", :CHPL_HOME => libexec
+    # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.
+    bin.install Dir[libexec/"bin/darwin/*"]
+    bin.env_script_all_files libexec/"bin/darwin/", :CHPL_HOME => libexec
     man1.install_symlink Dir["#{libexec}/man/man1/*.1"]
   end
 


### PR DESCRIPTION
* Add 1.11 tarball and update sha.

* Remove ENV.deparallelize, since as of 1.11 chapel makefiles support
  parallel execution.

* Update install to create env scripts for all binaries (i.e. chpl, chpldoc,
  and chpl-ipe).