### PR TITLE
Change dependency for CasperJS

### DIFF
--- a/Library/Formula/casperjs.rb
+++ b/Library/Formula/casperjs.rb
@@ -13,7 +13,7 @@ class Casperjs < Formula
 
   head 'https://github.com/n1k0/casperjs.git'
 
-  depends_on 'phantomjs'
+  depends_on 'homebrew/versions/phantomjs198'
 
   def install
     libexec.install Dir['*']


### PR DESCRIPTION
CasperJS does not support PhantomJS 2.0 now.