### PR TITLE
mysql-connector-c 6.1.6

### DIFF
--- a/Library/Formula/mysql-connector-c.rb
+++ b/Library/Formula/mysql-connector-c.rb
@@ -1,14 +1,12 @@
-require 'formula'
-
 class MysqlConnectorC < Formula
-  homepage 'http://dev.mysql.com/downloads/connector/c/'
-  url 'http://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.3-src.tar.gz'
-  sha1 'd70392aafb9ddeddd797c8131898e8727f904898'
+  homepage "http://dev.mysql.com/downloads/connector/c/"
+  url "http://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.6-src.tar.gz"
+  sha256 "2222433012c415871958b61bc4f3683e1ebe77e3389f698b267058c12533ea78"
 
-  depends_on 'cmake' => :build
+  depends_on "cmake" => :build
 
-  conflicts_with 'mysql', 'mariadb', 'percona-server',
-    :because => 'both install MySQL client libraries'
+  conflicts_with "mysql", "mariadb", "percona-server",
+    :because => "both install MySQL client libraries"
 
   fails_with :llvm do
     build 2334
@@ -17,8 +15,14 @@ class MysqlConnectorC < Formula
 
   def install
     system "cmake", ".", *std_cmake_args
-    system 'make'
+    system "make"
     ENV.j1
-    system 'make install'
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/mysql_config", "--cflags"
+    system "#{bin}/mysql_config", "--include"
+    system "#{bin}/mysql_config", "--libs"
   end
 end


### PR DESCRIPTION
Also modernize the formula following ``brew audit --strict``:
- remove `require 'formula'`
- use sha256
- replace single quotes with double quotes

And add a simple test.