### PR TITLE
pdfjam: basic test added

### DIFF
--- a/Library/Formula/pdfjam.rb
+++ b/Library/Formula/pdfjam.rb
@@ -1,15 +1,17 @@
-require 'formula'
-
 class Pdfjam < Formula
-  homepage 'http://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam'
-  url 'http://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam/pdfjam_208.tgz'
-  sha1 '981b504ef96369a203f85fefb42d4ea0d1194493'
-  version '2.08'
+  homepage "https://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam"
+  url "https://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam/pdfjam_208.tgz"
+  sha256 "c731c598cfad076c985526ff89cbf34423a216101aa5e2d753a71de119ecc0f3"
+  version "2.08"
 
   depends_on :tex
 
   def install
-    bin.install Dir['bin/*']
-    man.install 'man1'
+    bin.install Dir["bin/*"]
+    man.install "man1"
+  end
+
+  test do
+    system "#{bin}/pdfjam", "-h"
   end
 end


### PR DESCRIPTION
From its description, “pdfjam is a shell-script front end to the LaTeX 'pdfpages' package”, so we can’t write a better test since it requires the user/bot to have pdfpages to work.