### PR TITLE
Allows the openssl formula to work from linuxbrew

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -17,6 +17,7 @@ class Openssl < Formula
   option "without-check", "Skip build-time tests (not recommended)"
 
   depends_on "makedepend" => :build
+  depends_on "pkg-config" => :build  # needed to build makedepend
 
   keg_only :provided_by_osx,
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"


### PR DESCRIPTION
- pkg-config is not always present
- makedepend just has a build dependency on pkg-config, so that is
  needed here as well.