### PR TITLE
gtk+3 3.16.2 and gtkmm3 3.16.0

### DIFF
--- a/Library/Formula/gsettings-desktop-schemas.rb
+++ b/Library/Formula/gsettings-desktop-schemas.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class GsettingsDesktopSchemas < Formula
   homepage "http://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/"
   url "http://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/3.14/gsettings-desktop-schemas-3.14.0.tar.xz"
@@ -14,7 +12,7 @@ class GsettingsDesktopSchemas < Formula
 
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
-  depends_on "glib" => :build # for glib-mkenums
+  depends_on "glib"
   depends_on "gobject-introspection" => :build
   depends_on "gettext"
   depends_on "libffi"
@@ -25,11 +23,23 @@ class GsettingsDesktopSchemas < Formula
                           "--prefix=#{prefix}",
                           "--disable-schemas-compile",
                           "--enable-introspection=yes"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gdesktop-enums.h>
+
+      int main(int argc, char *argv[]) {
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{HOMEBREW_PREFIX}/include/gsettings-desktop-schemas", "test.c", "-o", "test"
+    system "./test"
   end
 
   def post_install
     # manual schema compile step
-    system Formula["glib"].opt_bin/"glib-compile-schemas", share/"glib-2.0/schemas"
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Gtkx3 < Formula
   homepage "http://gtk.org/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gtk+/3.14/gtk+-3.14.6.tar.xz"
-  sha256 "cfc424e6e10ffeb34a33762aeb77905c3ed938f0b4006ddb7e880aad234ef119"
+  url "http://ftp.gnome.org/pub/gnome/sources/gtk+/3.16/gtk+-3.16.2.tar.xz"
+  sha256 "a03963a61c9f5253a8d4003187190be165d92f95acf97ca783735071a8781cfa"
 
   bottle do
     sha1 "f2074aa249d5695a575a210d2452e8182f8c3435" => :yosemite
@@ -13,19 +11,15 @@ class Gtkx3 < Formula
 
   option :universal
 
-  depends_on :x11 => ["2.5", :recommended] # needs XInput2, introduced in libXi 1.3
   depends_on "pkg-config" => :build
-  depends_on "glib"
-  depends_on "jpeg"
-  depends_on "libtiff"
   depends_on "gdk-pixbuf"
-  depends_on "pango"
-  depends_on "cairo"
   depends_on "jasper" => :optional
   depends_on "atk"
-  depends_on "at-spi2-atk" if build.with? "x11"
   depends_on "gobject-introspection"
+  depends_on "libepoxy"
   depends_on "gsettings-desktop-schemas" => :recommended
+  depends_on "pango"
+  depends_on "glib"
 
   def install
     ENV.universal_binary if build.universal?
@@ -37,15 +31,15 @@ class Gtkx3 < Formula
       --disable-glibtest
       --enable-introspection=yes
       --disable-schemas-compile
+      --enable-quartz-backend
+      --enable-quartz-relocation
+      --disable-x11-backend
     ]
 
-    if build.without? "x11"
-      args << "--enable-quartz-backend" << "--enable-quartz-relocation"
-    else
-      args << "--enable-x11-backend"
-    end
-
     system "./configure", *args
+    # necessary to avoid gtk-update-icon-cache not being found during make install
+    bin.mkpath
+    ENV.prepend_path "PATH", "#{bin}"
     system "make", "install"
     # Prevent a conflict between this and Gtk+2
     mv bin/"gtk-update-icon-cache", bin/"gtk3-update-icon-cache"
@@ -53,5 +47,18 @@ class Gtkx3 < Formula
 
   def post_install
     system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtk/gtk.h>
