### PR TITLE
harfbuzz: fix homepage

### DIFF
--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 class Harfbuzz < Formula
-  homepage "https://www.freedesktop.org/wiki/Software/HarfBuzz"
+  homepage "https://wiki.freedesktop.org/www/Software/HarfBuzz/"
   url "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.40.tar.bz2"
   sha256 "1771d53583be6d91ca961854b2a24fb239ef0545eed221ae3349abae0ab8321f"
 


### PR DESCRIPTION
Re: #38408

Was going to add an ` audit ` check to look for incorrect ` https:// ` freedesktop links, but this is the only place there was one, so I'll hold off for now.