### PR TITLE
rubocop: update for 0.30.0

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -10,6 +10,14 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
     EnforcedStyle: double_quotes
 
+# percent-x is allowed for multiline
+Style/CommandLiteral:
+    EnforcedStyle: mixed
+
+# paths abound, easy escape
+Style/RegexpLiteral:
+    EnforcedStyle: slashes
+
 # no metrics for formulas
 Metrics/AbcSize:
     Enabled: false
@@ -47,10 +55,6 @@ Style/EmptyLineBetweenDefs:
 # port numbers and such tech stuff
 Style/NumericLiterals:
     Enabled: false
-
-# paths abound, easy escape
-Style/RegexpLiteral:
-    MaxSlashes: 0
 
 # consistency and readability when faced with string interpolation
 Style/PercentLiteralDelimiters:
@@ -99,12 +103,6 @@ Style/FileName:
 Style/WordArray:
     Enabled: false
 Style/UnneededCapitalW:
-    Enabled: false
-
-# percent-x is allowed for multiline
-# TODO: enforce when rubocop has fixed this
-# https://github.com/bbatsov/rubocop/issues/1397
-Style/UnneededPercentX:
     Enabled: false
 
 # TODO: rubocop bug regarding __END__


### PR DESCRIPTION
v0.30.0 has killed a couple of the methods being used and is throwing warnings around like candy at Halloween. This switches to the new methods.

Rubocops are obviously a matter of choice, and I’ve added choice here based on what was said in previous PRs and my own personal views on readability. Happy to be told to change things to different variables.

For upstream detail, see:

* https://github.com/bbatsov/rubocop/blob/master/relnotes/v0.30.0.md#changes
* https://github.com/bbatsov/rubocop/pull/1721/files
* https://github.com/bbatsov/rubocop/pull/1655/files