### PR TITLE
hidapi 0.8.0-rc1-with-macfix

### DIFF
--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Hidapi < Formula
   homepage 'https://github.com/signal11/hidapi'
-  url 'https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz'
-  sha1 '5e72a4c7add8b85c8abcdd360ab8b1e1421da468'
+  url 'https://github.com/rbarazzutti/hidapi/archive/hidapi-0.8.0-rc1-with-macfix.tar.gz'
+  sha1 '8fa3f991839713be48279e6047b74df7f4e2c4df'
 
   bottle do
     cellar :any


### PR DESCRIPTION
hidapi 0.8.0-rc1 contains a bug in the implementation of hid_get_feature_report for the Mac platform. This bug prevents many uses of that library.