### PR TITLE
saltstack 2015.2.0rc2 (devel)

### DIFF
--- a/Library/Formula/saltstack.rb
+++ b/Library/Formula/saltstack.rb
@@ -2,6 +2,7 @@ class Saltstack < Formula
   homepage "http://www.saltstack.org"
   url "https://github.com/saltstack/salt/archive/v2014.7.1.tar.gz"
   sha256 "5fcf2cff700d0719b419c9cb489552645ce1287a15c7b3a8745959773d9b0dd1"
+  head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
 
   bottle do
     sha1 "4ef3922ffd2b36d775f22fce055ebf692d1e14b7" => :yosemite
@@ -9,80 +10,96 @@ class Saltstack < Formula
     sha1 "738d8efecb7b916f10acf8707822945623226524" => :mountain_lion
   end
 
-  head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
+  devel do
+    url "https://github.com/saltstack/salt/archive/v2015.2.0rc2.tar.gz"
+    sha256 "be71c1f2f9f878d5f958396620983c5981f55eaf32913e7f28c129c35f37657a"
+    version "2015.2.0rc2"
+  end
 
   depends_on :python if MacOS.version <= :snow_leopard
-  depends_on "swig" => :build
   depends_on "zeromq"
   depends_on "libyaml"
 
+  # For vendored Swig
+  depends_on "pcre" => :build
+
+  # Homebrew's swig breaks M2Crypto due to upstream's undermaintained status.
+  # https://github.com/swig/swig/issues/344
+  # https://github.com/martinpaljak/M2Crypto/issues/60
+  resource "swig304" do
+    url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
+    sha256 "410ffa80ef5535244b500933d70c1b65206333b546ca5a6c89373afb65413795"
+  end
+
   # Don't depend on Homebrew's openssl due to upstream build issues with non-system OpenSSL in M2Crypto
   # See: https://github.com/martinpaljak/M2Crypto/issues/11
-
   resource "m2crypto" do
     url "https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.22.3.tar.gz"
-    sha1 "c5e39d928aff7a47e6d82624210a7a31b8220a50"
+    sha256 "6071bfc817d94723e9b458a010d565365104f84aa73f7fe11919871f7562ff72"
+  end
+
+  resource "requests" do
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.6.0.tar.gz"
+    sha256 "1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75"
   end
 
   resource "pycrypto" do
     url "https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz"
-    sha1 "aeda3ed41caf1766409d4efc689b9ca30ad6aeb2"
+    sha256 "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
   end
 
   resource "pyyaml" do
     url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.11.tar.gz"
-    sha1 "1a2d5df8b31124573efb9598ec6d54767f3c4cd4"
+    sha256 "c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8"
   end
 
   resource "markupsafe" do
     url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
-    sha1 "cd5c22acf6dd69046d6cb6a3920d84ea66bdf62a"
+    sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
   end
 
   resource "jinja2" do
     url "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.7.3.tar.gz"
-    sha1 "25ab3881f0c1adfcf79053b58de829c5ae65d3ac"
+    sha256 "2e24ac5d004db5714976a04ac0e80c6df6e47e98c354cb2c0d82f8879d4f8fdb"
   end
 
   resource "pyzmq" do
     url "https://pypi.python.org/packages/source/p/pyzmq/pyzmq-14.3.1.tar.gz"
-    sha1 "a6cd6b0861fde75bfc85534e446364088ba97243"
+    sha256 "00e263c26a524f81127247e6f37cbf427eddf3a3657d170cf4865bd522df3914"
   end
 
   resource "msgpack-python" do
     url "https://pypi.python.org/packages/source/m/msgpack-python/msgpack-python-0.4.2.tar.gz"
-    sha1 "127ca4c63b182397123d84032ece70d43fa4f869"
+    sha256 "0476e8fdd79e5b648b349bd0edebf06e41271ee29421ef7adb12cdbe55dac2a9"
   end
 
   resource "apache-libcloud" do
     url "https://pypi.python.org/packages/source/a/apache-libcloud/apache-libcloud-0.15.1.tar.gz"
-    sha1 "0631bfa3201a5d4c3fdd3d9c39756051c1c70b0f"
-  end
-
-  resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.3.0.tar.gz"
-    sha1 "f57bc125d35ec01a81afe89f97dc75913a927e65"
+    sha256 "f12f80c2f66e46c406c53b90c41eb572c29751c407bdbe7204ec6d9264ce16bc"
   end
 
   def install
-    ENV["PYTHONPATH"] = lib+"python2.7/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python2.7/site-packages"
+    resource("swig304").stage do
+      system "./configure", "--disable-dependency-tracking", "--prefix=#{buildpath}/swig"
+      system "make"
+      system "make", "install"
+    end
 
-    resources.each do |r|
-      r.stage do
-        pyargs = ["setup.py", "install", "--prefix=#{libexec}"]
-          unless %w[pycrypto pyyaml pyzmq].include? r.name
-            pyargs << "--single-version-externally-managed" << "--record=installed.txt"
-          end
-        system "python", *pyargs
+    ENV.prepend_path "PATH", buildpath/"swig/bin"
+
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    %w[requests m2crypto pycrypto pyyaml markupsafe jinja2 pyzmq msgpack-python apache-libcloud].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
 
-    system "python", "setup.py", "install", "--prefix=#{prefix}"
-
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
     man1.install Dir["doc/man/*.1"]
     man7.install Dir["doc/man/*.7"]
 
+    bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 


### PR DESCRIPTION
* Adds devel block.
* Vendors swig304 due to upstream M2Crypto issues.
* Bump everything to SHA256.
* Modernises the Python arguments.

Closes #38608
Closes https://github.com/Homebrew/homebrew-versions/pull/770