### PR TITLE
Keep Homebrew site-packages in sys.path during brew test

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -634,6 +634,7 @@ class Formula
     mktemp do
       @testpath = Pathname.pwd
       ENV["HOME"] = @testpath
+      setup_test_home @testpath
       test
     end
   ensure
@@ -657,6 +658,16 @@ class Formula
   end
 
   protected
+
+  def setup_test_home home
+    # keep Homebrew's site-packages in sys.path when testing with system Python
+    user_site_packages = home/"Library/Python/2.7/lib/python/site-packages"
+    user_site_packages.mkpath
+    (user_site_packages/"homebrew.pth").write <<-EOS.undent
+      import site; site.addsitedir("#{HOMEBREW_PREFIX}/lib/python2.7/site-packages")
+      import sys; sys.path.insert(0, "#{HOMEBREW_PREFIX}/lib/python2.7/site-packages")
+    EOS
+  end
 
   # Pretty titles the command and buffers stdout/stderr
   # Throws if there's an error


### PR DESCRIPTION
Formulas that build python things and which are tested with system
Python will encounter test failures unless system Python is configured
to add Homebrew's site-packages to sys.path. This change makes sure that
configuration is performed in the test environment.

Both lines are needed; the first reads and processes .pth files and the
second makes sure that Homebrew's site-packages is read before the
system extras, so that formulas depending on Homebrew/python/numpy get
the Homebrew/python version and not the old system version.