### PR TITLE
ncdc: Use :shallow => false

### DIFF
--- a/Library/Formula/ncdc.rb
+++ b/Library/Formula/ncdc.rb
@@ -15,7 +15,7 @@ class Ncdc < Formula
   depends_on 'geoip' => :optional
 
   head do
-    url "git://g.blicky.net/ncdc.git"
+    url "git://g.blicky.net/ncdc.git", :shallow => false
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
ncdc depends on `git describe` to set its version. This breaks[0] on a
shallow clone, so use `:shallow => false`.

[0] http://dev.yorhel.nl/ncdc/bug/76