### PR TITLE
asciidoc: add note about docbook-xsl installation

### DIFF
--- a/Library/Formula/asciidoc.rb
+++ b/Library/Formula/asciidoc.rb
@@ -18,6 +18,9 @@ class Asciidoc < Formula
 
   depends_on "docbook"
 
+  option "with-docbook-xsl", "Install DTDs to generate manpages"
+  depends_on "docbook-xsl" => :optional
+
   def install
     system "autoconf" if build.head?
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
This pull request adds a recommendation to install `docbook-xsl` to the caveats section of the `asciidoc` formula.

While manpages can be created without having docbook-xsl installed, the relevant DTD files are downloaded by a2x on each run, resulting in slow performance and unnecessary network traffic and strain on the download servers.

Converting a short manpage without docbook-xsl:
```
% time a2x --format manpage man/wright.1.txt                                                                                :(
a2x --format manpage man/wright.1.txt  1.60s user 0.33s system 5% cpu 35.507 total
```

With docbook-xsl:
```
% time a2x --format manpage man/wright.1.txt 
a2x --format manpage man/wright.1.txt  1.39s user 0.19s system 94% cpu 1.674 total
```

The exact behaviour can be observed in more detail by using DTrace:
```
curl -O http://www.methods.co.nz/asciidoc/asciidoc.1.txt
export XML_CATALOG_FILES=/usr/local/etc/xml/catalog
sudo brew uninstall docbook-xsl
sudo dtruss -f sudo -u $USER a2x --format manpage asciidoc.1.txt 2> without-docbook-xsl.txt
sudo brew install docbook-xsl
sudo dtruss -f sudo -u $USER a2x --format manpage asciidoc.1.txt 2> with-docbook-xsl.txt
```