### PR TITLE
Create Node special dependency

### DIFF
--- a/Library/Formula/emscripten.rb
+++ b/Library/Formula/emscripten.rb
@@ -1,7 +1,20 @@
 class Emscripten < Formula
   homepage "https://kripken.github.io/emscripten-site/"
-  url "https://github.com/kripken/emscripten/archive/1.31.0.tar.gz"
-  sha256 "d566f743923008ad11768941f51b2079ba4019b0b41c5b3e53c1a655d4f4e5a7"
+
+  stable do
+    url "https://github.com/kripken/emscripten/archive/1.31.0.tar.gz"
+    sha256 "d566f743923008ad11768941f51b2079ba4019b0b41c5b3e53c1a655d4f4e5a7"
+
+    resource "fastcomp" do
+      url "https://github.com/kripken/emscripten-fastcomp/archive/1.31.0.tar.gz"
+      sha256 "750de063df3badb04e81bd56a2166ebcf6dfdd4380f59ff9409b4ca37de4b0ab"
+    end
+
+    resource "fastcomp-clang" do
+      url "https://github.com/kripken/emscripten-fastcomp-clang/archive/1.31.0.tar.gz"
+      sha256 "cc2fbaf53e1fe2a00bb5b06f0f75bd8b9a14a86774f76e8a3c69544f732fcacf"
+    end
+  end
 
   bottle do
     sha256 "e152e4c9ae71b8578c094b80cbd030949445a273352ad3d5edd7242d08bf9182" => :yosemite
@@ -21,22 +34,10 @@ class Emscripten < Formula
     end
   end
 
-  stable do
-    resource "fastcomp" do
-      url "https://github.com/kripken/emscripten-fastcomp/archive/1.31.0.tar.gz"
-      sha256 "750de063df3badb04e81bd56a2166ebcf6dfdd4380f59ff9409b4ca37de4b0ab"
-    end
-
-    resource "fastcomp-clang" do
-      url "https://github.com/kripken/emscripten-fastcomp-clang/archive/1.31.0.tar.gz"
-      sha256 "cc2fbaf53e1fe2a00bb5b06f0f75bd8b9a14a86774f76e8a3c69544f732fcacf"
-    end
-  end
-
   needs :cxx11
 
   depends_on :python if MacOS.version <= :snow_leopard
-  depends_on "node"
+  depends_on :node
   depends_on "closure-compiler" => :optional
   depends_on "yuicompressor"
 

--- a/Library/Formula/keybase.rb
+++ b/Library/Formula/keybase.rb
@@ -4,7 +4,7 @@ class Keybase < Formula
   sha256 "ae08423181867d071b23acb3f359b7341532290014eb42775eb7384a7ea757dc"
   head "https://github.com/keybase/node-client.git"
 
-  depends_on "node"
+  depends_on :node
   depends_on :gpg
 
   def install
@@ -18,7 +18,7 @@ class Keybase < Formula
     (bin/"keybase").write <<-EOS.undent
       #!/bin/sh
       export KEYBASE_BIN="#{bin}/keybase"
-      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/bin/main.js" "$@"
+      exec node "#{libexec}/bin/main.js" "$@"
     EOS
   end
 

--- a/Library/Formula/pow.rb
+++ b/Library/Formula/pow.rb
@@ -1,18 +1,16 @@
-require "formula"
-
 class Pow < Formula
   homepage "http://pow.cx/"
   url "http://get.pow.cx/versions/0.5.0.tar.gz"
-  sha1 "ef44f886a444340b91fb28e2fab3ce5471837a08"
+  sha256 "2e5f74d7c2f44004eb722eddf37356cd09b5563fde987b4c222fa6947ce388b7"
 
-  depends_on "node"
+  depends_on :node
 
   def install
     libexec.install Dir["*"]
     (bin/"pow").write <<-EOS.undent
       #!/bin/sh
       export POW_BIN="#{bin}/pow"
-      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/lib/command.js" "$@"
+      exec node "#{libexec}/lib/command.js" "$@"
     EOS
   end
 
