### PR TITLE
highlighting-kate (new formula)

### DIFF
--- a/Library/Formula/highlighting-kate.rb
+++ b/Library/Formula/highlighting-kate.rb
@@ -1,0 +1,27 @@
+require "language/haskell"
+
+class HighlightingKate < Formula
+  include Language::Haskell::Cabal
+
+  homepage "https://github.com/jgm/highlighting-kate"
+  url "https://github.com/jgm/highlighting-kate/archive/0.5.15.tar.gz"
+  sha256 "fc4b22e3709da6a15f5fac5feda31bd08807f8b6e63f45c8dbd50ad489d750c9"
+
+  head "https://github.com/jgm/highlighting-kate.git"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+
+  def install
+    cabal_sandbox do
+      cabal_install "--only-dependencies"
+      system "make", "prep"
+      cabal_install "--prefix=#{prefix}", "-fsplitBase", "-fexecutable"
+    end
+    cabal_clean_lib
+  end
+
+  test do
+    system "highlighting-kate", "-s", "json", prefix/"INSTALL_RECEIPT.json"
+  end
+end


### PR DESCRIPTION
This is the @jgm's syntax highlighter, used in pandoc, based on the syntaxes used in "Kate", the KDE text editor. Sometimes nice to have something around thats *not* based on TextMate bundles or pygments. :stuck_out_tongue_winking_eye:

This formula is pretty much straight-down-the-line ripped off from the pandoc formula. Which is awesome. Props to whomever implemented those cabal sandbox methods!

Note that presently the executable conflicts with that installed by the "highlight" formula, perhaps in part due to HFS case-sensitivity, so I've renamed the file here, in the formula, and [inquired upstream](https://github.com/jgm/highlighting-kate/issues/66) as to how @jgm would prefer this be handled.
