### PR TITLE
Clang-omp: Added C++ Support, minor code cleanup

### DIFF
--- a/Library/Formula/clang-omp.rb
+++ b/Library/Formula/clang-omp.rb
@@ -4,12 +4,6 @@ class ClangOmp < Formula
   version "2015-04-01"
   sha256 "37f990ad99b3213507ec88f86702c5a057ce397cc16638eeee5c88906572daec"
 
-  bottle do
-    sha256 "ed23f2f98cd280c73f53c31a281a3baee6a7e89cdd2f6f1388502fae6ea043fe" => :yosemite
-    sha256 "de14d6887271d0926d0ef4b3eb5f74366955d92d7de231a9ba8c71ce6f8443d1" => :mavericks
-    sha256 "7d58ef5113604b044c916dcb1920157d77247eb60e0c508a67d285e139b576e0" => :mountain_lion
-  end
-
   depends_on "libiomp"
   depends_on "cmake" => :build
 
@@ -23,16 +17,27 @@ class ClangOmp < Formula
     sha256 "2717115e5ba491e3b8119311f0d792420ba41be34a89733b9880eb3d3c09fbe5"
   end
 
+  resource "libcxx" do
+    url "https://github.com/llvm-mirror/libcxx/archive/release_35.tar.gz"
+    sha256 "df23b356ae1953de671d1dc9093568330e074bbe48cd6d93d16173a793550c71"
+  end
+
   needs :cxx11
 
   def install
-    resource("compiler-rt").stage { (buildpath/"projects/compiler-rt").install Dir["*"] }
-    resource("clang").stage { (buildpath/"tools/clang").install Dir["*"] }
+    (buildpath/"projects/compiler-rt").install resource("compiler-rt")
+    (buildpath/"tools/clang").install resource("clang")
+	(buildpath/"projects/libcxx").install resource "libcxx"
 
     system "./configure", "--prefix=#{libexec}", "--enable-cxx11", "--enable-libcpp"
+    system "make"
     system "make", "install"
 
+    system "make", "-C", "projects/libcxx", "install",
+      "DSTROOT=#{prefix}", "SYMROOT=#{buildpath}/projects/libcxx"
+
     bin.install_symlink libexec/"bin/clang" => "clang-omp"
+    bin.install_symlink libexec/"bin/clang" => "clang-omp++" 
   end
 
   test do

--- a/Library/Formula/clang-omp.rb
+++ b/Library/Formula/clang-omp.rb
@@ -27,7 +27,7 @@ class ClangOmp < Formula
   def install
     (buildpath/"projects/compiler-rt").install resource("compiler-rt")
     (buildpath/"tools/clang").install resource("clang")
-	(buildpath/"projects/libcxx").install resource "libcxx"
+    (buildpath/"projects/libcxx").install resource "libcxx"
 
     system "./configure", "--prefix=#{libexec}", "--enable-cxx11", "--enable-libcpp"
     system "make"

--- a/Library/Formula/clang-omp.rb
+++ b/Library/Formula/clang-omp.rb
@@ -4,6 +4,12 @@ class ClangOmp < Formula
   version "2015-04-01"
   sha256 "37f990ad99b3213507ec88f86702c5a057ce397cc16638eeee5c88906572daec"
 
+  bottle do
+    sha256 "ed23f2f98cd280c73f53c31a281a3baee6a7e89cdd2f6f1388502fae6ea043fe" => :yosemite
+    sha256 "de14d6887271d0926d0ef4b3eb5f74366955d92d7de231a9ba8c71ce6f8443d1" => :mavericks
+    sha256 "7d58ef5113604b044c916dcb1920157d77247eb60e0c508a67d285e139b576e0" => :mountain_lion
+  end
+
   depends_on "libiomp"
   depends_on "cmake" => :build
 
@@ -37,7 +43,7 @@ class ClangOmp < Formula
       "DSTROOT=#{prefix}", "SYMROOT=#{buildpath}/projects/libcxx"
 
     bin.install_symlink libexec/"bin/clang" => "clang-omp"
-    bin.install_symlink libexec/"bin/clang" => "clang-omp++" 
+    bin.install_symlink libexec/"bin/clang" => "clang-omp++"
   end
 
   test do


### PR DESCRIPTION
If one attempts to compile any C++ code with clang built using the clang-omp formula, it will not find the header files or standard libraries.  

I have made modifications to address this in the same way the llvm formula does if it is built with clang.  I also cleaned up the resource installation lines and had the formula install a clang-omp++ symlink in addtion to clang-omp.  I know this is redundant, as they both just point to clang, but many developers are used to seeing clang and clang++ for their CC and CXX compilers, so I thought this would give a more familiar work flow.

Thanks!