### PR TITLE
ola 0.9.5

### DIFF
--- a/Library/Formula/ola.rb
+++ b/Library/Formula/ola.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Ola < Formula
   homepage "http://www.openlighting.org/ola/"
-  url "https://github.com/OpenLightingProject/ola/releases/download/0.9.3/ola-0.9.3.tar.gz"
-  sha1 "f6a81087761218063a4bb8006b73ffa407cd0170"
+  url "https://github.com/OpenLightingProject/ola/releases/download/0.9.5/ola-0.9.5.tar.gz"
+  sha1 "e9b0d8e4e3e4acd696cd7a0877d72d593727a7bc"
 
   bottle do
     sha1 "084b25099b2eaf5d90a69ebc20b43c0cf338b614" => :yosemite

--- a/Library/Formula/ola.rb
+++ b/Library/Formula/ola.rb
@@ -3,7 +3,7 @@ require "formula"
 class Ola < Formula
   homepage "http://www.openlighting.org/ola/"
   url "https://github.com/OpenLightingProject/ola/releases/download/0.9.5/ola-0.9.5.tar.gz"
-  sha1 "e9b0d8e4e3e4acd696cd7a0877d72d593727a7bc"
+  sha256 "7c24ac98e865b4c354a04563b88012e782205ffd932a05cf944273f6f5ea82ca"
 
   bottle do
     sha1 "084b25099b2eaf5d90a69ebc20b43c0cf338b614" => :yosemite


### PR DESCRIPTION
Update the version of the Open Lighting Archicitecture to
the latest stable release, currently 0.9.5.