### PR TITLE
FortranDependency: make sure gfortran ends up in PATH

### DIFF
--- a/Library/Homebrew/requirements/fortran_dependency.rb
+++ b/Library/Homebrew/requirements/fortran_dependency.rb
@@ -8,6 +8,6 @@ class FortranDependency < Requirement
   env { ENV.fortran }
 
   satisfy :build_env => false do
-    (ENV['FC'] || which('gfortran')) ? true : false
+    which(ENV["FC"] || "gfortran")
   end
 end


### PR DESCRIPTION
Per requirements.rb:

    >#  XXX If the satisfy block returns a Pathname, then make sure that it
    >#  remains available on the PATH. This makes requirements like
    >#    satisfy { which("executable") }
    >#  work, even under superenv where "executable" wouldn't normally be on the
    >#  PATH.
    >#  This is undocumented magic and it should be removed, but we need to add
    >#  a way to declare path-based requirements that work with superenv first.

Fixes homebrew/homebrew-python#170, where numpy can't figure out how to find a non-Homebrew gfortran.