### PR TITLE
cairomm 1.11.2

### DIFF
--- a/Library/Formula/cairomm.rb
+++ b/Library/Formula/cairomm.rb
@@ -1,10 +1,7 @@
-require 'formula'
-
 class Cairomm < Formula
-  homepage 'http://cairographics.org/cairomm/'
-  url 'http://cairographics.org/releases/cairomm-1.10.0.tar.gz'
-  sha256 '068d96c43eae7b0a3d98648cbfc6fbd16acc385858e9ba6d37b5a47e4dba398f'
-  revision 1
+  homepage "http://cairographics.org/cairomm/"
+  url "http://cairographics.org/releases/cairomm-1.11.2.tar.gz"
+  sha256 "ccf677098c1e08e189add0bd146f78498109f202575491a82f1815b6bc28008d"
 
   bottle do
     revision 1
@@ -17,21 +14,40 @@ class Cairomm < Formula
 
   deprecated_option "without-x" => "without-x11"
 
-  depends_on 'pkg-config' => :build
+  depends_on "pkg-config" => :build
   if build.cxx11?
-    depends_on 'libsigc++' => 'c++11'
+    depends_on "libsigc++" => "c++11"
   else
-    depends_on 'libsigc++'
+    depends_on "libsigc++"
   end
 
-  depends_on 'cairo'
-  depends_on 'libpng'
+  depends_on "libpng"
   depends_on :x11 => :recommended
+
+  if build.without? "x11"
+    depends_on "cairo" => "without-x11"
+  else
+    depends_on "cairo"
+  end
 
   def install
     ENV.cxx11 if build.cxx11?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <cairomm/cairomm.h>
+
+      int main(int argc, char *argv[])
+      {
+         Cairo::RefPtr<Cairo::ImageSurface> surface = Cairo::ImageSurface::create(Cairo::FORMAT_ARGB32, 600, 400);
+         Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(surface);
+         return 0;
+      }
+    EOS
+    system ENV.cxx, "-I#{HOMEBREW_PREFIX}/include/cairomm-1.0", "-I#{HOMEBREW_PREFIX}/lib/cairomm-1.0/include", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/glib-2.0", "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include", "-I#{HOMEBREW_PREFIX}/opt/gettext/include", "-I#{HOMEBREW_PREFIX}/include/pixman-1", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/freetype2", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/sigc++-2.0", "-I#{HOMEBREW_PREFIX}/lib/sigc++-2.0/include", "test.cpp", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-lcairomm-1.0", "-lcairo", "-lsigc-2.0", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
version bump
test block added
without-x11 option now requires the same for the cairo dependency