### PR TITLE
rpm: upgrade to 5.4.15

### DIFF
--- a/Library/Formula/rpm.rb
+++ b/Library/Formula/rpm.rb
@@ -15,30 +15,29 @@ end
 
 class Rpm < Formula
   homepage 'http://www.rpm5.org/'
-  url 'http://rpm5.org/files/rpm/rpm-5.4/rpm-5.4.14-0.20131024.src.rpm',
+  url 'http://rpm5.org/files/rpm/rpm-5.4/rpm-5.4.15-0.20140824.src.rpm',
       :using => RpmDownloadStrategy
-  version '5.4.14'
-  sha1 'ea1a5f073ba4923d32f98b4e95a3f2555824f22c'
+  version '5.4.15'
+  sha1 '5e94f4679759c36ce76a4847401b22b660a97227'
 
   depends_on 'berkeley-db'
   depends_on 'libmagic'
   depends_on 'popt'
-  depends_on 'beecrypt'
   depends_on 'libtasn1'
-  depends_on 'neon'
   depends_on 'gettext'
   depends_on 'xz'
   depends_on 'ossp-uuid'
-  depends_on 'pcre'
   depends_on 'rpm2cpio' => :build
 
   def install
+    # only rpm should go into HOMEBREW_CELLAR, not rpms built
+    inreplace "macros/macros.in", '@prefix@', HOMEBREW_PREFIX
     args = %W[
         --prefix=#{prefix}
         --localstatedir=#{var}
         --with-path-cfg=#{etc}/rpm
         --with-path-magic=#{HOMEBREW_PREFIX}/share/misc/magic
-        --with-extra-path-macros=#{lib}/rpm/macros.*
+        --with-path-sources=#{HOMEBREW_PREFIX}/var/lib/rpmbuild
         --with-libiconv-prefix=/usr
         --disable-openmp
         --disable-nls
@@ -47,23 +46,65 @@ class Rpm < Formula
         --with-sqlite=external
         --with-file=external
         --with-popt=external
-        --with-beecrypt=external
+        --with-beecrypt=internal
         --with-libtasn1=external
-        --with-neon=external
+        --with-neon=internal
         --with-uuid=external
-        --with-pcre=external
+        --with-pcre=internal
         --with-lua=internal
         --with-syck=internal
         --without-apidocs
         varprefix=#{var}
     ]
 
-    inreplace "configure", "db-6.0", "db-5.3"
-    inreplace "configure", "db_sql-6.0", "db_sql-5.3"
     system "./configure", *args
     inreplace "Makefile", "--tag=CC", "--tag=CXX"
     inreplace "Makefile", "--mode=link $(CCLD)", "--mode=link $(CXX)"
     system "make"
+    # enable rpmbuild macros, for building *.rpm packages
+    inreplace "macros/macros", "#%%{load:%{_usrlibrpm}/macros.rpmbuild}", "%{load:%{_usrlibrpm}/macros.rpmbuild}"
+    # using __scriptlet_requires needs bash --rpm-requires
+    inreplace "macros/macros.rpmbuild", "%_use_internal_dependency_generator\t2", "%_use_internal_dependency_generator\t1"
     system "make install"
+  end
+
+  def spec
+    <<-EOS.undent
+      Summary:   Test package
+      Name:      test
+      Version:   1.0
+      Release:   1
+      License:   Public Domain
+      Group:     Development/Tools
+      BuildArch: noarch
+
+      %description
+      Trivial test package
+
+      %prep
+      %build
+      %install
+      mkdir -p $RPM_BUILD_ROOT/tmp
+      touch $RPM_BUILD_ROOT/tmp/test
+
+      %files
+      /tmp/test
+
+      %changelog
+
+    EOS
+  end
+
+  def rpmdir macro
+    return Pathname.new(`#{bin}/rpm --eval #{macro}`.chomp)
+  end
+
+  test do
+    system "#{bin}/rpm", "-vv", "-qa"
+    rpmdir('%_builddir').mkpath
+    specfile = rpmdir('%_specdir')+'test.spec'
+    specfile.unlink if specfile.exist?
+    (specfile).write(spec)
+    system "#{bin}/rpmbuild", "-ba", specfile
   end
 end


### PR DESCRIPTION
Change from berkeley-db 5.3 to 6.1, and use external lua/syck.
Also make sure to set the right macros, for prefix / rpmbuild.

The rpm installation should go into prefix (in HOMEBREW_CELLAR),
while any rpms built by rpmbuild should go into HOMEBREW_PREFIX.

----
There is a test with rpm spec available in afb/rpm-5.4.15-test (6bec1e0589e07bf09203991a3036228e65260d2b)