### PR TITLE
Revert "brew pull: add automatic tap repair"

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -187,8 +187,6 @@ module Homebrew
       ohai 'Patch changed:'
       safe_system "git", "diff-tree", "-r", "--stat", revision, "HEAD"
 
-      safe_system "brew", "tap", "--repair" if tap_name
-
       if ARGV.include? '--install'
         changed_formulae.each do |f|
           ohai "Installing #{f.name}"


### PR DESCRIPTION
This reverts commit bcd34ded9e4b17b8658b7ae947cd392a4e5942c0.

Mea Culpa on this. My apologies.

It's working fine locally, but for some reason it's failing *every* single Homebrew/versions bottle build on the ` --repair ` step and I presume that's happening for other taps as well. Needs to be reverted unless we can stop it happening on the bot alone.

```
Error: Failure while executing: brew tap --repair
Error: Failure while executing: brew pull --clean https://github.com/Homebrew/homebrew-versions/pull/774
Build step 'Execute shell' marked build as failure
```