### PR TITLE
without-x11 option removed in cairo, cairomm, pango and pangomm

### DIFF
--- a/Library/Formula/cairomm.rb
+++ b/Library/Formula/cairomm.rb
@@ -11,8 +11,6 @@ class Cairomm < Formula
 
   option :cxx11
 
-  deprecated_option "without-x" => "without-x11"
-
   depends_on "pkg-config" => :build
   if build.cxx11?
     depends_on "libsigc++" => "c++11"
@@ -21,13 +19,7 @@ class Cairomm < Formula
   end
 
   depends_on "libpng"
-  depends_on :x11 => :recommended
-
-  if build.without? "x11"
-    depends_on "cairo" => "without-x11"
-  else
-    depends_on "cairo"
-  end
+  depends_on "cairo"
 
   def install
     ENV.cxx11 if build.cxx11?

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class Pango < Formula
   homepage "http://www.pango.org/"
   url "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz"
   sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
 
   head do
-    url 'https://git.gnome.org/browse/pango'
+    url "https://git.gnome.org/browse/pango"
 
-    depends_on 'automake' => :build
-    depends_on 'autoconf' => :build
-    depends_on 'libtool' => :build
-    depends_on 'gtk-doc' => :build
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+    depends_on "gtk-doc" => :build
   end
 
   bottle do
@@ -23,13 +21,13 @@ class Pango < Formula
 
   option :universal
 
-  depends_on 'pkg-config' => :build
-  depends_on 'glib'
-  depends_on 'cairo'
-  depends_on 'harfbuzz'
-  depends_on 'fontconfig'
-  depends_on :x11 => :recommended
-  depends_on 'gobject-introspection'
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "harfbuzz"
+  depends_on "fontconfig"
+  depends_on :x11
+  depends_on "cairo"
+  depends_on "gobject-introspection"
 
   fails_with :llvm do
     build 2326
@@ -46,18 +44,14 @@ class Pango < Formula
       --enable-man
       --with-html-dir=#{share}/doc
       --enable-introspection=yes
+      --with-xft
+      --with-included-modules
     ]
-
-    if build.without? "x11"
-      args << '--without-xft'
-    else
-      args << '--with-xft'
-    end
 
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make"
-    system "make install"
+    system "make", "install"
   end
 
   test do

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Pangomm < Formula
-  homepage 'http://www.pango.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.34/pangomm-2.34.0.tar.xz'
-  sha256 '0e82bbff62f626692a00f3772d8b17169a1842b8cc54d5f2ddb1fec2cede9e41'
+  homepage "http://www.pango.org/"
+  url "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.36/pangomm-2.36.0.tar.xz"
+  sha256 "a8d96952c708d7726bed260d693cece554f8f00e48b97cccfbf4f5690b6821f0"
 
   bottle do
     revision 1
@@ -12,13 +10,25 @@ class Pangomm < Formula
     sha1 "3df791891b37c582cad8712fe5a93d6c067ca90e" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'pango'
-  depends_on 'glibmm'
-  depends_on 'cairomm'
+  depends_on "pkg-config" => :build
+  depends_on "glibmm"
+  depends_on "cairomm"
+  depends_on "pango"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <pangomm.h>
+      int main(int argc, char *argv[])
+      {
+        Pango::FontDescription fd;
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-I#{HOMEBREW_PREFIX}/include/pangomm-1.4", "-I#{HOMEBREW_PREFIX}/lib/pangomm-1.4/include", "-I#{HOMEBREW_PREFIX}/include/glibmm-2.4", "-I#{HOMEBREW_PREFIX}/lib/glibmm-2.4/include", "-I#{HOMEBREW_PREFIX}/include/cairomm-1.0", "-I#{HOMEBREW_PREFIX}/lib/cairomm-1.0/include", "-I#{HOMEBREW_PREFIX}/include/sigc++-2.0", "-I#{HOMEBREW_PREFIX}/lib/sigc++-2.0/include", "-I#{HOMEBREW_PREFIX}/include/pango-1.0", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/glib-2.0", "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include", "-I#{HOMEBREW_PREFIX}/opt/gettext/include", "-I#{HOMEBREW_PREFIX}/include/pixman-1", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/freetype2", "-I#{HOMEBREW_PREFIX}/include/libpng16", "test.cpp", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/opt/gettext/lib", "-L#{HOMEBREW_PREFIX}/lib", "-lpangomm-1.4", "-lglibmm-2.4", "-lcairomm-1.0", "-lsigc-2.0", "-lpangocairo-1.0", "-lpango-1.0", "-lgobject-2.0", "-lglib-2.0", "-lintl", "-lcairo", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
@mikemcquaid @jacknagel 

Ok, this is a big one...

I went through the complete gtkmm (2 and 3) dependency graph this morning and see if something could be done about the x11/quartz issue. First thing I figured out is that it is not necessary for cairo(mm) and pango(mm) to have the --without-x11 option. The best thing to do is just build cairo and pango with all possible backends, which creates no internal conflicts at all. This does not impact the gtk+ package: whether or not it installed with or without X11 support, the cairo and pango packages do not need rebuilding.

pangomm and cairomm's functionality depends entirely on how respectively pango and cairo were configured. So I just removed the --without-x11 option I erroneously introduced yesterday.

Regarding a separate gtk-quartz tap: this will still be necessary for gtk+ (2 only), gtkmm (2 only), and every package that depends on these two. cairo(mm) and pango(mm) should never be part of this tap.

I also made some changes to gtk+, gtk+3, gtkmm and gtkmm3. I will create separate pull requests for these. Important here will be that gtk+3 no longer supports the X11 backend (change introduced in 3.16.0), due to changes in the libepoxy dependency. 