### PR TITLE
stop supporting 0_5_0 style bottle version

### DIFF
--- a/Library/Homebrew/bottle_version.rb
+++ b/Library/Homebrew/bottle_version.rb
@@ -40,10 +40,6 @@ class BottleVersion < Version
     m = /-(\d+\.(\d)+(p(\d)+)?)/.match(stem)
     return m.captures.first unless m.nil?
 
-    # e.g. 0_5_0 from disco-0_5_0.mavericks.bottle.tar.gz
-    m = /-(\d+_\d+(_\d+)+)/.match(stem)
-    return m.captures.first unless m.nil?
-
     # e.g. 20120731 from fontforge-20120731.mavericks.bottle.tar.gz
     m = /-(\d{8})/.match(stem)
     return m.captures.first unless m.nil?

--- a/Library/Homebrew/test/test_bottle_versions.rb
+++ b/Library/Homebrew/test/test_bottle_versions.rb
@@ -36,11 +36,6 @@ class BottleVersionParsingTests < Homebrew::TestCase
       '/usr/local/pazpar2-1.6.39.mavericks.bottle.tar.gz'
   end
 
-  def test_disco_style
-    assert_version_detected '0_5_0',
-      '/usr/local/disco-0_5_0.mavericks.bottle.tar.gz'
-  end
-
   def test_zpython_style
     assert_version_detected '00-5.0.5',
       '/usr/local/zpython-00-5.0.5.mavericks.bottle.tar.gz'


### PR DESCRIPTION
The original formula (disco) has been moved to use 0.5.0 style version
string. So actually no one is using such style.

Stop supporting such style, so it wouldn't be ambiguous with revision
part in `Formula#pkg_version`.