### PR TITLE
audit: make removal of require formula mandatory

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -711,6 +711,10 @@ class FormulaAuditor
       problem "#{$1} is unnecessary; just use #{$2}"
     end
 
+    if line =~ /(require ["']formula["'])/
+      problem "`#{$1}` is now unnecessary"
+    end
+
     if line =~ /system (["'](#{FILEUTILS_METHODS})["' ])/o
       system = $1
       method = $2
@@ -724,10 +728,6 @@ class FormulaAuditor
           good_system = bad_system.gsub(" ", "\", \"")
           problem "Use `system #{good_system}` instead of `system #{bad_system}` "
         end
-      end
-
-      if line =~ /(require ["']formula["'])/
-        problem "`#{$1}` is now unnecessary"
       end
     end
   end


### PR DESCRIPTION
Don’t know how maintainers feel about this, but asking formula authors to make this change doesn’t seem particularly odious. It’s just removing one line, and the prevalence of it in other formulae means a lot of the time we’re still getting new formulae submitted with the ` require “formula” ` line in.