### PR TITLE
gexiv2: build python wrappers

### DIFF
--- a/Library/Formula/gexiv2.rb
+++ b/Library/Formula/gexiv2.rb
@@ -14,11 +14,14 @@ class Gexiv2 < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "exiv2"
+  depends_on "gobject-introspection"
+  depends_on "libtool"
 
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--enable-introspection",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Hi,

I had to do these changes to build the Python introspection rules, for python-gobject to load the GExiv2 wrapper.

Gobject-introspection is required for g-ir-scanner, libtool for linking (the makefile is using some specific arguments that Mac OS X tools don't like).

One remaining issue is that the introspection rules are not automatically linked into /usr/local/share/gir-1.0/, unlike similar packages (like, e.g., libgit2-glib) and I don't understand why.