### PR TITLE
entr 3.2

### DIFF
--- a/Library/Formula/entr.rb
+++ b/Library/Formula/entr.rb
@@ -1,8 +1,13 @@
 class Entr < Formula
   homepage "http://entrproject.org/"
-  url "http://entrproject.org/code/entr-3.1.tar.gz"
-  mirror "https://bitbucket.org/eradman/entr/get/entr-3.1.tar.gz"
-  sha256 "f0f27e8fc610936f5ec72891687fc77e0df0b21172f14e85ff381d2fe5e3aadd"
+  url "http://entrproject.org/code/entr-3.2.tar.gz"
+  mirror "https://bitbucket.org/eradman/entr/get/entr-3.2.tar.gz"
+  sha256 "b1eee00afbeccf03010c1c557436854be6aaf0ef9b72ab8d44b94affdd7d7146"
+
+  head do
+    url "https://bitbucket.org/eradman/entr", :using => :hg
+    depends_on :hg => :build
+  end
 
   bottle do
     cellar :any
@@ -25,6 +30,6 @@ class Entr < Formula
       sleep 0.5
       touch testpath/"test.2"
     end
-    assert_equal "New File", pipe_output("#{bin}/entr -d echo 'New File'", testpath).strip
+    assert_equal "New File", pipe_output("#{bin}/entr -p -d echo 'New File'", testpath).strip
   end
 end


### PR DESCRIPTION
Default behavior [changed](https://bitbucket.org/eradman/entr/commits/425479dcc0925473098d49b0bbe2f01cd9c6904f) in this release; using the `-p` flag reverts to the old behavior so the test passes.