### PR TITLE
gnutls: tweak postinstall

### DIFF
--- a/Library/Formula/gnutls.rb
+++ b/Library/Formula/gnutls.rb
@@ -52,7 +52,14 @@ class Gnutls < Formula
   end
 
   def post_install
-    Formula["openssl"].post_install
+    keychains = %w[
+      /Library/Keychains/System.keychain
+      /System/Library/Keychains/SystemRootCertificates.keychain
+    ]
+
+    openssldir = etc/"openssl"
+    openssldir.mkpath
+    (openssldir/"cert.pem").atomic_write `security find-certificate -a -p #{keychains.join(" ")}`
   end
 
   test do


### PR DESCRIPTION
Since we’ve had to stick a temporary patch to OpenSSL’s postinstall pending Apple’s response on the Equifax situation, GnuTLS which leans on the OpenSSL formula to do postinstall is blowing up on every Yosemite test-bot that calls GnuTLS as a dep.

```
==> Downloading
https://www.geotrust.com/resources/root_certificates/certificates/Equifax_Secure_Certificate_Authority.pem
Already downloaded: /Library/Caches/Homebrew/openssl--Equifax_CA-Secure.pem
==> Verifying openssl--Equifax_CA-Secure.pem checksum
==> /usr/local/Cellar/openssl/1.0.2a-1/bin/c_rehash
Failed to execute: /usr/local/Cellar/openssl/1.0.2a-1/bin/c_rehash
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall gnutls`
```

This works around that for now to stop the bot flagging failures everywhere.