### PR TITLE
Create ActiveMQ plist, fix #38713

### DIFF
--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -11,7 +11,33 @@ class Activemq < Formula
     (bin/"activemq").write_env_script libexec/"bin/activemq", Language::Java.java_home_env("1.6+")
     (bin/"activemq-admin").write_env_script libexec/"bin/activemq-admin", Language::Java.java_home_env("1.6+")
   end
-
+  
+  plist_options :manual => "activemq start"
+  
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>Program</key>
+        <string>#{opt_sbin}/activemq</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{libexec}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/activemq</string>
+          <string>start</string>
+        </array>
+      </dict>
+    </plist>
+    EOS
+  end
+  
   test do
     system "#{bin}/activemq-admin", "browse", "-h"
   end

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -22,8 +22,6 @@ class Activemq < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-        <key>Program</key>
-        <string>#{opt_bin}/activemq</string>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -23,7 +23,7 @@ class Activemq < Formula
         <key>Label</key>
         <string>#{plist_name}</string>
         <key>Program</key>
-        <string>#{opt_sbin}/activemq</string>
+        <string>#{opt_bin}/activemq</string>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -11,9 +11,9 @@ class Activemq < Formula
     (bin/"activemq").write_env_script libexec/"bin/activemq", Language::Java.java_home_env("1.6+")
     (bin/"activemq-admin").write_env_script libexec/"bin/activemq-admin", Language::Java.java_home_env("1.6+")
   end
-  
+
   plist_options :manual => "activemq start"
-  
+
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
@@ -37,7 +37,7 @@ class Activemq < Formula
     </plist>
     EOS
   end
-  
+
   test do
     system "#{bin}/activemq-admin", "browse", "-h"
   end

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -16,7 +16,7 @@ class Activemq < Formula
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
       <dict>


### PR DESCRIPTION
Fix #38713. But ActiveMQ use 61613 as broker port, whic might conflict with RabbitMQ and other MQs. There should be some hints or warnings.  