### PR TITLE
Update solr formula from 5.0 to 5.1

### DIFF
--- a/Library/Formula/solr.rb
+++ b/Library/Formula/solr.rb
@@ -1,6 +1,6 @@
 class Solr < Formula
   homepage "https://lucene.apache.org/solr/"
-  url "http://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.1.0/solr-5.1.0.tgz"
+  url "https://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.1.0/solr-5.1.0.tgz"
   mirror "https://archive.apache.org/dist/lucene/solr/5.1.0/solr-5.1.0.tgz"
   sha256 "8718cbfb789a170d210b0b4adbe4fd8187ecdc67c5348ed9d551578087d8a628"
 

--- a/Library/Formula/solr.rb
+++ b/Library/Formula/solr.rb
@@ -1,8 +1,8 @@
 class Solr < Formula
   homepage "https://lucene.apache.org/solr/"
-  url "http://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.0.0/solr-5.0.0.tgz"
-  mirror "https://archive.apache.org/dist/lucene/solr/5.0.0/solr-5.0.0.tgz"
-  sha256 "48c77aede40fceda73cf4e13e08e328899685446f80f76f2e893eaffea714297"
+  url "http://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.1.0/solr-5.1.0.tgz"
+  mirror "https://archive.apache.org/dist/lucene/solr/5.1.0/solr-5.1.0.tgz"
+  sha256 "8718cbfb789a170d210b0b4adbe4fd8187ecdc67c5348ed9d551578087d8a628"
 
   depends_on :java
 


### PR DESCRIPTION
Bumped solr version to 5.1.0 which apache released last week. Confirmed working on Yosemite.