### PR TITLE
sandbox test and postinstall

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -1,5 +1,5 @@
 # This script is loaded by formula_installer as a separate instance.
-# Thrown exceptions are propogated back to the parent process over a pipe
+# Thrown exceptions are propagated back to the parent process over a pipe
 
 old_trap = trap("INT") { exit! 130 }
 

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -1,5 +1,34 @@
+require "sandbox"
+
 module Homebrew
   def postinstall
-    ARGV.formulae.each { |f| f.run_post_install }
+    ARGV.formulae.each { |f| run_post_install(f) }
+  end
+
+  def run_post_install(formula)
+    args = %W[
+      nice #{RUBY_PATH}
+      -W0
+      -I #{HOMEBREW_LIBRARY_PATH}
+      --
+      #{HOMEBREW_LIBRARY_PATH}/postinstall.rb
+      #{formula.path}
+    ].concat(ARGV.options_only)
+
+    Utils.safe_fork do
+      if Sandbox.available? && ARGV.sandbox?
+        sandbox = Sandbox.new
+        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_log(formula)
+        sandbox.allow_write_cellar(formula)
+        sandbox.allow_write_path HOMEBREW_PREFIX
+        sandbox.deny_write_path HOMEBREW_LIBRARY
+        sandbox.deny_write_path HOMEBREW_REPOSITORY/".git"
+        sandbox.deny_write HOMEBREW_BREW_FILE
+        sandbox.exec(*args)
+      else
+        exec(*args)
+      end
+    end
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -9,6 +9,7 @@ require 'cleaner'
 require 'formula_cellar_checks'
 require 'install_renamed'
 require 'cmd/tap'
+require 'cmd/postinstall'
 require 'hooks/bottles'
 require 'debrew'
 require 'sandbox'
@@ -586,7 +587,7 @@ class FormulaInstaller
   end
 
   def post_install
-    formula.run_post_install
+    Homebrew.run_post_install(formula)
   rescue Exception => e
     opoo "The post-install step did not complete successfully"
     puts "You can try again using `brew postinstall #{formula.name}`"

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -474,7 +474,10 @@ class FormulaInstaller
 
     Utils.safe_fork do
       if Sandbox.available? && ARGV.sandbox?
-        sandbox = Sandbox.new(formula)
+        sandbox = Sandbox.new
+        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_log(formula)
+        sandbox.allow_write_cellar(formula)
         sandbox.exec(*args)
       else
         exec(*args)

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -1,0 +1,21 @@
+old_trap = trap("INT") { exit! 130 }
+
+require "global"
+require "debrew"
+require "fcntl"
+require "socket"
+
+begin
+  error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
+  error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+
+  trap("INT", old_trap)
+
+  formula = ARGV.formulae.first
+  formula.extend(Debrew::Formula) if ARGV.debug?
+  formula.run_post_install
+rescue Exception => e
+  Marshal.dump(e, error_pipe)
+  error_pipe.close
+  exit! 1
+end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -1,0 +1,34 @@
+old_trap = trap("INT") { exit! 130 }
+
+require "global"
+require "extend/ENV"
+require "timeout"
+require "debrew"
+require "formula_assertions"
+require "fcntl"
+require "socket"
+
+TEST_TIMEOUT_SECONDS = 5*60
+
+begin
+  error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
+  error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+
+  ENV.extend(Stdenv)
+  ENV.setup_build_environment
+
+  trap("INT", old_trap)
+
+  formula = ARGV.formulae.first
+  formula.extend(Homebrew::Assertions)
+  formula.extend(Debrew::Formula) if ARGV.debug?
+
+  # tests can also return false to indicate failure
+  Timeout::timeout TEST_TIMEOUT_SECONDS do
+    raise "test returned false" if formula.run_test == false
+  end
+rescue Exception => e
+  Marshal.dump(e, error_pipe)
+  error_pipe.close
+  exit! 1
+end

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -10,7 +10,7 @@ class SandboxTest < Homebrew::TestCase
     s = Sandbox.new
     testpath = Pathname.new(TEST_TMPDIR)
     foo = testpath/"foo"
-    s.allow_write "#{testpath}", :type => :subpath
+    s.allow_write foo
     s.exec "touch", foo
     assert_predicate foo, :exist?
     foo.unlink

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -4,6 +4,7 @@ require 'os/mac'
 require 'utils/json'
 require 'utils/inreplace'
 require 'utils/popen'
+require 'utils/fork'
 require 'open-uri'
 
 class Tty

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -1,0 +1,45 @@
+require "fcntl"
+require "socket"
+
+module Utils
+  def self.safe_fork(&block)
+    socket_path = "#{Dir.mktmpdir("homebrew", HOMEBREW_TEMP)}/socket"
+    server = UNIXServer.new(socket_path)
+    ENV["HOMEBREW_ERROR_PIPE"] = socket_path
+    read, write = IO.pipe
+
+    pid = fork do
+      begin
+        server.close
+        read.close
+        write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+        yield
+      rescue Exception => e
+        Marshal.dump(e, write)
+        write.close
+        exit! 1
+      end
+    end
+
+    ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back
+      begin
+        socket = server.accept_nonblock
+      rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINTR
+        retry unless Process.waitpid(pid, Process::WNOHANG)
+      else
+        socket.send_io(write)
+      end
+      write.close
+      data = read.read
+      read.close
+      Process.wait(pid) unless socket.nil?
+      raise Marshal.load(data) unless data.nil? or data.empty?
+      raise Interrupt if $?.exitstatus == 130
+      raise "Suspicious failure" unless $?.success?
+    end
+  ensure
+    server.close
+    FileUtils.rm_r File.dirname(socket_path)
+  end
+end
+


### PR DESCRIPTION
Clearly, my first implemented sandbox has some poor API design.(thankfully it's private API for now). `brew test` is a little more complex than I previously thought. "test should probably only write to testpath" is incorrect. For general purpose, it need to be allowed to write temp folders. And some formulae would download resource in the test, so I need to allow them to write cache. Finally `Formula.system` requires to write into log folder.

Asking for comments especially on **API design**.

cc @Homebrew/owners 