### PR TITLE
apache-spark 1.3.1

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -3,9 +3,9 @@ require "formula"
 class ApacheSpark < Formula
   homepage "https://spark.apache.org/"
   head "https://github.com/apache/spark.git"
-  url "https://d3kbcqa49mib13.cloudfront.net/spark-1.3.0-bin-hadoop2.4.tgz"
-  version "1.3.0"
-  sha1 "d94f2847bf92dd6e5a388c8126207cfe57e2c85e"
+  url "http://d3kbcqa49mib13.cloudfront.net/spark-1.3.1-bin-hadoop2.6.tgz"
+  version "1.3.1"
+  sha1 "86911b6c8964230a93691bd45589f491c10d36c0"
 
   conflicts_with 'hive', :because => 'both install `beeline` binaries'
 


### PR DESCRIPTION
Apache spark has a new bugfix release, 1.3.1: [spark release blog post](https://spark.apache.org/news/spark-1-2-2-released.html)

This PR also changes from using the distribution targeting hadoop 2.4 to hadoop 2.6, the current version homebrew supports (see [hadoop formula](https://github.com/Homebrew/homebrew/blob/ad4be31673defad4a12776aff67f744b45e68978/Library/Formula/hadoop.rb#L3))