### PR TITLE
redir: reassign version from 2.2.1_9 to 2.2.1-9

### DIFF
--- a/Library/Formula/redir.rb
+++ b/Library/Formula/redir.rb
@@ -1,7 +1,7 @@
 class Redir < Formula
   homepage "http://sammy.net/~sammy/hacks/"
   url "https://github.com/TracyWebTech/redir/archive/2.2.1-9.tar.gz"
-  version "2.2.1_9"
+  version "2.2.1-9"
   sha1 "84ae75104d79432bbc15f67e4dc2980e0912b2b6"
 
   bottle do


### PR DESCRIPTION
Version string like `2.2.1_9` can be ambiguous with revision number.