### PR TITLE
Update download url of gpac formula to new github repo

### DIFF
--- a/Library/Formula/gpac.rb
+++ b/Library/Formula/gpac.rb
@@ -12,11 +12,11 @@ class Gpac < Formula
   homepage 'http://gpac.wp.mines-telecom.fr/'
 
   stable do
-    url 'https://downloads.sourceforge.net/gpac/gpac-0.5.0.tar.gz'
-    sha1 '48ba16272bfa153abb281ff8ed31b5dddf60cf20'
+    url 'https://github.com/gpac/gpac/archive/v0.5.2.tar.gz'
+    sha1 '467128110636dc793be89f33765b42543dd97f7c'
 
     # Fixes build against ffmpeg 2.x; backported from upstream SVN
-    patch :DATA
+    #patch :DATA
   end
 
   head 'https://gpac.svn.sourceforge.net/svnroot/gpac/trunk/gpac'


### PR DESCRIPTION
Gpac recently moved from sourceforge to github but the gpac formula still builds against the SF release. This is an update to download and install using the .tar.gz file in gpac github repo. It's been tested in OSX Yosemite.