### PR TITLE
gtk+3 3.16.2

### DIFF
--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Gtkx3 < Formula
   homepage "http://gtk.org/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gtk+/3.14/gtk+-3.14.6.tar.xz"
-  sha256 "cfc424e6e10ffeb34a33762aeb77905c3ed938f0b4006ddb7e880aad234ef119"
+  url "http://ftp.gnome.org/pub/gnome/sources/gtk+/3.16/gtk+-3.16.2.tar.xz"
+  sha256 "a03963a61c9f5253a8d4003187190be165d92f95acf97ca783735071a8781cfa"
 
   bottle do
     sha1 "f2074aa249d5695a575a210d2452e8182f8c3435" => :yosemite
@@ -13,19 +11,15 @@ class Gtkx3 < Formula
 
   option :universal
 
-  depends_on :x11 => ["2.5", :recommended] # needs XInput2, introduced in libXi 1.3
   depends_on "pkg-config" => :build
-  depends_on "glib"
-  depends_on "jpeg"
-  depends_on "libtiff"
   depends_on "gdk-pixbuf"
-  depends_on "pango"
-  depends_on "cairo"
   depends_on "jasper" => :optional
   depends_on "atk"
-  depends_on "at-spi2-atk" if build.with? "x11"
+  depends_on "at-spi2-atk"
   depends_on "gobject-introspection"
+  depends_on "libepoxy"
   depends_on "gsettings-desktop-schemas" => :recommended
+  depends_on "pango"
 
   def install
     ENV.universal_binary if build.universal?
@@ -37,15 +31,18 @@ class Gtkx3 < Formula
       --disable-glibtest
       --enable-introspection=yes
       --disable-schemas-compile
+      --enable-quartz-backend
+      --enable-quartz-relocation
+      --disable-x11-backend
     ]
-
-    if build.without? "x11"
-      args << "--enable-quartz-backend" << "--enable-quartz-relocation"
-    else
-      args << "--enable-x11-backend"
-    end
+    # --enable-x11-backend not possible because of libepoxy, which is now a hard dependency of gtk3.
+    # Looks like this will remain so
+    # according to the comments in https://github.com/anholt/libepoxy/pull/28
 
     system "./configure", *args
+    # necessary to avoid gtk-update-icon-cache not being found during make install
+    mkdir_p bin
+    ENV.prepend_path "PATH", "#{bin}"
     system "make", "install"
     # Prevent a conflict between this and Gtk+2
     mv bin/"gtk-update-icon-cache", bin/"gtk3-update-icon-cache"
@@ -53,5 +50,17 @@ class Gtkx3 < Formula
 
   def post_install
     system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+  end
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtk/gtk.h>
+
+      int main(int argc, char *argv[]) {
+        gtk_disable_setlocale();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{HOMEBREW_PREFIX}/include/gtk-3.0", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/gio-unix-2.0/", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/pango-1.0", "-I#{HOMEBREW_PREFIX}/include/atk-1.0", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/pixman-1", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/freetype2", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/gdk-pixbuf-2.0", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/glib-2.0", "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include", "-I#{HOMEBREW_PREFIX}/opt/gettext/include", "-I/opt/X11/include", "test.c", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/opt/gettext/lib", "-lgtk-3", "-lgdk-3", "-lpangocairo-1.0", "-lpango-1.0", "-latk-1.0", "-lcairo-gobject", "-lcairo", "-lgdk_pixbuf-2.0", "-lgio-2.0", "-lgobject-2.0", "-lglib-2.0", "-lintl", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
version bump
Due to the new dependency on libepoxy, Quartz has become the only
supported backend according to the discussion in
https://github.com/anholt/libepoxy/pull/28 and this seems unlikely to
change in the future.