### PR TITLE
nagios: update caveat information

### DIFF
--- a/Library/Formula/nagios.rb
+++ b/Library/Formula/nagios.rb
@@ -79,10 +79,13 @@ class Nagios < Formula
 
       1) Turn on Personal Web Sharing.
 
-      2) Load the php module by patching /etc/apache2/httpd.conf:
+      2) Load the cgi and php modules by patching /etc/apache2/httpd.conf:
 
         -#LoadModule php5_module        libexec/apache2/libphp5.so
         +LoadModule php5_module        libexec/apache2/libphp5.so
+        
+        -#LoadModule cgi_module libexec/apache2/mod_cgi.so
+        +LoadModule cgi_module libexec/apache2/mod_cgi.so
 
       3) Symlink the sample config and create your web account:
 


### PR DESCRIPTION
The caveat mentions to patch /etc/apache2/httpd.conf, concerning the `LoadModule` directive for php5.

Loading `cgi_module` is also mandatory.