### PR TITLE
cloog 0.18.3

### DIFF
--- a/Library/Formula/cloog.rb
+++ b/Library/Formula/cloog.rb
@@ -1,10 +1,7 @@
-require 'formula'
-
 class Cloog < Formula
-  homepage 'http://www.cloog.org/'
-  url 'http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.1.tar.gz'
-  mirror 'http://gcc.cybermirror.org/infrastructure/cloog-0.18.1.tar.gz'
-  sha1 '2dc70313e8e2c6610b856d627bce9c9c3f848077'
+  homepage "http://www.cloog.org/"
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.3.tar.gz"
+  sha256 "460c6c740acb8cdfbfbb387156b627cf731b3837605f2ec0001d079d89c69734"
 
   bottle do
     cellar :any
@@ -15,15 +12,15 @@ class Cloog < Formula
   end
 
   head do
-    url 'http://repo.or.cz/r/cloog.git'
+    url "http://repo.or.cz/r/cloog.git"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gmp'
-  depends_on 'isl'
+  depends_on "pkg-config" => :build
+  depends_on "gmp"
+  depends_on "isl"
 
   def install
     system "./autogen.sh" if build.head?
@@ -35,13 +32,13 @@ class Cloog < Formula
       "--with-gmp=system",
       "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}",
       "--with-isl=system",
-      "--with-isl-prefix=#{Formula["isl"].opt_prefix}"
+      "--with-isl-prefix=#{Formula["isl"].opt_prefix}",
     ]
 
     args << "--with-osl=bundled" if build.head?
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
   end
 
   test do
@@ -62,6 +59,6 @@ class Cloog < Formula
     EOS
 
     output = pipe_output("#{bin}/cloog /dev/stdin", cloog_source)
-    assert_match /Generated from \/dev\/stdin by CLooG/, output
+    assert_match %r{Generated from \/dev\/stdin by CLooG}, output
   end
 end


### PR DESCRIPTION
`brew test cloog` fails on the HEAD build since it's looking in the wrong directory, `cloog/0.18.3/bin` instead of `cloog/HEAD/bin`:

```
🐙  brew test cloog
Testing cloog
==> /usr/local/Cellar/cloog/0.18.3/bin/cloog /dev/stdin
Error: cloog: failed
No such file or directory - /usr/local/Cellar/cloog/0.18.3/bin/cloog
/usr/local/Library/Homebrew/formula_assertions.rb:38:in `popen'
/usr/local/Library/Homebrew/formula_assertions.rb:38:in `pipe_output'
/usr/local/Library/Formula/cloog.rb:61:in `block in <class:Cloog>'
/usr/local/Library/Homebrew/formula.rb:637:in `block in run_test'
/usr/local/Library/Homebrew/extend/fileutils.rb:17:in `mktemp'
/usr/local/Library/Homebrew/formula.rb:634:in `run_test'
/usr/local/Library/Homebrew/cmd/test.rb:38:in `block (2 levels) in test'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
/usr/local/Library/Homebrew/cmd/test.rb:37:in `block in test'
/usr/local/Library/Homebrew/cmd/test.rb:15:in `each'
/usr/local/Library/Homebrew/cmd/test.rb:15:in `test'
/usr/local/Library/brew.rb:135:in `<main>'
```