### PR TITLE
gpg-agent: Remove needless launchd plist

### DIFF
--- a/Library/Formula/gpg-agent.rb
+++ b/Library/Formula/gpg-agent.rb
@@ -34,8 +34,8 @@ class GpgAgent < Formula
   end
 
   def caveats; <<-EOS.undent
-      Remember to set a graphical pinentry program (such as pinentry-mac) in your
-      ~/.gnupg/gpg-agent.conf if you configure launchd to start gpg-agent at login.
+      Remember to add "use-standard-socket" to your ~/.gnupg/gpg-agent.conf
+      file.
     EOS
   end
 
@@ -43,31 +43,6 @@ class GpgAgent < Formula
     system "#{bin}/gpg-agent", "--help"
   end
 
-  def plist; <<-EOS.undent
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-            <string>/bin/sh</string>
-            <string>-c</string>
-            <string>#{opt_prefix}/bin/gpg-agent -c --daemon | /bin/launchctl</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardErrorPath</key>
-        <string>/dev/null</string>
-        <key>StandardOutPath</key>
-        <string>/dev/null</string>
-        <key>ServiceDescription</key>
-        <string>Run gpg-agent at login</string>
-    </dict>
-    </plist>
-    EOS
-  end
 end
 
 __END__


### PR DESCRIPTION
There is no reason to have a launchd plist here.  gpg-agent will start as soon as is requested, and it will remain alive in daemon mode; it is not necessary to put it under launchd control.

What is required is that users add a line containing `use-standard-socket` to their `~/.gnupg/gpg-agent.conf` file.