### PR TITLE
vim: enable system Python on Xcode-only systems

### DIFF
--- a/Library/Formula/vim.rb
+++ b/Library/Formula/vim.rb
@@ -1,11 +1,9 @@
-require "formula"
-
 class Vim < Formula
   homepage "http://www.vim.org/"
   head "https://vim.googlecode.com/hg/"
   # This package tracks debian-unstable: http://packages.debian.org/unstable/vim
   url "http://ftp.debian.org/debian/pool/main/v/vim/vim_7.4.488.orig.tar.gz"
-  sha1 "6edad8cf9a08acb6a6e415b89bb13ccbd887d7c3"
+  sha256 "5b58ef7d4ce2c2eb84af2f3dbb3b5d6919adc97f12de1509a13681fa58936faf"
 
   # We only have special support for finding depends_on :python, but not yet for
   # :ruby, :perl etc., so we use the standard environment that leaves the
@@ -41,6 +39,12 @@ class Vim < Formula
 
     # vim doesn't require any Python package, unset PYTHONPATH.
     ENV.delete("PYTHONPATH")
+
+    if build.with?("python") && which("python").to_s == "/usr/bin/python" && !MacOS.clt_installed?
+      # break -syslibpath jail
+      ln_s "/System/Library/Frameworks", buildpath
+      ENV.append "LDFLAGS", "-F#{buildpath}/Frameworks"
+    end
 
     opts = []
     opts += LANGUAGES_OPTIONAL.map do |language|


### PR DESCRIPTION
-syslibroot tries to prefix anything that looks like a standard framework path with SDKROOT, which is fine, except that Python was removed from the 10.9 SDK, so adding -F/System/Library/Frameworks doesn't help ld find -framework Python because it doesn't exist in SDKROOT/System/Library/Frameworks/Python.framework anymore. We need to camouflage the system frameworks path using a symlink in order to actually add it to the linker search path.

Would close #31893.