### PR TITLE
cogl 1.20.0

### DIFF
--- a/Library/Formula/cogl.rb
+++ b/Library/Formula/cogl.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Cogl < Formula
   homepage "https://developer.gnome.org/cogl/"
-  url "http://ftp.gnome.org/pub/gnome/sources/cogl/1.18/cogl-1.18.2.tar.xz"
-  sha256 "9278e519d5480eb0379efd48db024e8fdbf93f01dff48a7e756b85b508a863aa"
+  url "http://ftp.gnome.org/pub/gnome/sources/cogl/1.20/cogl-1.20.0.tar.xz"
+  sha256 "729e35495829e7d31fafa3358e47b743ba21a2b08ff9b6cd28fb74c0de91192b"
 
   bottle do
     revision 1
@@ -13,86 +11,78 @@ class Cogl < Formula
   end
 
   head do
-    url "https://git.gnome.org/browse/cogl"
+    url "https://git.gnome.org/browse/cogl", :using => :git
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  deprecated_option "without-x" => "without-x11"
-
   depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on "glib"
-  depends_on "pango"
-  depends_on :x11 => ["2.5.1", :recommended]
   depends_on "gobject-introspection"
+  depends_on "gtk-doc"
+  depends_on "pango"
+
+  depends_on :x11 => ["2.5.1", :recommended]
+  deprecated_option "without-x" => "without-x11"
 
   # Lion's grep fails, which later results in compilation failures:
   # libtool: link: /usr/bin/grep -E -e [really long regexp] ".libs/libcogl.exp" > ".libs/libcogl.expT"
   # grep: Regular expression too big
-  resource "grep" do
-    url "http://ftpmirror.gnu.org/grep/grep-2.20.tar.xz"
-    mirror "https://ftp.gnu.org/gnu/grep/grep-2.20.tar.xz"
-    sha256 "f0af452bc0d09464b6d089b6d56a0a3c16672e9ed9118fbe37b0b6aeaf069a65"
-  end if MacOS.version == :lion
-
-  # Patch from MacPorts, reported upstream at https://bugzilla.gnome.org/show_bug.cgi?id=708825
-  # https://trac.macports.org/browser/trunk/dports/graphics/cogl/files/patch-clock_gettime.diff
-  patch :DATA
+  if MacOS.version == :lion
+    resource "grep" do
+      url "http://ftpmirror.gnu.org/grep/grep-2.20.tar.xz"
+      mirror "https://ftp.gnu.org/gnu/grep/grep-2.20.tar.xz"
+      sha256 "f0af452bc0d09464b6d089b6d56a0a3c16672e9ed9118fbe37b0b6aeaf069a65"
+    end
+  end
 
   def install
     # Don't dump files in $HOME.
     ENV["GI_SCANNER_DISABLE_CACHE"] = "yes"
 
-    resource("grep").stage do
-      system "./configure", "--disable-dependency-tracking",
-                            "--disable-nls",
-                            "--prefix=#{buildpath}/grep"
-      system "make", "install"
-      ENV["GREP"] = "#{buildpath}/grep/bin/grep"
-    end if MacOS.version == :lion
+    if MacOS.version == :lion
+      resource("grep").stage do
+        system "./configure", "--disable-dependency-tracking",
+               "--disable-nls",
+               "--prefix=#{buildpath}/grep"
+        system "make", "install"
+        ENV["GREP"] = "#{buildpath}/grep/bin/grep"
+      end
+    end
 
-    system "./autogen.sh" if build.head?
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-cogl-pango=yes
       --enable-introspection=yes
+      --disable-glx
     ]
     args << "--without-x" if build.without? "x11"
-    system "./configure", *args
-    system "make install"
+
+    if build.head?
+      system "./autogen.sh", *args
+    else
+      system "./configure", *args
+    end
+    system "make", "install"
+    doc.install "examples"
+  end
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <cogl/cogl.h>
+
+      int main()
+      {
+          return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}/cogl",
+           "-I#{Formula["glib"].opt_include}/glib-2.0",
+           "-I#{Formula["glib"].opt_lib}/glib-2.0/include",
+           testpath/"test.c", "-o", testpath/"test"
+    system "./test"
   end
 end
-__END__
-diff --git a/cogl/winsys/cogl-winsys-glx.c b/cogl/winsys/cogl-winsys-glx.c
---- a/cogl/winsys/cogl-winsys-glx.c
-+++ b/cogl/winsys/cogl-winsys-glx.c
-@@ -56,7 +56,26 @@
- #include <sys/stat.h>
- #include <sys/time.h>
- #include <fcntl.h>
-+
-+#ifdef __MACH__
-+#include <mach/mach_time.h>
-+#define CLOCK_REALTIME 0
-+#define CLOCK_MONOTONIC 0
-+static int
-+clock_gettime(int clk_id, struct timespec *t){
-+    mach_timebase_info_data_t timebase;
-+    mach_timebase_info(&timebase);
-+    uint64_t time;
-+    time = mach_absolute_time();
-+    double nseconds = ((double)time * (double)timebase.numer)/((double)timebase.denom);
-+    double seconds = ((double)time * (double)timebase.numer)/((double)timebase.denom * 1e9);
-+    t->tv_sec = seconds;
-+    t->tv_nsec = nseconds;
-+    return 0;
-+}
-+#else
- #include <time.h>
-+#endif
-
- #include <glib/gi18n-lib.h>


### PR DESCRIPTION
- removed the patch since [the problem was basically marked as WONTFIX](https://bugzilla.gnome.org/show_bug.cgi?id=708825#c1) and Mac users were told to compile with `--disable-glx`
- garbage test because I couldn't get any of the examples to compile; kept getting errors like this:
```
/usr/local/Cellar/cogl/1.20.0/share/doc/cogl/examples/cogl-hello.c:75:5: error: unknown type name 'CoglOnscreen'; did you mean 'CoglOffscreen'?
    CoglOnscreen *onscreen;
    ^~~~~~~~~~~~
    CoglOffscreen
```
Are they maybe outdated tests, or is this something to worry about?