### PR TITLE
scalariform: add HEAD

### DIFF
--- a/Library/Formula/scalariform.rb
+++ b/Library/Formula/scalariform.rb
@@ -3,9 +3,20 @@ class Scalariform < Formula
   url "https://github.com/daniel-trinh/scalariform/releases/download/0.1.6/scalariform.jar"
   sha256 "346276c5f3a25a44d64ed38f43739813933487299a651f7c64db748427641c54"
 
+  head do
+    url "https://github.com/daniel-trinh/scalariform.git"
+    depends_on "sbt" => :build
+  end
+
   def install
-    libexec.install "scalariform.jar"
-    bin.write_jar_script libexec/"scalariform.jar", "scalariform"
+    if build.head?
+      system "sbt", "project cli", "assembly"
+      libexec.install Dir["cli/target/scala-*/cli-assembly-*.jar"]
+      bin.write_jar_script Dir[libexec/"cli-assembly-*.jar"][0], "scalariform"
+    else
+      libexec.install "scalariform.jar"
+      bin.write_jar_script libexec/"scalariform.jar", "scalariform"
+    end
   end
 
   test do


### PR DESCRIPTION
Some globbing is necessary since `version` is not available during a `HEAD` install, and the Scala version can vary depending on the user's environment and the project's `sbt` configuration.