### PR TITLE
sshuttle 0.7.1

### DIFF
--- a/Library/Formula/sshuttle.rb
+++ b/Library/Formula/sshuttle.rb
@@ -8,10 +8,7 @@ class Sshuttle < Formula
   head 'https://github.com/sshuttle/sshuttle.git'
 
   #Pre-Yosemite support dropped in sshuttle 0.7.1
-  if MacOS.version < :yosemite
-    url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.70.tar.gz'
-    sha256 'b6fd3468f80db18fb33276881facc59e113745da049d3346b5e604dc55675588'
-  end
+  depends_on :macos => :yosemite
 
   def install
     # Building the docs requires installing

--- a/Library/Formula/sshuttle.rb
+++ b/Library/Formula/sshuttle.rb
@@ -9,8 +9,8 @@ class Sshuttle < Formula
 
   #Pre-Yosemite support dropped in sshuttle 0.7.1
   if MacOS.version < :yosemite
-	url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.70.tar.gz'
-	sha256 'b6fd3468f80db18fb33276881facc59e113745da049d3346b5e604dc55675588'
+    url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.70.tar.gz'
+    sha256 'b6fd3468f80db18fb33276881facc59e113745da049d3346b5e604dc55675588'
   end
 
   def install

--- a/Library/Formula/sshuttle.rb
+++ b/Library/Formula/sshuttle.rb
@@ -1,17 +1,23 @@
 require 'formula'
 
 class Sshuttle < Formula
-  homepage 'https://github.com/apenwarr/sshuttle'
-  url 'https://github.com/apenwarr/sshuttle/archive/sshuttle-0.61.tar.gz'
-  sha1 '05551cdc78e866d983470ba4084beb206bacebd8'
+  homepage 'https://github.com/sshuttle/sshuttle'
+  url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.71.tar.gz'
+  sha256 '62f0f8be5497c2d0098238c54e881ac001cd84fce442c2506ab6d37aa2f698f0'
 
-  head 'https://github.com/apenwarr/sshuttle.git'
+  head 'https://github.com/sshuttle/sshuttle.git'
+
+  #Pre-Yosemite support dropped in sshuttle 0.7.1
+  if MacOS.version < :yosemite
+	url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.70.tar.gz'
+	sha256 'b6fd3468f80db18fb33276881facc59e113745da049d3346b5e604dc55675588'
+  end
 
   def install
     # Building the docs requires installing
     # markdown & BeautifulSoup Python modules
     # so we don't.
-    libexec.install Dir['*']
+    libexec.install Dir['src/*']
     bin.write_exec_script libexec/'sshuttle'
   end
 end


### PR DESCRIPTION
Bump version and now pointing to the repository maintained by the community[1].
This version supports Yosemite[2] but drops support for the older OSX releases, the formula selects the release 0.7.0 when installed on older OSX.
I had to add a specific version check with an If for that, let me know if there are better ways to manage this situation.

[1] https://github.com/sshuttle/sshuttle
[2] https://github.com/sshuttle/sshuttle/pull/3