+
+      int main(int argc, char *argv[]) {
+        gtk_disable_setlocale();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{HOMEBREW_PREFIX}/include/gtk-3.0", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/gio-unix-2.0/", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/pango-1.0", "-I#{HOMEBREW_PREFIX}/include/atk-1.0", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/pixman-1", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/freetype2", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/gdk-pixbuf-2.0", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/glib-2.0", "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include", "-I#{HOMEBREW_PREFIX}/opt/gettext/include", "-I/opt/X11/include", "test.c", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/opt/gettext/lib", "-lgtk-3", "-lgdk-3", "-lpangocairo-1.0", "-lpango-1.0", "-latk-1.0", "-lcairo-gobject", "-lcairo", "-lgdk_pixbuf-2.0", "-lgio-2.0", "-lgobject-2.0", "-lglib-2.0", "-lintl", "-o", "test"
+    system "./test"
   end
 end

--- a/Library/Formula/gtkmm3.rb
+++ b/Library/Formula/gtkmm3.rb
@@ -1,9 +1,7 @@
-require "formula"
-
 class Gtkmm3 < Formula
   homepage "http://www.gtkmm.org/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.14/gtkmm-3.14.0.tar.xz"
-  sha256 "d9f528a62c6ec226fa08287c45c7465b2dce5aae5068e9ac48d30a64a378e48b"
+  url "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.16/gtkmm-3.16.0.tar.xz"
+  sha256 "9b8d4af5e1bb64e52b53bc8ef471ef43e1b9d11a829f16ef54c3a92985b0dd0c"
 
   bottle do
     sha1 "6d2d49346ac6e7ca5dab76033fbeec1bf54f3af6" => :mavericks
@@ -12,15 +10,25 @@ class Gtkmm3 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "glibmm"
   depends_on "gtk+3"
-  depends_on "libsigc++"
   depends_on "pangomm"
   depends_on "atkmm"
-  depends_on "cairomm"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <gtkmm.h>
+      class MyLabel : public Gtk::Label {
+        MyLabel(Glib::ustring text) : Gtk::Label(text) {}
+      };
+      int main(int argc, char *argv[]) {
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-I#{HOMEBREW_PREFIX}/include/gtkmm-3.0", "-I#{HOMEBREW_PREFIX}/lib/gtkmm-3.0/include", "-I#{HOMEBREW_PREFIX}/include/atkmm-1.6", "-I#{HOMEBREW_PREFIX}/include/gtk-3.0/unix-print", "-I#{HOMEBREW_PREFIX}/include/gdkmm-3.0", "-I#{HOMEBREW_PREFIX}/lib/gdkmm-3.0/include", "-I#{HOMEBREW_PREFIX}/include/giomm-2.4", "-I#{HOMEBREW_PREFIX}/lib/giomm-2.4/include", "-I#{HOMEBREW_PREFIX}/include/pangomm-1.4", "-I#{HOMEBREW_PREFIX}/lib/pangomm-1.4/include", "-I#{HOMEBREW_PREFIX}/include/glibmm-2.4", "-I#{HOMEBREW_PREFIX}/lib/glibmm-2.4/include", "-I#{HOMEBREW_PREFIX}/include/gtk-3.0", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/gio-unix-2.0/", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/pango-1.0", "-I#{HOMEBREW_PREFIX}/include/atk-1.0", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/cairomm-1.0", "-I#{HOMEBREW_PREFIX}/lib/cairomm-1.0/include", "-I#{HOMEBREW_PREFIX}/include/cairo", "-I#{HOMEBREW_PREFIX}/include/pixman-1", "-I#{HOMEBREW_PREFIX}/include", "-I#{HOMEBREW_PREFIX}/include/freetype2", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/sigc++-2.0", "-I#{HOMEBREW_PREFIX}/lib/sigc++-2.0/include", "-I#{HOMEBREW_PREFIX}/include/gdk-pixbuf-2.0", "-I#{HOMEBREW_PREFIX}/include/libpng16", "-I#{HOMEBREW_PREFIX}/include/glib-2.0", "-I#{HOMEBREW_PREFIX}/lib/glib-2.0/include", "-I#{HOMEBREW_PREFIX}/opt/gettext/include", "-I/opt/X11/include", "test.cpp", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/lib", "-L#{HOMEBREW_PREFIX}/opt/gettext/lib", "-lgtkmm-3.0", "-latkmm-1.6", "-lgdkmm-3.0", "-lgiomm-2.4", "-lpangomm-1.4", "-lglibmm-2.4", "-lgtk-3", "-lgdk-3", "-lpangocairo-1.0", "-lpango-1.0", "-latk-1.0", "-lcairo-gobject", "-lgio-2.0", "-lcairomm-1.0", "-lcairo", "-lsigc-2.0", "-lgdk_pixbuf-2.0", "-lgobject-2.0", "-lglib-2.0", "-lintl", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
version bumps
Due to the new dependency on libepoxy, Quartz has become the only
supported backend according to the discussion in
anholt/libepoxy#28 and this seems unlikely to
change in the future.