### PR TITLE
Updating docker-machine to 0.2.0

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class DockerMachine < Formula
   homepage "https://docs.docker.com/machine"
   url "https://github.com/docker/machine/archive/v0.2.0.tar.gz"
@@ -15,39 +13,17 @@ class DockerMachine < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/tools/godep" do
-    url "https://github.com/tools/godep.git", :revision => "58d90f262c13357d3203e67a33c6f7a9382f9223"
-  end
-
-  go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
-  end
-
-  go_resource "golang.org/x/tools" do
-    url "https://github.com/golang/tools.git", :revision => "473fd854f8276c0b22f17fb458aa8f1a0e2cf5f5"
-  end
-
-  go_resource "golang.org/x/crypto" do
-    url "https://github.com/golang/crypto.git", :revision => "8b27f58b78dbd60e9a26b60b0d908ea642974b6d"
-  end
-
-  go_resource "github.com/docker/machine" do
-    url "https://github.com/docker/machine.git", :revision => "8b9eaf2b6fda23550e09bde1054eeab78e5493bd"
-  end
-
   def install
-    ENV["GOPATH"] = buildpath
-    Language::Go.stage_deps resources, buildpath/"src"
+    mkdir_p buildpath/"src/github.com/docker"
+    ln_s buildpath, buildpath/"src/github.com/docker/machine"
 
-    cd "src/github.com/tools/godep" do
-      system "go", "install"
-    end
+    system "go", "build", "-o", "docker-machine"
 
-    system "./bin/godep", "go", "build", "-o", "docker-machine", "."
     bin.install "docker-machine"
   end
 
   test do
-    system bin/"docker-machine", "ls"
+    output = shell_output(bin/"docker-machine --version")
+    assert output.include? "machine version 0.2.0 (HEAD)"
   end
 end


### PR DESCRIPTION
NOTE: I removed the go_resource blocks which seemed erroneous since go build already takes care of those requirements simply by prepending the Godeps/_workspace to the GOPATH.

See: https://github.com/docker/swarm/blob/master/Dockerfile