### PR TITLE
add formulae for release of exact-image

### DIFF
--- a/Library/Formula/exact-image.rb
+++ b/Library/Formula/exact-image.rb
@@ -1,0 +1,18 @@
+class ExactImage < Formula
+  homepage "http://www.exactcode.com/site/open_source/exactimage"
+  url "http://dl.exactcode.de/oss/exact-image/exact-image-0.9.1.tar.bz2"
+  sha256 "79e6a58522897f9740aa3b5a337f63ad1e0361a772141b24aaff2e31264ece7d"
+
+  depends_on "pkg-config" => :build
+  depends_on "libagg"
+  depends_on "freetype" => :optional
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/bardecode"
+  end
+end


### PR DESCRIPTION
This already existed over in the homebrew-head-only repository. It was
pointed out that they actually have releases so we are switching to use
them.

Signed-off-by: Heiko Voigt <hvoigt@hvoigt.net>