### PR TITLE
list: exclude pypy from unbrewed

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -34,6 +34,10 @@ module Homebrew
     lib/gio/*
     lib/node_modules/*
     lib/python[23].[0-9]/*
+    lib/pypy/*
+    lib/pypy3/*
+    share/pypy/*
+    share/pypy3/*
     share/doc/homebrew/*
     share/info/dir
     share/man/man1/brew.1


### PR DESCRIPTION
Excludes the PyPy paths from the unbrewed list, since we do the same with Python.