### PR TITLE
test-bot cross-tap dependency fixes

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -366,24 +366,6 @@ module Homebrew
       end
 
       test "brew", "uses", canonical_formula_name
-      installed = Utils.popen_read("brew", "list").split("\n")
-      dependencies = Utils.popen_read("brew", "deps", "--skip-optional",
-                                      canonical_formula_name).split("\n")
-      dependencies -= installed
-      unchanged_dependencies = dependencies - @formulae
-      changed_dependences = dependencies - unchanged_dependencies
-
-      runtime_dependencies = Utils.popen_read("brew", "deps",
-                                              "--skip-build", "--skip-optional",
-                                              canonical_formula_name).split("\n")
-      build_dependencies = dependencies - runtime_dependencies
-      unchanged_build_dependencies = build_dependencies - @formulae
-
-      dependents = Utils.popen_read("brew", "uses", "--skip-build", "--skip-optional", canonical_formula_name).split("\n")
-      dependents -= @formulae
-      dependents = dependents.map {|d| Formulary.factory(d)}
-
-      testable_dependents = dependents.select { |d| d.test_defined? && d.bottled? }
 
       formula = Formulary.factory(canonical_formula_name)
       installed_gcc = false
@@ -425,6 +407,25 @@ module Homebrew
         puts e.message
         return
       end
+
+      installed = Utils.popen_read("brew", "list").split("\n")
+      dependencies = Utils.popen_read("brew", "deps", "--skip-optional",
+                                      canonical_formula_name).split("\n")
+      dependencies -= installed
+      unchanged_dependencies = dependencies - @formulae
+      changed_dependences = dependencies - unchanged_dependencies
+
+      runtime_dependencies = Utils.popen_read("brew", "deps",
+                                              "--skip-build", "--skip-optional",
+                                              canonical_formula_name).split("\n")
+      build_dependencies = dependencies - runtime_dependencies
+      unchanged_build_dependencies = build_dependencies - @formulae
+
+      dependents = Utils.popen_read("brew", "uses", "--skip-build", "--skip-optional", canonical_formula_name).split("\n")
+      dependents -= @formulae
+      dependents = dependents.map {|d| Formulary.factory(d)}
+
+      testable_dependents = dependents.select { |d| d.test_defined? && d.bottled? }
 
       if (deps | reqs).any? { |d| d.name == "mercurial" && d.build? }
         test "brew", "install", "mercurial"

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -89,12 +89,12 @@ class DependencyCollector
   end
 
   def parse_string_spec(spec, tags)
-    if tags.empty?
+    if HOMEBREW_TAP_FORMULA_REGEX === spec
+      TapDependency.new(spec, tags)
+    elsif tags.empty?
       Dependency.new(spec, tags)
     elsif (tag = tags.first) && LANGUAGE_MODULES.include?(tag)
       LanguageModuleDependency.new(tag, spec, tags[1])
-    elsif HOMEBREW_TAP_FORMULA_REGEX === spec
-      TapDependency.new(spec, tags)
     else
       Dependency.new(spec, tags)
     end


### PR DESCRIPTION
A couple of unrelated changes that improve cross-tap dependency support in brew test-bot, because homebrew/science and homebrew/python want to depend on each other's formulas:
* allow DependencyCollector#parse_string_spec to return a TapDependency for a dependency like `depends_on "homebrew/python/numpy"`; parse_string_spec was only returning a TapDependency if the dependency was specified with tags like :optional.
* ask test-bot to delay calling `brew deps` until any dependent taps have been tapped, since computing recursive dependencies will fail otherwise (yielding no output to stdout).

Ping @jacknagel, @mikemcquaid for review; thanks!