### PR TITLE
The command `brew tests' fails on Mac Book Pro early 2015.

### DIFF
--- a/Library/Homebrew/os/mac/hardware.rb
+++ b/Library/Homebrew/os/mac/hardware.rb
@@ -44,6 +44,8 @@ module MacCPUs
         :ivybridge
       when 0x10B282DC # Haswell
         :haswell
+      when 0x582ed09c # Broadwell
+        :broadwell
       else
         :dunno
       end

--- a/Library/Homebrew/test/test_hardware.rb
+++ b/Library/Homebrew/test/test_hardware.rb
@@ -7,7 +7,7 @@ class HardwareTests < Homebrew::TestCase
   end
 
   def test_hardware_intel_family
-    families = [:core, :core2, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell]
+    families = [:core, :core2, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell, :broadwell]
     assert_includes families, Hardware::CPU.family
   end if Hardware::CPU.intel?
 end


### PR DESCRIPTION
The reason it fails is sysctl hw.cpufamily returns different value
than previous models.