### PR TITLE
linkapps: output nothing if no apps exist

### DIFF
--- a/Library/Homebrew/cmd/linkapps.rb
+++ b/Library/Homebrew/cmd/linkapps.rb
@@ -25,7 +25,7 @@ module Homebrew
     kegs.each do |keg|
       keg = keg.opt_record if keg.optlinked?
       Dir["#{keg}/*.app", "#{keg}/bin/*.app", "#{keg}/libexec/*.app"].each do |app|
-        puts "Linking #{app}"
+        puts "Linking #{app} to #{target_dir}."
         app_name = File.basename(app)
         target = "#{target_dir}/#{app_name}"
 
@@ -33,10 +33,9 @@ module Homebrew
           onoe "#{target} already exists, skipping."
           next
         end
+
         system "ln", "-sf", app, target_dir
       end
     end
-
-    puts "Finished linking. Find the links under #{target_dir}."
   end
 end


### PR DESCRIPTION
The standard message can be somewhat confusing (#38695) in that it outputs “finished linking” language regardless of whether an app is actually present/linked or not.

This solution just stops it saying anything if there’s no app in the directory. It needs a little tidying in the output here probably, but it’s a discussion point.

Changes:

```
Linking /usr/local/opt/fontforge/FontForge.app
Linking /usr/local/opt/pinentry-mac/pinentry-mac.app
Linking /usr/local/opt/python/IDLE.app
Linking /usr/local/opt/python/Python Launcher.app
Linking /usr/local/opt/python3/IDLE 3.app
Linking /usr/local/opt/python3/Python Launcher 3.app
Finished linking. Find the links under /Applications.
```

Into:

```
Linking /usr/local/opt/fontforge/FontForge.app to /Applications.
Linking /usr/local/opt/pinentry-mac/pinentry-mac.app to /Applications.
Linking /usr/local/opt/python/IDLE.app to /Applications.
Linking /usr/local/opt/python/Python Launcher.app to /Applications.
Linking /usr/local/opt/python3/IDLE 3.app to /Applications.
Linking /usr/local/opt/python3/Python Launcher 3.app to /Applications.
```

And:

```
brew linkapps automake
Finished linking. Find the links under /Applications.
```

Into, well, no response, since ` automake ` doesn't ship an ` app `.
