### PR TITLE
Add JPEG-Archive (new formula)

### DIFF
--- a/Library/Formula/jpeg-archive.rb
+++ b/Library/Formula/jpeg-archive.rb
@@ -1,0 +1,20 @@
+require "formula"
+
+class JpegArchive < Formula
+  homepage "https://github.com/danielgtaylor/jpeg-archive"
+  url "https://github.com/danielgtaylor/jpeg-archive/archive/2.1.1.tar.gz"
+  sha1 "874846fdc3a44811cccec6415ddf4d46c0fcd568"
+
+  depends_on "mozjpeg"
+
+  def install
+    system "make"
+    bin.install "jpeg-archive", "jpeg-recompress", 'jpeg-hash', 'jpeg-compare'
+  end
+
+  test do
+    system "#{bin}/jpeg-recompress",
+           "/System/Library/CoreServices/DefaultDesktop.jpg",
+           "output.jpg"
+  end
+end

--- a/Library/Formula/jpeg-archive.rb
+++ b/Library/Formula/jpeg-archive.rb
@@ -6,16 +6,10 @@ class JpegArchive < Formula
   depends_on "mozjpeg"
 
   def install
-    args = %W[
-      PREFIX=#{prefix}
-    ]
-
-    system "make", "install", *args
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    system "#{bin}/jpeg-recompress",
-           test_fixtures("test.jpg"),
-           "output.jpg"
+    system "#{bin}/jpeg-recompress", test_fixtures("test.jpg"), "output.jpg"
   end
 end

--- a/Library/Formula/jpeg-archive.rb
+++ b/Library/Formula/jpeg-archive.rb
@@ -1,20 +1,21 @@
-require "formula"
-
 class JpegArchive < Formula
   homepage "https://github.com/danielgtaylor/jpeg-archive"
   url "https://github.com/danielgtaylor/jpeg-archive/archive/2.1.1.tar.gz"
-  sha1 "874846fdc3a44811cccec6415ddf4d46c0fcd568"
+  sha256 "494534f5308f99743f11f3a7c151a8d5ca8a5f1f8b61ea119098511d401bc618"
 
   depends_on "mozjpeg"
 
   def install
-    system "make"
-    bin.install "jpeg-archive", "jpeg-recompress", 'jpeg-hash', 'jpeg-compare'
+    args = %W[
+      PREFIX=#{prefix}
+    ]
+
+    system "make", "install", *args
   end
 
   test do
     system "#{bin}/jpeg-recompress",
-           "/System/Library/CoreServices/DefaultDesktop.jpg",
+           test_fixtures("test.jpg"),
            "output.jpg"
   end
 end


### PR DESCRIPTION
This adds my [JPEG-Archive](https://github.com/danielgtaylor/jpeg-archive) project to Homebrew.

There is also a precompiled binary available on the releases page, but I wasn't sure how to set up Homebrew to use it. This formula compiles the latest release and depends on `mozjpeg`.