### PR TITLE
gst-validate: add python depends

### DIFF
--- a/Library/Formula/gst-validate.rb
+++ b/Library/Formula/gst-validate.rb
@@ -19,6 +19,7 @@ class GstValidate < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
+  depends_on "python"
   depends_on "gobject-introspection"
   depends_on "gstreamer"
   depends_on "gst-plugins-base"


### PR DESCRIPTION
gobject-introspection had a dependency with python2, but it was removed at c6731dd.
gst-validate has a dependency with gobject-introspection use python2 in shebangs.
issue #38669