### PR TITLE
Unset RUBYOPT and RUBYLIB in bin/brew

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -21,6 +21,8 @@ BREW_LIBRARY_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)
 # at non-system gem paths
 unset GEM_HOME
 unset GEM_PATH
+unset RUBYOPT
+unset RUBYLIB
 
 BREW_SYSTEM=$(uname -s | tr "[:upper:]" "[:lower:]")
 if [ "$BREW_SYSTEM" = "darwin" ]


### PR DESCRIPTION
In specific cases (for example while using backticks) Homebrew may pick up RUBYOPT and RUBYLIB from different version of Ruby and crash as a result.

Such crash happens for example during Rubinius compilation in RVM (rvm/rvm#3386) due to [Rubinius'es configure file checking for LLVM using Homebrew](https://github.com/rubinius/rubinius/blob/master/configure#L579)