### PR TITLE
dpkg 1.17.25

### DIFF
--- a/Library/Formula/dpkg.rb
+++ b/Library/Formula/dpkg.rb
@@ -1,8 +1,8 @@
 class Dpkg < Formula
   homepage "https://wiki.debian.org/Teams/Dpkg"
-  url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.17.21.tar.xz"
-  mirror "http://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.17.21.tar.xz"
-  sha256 "3ed776627181cb9c1c9ba33f94a6319084be2e9ec9c23dd61ce784c4f602cf05"
+  url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
+  mirror "http://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
+  sha256 "07019d38ae98fb107c79dbb3690cfadff877f153b8c4970e3a30d2e59aa66baa"
 
   bottle do
     sha1 "15101b6619ae657e7d59e72d30155dd6fd7498fd" => :yosemite
@@ -12,33 +12,25 @@ class Dpkg < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gnu-tar"
-  depends_on "xz"
-
-  # Fixes the PERL_LIBDIR and MD5/SHA tool names & usage. Reported upstream:
-  # https://lists.debian.org/debian-dpkg/2014/11/msg00024.html
-  # https://lists.debian.org/debian-dpkg/2014/11/msg00027.html
-  patch do
-    url "https://raw.githubusercontent.com/DomT4/scripts/master/Homebrew_Resources/dpkg/dpkgosx.diff"
-    sha1 "b74e5a0738bd4f6e8244d49b04ed9cb44bf5de6e"
-  end
+  depends_on "xz" # For LZMA
 
   def install
-    # There was a commit merged prior to this release that forgot to add ; to the end of function lines
-    # Consequently = Build failure. Put the ; in here to fix the issue.
-    # Also removes a function left over from previous refactoring which causes issues now.
-    # This will all be in the 1.17.22 release.
-    # https://lists.debian.org/debian-dpkg/2014/11/msg00029.html
-    inreplace "lib/dpkg/fdio.c" do |s|
-      s.gsub! "fs_preallocate_setup(&fs, F_ALLOCATECONTIG, offset, len);", "fd_preallocate_setup(&fs, F_ALLOCATECONTIG, offset, len);"
-      s.gsub! "fs_preallocate_setup(&fs, F_ALLOCATEALL, offset, len);", "fd_preallocate_setup(&fs, F_ALLOCATEALL, offset, len);"
-      s.gsub! "rc = fcntl(fd, F_PREALLOCATE, &fs)", "rc = fcntl(fd, F_PREALLOCATE, &fs);"
+    # Fix for OS X checksum utility names.
+    inreplace "scripts/Dpkg/Checksums.pm" do |s|
+      s.gsub! "md5sum", "md5"
+      s.gsub! "sha1sum", "shasum"
+      s.gsub! "sha256sum", "'shasum', '-a', '256'"
     end
 
     # We need to specify a recent gnutar, otherwise various dpkg C programs will
     # use the system "tar", which will fail because it lacks certain switches.
     ENV["TAR"] = Formula["gnu-tar"].opt_bin/"gtar"
+    ENV["PERL_LIBDIR"] = lib/"perl5/site_perl"
     system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--localstatedir=#{var}",
                           "--disable-dselect",
                           "--disable-linker-optimisations",
                           "--disable-start-stop-daemon",
@@ -56,11 +48,11 @@ class Dpkg < Formula
   test do
     # Do not remove the empty line from the end of the control file
     # All deb control files MUST end with an empty line
-    mkdir_p "test/DEBIAN"
-    mkdir_p "test/data"
-    touch "test/data/empty.txt"
+    (testpath/"test/data/homebrew.txt").write <<-EOS.undent
+      Homebrew was here.
+    EOS
 
-    (testpath/"test"/"DEBIAN"/"control").write <<-EOS.undent
+    (testpath/"test/DEBIAN/control").write <<-EOS.undent
       Package: test
       Version: 1.40.99
       Architecture: amd64
@@ -68,7 +60,11 @@ class Dpkg < Formula
       Maintainer: Dpkg Developers <test@test.org>
 
     EOS
-    system "#{bin}/dpkg", "-b", testpath/"test", "test.deb"
+    system bin/"dpkg", "-b", testpath/"test", "test.deb"
     assert File.exist?("test.deb")
+
+    rm_rf "test"
+    system bin/"dpkg", "-x", "test.deb", testpath
+    assert File.exist?("data/homebrew.txt")
   end
 end


### PR DESCRIPTION
Version bump.

Upstream allows us to specify the PERL_LIBDIR now so the patch is gone. The checksum utilities are still hardcoded, but that part of the patch has been replaced with an `inreplace`.

Beefed up the test a bit as well.