@@ -30,5 +28,9 @@ class Pow < Formula
         sudo launchctl load -w /Library/LaunchDaemons/cx.pow.firewall.plist
         launchctl load -w ~/Library/LaunchAgents/cx.pow.powd.plist
     EOS
+  end
+
+  test do
+    system bin/"pow", "--print-config"
   end
 end

--- a/Library/Formula/skinny.rb
+++ b/Library/Formula/skinny.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class UniversalNpm < Requirement
   fatal true
   satisfy { which("npm") }
@@ -11,9 +9,9 @@ end
 class Skinny < Formula
   homepage "http://skinny-framework.org/"
   url "https://github.com/skinny-framework/skinny-framework/releases/download/1.3.16/skinny-1.3.16.tar.gz"
-  sha1 "b3fbf0e101a2a67c687bfe68b70495a2df386100"
+  sha256 "bc970edfe8c4be3bb7da6a7984698e44011c9ec5a55d41de42efa182f82b526b"
 
-  depends_on "node"
+  depends_on :node
   depends_on UniversalNpm
 
   option "without-npm-generator", "Yeoman generator will not be installed"

--- a/Library/Formula/tegh.rb
+++ b/Library/Formula/tegh.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class Tegh < Formula
-  homepage 'https://github.com/D1plo1d/tegh'
-  head 'https://github.com/D1plo1d/tegh.git', :branch => 'develop'
-  url 'https://s3.amazonaws.com/tegh_binaries/0.3.1/tegh-0.3.1-brew.tar.gz'
-  sha1 '7061165db148a27d229563e340d6c691b4fd92a8'
+  homepage "https://github.com/D1plo1d/tegh"
+  url "https://s3.amazonaws.com/tegh_binaries/0.3.1/tegh-0.3.1-brew.tar.gz"
+  sha256 "1aa9bdcc9579e8d56ab6a7b50704a1f32a6e5b8950ee2042f463b0a3b31daf4e"
+  head "https://github.com/D1plo1d/tegh.git", :branch => "develop"
 
-  depends_on 'node'
+  depends_on :node
 
   def install
     rm "bin/tegh.bat"
     system "npm", "install" if build.head?
-    libexec.install Dir['*']
+    libexec.install Dir["*"]
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -117,6 +117,7 @@ class DependencyCollector
     when :python3    then Python3Dependency.new(tags)
     when :java       then JavaDependency.new(tags)
     when :osxfuse    then OsxfuseDependency.new(tags)
+    when :node       then NodeDependency.new(tags)
     when :tuntap     then TuntapDependency.new(tags)
     when :ant        then ant_dep(spec, tags)
     when :apr        then AprDependency.new(tags)

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -71,6 +71,13 @@ class GPGDependency < Requirement
   satisfy { which("gpg") || which("gpg2") }
 end
 
+class NodeDependency < Requirement
+  fatal true
+  default_formula "node"
+
+  satisfy { which "node" }
+end
+
 class TeXDependency < Requirement
   fatal true
   cask "mactex"


### PR DESCRIPTION
This PR creates a special Node dependency.

I know historically I've been against this, but primarily getting to do a lil' looking after of Homebrew/versions piqued my interest in a better solution for Node. Homebrew/versions most download bottles *by far*, Node010 has been downloaded every single day since February 23rd, on average 1650 times a month. Small compared to Homebrew/homebrew's numbers I suspect, but not insignificant.

Per `npm`'s maintainer's disclosure of some *very general* analytics, the number of people using the Node 0.10.x branch and earlier dwarfs the number of those using the 0.12.x branch.

There's also the many, many requests from the ` iojs ` community to facilitate them a little more, and this would do that - Not automatically, but if they prepended their ` $PATH ` with their ` iojs ` installation, at their own risk, it would work as expected/desired. This also better supports the increasing range and popularity of Node version managers, removing the need for people to dupe their Node installations.

There's a minimal amount of risk to Homebrew in taking this step. We ship only 5 formulae which require Node, and all of them are proven to have worked and work with the 0.10.x branch and 0.12.x branch of Node.

This isn't intended to completely replace #36369 - I think that still has a lot of merit to discuss, but I think this change is better than the status quo whilst not upending Homebrew's desired way of dealing with Node particularly drastically.