### PR TITLE
readall: use named to check if ARGV is empty.

### DIFF
--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -31,7 +31,7 @@ module Homebrew
     end
 
     formulae = []
-    if ARGV.empty?
+    if ARGV.named.empty?
       formulae = Formula.names
     else
       user, repo = tap_args


### PR DESCRIPTION
Otherwise e.g. --debug will be interpreted as a (bad) tap argument.

CC @Homebrew/owners for review.