### PR TITLE
cmd/search: notification on attempted regex searches

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -61,7 +61,16 @@ module Homebrew
         end
       end
     end
-
+    metacharacters = %w[\\ | ( ) [ ] { } ^ $ * + ? .]
+    bad_regex = metacharacters.any? do |char|
+      ARGV.any? do |arg|
+        arg.include?(char) && !arg.start_with?('/')
+      end
+    end
+    if ARGV.any? && bad_regex
+      ohai "Did you mean to perform a regular expression search?"
+      ohai "Surround your query with /slashes/ to search by regex."
+    end
     raise SEARCH_ERROR_QUEUE.pop unless SEARCH_ERROR_QUEUE.empty?
   end
 


### PR DESCRIPTION
Since I'm used to grep etc where you can just surround the regular expression in quotes, I didn't realize `brew search` could even do regex searches until I looked at the code.