### PR TITLE
boost: Add option to build with brewed bzip2

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -19,7 +19,11 @@ class Boost < Formula
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"
   option "with-mpi", "Build with MPI support"
+  option "with-brewed-bzip2", "Use homebrew's bzip2"
+
   option :cxx11
+
+  depends_on "homebrew/dupes/bzip2" => :optional
 
   deprecated_option "with-icu" => "with-icu4c"
 
@@ -44,6 +48,12 @@ class Boost < Formula
         is not supported.  Please use "--with-mpi" together with
         "--without-single".
       EOS
+    end
+
+    if build.with? "brewed-bzip2"
+      bzip2 = Formula["bzip2"].opt_prefix
+      ENV["BZIP2_INCLUDE"] = "#{bzip2}/include"
+      ENV["BZIP2_LIBPATH"] = "#{bzip2}/lib"
     end
 
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
This is being upstreamed from Homebrew/linuxbrew#322.

Although boost will always build on OS X due to presence of system provided headers, this gives the option to build with a brewed bzip2. This would be helpful on downstream linuxbrew without bzip2, as well as isolating dependencies on regular homebrew.
