### PR TITLE
brew-pull: use pkg_version when publishing bottles

### DIFF
--- a/Library/Homebrew/bottles.rb
+++ b/Library/Homebrew/bottles.rb
@@ -55,10 +55,6 @@ class Bintray
     return "bottles" if tap.to_s.empty?
     "bottles-#{tap.sub(/^homebrew\/(homebrew-)?/i, "")}"
   end
-
-  def self.version(path)
-    BottleVersion.parse(path).to_s
-  end
 end
 
 class BottleCollector

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -170,8 +170,7 @@ module Homebrew
           changed_formulae.each do |f|
             ohai "Publishing on Bintray:"
             package = Bintray.package f.name
-            bottle = Bottle.new(f, f.bottle_specification)
-            version = Bintray.version(bottle.url)
+            version = f.pkg_version
             curl "--silent", "--fail",
               "-u#{bintray_user}:#{bintray_key}", "-X", "POST",
               "https://api.bintray.com/content/homebrew/#{repo}/#{package}/#{version}/publish"

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -771,8 +771,14 @@ module Homebrew
       formula_packaged = {}
 
       Dir.glob("*.bottle*.tar.gz") do |filename|
-        version = Bintray.version filename
         formula_name = bottle_filename_formula_name filename
+        canonical_formula_name = if tap
+          "#{tap}/#{formula_name}"
+        else
+          formula_name
+        end
+        formula = Formulary.factory canonical_formula_name
+        version = formula.pkg_version
         bintray_package = Bintray.package formula_name
         existing_bottle = existing_bottles[formula_name]
 


### PR DESCRIPTION
When formula gets bottled in the first time, there won't be a tag available.
Instead, <del>we insert a fake tag to help the version detection process.</del> We use `pkg_version` directly.

Related PR #38583.

Before the patch:
```
==> Publishing on Bintray:
Error: Failure while executing: /usr/bin/curl -f#LA Homebrew\ 0.9.5\ (Ruby\ 2.0.0-481;\ Mac\ OS\ X\ 10.10.3) --silent --fail -u***:*** -X POST https://api.bintray.com/content/homebrew/bottles/mkcue/1..bottle/publish
```

After the patch:
```
==> Publishing on Bintray:
{"files":3}
```
