### PR TITLE
Fix CVS download strategy to allow anoncvs.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -688,7 +688,8 @@ class CVSDownloadStrategy < VCSDownloadStrategy
 
   def clone_repo
     HOMEBREW_CACHE.cd do
-      quiet_safe_system cvspath, { :quiet_flag => "-Q" }, "-d", @url, "login"
+      # Login is only needed (and allowed) with pserver; skip for anoncvs.
+      quiet_safe_system cvspath, { :quiet_flag => "-Q" }, "-d", @url, "login" if @url.include? "pserver"
       quiet_safe_system cvspath, { :quiet_flag => "-Q" }, "-d", @url, "checkout", "-d", cache_filename, @module
     end
   end


### PR DESCRIPTION
Presently, the CVS download strategy assumes anonymous access will be accomplished via [pserver](http://stackoverflow.com/a/2006941). This patch allows for skiping the login step for anoncvs (SSH) servers.
It is simple to differentiate as `pserver` will always be in the user/URI string if that's the method being used unless its a _highly_ unusual configuration.