### PR TITLE
libmongoclient-legacy: add 1.0.1 legacy branch.

### DIFF
--- a/Library/Formula/libmongoclient-legacy.rb
+++ b/Library/Formula/libmongoclient-legacy.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class LibmongoclientLegacy < Formula
   homepage "http://www.mongodb.org"
   url "https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.1.tar.gz"
-  sha1 "356dafe8e8ca7fcd58e7da1e812470305c1fc0db"
+  sha256 "29ffbf3674192e1cb47af7ad620b9b0c1e60716033c6c342a3f935f3ce79c59e"
 
   head "https://github.com/mongodb/mongo-cxx-driver.git", :branch => "legacy"
 
@@ -33,7 +31,7 @@ class LibmongoclientLegacy < Formula
       # by SConstruct which causes "invalid deployment target for -stdlib=libc++"
       # when using libc++
       "--osx-version-min=#{MacOS.version}",
-      "install"
+      "install",
     ]
 
     args << "--libc++" if MacOS.version >= :mavericks
@@ -41,5 +39,3 @@ class LibmongoclientLegacy < Formula
     scons *args
   end
 end
-
-__END__

--- a/Library/Formula/libmongoclient-legacy.rb
+++ b/Library/Formula/libmongoclient-legacy.rb
@@ -38,4 +38,6 @@ class LibmongoclientLegacy < Formula
 
     scons *args
   end
+  test do
+  end
 end

--- a/Library/Formula/libmongoclient-legacy.rb
+++ b/Library/Formula/libmongoclient-legacy.rb
@@ -1,0 +1,45 @@
+require "formula"
+
+class LibmongoclientLegacy < Formula
+  homepage "http://www.mongodb.org"
+  url "https://github.com/mongodb/mongo-cxx-driver/archive/legacy-1.0.1.tar.gz"
+  sha1 "356dafe8e8ca7fcd58e7da1e812470305c1fc0db"
+
+  head "https://github.com/mongodb/mongo-cxx-driver.git", :branch => "legacy"
+
+  option :cxx11
+
+  depends_on "scons" => :build
+
+  if build.cxx11?
+    depends_on "boost" => "c++11"
+  else
+    depends_on "boost"
+  end
+
+  def install
+    ENV.cxx11 if build.cxx11?
+
+    boost = Formula["boost"].opt_prefix
+
+    args = [
+      "--prefix=#{prefix}",
+      "-j#{ENV.make_jobs}",
+      "--cc=#{ENV.cc}",
+      "--cxx=#{ENV.cxx}",
+      "--extrapath=#{boost}",
+      "--sharedclient",
+      # --osx-version-min is required to override --osx-version-min=10.6 added
+      # by SConstruct which causes "invalid deployment target for -stdlib=libc++"
+      # when using libc++
+      "--osx-version-min=#{MacOS.version}",
+      "install"
+    ]
+
+    args << "--libc++" if MacOS.version >= :mavericks
+
+    scons *args
+  end
+end
+
+__END__


### PR DESCRIPTION
This formula contains **legacy** stable branch of mongo-cxx-driver, while *libmongoclient* formula contains **26compat** branch.