### PR TITLE
gcc: Work around broken bootstrap with Xcode 6.3

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -101,6 +101,9 @@ class Gcc < Formula
       "--enable-stage1-checking",
       "--enable-checking=release",
       "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
       # A no-op unless --HEAD is built because in head warnings will
       # raise errors. But still a good idea to include.
       "--disable-werror",


### PR DESCRIPTION
As reported in #38501, Xcode 6.3 broke the `gcc` formula. This workaround fixes this by altering the mode of comparison during the bootstrap phase. Comparison of object files with full debug information is replaced by comparison of stripped object files. I believe this workaround to be relatively safe, as the issue is only an inconsistency in the debug information.