### PR TITLE
pkg-config: make `cellar :any` bottle.

### DIFF
--- a/Library/Formula/pkg-config.rb
+++ b/Library/Formula/pkg-config.rb
@@ -23,6 +23,7 @@ class PkgConfig < Formula
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
+                          "--libdir=#{HOMEBREW_PREFIX}/lib",
                           "--disable-host-tool",
                           "--with-internal-glib",
                           "--with-pc-path=#{pc_path}"


### PR DESCRIPTION
Seems pretty stupid considering this doesn't actually put anything in this path anyway.