### PR TITLE
Remove invalid/nonprinting UTF-8 definitions from gnu-units

### DIFF
--- a/Library/Formula/gnu-units.rb
+++ b/Library/Formula/gnu-units.rb
@@ -4,7 +4,7 @@ require "formula"
 class GnuUnits < Formula
   homepage "https://www.gnu.org/software/units/"
   url "http://ftpmirror.gnu.org/units/units-2.02.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/units/units-2.02.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/units/units-2.02.tar.gz"
   sha1 "e460371dc97034d17ce452e6b64991f7fd2d1409"
 
   bottle do

--- a/Library/Formula/gnu-units.rb
+++ b/Library/Formula/gnu-units.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "formula"
 
 class GnuUnits < Formula
@@ -16,6 +17,17 @@ class GnuUnits < Formula
 
   option "with-default-names", "Do not prepend 'g' to the binary"
 
+  # Temporary fix for "invalid/nonprinting UTF-8" warnings on startup,
+  # see https://github.com/Homebrew/homebrew/issues/20297.
+  #
+  # The current maintainer of GNU units, Adrian Mariano, is aware of
+  # the issue (reported by mail on 2015-04-08) and has fixed it in the
+  # currently unreleased development version which will be released
+  # later this year.
+  #
+  # See https://github.com/Homebrew/homebrew/issues/38454 for details.
+  patch :DATA
+
   def install
     args = ["--prefix=#{prefix}"]
     args << "--program-prefix=g" if build.without? "default-names"
@@ -28,3 +40,29 @@ class GnuUnits < Formula
     assert_equal "* 18288", shell_output("#{bin}/gunits '600 feet' 'cm' -1").strip
   end
 end
+
+__END__
+diff --git a/definitions.units b/definitions.units
+index a0c61f2..06269ce 100644
+--- a/definitions.units
++++ b/definitions.units
+@@ -5248,9 +5248,6 @@ röntgen                 roentgen
+ ㍴                      bar
+ # ㍵                          oV???
+ ㍶                      pc
+-#㍷                      dm      invalid on Mac
+-#㍸                      dm^2    invalid on Mac
+-#㍹                      dm^3    invalid on Mac
+ ㎀                      pA
+ ㎁                      nA
+ ㎂                      µA
+@@ -5342,9 +5339,6 @@ röntgen                 roentgen
+ ㏛                      sr
+ ㏜                      Sv
+ ㏝                      Wb
+-#㏞                      V/m     Invalid on Mac
+-#㏟                      A/m     Invalid on Mac
+-#㏿                      gal     Invalid on Mac
+ 
+ !endutf8
+ 


### PR DESCRIPTION
This pull request fixes the “invalid/nonprinting UTF-8” warnings emitted by gunits that were reported in #20297 by removing the offending lines from `definitions.units`.

As indicated by @reidpr's comment in #20297, upstream seems to think that merely commenting out these lines should fix the mistake. Therefore, I am going to file a separate bug report with the upstream maintainers.

However, it would be nice to see this fixed in Homebrew until the issue is resolved upstream.