### PR TITLE
bottle: discard bottle revision from prior pkg_version

### DIFF
--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -130,8 +130,9 @@ module Homebrew
     else
       ohai "Determining #{f.name} bottle revision..."
       versions = FormulaVersions.new(f)
-      max = versions.bottle_version_map("origin/master")[f.pkg_version].max
-      bottle_revision = max ? max + 1 : 0
+      bottle_revisions = versions.bottle_version_map("origin/master")[f.pkg_version]
+      bottle_revisions.pop if bottle_revisions.last > 0
+      bottle_revision = bottle_revisions.any? ? bottle_revisions.max + 1 : 0
     end
 
     filename = Bottle::Filename.create(f, bottle_tag, bottle_revision)


### PR DESCRIPTION
When a formula is upgraded, the old bottle revision for the previous pkg_version will carry over to the next pkg_version before the bot resets it to zero. This can result in an extra non-zero bottle revision X which will increment from 0->X+1 for the next bottle. See R for example: https://github.com/Homebrew/homebrew-science/pull/2077#issuecomment-91285659.

Octave is another test case:

```ruby
>> pp(FormulaVersions.new(Formula["octave"]).bottle_version_map("origin/master"))
{#<PkgVersion:0x007f8d2ba2db08
  @revision=0,
  @version=#<Version::FromURL:0x007f8d2ba2dba8 @version="3.8.2">>=>
  [0, 4],
 #<PkgVersion:0x007f8d2ba5e730
  @revision=1,
  @version=#<Version::FromURL:0x007f8d2ba5e898 @version="3.8.1">>=>
  [4, 4, 3, 3, 3, 2, 2, 1, 1, 1, 0, 0]}
```

Before: 
```
==> Determining octave bottle revision...
==> Bottling octave-3.8.2.yosemite.bottle.5.tar.gz...
```
After:
```
==> Determining octave bottle revision...
==> Bottling octave-3.8.2.yosemite.bottle.1.tar.gz...
```