### PR TITLE
Add ncdc --HEAD

### DIFF
--- a/Library/Formula/ncdc.rb
+++ b/Library/Formula/ncdc.rb
@@ -14,7 +14,16 @@ class Ncdc < Formula
   depends_on 'pkg-config' => :build
   depends_on 'geoip' => :optional
 
+  head do
+    url "git://g.blicky.net/ncdc.git"
+
+    depends_on 'autoconf' => :build
+    depends_on 'automake' => :build
+  end
+
   def install
+    system "autoreconf -i" if build.head?
+
     args = [
       "--disable-dependency-tracking",
       "--prefix=#{prefix}",


### PR DESCRIPTION
- Put the latest tagged version into a 'stable' block.
- Create a 'head' block that points to the ncdc git repo.
- Add dependencies for tip of master: zlib, bzip2 and ncurses. autconf
and automake are also required for building from the git repository.