### PR TITLE
More X11 optional dependencies

### DIFF
--- a/Library/Formula/harbour.rb
+++ b/Library/Formula/harbour.rb
@@ -13,7 +13,7 @@ class Harbour < Formula
   head "https://github.com/harbour/core.git"
 
   depends_on "pcre"
-  depends_on :x11 => :recommended
+  depends_on :x11 => :optional
 
   # Missing a header that was deprecated by libcurl @ version 7.12.0 and
   # deleted sometime after Harbour 3.0.0 release.

--- a/Library/Formula/pike.rb
+++ b/Library/Formula/pike.rb
@@ -9,7 +9,7 @@ class Pike < Formula
   depends_on "nettle"
   depends_on "gmp"
   depends_on "pcre"
-  depends_on :x11 => :recommended
+  depends_on :x11 => :optional
   depends_on 'libtiff' => :recommended
 
   # optional dependencies

--- a/Library/Formula/x11vnc.rb
+++ b/Library/Formula/x11vnc.rb
@@ -5,7 +5,7 @@ class X11vnc < Formula
   url 'https://downloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz'
   sha1 'f011d81488ac94dc8dce2d88739c23bd85a976fa'
 
-  depends_on :x11 => :recommended
+  depends_on :x11 => :optional
   depends_on 'jpeg'
 
   # Patch solid.c so a non-void function returns a NULL instead of a void.

--- a/Library/Formula/x11vnc.rb
+++ b/Library/Formula/x11vnc.rb
@@ -6,6 +6,7 @@ class X11vnc < Formula
   sha1 'f011d81488ac94dc8dce2d88739c23bd85a976fa'
 
   depends_on :x11 => :optional
+  depends_on 'openssl'
   depends_on 'jpeg'
 
   # Patch solid.c so a non-void function returns a NULL instead of a void.


### PR DESCRIPTION
These all have `:recommended` X11 dependencies. Let's make them `:optional` or move them to `homebrew-x11`.