### PR TITLE
.gitignore: remove unnecessary rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@
 !/LICENSE.txt
 !/README.md
 !/SUPPORTERS.md
-!/bin
-/bin/*
 !/bin/brew
 !/share/doc/homebrew
 !/share/man/man1/brew.1


### PR DESCRIPTION
It can also prevent `unisntall` script treating `bin/` as brew files.