### PR TITLE
audit: don't split shell commands when using a glob pattern

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -720,7 +720,7 @@ class FormulaAuditor
     if @strict
       if line =~ /system (["'][^"' ]*(?:\s[^"' ]*)+["'])/
         bad_system = $1
-        unless %w[| < > & ;].any? { |c| bad_system.include? c }
+        unless %w[| < > & ; *].any? { |c| bad_system.include? c }
           good_system = bad_system.gsub(" ", "\", \"")
           problem "Use `system #{good_system}` instead of `system #{bad_system}` "
         end


### PR DESCRIPTION
Without this, `brew audit <some formula>` may ask people to change:

```rb
system "./script.sh foo-*"
```

into:

```rb
system "./script.sh", "foo-*"
```

These are not the same. In the first example the shell expansion occurs while it doesn’t in the second one, breaking the build.

[`postmark`](https://github.com/Homebrew/homebrew/blob/5cd4c94134cf89c97a2cb2c16b415906285086e1/Library/Formula/postmark.rb#L10) is an example where this problem occurs (edit: fixed in #38542).

In fact, writing this I’m wondering if `system "./script foo-*"` should be replaced with `system "./script", *Dir["foo-*"]` instead. Thoughts?