### PR TITLE
ettercap 0.8.2

### DIFF
--- a/Library/Formula/ettercap.rb
+++ b/Library/Formula/ettercap.rb
@@ -1,26 +1,7 @@
-require "formula"
-
 class Ettercap < Formula
-  homepage "http://ettercap.github.io/ettercap/"
-
-  stable do
-    url "https://github.com/Ettercap/ettercap/archive/v0.8.1.tar.gz"
-    sha1 "66362ce69cd9b82b9eb8ea6a52048700704a7d9b"
-
-    # Upstream patch to fix Luajit compile on OS X
-    # Both of these patches are already in HEAD.
-    # https://github.com/Ettercap/ettercap/pull/618
-    # https://github.com/Homebrew/homebrew/issues/33902
-    patch do
-      url "https://github.com/Ettercap/ettercap/commit/190e4264e3.diff"
-      sha1 "4d8cadd8ca19956450e7e2d52f92dc649d393acf"
-    end
-
-    patch do
-      url "https://github.com/Ettercap/ettercap/commit/e505088db.diff"
-      sha1 "db0f121aeba34286c5f6a16e523ac675868b384c"
-    end
-  end
+  homepage "https://ettercap.github.io/ettercap/"
+  url "https://github.com/Ettercap/ettercap/archive/v0.8.2.tar.gz"
+  sha256 "f38514f35bea58bfe6ef1902bfd4761de0379942a9aa3e175fc9348f4eef2c81"
 
   bottle do
     sha1 "b7d7bfc3d98015cea228473b239a0fe9ae41127d" => :yosemite
@@ -39,15 +20,12 @@ class Ettercap < Formula
   depends_on "pcre"
   depends_on "libnet"
   depends_on "curl" # require libcurl >= 7.26.0
+  depends_on "openssl"
   depends_on "gtk+" => :optional
   depends_on "luajit" => :optional
-  depends_on "openssl"
 
   def install
     args = std_cmake_args
-
-    # specify build type manually since std_cmake_args sets the build type to "None".
-    args << "-DCMAKE_BUILD_TYPE=Release"
 
     args << "-DINSTALL_SYSCONFDIR=#{etc}"
     args << "-DENABLE_CURSES=OFF" if build.without? "curses"
@@ -62,5 +40,9 @@ class Ettercap < Formula
       system "cmake", *args
       system "make", "install"
     end
+  end
+
+  test do
+    system bin/"ettercap", "--version"
   end
 end


### PR DESCRIPTION
Version bump.

[Mountains](https://github.com/Ettercap/ettercap/releases/tag/v0.8.2) of fixes, including some CVE fixes.