### PR TITLE
emacs 24.5

### DIFF
--- a/Library/Formula/emacs.rb
+++ b/Library/Formula/emacs.rb
@@ -2,17 +2,9 @@ class Emacs < Formula
   homepage "https://www.gnu.org/software/emacs/"
 
   stable do
-    url "http://ftpmirror.gnu.org/emacs/emacs-24.4.tar.xz"
-    mirror "https://ftp.gnu.org/pub/gnu/emacs/emacs-24.4.tar.xz"
-    sha256 "47e391170db4ca0a3c724530c7050655f6d573a711956b4cd84693c194a9d4fd"
-
-    # Fix ns-antialias-text, broken in 24.4, from upstream:
-    # https://github.com/emacs-mirror/emacs/commit/604a4d21ead40691afe3efe13f0ba1000b2cd61a
-    # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=18876
-    patch do
-      url "https://gist.githubusercontent.com/scotchi/66edaf426d7375c0f061/raw/4c5229a8a719f81fa6bd2e1e0c85d10b6f635765/emacs-fix-ns-antialias-text-mac-os.patch"
-      sha256 "fab5cf538ade6afa949640b0f81bdea26cb23b6d64ca714b687dee6f33ff270e"
-    end
+    url "http://ftpmirror.gnu.org/emacs/emacs-24.5.tar.xz"
+    mirror "https://ftp.gnu.org/gnu/emacs/emacs-24.5.tar.xz"
+    sha256 "dd47d71dd2a526cf6b47cb49af793ec2e26af69a0951cc40e43ae290eacfc34e"
   end
 
   bottle do
@@ -24,7 +16,7 @@ class Emacs < Formula
 
   devel do
     url "http://git.sv.gnu.org/r/emacs.git", :branch => "emacs-24"
-    version "24.4-dev"
+    version "24.5-dev"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end


### PR DESCRIPTION
Emacs 24.5 was released a while ago. I verified that it works out of the box and I removed the `ns-antialias-text` patch, since it is in 24.5. Of course, the bottles need to be updated.