### PR TITLE
libressl: improve cert handling

### DIFF
--- a/Library/Formula/libressl.rb
+++ b/Library/Formula/libressl.rb
@@ -36,7 +36,7 @@ class Libressl < Formula
     system "make", "install"
 
     # Install the dummy openssl.cnf file to stop runtime warnings.
-    mkdir_p "#{etc}/libressl"
+    mkdir_p "#{etc}/libressl/certs"
     cp "apps/openssl.cnf", "#{etc}/libressl"
   end
 
@@ -53,7 +53,10 @@ class Libressl < Formula
   def caveats; <<-EOS.undent
     A CA file has been bootstrapped using certificates from the system
     keychain. To add additional certificates, place .pem files in
-      #{etc}/libressl
+      #{etc}/libressl/certs
+
+    and run
+      #{opt_bin}/openssl certhash #{etc}/libressl/certs
     EOS
   end
 


### PR DESCRIPTION
Missed the release notes a couple of versions back that LibreSSL had killed off the useful `c_rehash` script OpenSSL uses to support custom added certs and merged it into the OpenSSL command itself, with some changes, including renaming it ` certhash `.

This PR just allows people to take advantage of it without so much manual intervention and discovery. Nothing too fancy.