### PR TITLE
platypus 4.9

### DIFF
--- a/Library/Formula/platypus.rb
+++ b/Library/Formula/platypus.rb
@@ -16,8 +16,8 @@ class Platypus < Formula
   depends_on :xcode => :build
 
   def install
-    # 4.8 tarball has extra __MACOSX folder, so go to the right one
-    # The head tarball only has a single folder in it
+    # 4.9 stable tarball has unexpected unpacked name, so go to the right
+    # place.
     cd "platypus" if build.stable?
 
     xcodebuild "SYMROOT=build", "DSTROOT=#{buildpath}",

--- a/Library/Formula/platypus.rb
+++ b/Library/Formula/platypus.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Platypus < Formula
   homepage "http://sveinbjorn.org/platypus"
   url "https://github.com/sveinbjornt/Platypus/raw/master/Releases/platypus4.9.src.zip"

--- a/Library/Formula/platypus.rb
+++ b/Library/Formula/platypus.rb
@@ -2,8 +2,9 @@ require "formula"
 
 class Platypus < Formula
   homepage "http://sveinbjorn.org/platypus"
-  url "https://raw.githubusercontent.com/sveinbjornt/Platypus/4.8/Releases/platypus4.8.src.zip"
-  sha1 "39d165b9579600cef637b45c70c82307697bb7be"
+  url "https://github.com/sveinbjornt/Platypus/raw/master/Releases/platypus4.9.src.zip"
+  version "4.9"
+  sha256 "11b32fc5c68b4e73abeeabd22e1547c2c9b53bafe86cf04474c1f78863d2c1ae"
   head "https://github.com/sveinbjornt/Platypus.git"
 
   bottle do
@@ -19,15 +20,7 @@ class Platypus < Formula
   def install
     # 4.8 tarball has extra __MACOSX folder, so go to the right one
     # The head tarball only has a single folder in it
-    cd "Platypus 4.8 Source" if build.stable?
-
-    if build.stable? and MacOS.version >= :mountain_lion
-      # Platypus wants to use a compiler that isn't shipped with recent versions of XCode.
-      # See https://github.com/Homebrew/homebrew/pull/22618#issuecomment-24898050
-      # and https://github.com/sveinbjornt/Platypus/issues/22
-
-      inreplace "Platypus.xcodeproj/project.pbxproj", "GCC_VERSION", "//GCC_VERSION"
-    end
+    cd "platypus" if build.stable?
 
     xcodebuild "SYMROOT=build", "DSTROOT=#{buildpath}",
                "-project", "Platypus.xcodeproj",
@@ -49,7 +42,7 @@ class Platypus < Formula
   end
 
   test do
-    system "#{bin}/platypus", "-v"
+    system bin/"platypus", "-v"
   end
 
   def caveats

--- a/Library/Formula/platypus.rb
+++ b/Library/Formula/platypus.rb
@@ -40,7 +40,7 @@ class Platypus < Formula
   end
 
   test do
-    system bin/"platypus", "-v"
+    system "#{bin}/platypus", "-v"
   end
 
   def caveats


### PR DESCRIPTION
For some reason, `version` needed to be explicitly added.  The inreplace is no longer needed as of 4.9.

