### PR TITLE
rust with cargo

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -1,18 +1,44 @@
-require 'formula'
-
 class Rust < Formula
   homepage 'http://www.rust-lang.org/'
-  url 'https://static.rust-lang.org/dist/rustc-1.0.0-beta.3-src.tar.gz'
   version "1.0.0-beta.3"
-  sha256 'e751bc8a8ad236c8865697f866b2863e224af56b0194ddf9f3edd71f9ff6545f'
 
-  head 'https://github.com/rust-lang/rust.git'
+  stable do
+    url 'https://static.rust-lang.org/dist/rustc-1.0.0-beta.3-src.tar.gz'
+    sha256 'e751bc8a8ad236c8865697f866b2863e224af56b0194ddf9f3edd71f9ff6545f'
+
+    resource "cargo" do
+      url "https://github.com/rust-lang/cargo.git", :revision => "83a6d0ed8208d31a1f6dab5e5183ad9eb2d65eaf", :tag => "0.2.0"
+    end
+
+    # name includes date to satisfy cache
+    resource "cargo-nightly-2015-04-02" do
+      url "https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/2015-04-02/cargo-nightly-x86_64-apple-darwin.tar.gz"
+      sha256 "18647dccb34acb6085a04b0ea1bfb9d150dc9c17f7829932ddf7e62d518df2fe"
+    end
+
+    # name includes date to satisfy cache
+    resource "rustc-nightly-2015-04-04" do
+      url "https://static-rust-lang-org.s3.amazonaws.com/dist/2015-04-04/rustc-nightly-x86_64-apple-darwin.tar.gz"
+      sha256 "87068b325802fee65a388d249b98a184aff7670140133de78560ef375bae70a5"
+    end
+  end
+
+  head do
+    url "https://github.com/rust-lang/rust.git"
+    resource "cargo" do
+      url "https://github.com/rust-lang/cargo.git"
+    end
+  end
 
   bottle do
     sha256 "60450a633c8c5f42e208b647699fd872e594fd5475f460b0367bbbf02063a466" => :yosemite
     sha256 "1c265ffd3c678acd05b6525c2de6730881b540d1b8419f2b496cf244b46d88c2" => :mavericks
     sha256 "2385a4baa211953a94bb93f5ce6f5ca5d5826f3e1d7c0d12310e78c5571f3c89" => :mountain_lion
   end
+
+  depends_on "openssl"
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
 
   def install
     args = ["--prefix=#{prefix}"]
@@ -22,6 +48,37 @@ class Rust < Formula
     system "./configure", *args
     system "make"
     system "make install"
+
+    resource("cargo").stage do
+      cargo_stage_path = pwd
+
+      if build.stable?
+        resource("rustc-nightly-2015-04-04").stage do
+          system "./install.sh", "--prefix=#{cargo_stage_path}/rustc"
+        end
+
+        resource("cargo-nightly-2015-04-02").stage do
+          system "./install.sh", "--prefix=#{cargo_stage_path}/target/snapshot/cargo"
+          # satisfy make target to skip download
+          touch "#{cargo_stage_path}/target/snapshot/cargo/bin/cargo"
+        end
+      end
+
+      args = ["--prefix=#{prefix}"]
+
+      if build.head?
+        args << "--local-rust-root=#{prefix}"
+      else
+        args << "--local-rust-root=#{cargo_stage_path}/rustc"
+      end
+
+      system "./configure", *args
+      system "make"
+      system "make", "install"
+    end
+
+    rm_rf prefix/"lib/rustlib/uninstall.sh"
+    rm_rf prefix/"lib/rustlib/install.log"
   end
 
   test do
@@ -33,5 +90,8 @@ class Rust < Formula
     EOS
     system "#{bin}/rustc", "hello.rs"
     assert_equal "Hello World!\n", `./hello`
+    system "#{bin}/cargo", "new", "hello_world", "--bin"
+    assert_equal "Hello, world!",
+                 (testpath/"hello_world").cd { `#{bin}/cargo run`.split("\n").last }
   end
 end


### PR DESCRIPTION
This follows discussion on #33322, where it has been hypothesized that
the best course of action may very well be to include cargo in the rust
formula. Reasons include:

- upstream packages releases with cargo
- cargo has no formal versioning rules, merely binding a particular
  cargo nightly to a given rust release
- cargo needs a non feature-gated rust to build
- cargo needs to fetch cargo to bootstrap itself (at the make stage)

The most practical way to get the cargo version bound to a rust release
is to download a binary rust release and run cargo -V, which shows the
SHA1 it was built from. This is what has been done for the beta.

Alternatively, building with --HEAD relaxes all version constrains and
builds both from their respective master HEADs.

Curl is a dependency of .travis.install.deps.sh while both curl and
python are a dependency of make (via src/etc/dl-snapshot.py) to download
a cargo snapshot. Each one makes respective use of a src/rustversion.txt
and a src/snapshots.txt file, combined with some very lighteight
processing, to find the required downloads.

Thus it may be possible to include fetched downloads as resources to
improve cacheability and reduce the dependency profile, but this
requires patching of .travis.install.deps.sh, that currently
unconditionally downloads its stuff. Simply putting the cargo snapshot
in the right place ($(TARGET_ROOT)/snapshot/cargo) will certainly make
the makefile happy, as long as the proper filename unmangling is done
(see src/etc/dl-snapshot.py). Still, configure wants to probe for
python. Staying KISS, no patching has been done here: make it work, make
it right, make it fast.