### PR TITLE
tractorgen (fixed URLs)

### DIFF
--- a/Library/Formula/tractorgen.rb
+++ b/Library/Formula/tractorgen.rb
@@ -1,13 +1,12 @@
 require 'formula'
 
 class Tractorgen < Formula
-  homepage 'http://www.vergenet.net/~conrad/software/tractorgen/'
-  url 'http://www.vergenet.net/~conrad/software/tractorgen/dl/tractorgen-0.31.7.tar.gz'
+  homepage 'http://www.kfish.org/software/tractorgen/'
+  url 'http://www.kfish.org/software/tractorgen/dl/tractorgen-0.31.7.tar.gz'
   sha1 '7d5d0c84a030a71840ee909b2124797b5281ddcc'
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
 end


### PR DESCRIPTION
Old URLs are now 404s. Also removed unnecessary `configure` flags.