### PR TITLE
syncthing 0.11.0

### DIFF
--- a/Library/Formula/syncthing.rb
+++ b/Library/Formula/syncthing.rb
@@ -1,7 +1,7 @@
 class Syncthing < Formula
   homepage "https://syncthing.net/"
   url "https://github.com/syncthing/syncthing.git",
-    :tag => "v0.10.30", :revision => "3cc4cb0a0b71908ae2d6392f14457e7ca6712278"
+    :tag => "v0.11.0", :revision => "b35958d024175609a9e07934cdb1bedd3243939c"
 
   head "https://github.com/syncthing/syncthing.git"
 


### PR DESCRIPTION
Bump.

We may want to hold off on merging this for a few days.

**NOT COMPATIBLE WITH THE 0.10.x RELEASE BRANCH. See:**
https://forum.syncthing.net/t/syncthing-v0-11-0-release-notes/2426