### PR TITLE
cairomm: revert cairo x11 dependency

### DIFF
--- a/Library/Formula/cairomm.rb
+++ b/Library/Formula/cairomm.rb
@@ -21,13 +21,8 @@ class Cairomm < Formula
   end
 
   depends_on "libpng"
+  depends_on "cairo"
   depends_on :x11 => :recommended
-
-  if build.without? "x11"
-    depends_on "cairo" => "without-x11"
-  else
-    depends_on "cairo"
-  end
 
   def install
     ENV.cxx11 if build.cxx11?


### PR DESCRIPTION
This partially reverts https://github.com/Homebrew/homebrew/commit/c56017af9943aedd9d75de69bb5392f0407cba4a

Re #38942.