### PR TITLE
Fix bug in Cayley 0.4.0 with newer versions of leveldb

### DIFF
--- a/Library/Formula/cayley.rb
+++ b/Library/Formula/cayley.rb
@@ -1,4 +1,5 @@
 require "formula"
+require "language/go"
 
 class Cayley < Formula
   homepage "https://github.com/google/cayley"
@@ -18,37 +19,71 @@ class Cayley < Formula
 
   option "without-samples", "Disable installing sample data"
 
+  # This patch is only necessary until Cayley releases something beyond 0.4.0
+  # See https://github.com/google/cayley/pull/188
+  patch :DATA unless build.head?
+
+  # Go dependencies
+  go_resource "github.com/badgerodon/peg" do
+    url "https://github.com/badgerodon/peg.git", :revision => "9e5f7f4d07ca576562618c23e8abadda278b684f"
+  end
+
+  go_resource "github.com/barakmich/glog" do
+    url "https://github.com/barakmich/glog.git", :revision => "fafcb6128a8a2e6360ff034091434d547397d54a"
+  end
+
+  go_resource "github.com/cznic/mathutil" do
+    url "https://github.com/cznic/mathutil.git", :revision => "f9551431b78e71ee24939a1e9d8f49f43898b5cd"
+  end
+
+  go_resource "github.com/julienschmidt/httprouter" do
+    url "https://github.com/julienschmidt/httprouter.git", :revision => "b59a38004596b696aca7aa2adccfa68760864d86"
+  end
+
+  go_resource "github.com/petar/GoLLRB/llrb" do
+    url "https://github.com/petar/GoLLRB.git", :revision => "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+  end
+
+  go_resource "github.com/peterh/liner" do
+    url "https://github.com/peterh/liner.git", :revision => "1bb0d1c1a25ed393d8feb09bab039b2b1b1fbced"
+  end
+
+  go_resource "github.com/robertkrimen/otto" do
+    url "https://github.com/robertkrimen/otto.git", :revision => "d1b4d8ef0e0e4b088c8328c95ca63ab9ebd8fc9d"
+  end
+
+  go_resource "github.com/syndtr/gosnappy" do
+    url "https://github.com/syndtr/gosnappy.git", :revision => "156a073208e131d7d2e212cb749feae7c339e846"
+  end
+
+  go_resource "github.com/shurcooL/sanitized_anchor_name" do
+    url "https://github.com/shurcooL/sanitized_anchor_name.git", :revision => "8e87604bec3c645a4eeaee97dfec9f25811ff20d"
+  end
+
+  go_resource "github.com/russross/blackfriday" do
+    url "https://github.com/russross/blackfriday.git", :revision => "17bb7999de6cfb791d4f8986cc00b3309b370cdb"
+  end
+
+  go_resource "github.com/syndtr/goleveldb" do
+    url "https://github.com/syndtr/goleveldb.git", :revision => "4875955338b0a434238a31165cb87255ab6e9e4a"
+  end
+
+  go_resource "github.com/boltdb/bolt" do
+    url "https://github.com/boltdb/bolt.git", :revision => "3b449559cf34cbcc74460b59041a4399d3226e5a"
+  end
+
+  go_resource "gopkg.in/mgo.v2" do
+    url "https://github.com/go-mgo/mgo.git", :revision => "c6a7dce14133ccac2dcac3793f1d6e2ef048503a"
+  end
+
   def install
     # Prepare for Go build
     ENV["GOPATH"] = buildpath
+    Language::Go.stage_deps resources, buildpath/"src"
 
     # To avoid re-downloading Cayley, symlink its source from the tarball so that Go can find it
     mkdir_p "src/github.com/google/"
     ln_s buildpath, "src/github.com/google/cayley"
-
-    # Install Go dependencies
-    system "go", "get", "github.com/badgerodon/peg"
-    system "go", "get", "github.com/barakmich/glog"
-    system "go", "get", "github.com/cznic/mathutil"
-    system "go", "get", "github.com/julienschmidt/httprouter"
-    system "go", "get", "github.com/petar/GoLLRB/llrb"
-    system "go", "get", "github.com/peterh/liner"
-    system "go", "get", "github.com/robertkrimen/otto"
-    system "go", "get", "github.com/russross/blackfriday"
-    system "go", "get", "github.com/syndtr/goleveldb/leveldb"
-    system "go", "get", "github.com/syndtr/goleveldb/leveldb/cache"
-    system "go", "get", "github.com/syndtr/goleveldb/leveldb/iterator"
-    system "go", "get", "github.com/syndtr/goleveldb/leveldb/opt"
-    system "go", "get", "github.com/syndtr/goleveldb/leveldb/util"
-    system "go", "get", "github.com/boltdb/bolt"
-    system "go", "get", "gopkg.in/mgo.v2"
-    system "go", "get", "gopkg.in/mgo.v2/bson"
-
-    # HEAD does not require the extra work to get 0.3.1 to build properly so avoid it
-    unless build.head?
-      # Install Go dependencies
-      system "go", "get", "github.com/stretchrcom/testify/mock"
-    end
 
     # Build
     system "go", "build", "-o", "cayley"
@@ -120,3 +155,27 @@ class Cayley < Formula
     assert result.include?("Cayley snapshot")
   end
 end
+
+# This patch is only necessary until Cayley releases something beyond 0.4.0
+# See https://github.com/google/cayley/pull/188
+__END__
+diff --git a/graph/leveldb/triplestore.go b/graph/leveldb/triplestore.go
+index 641a6f5..ee41dff 100644
+--- a/graph/leveldb/triplestore.go
++++ b/graph/leveldb/triplestore.go
+@@ -26,7 +26,6 @@
+
+ 	"github.com/barakmich/glog"
+ 	"github.com/syndtr/goleveldb/leveldb"
+-	"github.com/syndtr/goleveldb/leveldb/cache"
+ 	"github.com/syndtr/goleveldb/leveldb/opt"
+ 	"github.com/syndtr/goleveldb/leveldb/util"
+
+@@ -94,7 +93,7 @@
+ 		cache_size = val
+ 	}
+ 	qs.dbOpts = &opt.Options{
+-		BlockCache: cache.NewLRUCache(cache_size * opt.MiB),
++		BlockCacheCapacity: cache_size * opt.MiB,
+ 	}
+ 	qs.dbOpts.ErrorIfMissing = true


### PR DESCRIPTION
Upstream was fixed in https://github.com/google/cayley/pull/188 but they've haven't released in a while.  This patch will allow Cayley to compile and run with the never versions of LevelDB.