### PR TITLE
gcc5: add regex

### DIFF
--- a/Library/Homebrew/bottle_version.rb
+++ b/Library/Homebrew/bottle_version.rb
@@ -3,6 +3,10 @@ class BottleVersion < Version
     spec = Pathname.new(spec) unless spec.is_a? Pathname
     stem = spec.stem
 
+    # e.g. 5-20150215 from gcc5-5-20150215.yosemite.bottle.tar.gz
+    m = /[a-z]{3}\d-(\d{1}-\d{8})/.match(stem)
+    return m.captures.first unless m.nil?
+
     # e.g. perforce-2013.1.610569-x86_64.mountain_lion.bottle.tar.gz
     m = /-([\d\.]+-x86(_64)?)/.match(stem)
     return m.captures.first unless m.nil?

--- a/Library/Homebrew/test/test_bottle_versions.rb
+++ b/Library/Homebrew/test/test_bottle_versions.rb
@@ -80,4 +80,9 @@ class BottleVersionParsingTests < Homebrew::TestCase
     assert_version_detected '11-062',
       'apparix-11-062.yosemite.bottle.tar.gz'
   end
+
+  def test_gcc_versions_style
+    assert_version_detected '5-20150215',
+      'gcc5-5-20150215.yosemite.bottle.tar.gz'
+  end
 end


### PR DESCRIPTION
Fixes the bottle regex problem seen in https://github.com/Homebrew/homebrew-versions/pull/678.

I don’t know whether it’s a good regex, or an awful regex, but it works and passes `brew tests` and a bottled install. Open to improvements if anyone has them.