### PR TITLE
nfdump 1.6.13 (new formula)

### DIFF
--- a/Library/Formula/nfdump.rb
+++ b/Library/Formula/nfdump.rb
@@ -1,0 +1,14 @@
+class Nfdump < Formula
+  homepage "http://nfdump.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/nfdump/stable/nfdump-1.6.13/nfdump-1.6.13.tar.gz"
+  sha256 "251533c316c9fe595312f477cdb051e9c667517f49fb7ac5b432495730e45693"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+      system "nfdump -Z \'host 8.8.8.8\'"
+  end
+end

--- a/Library/Formula/nfdump.rb
+++ b/Library/Formula/nfdump.rb
@@ -9,6 +9,6 @@ class Nfdump < Formula
   end
 
   test do
-      system "nfdump -Z \'host 8.8.8.8\'"
+    system "#{bin}/nfdump", "-Z 'host 8.8.8.8'"
   end
 end


### PR DESCRIPTION
Add nfdump to Homebrew. Nfdump is a tool for capturing, processing, and replaying netflow data. Site is located at http://nfdump.sourceforge.net