### PR TITLE
ENV: Add ENV.parallelize method.

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -83,6 +83,10 @@ module Stdenv
   end
   alias_method :j1, :deparallelize
 
+  def parallelize
+    self['MAKEFLAGS'] ||= "-j#{self.make_jobs}"
+  end
+
   # These methods are no-ops for compatibility.
   %w{fast O4 Og}.each { |opt| define_method(opt) {} }
 

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -246,6 +246,10 @@ module Superenv
   end
   alias_method :j1, :deparallelize
 
+  def parallelize
+    self['MAKEFLAGS'] ||= "-j#{determine_make_jobs}"
+  end
+
   def make_jobs
     self['MAKEFLAGS'] =~ /-\w*j(\d)+/
     [$1.to_i, 1].max


### PR DESCRIPTION
I was wondering why #39025 was taking so long to test, and realized that the `ENV.deparallelize` used early on (when installing GMP) prevented a parallel build for the rest of the install. So — I propose a complementary method, `ENV.parallelize`, to re-enable a parallel build.