### PR TITLE
compiler: blacklist llvm from :openmp

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -59,7 +59,10 @@ class CompilerFailure
       create(:gcc => "4.5"),
       create(:gcc => "4.6"),
     ],
-    :openmp => [create(:clang)],
+    :openmp => [
+      create(:clang),
+      create(:llvm),
+    ],
   }
 end
 


### PR DESCRIPTION
OpenMP is ostensibly supported by llvm-gcc, but either due to an outdated standard or some other reason formulae in Homebrew Science that require `:openmp` will fail if the bots choose llvm-gcc over `gcc`. Since current `llvm` doesn't yet support OpenMP, and llvm-gcc support is questionable, I propose blacklisting `:llvm` until OpenMP is supported on the mainline LLVM/Clang.