### PR TITLE
hidapi 0.8.0-rc1 patched

### DIFF
--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -4,6 +4,20 @@ class Hidapi < Formula
   homepage 'https://github.com/signal11/hidapi'
   url 'https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz'
   sha1 '5e72a4c7add8b85c8abcdd360ab8b1e1421da468'
+  
+  ## Patch - April 8th, 2015 - Raphaël P. Barazzutti
+
+  # This patch addresses a bug discovered in the HidApi IOHidManager back-end 
+  # that is being used with Macs.
+  # The bug was dramatically changing the behaviour of the function 
+  # "hid_get_feature_report". As a consequence, many applications working
+  # with HidApi were not behaving correctly on OSX.
+  # 
+  # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
+  patch do
+    url 'https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.patch'
+    sha1 '087560554b232b7051c229eb14aa79adc189be22'
+  end
 
   bottle do
     cellar :any

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -5,8 +5,6 @@ class Hidapi < Formula
   url 'https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz'
   sha1 '5e72a4c7add8b85c8abcdd360ab8b1e1421da468'
   
-  ## Patch - April 8th, 2015 - Raphaël P. Barazzutti
-
   # This patch addresses a bug discovered in the HidApi IOHidManager back-end 
   # that is being used with Macs.
   # The bug was dramatically changing the behaviour of the function 

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -10,7 +10,6 @@ class Hidapi < Formula
   # The bug was dramatically changing the behaviour of the function
   # "hid_get_feature_report". As a consequence, many applications working
   # with HidApi were not behaving correctly on OSX.
-  #
   # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
   patch do
     url "https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.diff"

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -4,7 +4,7 @@ class Hidapi < Formula
   homepage "https://github.com/signal11/hidapi"
   url "https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz"
   sha1 "5e72a4c7add8b85c8abcdd360ab8b1e1421da468"
- 
+
   # This patch addresses a bug discovered in the HidApi IOHidManager back-end
   # that is being used with Macs.
   # The bug was dramatically changing the behaviour of the function

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Hidapi < Formula
-  homepage 'https://github.com/signal11/hidapi'
-  url 'https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz'
-  sha1 '5e72a4c7add8b85c8abcdd360ab8b1e1421da468'
+  homepage "https://github.com/signal11/hidapi"
+  url "https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz"
+  sha1 "5e72a4c7add8b85c8abcdd360ab8b1e1421da468"
   
   # This patch addresses a bug discovered in the HidApi IOHidManager back-end 
   # that is being used with Macs.
@@ -13,8 +13,8 @@ class Hidapi < Formula
   # 
   # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
   patch do
-    url 'https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.patch'
-    sha1 '087560554b232b7051c229eb14aa79adc189be22'
+    url "https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.diff"
+    sha1 "087560554b232b7051c229eb14aa79adc189be22"
   end
 
   bottle do

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -4,13 +4,13 @@ class Hidapi < Formula
   homepage "https://github.com/signal11/hidapi"
   url "https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz"
   sha1 "5e72a4c7add8b85c8abcdd360ab8b1e1421da468"
-  
-  # This patch addresses a bug discovered in the HidApi IOHidManager back-end 
+ 
+  # This patch addresses a bug discovered in the HidApi IOHidManager back-end
   # that is being used with Macs.
-  # The bug was dramatically changing the behaviour of the function 
+  # The bug was dramatically changing the behaviour of the function
   # "hid_get_feature_report". As a consequence, many applications working
   # with HidApi were not behaving correctly on OSX.
-  # 
+  #
   # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
   patch do
     url "https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.diff"

--- a/Library/Formula/hidapi.rb
+++ b/Library/Formula/hidapi.rb
@@ -14,7 +14,7 @@ class Hidapi < Formula
   # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
   patch do
     url "https://patch-diff.githubusercontent.com/raw/signal11/hidapi/pull/219.diff"
-    sha1 "087560554b232b7051c229eb14aa79adc189be22"
+    sha256 "82631c8a6ec307482c09c133f9da89672c781665704304aa0ef286467b7fe5c2"
   end
 
   bottle do


### PR DESCRIPTION
Fix for the HidApi IOHidManager back-end. hidapi 0.8.0-rc1 contains a bug in the implementation of hid_get_feature_report for the Mac platform. This bug prevents many uses of that library.