### PR TITLE
mariadb: protect etc/my.cnf.d from brew prune

### DIFF
--- a/Library/Formula/mariadb.rb
+++ b/Library/Formula/mariadb.rb
@@ -123,6 +123,7 @@ class Mariadb < Formula
     inreplace "#{etc}/my.cnf" do |s|
       s.gsub!("!includedir /etc/my.cnf.d", "!includedir #{etc}/my.cnf.d")
     end
+    touch etc/"my.cnf.d/.homebrew_dont_prune_me"
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975


### PR DESCRIPTION
Closes #31760.