### PR TITLE
Properly flag Rust release channel as beta

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -18,6 +18,7 @@ class Rust < Formula
     args = ["--prefix=#{prefix}"]
     args << "--disable-rpath" if build.head?
     args << "--enable-clang" if ENV.compiler == :clang
+    args << "--release-channel=beta" unless build.head?
     system "./configure", *args
     system "make"
     system "make install"


### PR DESCRIPTION
The `--release-channel` flag governs the visibility of unstable language features and should  be set to "beta" unless building HEAD.

This change brings the Homebrew formula into line with the official builds.