### PR TITLE
mandoc (mdocml) —  [proper] new formula

### DIFF
--- a/Library/Aliases/mdocml
+++ b/Library/Aliases/mdocml
@@ -1,0 +1,1 @@
+../Formula/mandoc.rb

--- a/Library/Formula/mandoc.rb
+++ b/Library/Formula/mandoc.rb
@@ -1,0 +1,78 @@
+class Mandoc < Formula
+  desc "The mandoc UNIX manpage compiler toolset"
+  homepage "http://mdocml.bsd.lv"
+  url "http://mdocml.bsd.lv/snapshots/mdocml-1.13.3.tar.gz"
+  sha256 "23ccab4800d50bf4c327979af5d4aa1a6a2dc490789cb67c4c3ac1bd40b8cad8"
+
+  head "anoncvs@mdocml.bsd.lv:/cvs", :module => "mdocml", :using => :cvs
+
+  option "without-sqlite", "Only install the mandoc/demandoc utilities."
+  option "without-cgi", "Don't build man.cgi (and extra CSS files)."
+
+  depends_on "sqlite" => :recommended
+
+  def install
+    localconfig = [
+
+      # Sane prefixes.
+      "PREFIX=#{prefix}",
+      "INCLUDEDIR=#{include}",
+      "LIBDIR=#{lib}",
+      "MANDIR=#{man}",
+      "WWWPREFIX=#{prefix}/var/www",
+      "EXAMPLEDIR=#{share}/examples",
+
+      # Executable names, where utilities would be replaced/duplicated.
+      # The mdocml versions of the utilities are definitely *not* ready
+      # for prime-time on Darwin, though some changes in HEAD are promising.
+      # The "bsd" prefix (like bsdtar, bsdmake) is more informative than "m".
+      "BINM_MAN=bsdman",
+      "BINM_APROPOS=bsdapropos",
+      "BINM_WHATIS=bsdwhatis",
+      "BINM_MAKEWHATIS=bsdmakewhatis",	# default is "makewhatis".
+
+      # These are names for *section 7* pages only. Several other pages are
+      # prefixed "mandoc_", similar to the "groff_" pages.
+      "MANM_MAN=man",
+      "MANM_MDOC=mdoc",
+      "MANM_ROFF=mandoc_roff", # This is the only one that conflicts (groff).
+      "MANM_EQN=eqn",
+      "MANM_TBL=tbl",
+
+      "OSNAME='Mac OS X #{MacOS.version}'", # Bottom corner signature line.
+
+      # Not quite sure what to do here. The default ("/usr/share", etc.) needs
+      # sudoer privileges, or will error. So just brew's manpages for now?
+      "MANPATH_DEFAULT=#{HOMEBREW_PREFIX}/share/man",
+
+      "HAVE_MANPATH=0",   # Our `manpath` is a symlink to system `man`.
+      "STATIC=",          # No static linking on Darwin.
+
+      "HOMEBREWDIR=#{HOMEBREW_CELLAR}" # ? See configure.local.example, NEWS.
+    ]
+
+    localconfig << "BUILD_DB=1" if build.with? "db"
+    localconfig << "BUILD_CGI=1" if build.with? "cgi"
+    File.rename("cgi.h.example", "cgi.h") # For man.cgi, harmless in any case.
+
+    (buildpath/"configure.local").write localconfig.join("\n")
+    system "./configure"
+
+    # I've tried twice to send a bug report on this to tech@mdocml.bsd.lv.
+    # In theory, it should show up with:
+    # search.gmane.org/?query=jobserver&group=gmane.comp.tools.mdocml.devel
+    ENV.deparallelize do
+      system "make"
+      system "make", "install"
+    end
+
+    system "make", "manpage" # Left out of the install for some reason.
+    bin.install "manpage"
+  end
+
+  test do
+    system "mandoc", "-Thtml",
+      "-Ostyle=#{share}/examples/example.style.css",
+      "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
+  end
+end


### PR DESCRIPTION
I've been sitting on this as a "personal" formula for a while and decided it was time to fix it up and contribute it, especially in light of #30176, #30874, and #35790.

Briefly, since we's seen this one before:
- These are "new" BSD tools that (somewhat/might/are meant to) replace the [g]roff / man suite.
- It is extremely lightweight, and is already in production use on BSD. No dependencies except sqlite (optional) — no ghostscript! — and produces very nice PDF and HTML output, amongst other formats.
- Means to also replace text `whatis` "databases" with sqlite **databases**; this is **definitely** a WIP, at least on Darwin, as is the replacement `man` util.
- Building from `HEAD` is predicated on #38965.

I haven't thoroughly looked through the discussions on the previous PRs or the mailing list, but following up on a couple of things:
- This formula is not based on any of the previous iterations.
- I do *not* think this needs to be keg-only; there is a documented method within the "build system" for using an alternate naming scheme, specifically meant to avoid such conflicts. I've used it here in this formula.
- There are some bizarre references to homebrew in the code and docs, possibly stemming from one of these previous PRs. I plan on doing a bit of work to figure that out (and make this build a little less heinous) upstream, when I have some time.
- The makefiles are definitely *not* jobserver safe.

Although my intention with this formula is to close #35790, #30874, and #30176, @afh @ilovezfs @benjaminweb, additional thoughts are of course welcomed. :beers: 