### PR TITLE
rtmpdump 2.4+20150115

### DIFF
--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -4,10 +4,9 @@ require 'formula'
 # http://livestreamer.tanuki.se/en/latest/issues.html#installed-rtmpdump-does-not-support-jtv-argument
 class Rtmpdump < Formula
   homepage 'http://rtmpdump.mplayerhq.hu'
-  url 'http://ftp.de.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20131018.git79459a2.orig.tar.gz'
-  version '2.4+20131018'
-  sha1 '17decff9d16bbcf45f622ca8ee2400c46c277500'
-  revision 1
+  url 'http://ftp.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20150115.gita107cef.orig.tar.gz'
+  version '2.4+20150115'
+  sha256 'd47ef3a07815079bf73eb5d053001c4341407fcbebf39f34e6213c4b772cb29a'
 
   bottle do
     cellar :any
@@ -36,5 +35,9 @@ class Rtmpdump < Formula
                    "prefix=#{prefix}",
                    "sbindir=#{bin}",
                    "install"
+  end
+
+  test do
+    system "#{bin}/rtmpdump", "-h"
   end
 end


### PR DESCRIPTION
Also upgraded hash to SHA-256 and added a simple test (just calling the binary with the `-h` help option).

The old URI is obsolete, returning a 404 upon request, since apparently Debian has removed the outdated version. So the formula won't even install in its current form. This PR fixes that with the current version in Debian.

The reason for using the tarball from Debian is because the upstream stopped cutting and tarballing releases and encouraged to do git check outs instead (since around 2010), and the last release tarball from upstream is badly outdated and contains critical bugs.