### PR TITLE
rmtrash: basic test added

### DIFF
--- a/Library/Formula/rmtrash.rb
+++ b/Library/Formula/rmtrash.rb
@@ -1,14 +1,23 @@
-require 'formula'
-
 class Rmtrash < Formula
-  homepage 'http://www.nightproductions.net/cli.htm'
-  url 'http://www.nightproductions.net/downloads/rmtrash_source.tar.gz'
-  sha1 '3e24ca03c2aadcb804681b4790177569ac83a8c6'
-  version '0.3.3'
+  homepage "http://www.nightproductions.net/cli.htm"
+  url "http://www.nightproductions.net/downloads/rmtrash_source.tar.gz"
+  sha256 "9b30561454529e5923ffb62327d3fe009d23495263efc958534ac6b637e361d6"
+  version "0.3.3"
 
   def install
-    system "make LDFLAGS='-framework Foundation -prebind' all"
-    man1.install gzip("rmtrash.1")
-    bin.install "rmtrash"
+    # don't install as root
+    inreplace "Makefile", "-o root -g wheel", ""
+    # install manpages under share/man/
+    inreplace "Makefile", "${DESTDIR}/man", "${DESTDIR}/share/man"
+
+    bin.mkpath
+    man1.mkpath
+
+    system "make", "CC=#{ENV.cc}", "LDFLAGS=-framework Foundation -prebind"
+    system "make", "install", "DESTDIR=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/rmtrash", "-h"
   end
 end


### PR DESCRIPTION
I wanted to write a better test but `rmtrash` needs to write in a user’s home directory and I couldn’t find a way to trick it into using `testpath` as my home directory (it doesn’t seem to rely on `$HOME`).