### PR TITLE
suricata 2.0.7

### DIFF
--- a/Library/Formula/libmagic.rb
+++ b/Library/Formula/libmagic.rb
@@ -2,7 +2,8 @@ class Libmagic < Formula
   homepage "http://www.darwinsys.com/file/"
   url "ftp://ftp.astron.com/pub/file/file-5.22.tar.gz"
   mirror "https://fossies.org/unix/misc/file-5.22.tar.gz"
-  sha1 "20fa06592291555f2b478ea2fb70b53e9e8d1f7c"
+  sha256 "c4e3a8e44cb888c5e4b476e738503e37fb9de3b25a38c143e214bfc12109fc0b"
+  revision 1
 
   bottle do
     revision 3
@@ -22,10 +23,12 @@ class Libmagic < Formula
     rm "src/magic.h"
 
     system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--enable-fsect-man5",
                           "--enable-static"
     system "make", "install"
+    (share+"misc/magic").install Dir["magic/Magdir/*"]
 
     if build.with? "python"
       cd "python" do

--- a/Library/Formula/suricata.rb
+++ b/Library/Formula/suricata.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Suricata < Formula
   homepage "http://suricata-ids.org"
-  url "http://www.openinfosecfoundation.org/download/suricata-2.0.tar.gz"
-  sha1 "37819a0d6ecb7ebd4201bc32dec40824c145da98"
+  url "http://www.openinfosecfoundation.org/download/suricata-2.0.7.tar.gz"
+  sha256 "c5c3ccebeecbace39df0ff2d50ec4515b541103ffaa5e33cd1dc79d4955c0dfd"
 
   bottle do
     sha1 "e696fc00b003d1ea19631e385f4dc84631eb2c64" => :mavericks
@@ -11,25 +9,52 @@ class Suricata < Formula
     sha1 "3fcae2900b1f4070c48bb8d0720869b8364a9202" => :lion
   end
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "pkg-config" => :build
   depends_on "libmagic"
   depends_on "libnet"
   depends_on "libyaml"
   depends_on "pcre"
   depends_on "geoip" => :optional
+  depends_on "lua" => :optional
+  depends_on "luajit" => :optional
 
-  # Use clang provided strl* functions. Reported upstream:
-  # https://redmine.openinfosecfoundation.org/issues/1192
-  patch :DATA
+  resource "argparse" do
+    url "https://pypi.python.org/packages/source/a/argparse/argparse-1.3.0.tar.gz"
+    sha256 "b3a79a23d37b5a02faa550b92cbbbebeb4aa1d77e649c3eb39c19abf5262da04"
+  end
+
+  resource "simplejson" do
+    url "https://pypi.python.org/packages/source/s/simplejson/simplejson-3.6.5.tar.gz"
+    sha256 "2a3189f79d1c7b8a2149a0e783c0b4217fad9b30a6e7d60450f2553dc2c0e57e"
+  end
 
   def install
     libnet = Formula["libnet"]
-    args = ["--disable-debug",
-            "--disable-dependency-tracking",
-            "--disable-silent-rules",
-            "--prefix=#{prefix}",
-            "--with-libnet-includes=#{libnet.opt_include}",
-            "--with-libnet-libs=#{libnet.opt_lib}"]
+    libmagic = Formula["libmagic"]
+
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    resources.each do |r|
+      r.stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+      --with-libnet-includes=#{libnet.opt_include}
+      --with-libnet-libs=#{libnet.opt_lib}
+      --with-libmagic-includes=#{libmagic.opt_include}
+      --with-libmagic-libraries=#{libmagic.opt_lib}
+    ]
+
+    args << "--enable-lua" if build.with? "lua"
+    args << "--enable-luajit" if build.with? "luajit"
 
     if build.with? "geoip"
       geoip = Formula["geoip"]
@@ -39,52 +64,15 @@ class Suricata < Formula
     end
 
     system "./configure", *args
-    system "make", "install"
+    system "make", "install-full"
+
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+
+    # Leave the magic-file: prefix in otherwise it overrides a commented out line rather than intended line.
+    inreplace etc/"suricata/suricata.yaml", "magic-file: /usr/share/file/magic", "magic-file: #{libmagic.opt_share}/misc/magic"
+  end
+
+  test do
+    assert_match /#{version}/, shell_output("#{bin}/suricata --build-info")
   end
 end
-
-__END__
-diff --git a/src/Makefile.in b/src/Makefile.in
-index 32cb702..68ef842 100644
---- a/src/Makefile.in
-+++ b/src/Makefile.in
-@@ -266,7 +266,6 @@ am_suricata_OBJECTS = alert-debuglog.$(OBJEXT) alert-fastlog.$(OBJEXT) \
- 	util-signal.$(OBJEXT) util-spm-bm.$(OBJEXT) \
- 	util-spm-bs2bm.$(OBJEXT) util-spm-bs.$(OBJEXT) \
- 	util-spm.$(OBJEXT) util-storage.$(OBJEXT) \
--	util-strlcatu.$(OBJEXT) util-strlcpyu.$(OBJEXT) \
- 	util-syslog.$(OBJEXT) util-threshold-config.$(OBJEXT) \
- 	util-time.$(OBJEXT) util-unittest.$(OBJEXT) \
- 	util-unittest-helper.$(OBJEXT) util-affinity.$(OBJEXT) \
-@@ -862,8 +861,6 @@ util-spm-bs2bm.c util-spm-bs2bm.h \
- util-spm-bs.c util-spm-bs.h \
- util-spm.c util-spm.h util-clock.h \
- util-storage.c util-storage.h \
--util-strlcatu.c \
--util-strlcpyu.c \
- util-syslog.c util-syslog.h \
- util-threshold-config.c util-threshold-config.h \
- util-time.c util-time.h \
-@@ -1353,8 +1350,6 @@ distclean-compile:
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-spm-bs2bm.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-spm.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-storage.Po@am__quote@
--@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-strlcatu.Po@am__quote@
--@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-strlcpyu.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-syslog.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-threshold-config.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util-time.Po@am__quote@
-diff --git a/src/suricata-common.h b/src/suricata-common.h
-index 43c76c1..b6010f4 100644
---- a/src/suricata-common.h
-+++ b/src/suricata-common.h
-@@ -323,9 +323,6 @@ typedef enum PacketProfileDetectId_ {
- #include "util-path.h"
- #include "util-conf.h"
- 
--size_t strlcat(char *, const char *src, size_t siz);
--size_t strlcpy(char *dst, const char *src, size_t siz);
--
- extern int coverage_unittests;
- extern int g_ut_modules;
- extern int g_ut_covered;


### PR DESCRIPTION
Suricata:

* Version bump.
* Build fixes to stop the var & etc files wandering around like Little Bo Peep's sheep.
* Make the Python element work without manual user intervention.
* Add option to use Lua & Luajit.
* Actually install the example config and rules files.
* Other minor build fix-ups.

Libmagic:

* Mimic [Apple's installation of the actual magic files](https://opensource.apple.com/source/file/file-46/xcodescripts/magic.sh).
* Bump to SHA256 :tada:.
* Revision because otherwise `Suricata` remains broken without users doing `brew reinstall libmagic`. Other formulae may be affected as well, but I haven't gone on a massive hunt. The magic files are in a different prefix than the system so they won't override the system naturally. I think this is desirable, but it can be fixed if we're happy jumping over the system magic files.

Closes #38536