### PR TITLE
add --use-standard-socket to launchd invocation

### DIFF
--- a/Library/Formula/gpg-agent.rb
+++ b/Library/Formula/gpg-agent.rb
@@ -54,7 +54,7 @@ class GpgAgent < Formula
         <array>
             <string>/bin/sh</string>
             <string>-c</string>
-            <string>#{opt_prefix}/bin/gpg-agent -c --daemon | /bin/launchctl</string>
+            <string>#{opt_prefix}/bin/gpg-agent -c --daemon --use-standard-socket | /bin/launchctl</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
I needed to add --use-standard-socket to the
invocation to enable gpg2 to communicate with
gpg-agent running as a daemon. 

Without this gpg2 would start a separate gpg-agent
in --server mode and I'd need to enter a passphrase
every time I used gpg2.

gpg2 communication with gpg-agent also works
correctly when I add: use-standard-socket to
~/.gnupg/gpg-agent.conf

I tested this by running this gpg2 command several times:

    $ gpg2 --clearsign <<EOT
    > test
    > EOT

Without adding --use-standard-socket each time I ran this mac-pinentry would open.

After adding --use-standard-socket I was only asked for my passphrase once.