### PR TITLE
add option to build ffmpeg without jack

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -15,8 +15,8 @@ class Ffmpeg < Formula
   option "without-lame", "Disable MP3 encoder"
   option "without-libvo-aacenc", "Disable VisualOn AAC encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
-  option "without-qtkit", "Disable deprecated QuickTime framework"
-  option "without-jack", "Disable Jack"
+  option "with-qtkit", "Enable deprecated QuickTime framework"
+  option "with-jack", "Enable Jack"
 
   option "with-rtmpdump", "Enable RTMP protocol"
   option "with-libass", "Enable ASS/SSA subtitle format"
@@ -111,8 +111,8 @@ class Ffmpeg < Formula
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
-    args << "--disable-indev=qtkit" if build.without? "qtkit"
-    args << "--disable-indev=jack" if build.without? "jack"
+    args << "--enable-indev=qtkit" if build.with? "qtkit"
+    args << "--enable-indev=jack" if build.with? "jack"
 
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -16,6 +16,7 @@ class Ffmpeg < Formula
   option "without-libvo-aacenc", "Disable VisualOn AAC encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
   option "without-qtkit", "Disable deprecated QuickTime framework"
+  option "without-jack", "Disable Jack"
 
   option "with-rtmpdump", "Enable RTMP protocol"
   option "with-libass", "Enable ASS/SSA subtitle format"
@@ -111,6 +112,7 @@ class Ffmpeg < Formula
     args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
+    args << "--disable-indev=jack" if build.without? "jack"
 
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -15,8 +15,7 @@ class Ffmpeg < Formula
   option "without-lame", "Disable MP3 encoder"
   option "without-libvo-aacenc", "Disable VisualOn AAC encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
-  option "with-qtkit", "Enable deprecated QuickTime framework"
-  option "with-jack", "Enable Jack"
+  option "without-qtkit", "Disable deprecated QuickTime framework"
 
   option "with-rtmpdump", "Enable RTMP protocol"
   option "with-libass", "Enable ASS/SSA subtitle format"
@@ -32,6 +31,7 @@ class Ffmpeg < Formula
   option "with-x265", "Enable x265 encoder"
   option "with-libsoxr", "Enable the soxr resample library"
   option "with-webp", "Enable using libwebp to encode WEBP images"
+  option "with-jack", "Enable Jack"
 
   depends_on "pkg-config" => :build
 
@@ -111,7 +111,7 @@ class Ffmpeg < Formula
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
-    args << "--enable-indev=qtkit" if build.with? "qtkit"
+    args << "--disable-indev=qtkit" if build.without? "qtkit"
     args << "--enable-indev=jack" if build.with? "jack"
 
     if build.with? "openjpeg"


### PR DESCRIPTION
Last ffmpeg version build ffmpeg with jack dependency which makes impossible to deploy my software on non dev machine. This new option enable the possibility to build ffmpeg without jack. This PR is very similar to this: https://github.com/Homebrew/homebrew/commit/5972821454017ab4900fe13b05d37a7fae319822