### PR TITLE
Fixing audit warnings

### DIFF
--- a/Library/Formula/a2ps.rb
+++ b/Library/Formula/a2ps.rb
@@ -1,7 +1,7 @@
 class A2ps < Formula
-  homepage "http://www.gnu.org/software/a2ps/"
+  homepage "https://www.gnu.org/software/a2ps/"
   url "http://ftpmirror.gnu.org/a2ps/a2ps-4.14.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/a2ps/a2ps-4.14.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/a2ps/a2ps-4.14.tar.gz"
   sha1 "365abbbe4b7128bf70dad16d06e23c5701874852"
 
   bottle do
@@ -13,7 +13,7 @@ class A2ps < Formula
   # Software was last updated in 2007, so take MacPorts patches to get
   # it working on 10.6. See:
   # https://svn.macports.org/ticket/20867
-  # http://trac.macports.org/ticket/18255
+  # https://trac.macports.org/ticket/18255
   patch :p0 do
     url "https://trac.macports.org/export/56498/trunk/dports/print/a2ps/files/patch-contrib_sample_Makefile.in"
     sha1 "9b385295c2377e5362d62991e84d138d1713aabd"

--- a/Library/Formula/activemq-cpp.rb
+++ b/Library/Formula/activemq-cpp.rb
@@ -1,6 +1,6 @@
 class ActivemqCpp < Formula
   homepage "https://activemq.apache.org/cms/index.html"
-  url "http://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.8.4/activemq-cpp-library-3.8.4-src.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.8.4/activemq-cpp-library-3.8.4-src.tar.bz2"
   sha1 "7c0c79833f1647df3905948f3b8f2592bc7a8994"
 
   bottle do

--- a/Library/Formula/aldo.rb
+++ b/Library/Formula/aldo.rb
@@ -2,13 +2,13 @@ require 'formula'
 
 class Aldo < Formula
   homepage 'http://www.nongnu.org/aldo/'
-  url 'http://savannah.nongnu.org/download/aldo/aldo-0.7.7.tar.bz2'
+  url 'https://savannah.nongnu.org/download/aldo/aldo-0.7.7.tar.bz2'
   sha1 'c37589f8cb0855d33814b7462b3e5ded21caa8ea'
 
   depends_on 'libao'
 
   # Reported upstream:
-  # http://savannah.nongnu.org/bugs/index.php?42127
+  # https://savannah.nongnu.org/bugs/index.php?42127
   patch :DATA
 
   def install

--- a/Library/Formula/alpine.rb
+++ b/Library/Formula/alpine.rb
@@ -14,7 +14,7 @@ class Alpine < Formula
   depends_on "openssl"
 
   # Upstream builds are broken on Snow Leopard due to a hack put in for prior
-  # versions of OS X. See: http://trac.macports.org/ticket/20971
+  # versions of OS X. See: https://trac.macports.org/ticket/20971
   if MacOS.version >= :snow_leopard
     patch do
       url "https://trac.macports.org/export/89747/trunk/dports/mail/alpine/files/alpine-osx-10.6.patch"

--- a/Library/Formula/ant.rb
+++ b/Library/Formula/ant.rb
@@ -1,6 +1,6 @@
 class Ant < Formula
-  homepage "http://ant.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.9.4-bin.tar.gz"
+  homepage "https://ant.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.9.4-bin.tar.gz"
   sha1 "6c41481e8201f6b3f7e216146b95bb6de70208bb"
   head "https://git-wip-us.apache.org/repos/asf/ant.git"
 
@@ -17,7 +17,7 @@ class Ant < Formula
   option "with-bcel", "Install Byte Code Engineering Library"
 
   resource "ivy" do
-    url "http://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
     sha1 "97a206e3b6ec2ce9793d2ee151fa997a12647c7f"
   end
 

--- a/Library/Formula/apache-forrest.rb
+++ b/Library/Formula/apache-forrest.rb
@@ -1,12 +1,12 @@
 require 'formula'
 
 class ApacheForrest < Formula
-  homepage 'http://forrest.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-sources.tar.gz'
+  homepage 'https://forrest.apache.org/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-sources.tar.gz'
   sha1 '8c7b49a7dff4b3f60a52c7696684168b6d454a47'
 
   resource 'deps' do
-    url 'http://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-dependencies.tar.gz'
+    url 'https://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-dependencies.tar.gz'
     sha1 '10a4442d46baeadd3ba3377ed29ed694c86ece25'
   end
 

--- a/Library/Formula/apache-opennlp.rb
+++ b/Library/Formula/apache-opennlp.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class ApacheOpennlp < Formula
-  homepage "http://opennlp.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=opennlp/opennlp-1.5.3/apache-opennlp-1.5.3-bin.tar.gz"
-  mirror "http://www.us.apache.org/dist/opennlp/opennlp-1.5.3/apache-opennlp-1.5.3-bin.tar.gz"
+  homepage "https://opennlp.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=opennlp/opennlp-1.5.3/apache-opennlp-1.5.3-bin.tar.gz"
+  mirror "https://www.us.apache.org/dist/opennlp/opennlp-1.5.3/apache-opennlp-1.5.3-bin.tar.gz"
   sha1 "e14b41a4f1f1ae7fd12713bbdd8452b367bfdc9e"
 
   def install

--- a/Library/Formula/apachetop.rb
+++ b/Library/Formula/apachetop.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Apachetop < Formula
   homepage 'http://freecode.com/projects/apachetop'
-  url 'http://ftp.debian.org/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz'
+  url 'https://ftp.debian.org/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz'
   sha1 '005c9479800a418ee7febe5027478ca8cbf3c51b'
 
   bottle do

--- a/Library/Formula/apollo.rb
+++ b/Library/Formula/apollo.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Apollo < Formula
-  homepage 'http://activemq.apache.org/apollo'
+  homepage 'https://activemq.apache.org/apollo'
   url 'https://archive.apache.org/dist/activemq/activemq-apollo/1.7.1/apache-apollo-1.7.1-unix-distro.tar.gz'
   version '1.7.1'
   sha1 '5f9921042cc3167e48f54588f30da59f557f5a5a'

--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -1,6 +1,6 @@
 class AprUtil < Formula
   homepage "https://apr.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
   sha1 "b00038b5081472ed094ced28bcbf2b5bb56c589d"
 
   bottle do

--- a/Library/Formula/apr.rb
+++ b/Library/Formula/apr.rb
@@ -1,6 +1,6 @@
 class Apr < Formula
   homepage "https://apr.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.1.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.1.tar.bz2"
   sha1 "f94e4e0b678282e0704e573b5b2fe6d48bd1c309"
 
   bottle do

--- a/Library/Formula/apt-cacher-ng.rb
+++ b/Library/Formula/apt-cacher-ng.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class AptCacherNg < Formula
   homepage 'http://www.unix-ag.uni-kl.de/~bloch/acng/'
-  url "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_0.7.27.orig.tar.xz"
+  url "https://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_0.7.27.orig.tar.xz"
   sha1 "ae1324bf3c42909546f2b9d2a25cd9d837977a42"
 
   bottle do

--- a/Library/Formula/archey.rb
+++ b/Library/Formula/archey.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Archey < Formula
-  homepage 'http://obihann.github.io/archey-osx/'
+  homepage 'https://obihann.github.io/archey-osx/'
   url 'https://github.com/obihann/archey-osx/archive/1.4.tar.gz'
   sha1 '545896848444cd77b0c2cad50d5477f824ecf72f'
   head 'https://github.com/obihann/archey-osx.git'

--- a/Library/Formula/artifactory.rb
+++ b/Library/Formula/artifactory.rb
@@ -1,6 +1,6 @@
 class Artifactory < Formula
   homepage "http://www.jfrog.com/artifactory/"
-  url "http://dl.bintray.com/jfrog/artifactory/artifactory-3.5.1.zip"
+  url "https://dl.bintray.com/jfrog/artifactory/artifactory-3.5.1.zip"
   sha1 "bf07c877c73c0bf18754e0a31b347eb27cd07ada"
 
   depends_on :java => "1.7+"

--- a/Library/Formula/at-spi2-atk.rb
+++ b/Library/Formula/at-spi2-atk.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class AtSpi2Atk < Formula
   homepage "http://a11y.org"
-  url "http://ftp.gnome.org/pub/gnome/sources/at-spi2-atk/2.14/at-spi2-atk-2.14.1.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/at-spi2-atk/2.14/at-spi2-atk-2.14.1.tar.xz"
   sha256 "058f34ea60edf0a5f831c9f2bdd280fe95c1bcafb76e466e44aa0fb356d17bcb"
 
   bottle do

--- a/Library/Formula/at-spi2-core.rb
+++ b/Library/Formula/at-spi2-core.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class AtSpi2Core < Formula
   homepage "http://a11y.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/at-spi2-core/2.14/at-spi2-core-2.14.1.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/at-spi2-core/2.14/at-spi2-core-2.14.1.tar.xz"
   sha256 "eef9660b14fdf0fb1f30d1be7c72d591fa7cbb87b00ca3a444425712f46ce657"
 
   bottle do

--- a/Library/Formula/atkmm.rb
+++ b/Library/Formula/atkmm.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Atkmm < Formula
   homepage 'http://www.gtkmm.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.22/atkmm-2.22.7.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/atkmm/2.22/atkmm-2.22.7.tar.xz'
   sha256 'bfbf846b409b4c5eb3a52fa32a13d86936021969406b3dcafd4dd05abd70f91b'
 
   bottle do

--- a/Library/Formula/atool.rb
+++ b/Library/Formula/atool.rb
@@ -1,6 +1,6 @@
 class Atool < Formula
   homepage "https://savannah.nongnu.org/projects/atool/"
-  url "http://savannah.nongnu.org/download/atool/atool-0.39.0.tar.gz"
+  url "https://savannah.nongnu.org/download/atool/atool-0.39.0.tar.gz"
   sha1 "40865bdc533f95fcaffdf8002889eb2ac67224a9"
 
   bottle do

--- a/Library/Formula/autoconf-archive.rb
+++ b/Library/Formula/autoconf-archive.rb
@@ -25,7 +25,7 @@ class AutoconfArchive < Formula
 
       m4_include([#{share}/aclocal/ax_have_select.m4])
 
-      # from http://www.gnu.org/software/autoconf-archive/ax_have_select.html
+      # from https://www.gnu.org/software/autoconf-archive/ax_have_select.html
       AX_HAVE_SELECT(
         [AX_CONFIG_FEATURE_ENABLE(select)],
         [AX_CONFIG_FEATURE_DISABLE(select)])

--- a/Library/Formula/avidemux.rb
+++ b/Library/Formula/avidemux.rb
@@ -65,7 +65,7 @@ class Avidemux < Formula
     ENV["REV"] = version.to_s
 
     # For 32-bit compilation under gcc 4.2, see:
-    # http://trac.macports.org/ticket/20938#comment:22
+    # https://trac.macports.org/ticket/20938#comment:22
     if MacOS.version <= :leopard || (Hardware.is_32_bit? && Hardware::CPU.intel? && ENV.compiler == :clang)
       inreplace "cmake/admFFmpegBuild.cmake",
         "${CMAKE_INSTALL_PREFIX})",

--- a/Library/Formula/avrdude.rb
+++ b/Library/Formula/avrdude.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Avrdude < Formula
-  homepage 'http://savannah.nongnu.org/projects/avrdude/'
+  homepage 'https://savannah.nongnu.org/projects/avrdude/'
   url 'http://download.savannah.gnu.org/releases/avrdude/avrdude-6.1.tar.gz'
   mirror 'http://download-mirror.savannah.gnu.org/releases/avrdude/avrdude-6.1.tar.gz'
   sha1 '15525cbff5918568ef3955d871dbb94feaf83c79'

--- a/Library/Formula/avro-c.rb
+++ b/Library/Formula/avro-c.rb
@@ -1,6 +1,6 @@
 class AvroC < Formula
-  homepage "http://avro.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz"
+  homepage "https://avro.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz"
   sha1 "cbb698682d662c5e0abec023dcd37ce1f3db80d4"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/avro-cpp.rb
+++ b/Library/Formula/avro-cpp.rb
@@ -1,6 +1,6 @@
 class AvroCpp < Formula
-  homepage "http://avro.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/cpp/avro-cpp-1.7.7.tar.gz"
+  homepage "https://avro.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/cpp/avro-cpp-1.7.7.tar.gz"
   sha1 "2fdc16bfee5786053846341d89d11160df8d57d4"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/avro-tools.rb
+++ b/Library/Formula/avro-tools.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class AvroTools < Formula
-  homepage "http://avro.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/java/avro-tools-1.7.7.jar"
+  homepage "https://avro.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/java/avro-tools-1.7.7.jar"
   sha1 "a2c493c897583892b0423f0c9c732c242cd8816d"
 
   def install

--- a/Library/Formula/bam.rb
+++ b/Library/Formula/bam.rb
@@ -1,5 +1,5 @@
 class Bam < Formula
-  homepage "http://matricks.github.io/bam/"
+  homepage "https://matricks.github.io/bam/"
   url "https://github.com/downloads/matricks/bam/bam-0.4.0.tar.gz"
   sha1 "c0f32ff9272d5552e02a9d68fbdd72106437ee69"
 

--- a/Library/Formula/bash-completion.rb
+++ b/Library/Formula/bash-completion.rb
@@ -9,7 +9,7 @@ class BashCompletion < Formula
   sha1 '6a46b93f44c56cc336632ab28d90c0595fbcc98f'
 
   # Backports the following upstream patch from 2.x:
-  # http://anonscm.debian.org/gitweb/?p=bash-completion/bash-completion.git;a=patch;h=50ae57927365a16c830899cc1714be73237bdcb2
+  # https://anonscm.debian.org/gitweb/?p=bash-completion/bash-completion.git;a=patch;h=50ae57927365a16c830899cc1714be73237bdcb2
   patch :DATA
 
   def compdir

--- a/Library/Formula/beanstalk.rb
+++ b/Library/Formula/beanstalk.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Beanstalk < Formula
-  homepage "http://kr.github.io/beanstalkd/"
+  homepage "https://kr.github.io/beanstalkd/"
   url "https://github.com/kr/beanstalkd/archive/v1.10.tar.gz"
   sha1 "bfc0ccf99e15b15eac03ec1d8a57a3aaff143237"
 

--- a/Library/Formula/binutils.rb
+++ b/Library/Formula/binutils.rb
@@ -1,7 +1,7 @@
 class Binutils < Formula
-  homepage "http://www.gnu.org/software/binutils/binutils.html"
+  homepage "https://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
   sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
 
   # No --default-names option as it interferes with Homebrew builds.

--- a/Library/Formula/blitzwave.rb
+++ b/Library/Formula/blitzwave.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Blitzwave < Formula
-  homepage 'http://oschulz.github.io/blitzwave'
+  homepage 'https://oschulz.github.io/blitzwave'
   url 'https://github.com/oschulz/blitzwave/archive/v0.8.0.tar.gz'
   sha1 '16d96f28ba295659301ab6485782715786fd496e'
 

--- a/Library/Formula/ccze.rb
+++ b/Library/Formula/ccze.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ccze < Formula
-  homepage 'http://packages.debian.org/wheezy/ccze'
+  homepage 'https://packages.debian.org/wheezy/ccze'
   url 'http://ftp.de.debian.org/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz'
   sha1 'a265e826be8018cd2f1b13ea1e96e27cc1941d02'
 

--- a/Library/Formula/cdrdao.rb
+++ b/Library/Formula/cdrdao.rb
@@ -24,7 +24,7 @@ class Cdrdao < Formula
   end
 
   # second patch fixes device autodetection on OS X
-  # see http://trac.macports.org/ticket/27819
+  # see https://trac.macports.org/ticket/27819
   # upstream bug report:
   # http://sourceforge.net/tracker/?func=detail&aid=3381672&group_id=2171&atid=102171
   patch :p0, :DATA

--- a/Library/Formula/chibi-scheme.rb
+++ b/Library/Formula/chibi-scheme.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class ChibiScheme < Formula
-  homepage "http://code.google.com/p/chibi-scheme/"
+  homepage "https://code.google.com/p/chibi-scheme/"
 
   stable do
     url "http://abrek.synthcode.com/chibi-scheme-0.7.2.tgz"

--- a/Library/Formula/cifer.rb
+++ b/Library/Formula/cifer.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Cifer < Formula
-  homepage 'http://code.google.com/p/cifer/'
+  homepage 'https://code.google.com/p/cifer/'
   url 'https://cifer.googlecode.com/files/cifer-1.2.0.tar.gz'
   sha1 'dba2abbd672cd072c01f91a923e0830c009b66f2'
 

--- a/Library/Formula/clamz.rb
+++ b/Library/Formula/clamz.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Clamz < Formula
-  homepage 'http://code.google.com/p/clamz/'
+  homepage 'https://code.google.com/p/clamz/'
   url 'https://clamz.googlecode.com/files/clamz-0.5.tar.gz'
   sha1 '54664614e5098f9e4e9240086745b94fe638b176'
   revision 1

--- a/Library/Formula/clisp.rb
+++ b/Library/Formula/clisp.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Clisp < Formula
   homepage 'http://www.clisp.org/'
   url 'http://ftpmirror.gnu.org/clisp/release/2.49/clisp-2.49.tar.bz2'
-  mirror 'http://ftp.gnu.org/gnu/clisp/release/2.49/clisp-2.49.tar.bz2'
+  mirror 'https://ftp.gnu.org/gnu/clisp/release/2.49/clisp-2.49.tar.bz2'
   sha1 '7e8d585ef8d0d6349ffe581d1ac08681e6e670d4'
 
   depends_on 'libsigsegv'

--- a/Library/Formula/clutter-gst.rb
+++ b/Library/Formula/clutter-gst.rb
@@ -1,6 +1,6 @@
 class ClutterGst < Formula
   homepage "https://developer.gnome.org/clutter-gst/"
-  url "http://ftp.gnome.org/pub/gnome/sources/clutter-gst/2.0/clutter-gst-2.0.12.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/clutter-gst/2.0/clutter-gst-2.0.12.tar.xz"
   sha256 "c2f1453692b0c3ff6a500113bc1d2c95d2bde11caca0809610a6d1424bbbffb5"
 
   bottle do

--- a/Library/Formula/clutter-gtk.rb
+++ b/Library/Formula/clutter-gtk.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class ClutterGtk < Formula
   homepage "https://wiki.gnome.org/Projects/Clutter"
-  url "http://ftp.gnome.org/pub/gnome/sources/clutter-gtk/1.6/clutter-gtk-1.6.0.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/clutter-gtk/1.6/clutter-gtk-1.6.0.tar.xz"
   sha256 "883550b574a036363239442edceb61cf3f6bedc8adc97d3404278556dc82234d"
 
   deprecated_option "without-x" => "without-x11"

--- a/Library/Formula/clutter.rb
+++ b/Library/Formula/clutter.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Clutter < Formula
   homepage "https://wiki.gnome.org/Projects/Clutter"
-  url "http://ftp.gnome.org/pub/gnome/sources/clutter/1.20/clutter-1.20.0.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/clutter/1.20/clutter-1.20.0.tar.xz"
   sha256 "cc940809e6e1469ce349c4bddb0cbcc2c13c087d4fc15cda9278d855ee2d1293"
 
   bottle do

--- a/Library/Formula/cmigemo.rb
+++ b/Library/Formula/cmigemo.rb
@@ -16,7 +16,7 @@ class Cmigemo < Formula
   depends_on 'nkf' => :build
 
   def install
-    system "chmod +x ./configure"
+    chmod "+x", "./configure"
     system "./configure", "--prefix=#{prefix}"
     system "make osx"
     system "make osx-dict"

--- a/Library/Formula/cmockery.rb
+++ b/Library/Formula/cmockery.rb
@@ -1,13 +1,13 @@
 require 'formula'
 
 class Cmockery < Formula
-  homepage 'http://code.google.com/p/cmockery/'
+  homepage 'https://code.google.com/p/cmockery/'
   url 'https://cmockery.googlecode.com/files/cmockery-0.1.2.tar.gz'
   sha1 '964ed1104a0cbbea8a9a34e88c6e79b546eff1bc'
 
   # This patch will be integrated upstream in 0.1.3, this is due to malloc.h being already in stdlib on OSX
   # It is safe to remove it on the next version
-  # More info on http://code.google.com/p/cmockery/issues/detail?id=3
+  # More info on https://code.google.com/p/cmockery/issues/detail?id=3
   patch :DATA
 
   def install

--- a/Library/Formula/confuse.rb
+++ b/Library/Formula/confuse.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Confuse < Formula
   homepage 'http://www.nongnu.org/confuse/'
-  url 'http://savannah.nongnu.org/download/confuse/confuse-2.7.tar.gz'
+  url 'https://savannah.nongnu.org/download/confuse/confuse-2.7.tar.gz'
   sha1 'b3f74f9763e6c9012476dbd323d083af4be34cad'
 
   bottle do

--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Couchdb < Formula
-  homepage "http://couchdb.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
+  homepage "https://couchdb.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
   sha1 "6275f3818579d7b307052e9735c42a8a64313229"
   revision 1
 

--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -13,7 +13,7 @@ class Couchdb < Formula
   end
 
   head do
-    url "http://git-wip-us.apache.org/repos/asf/couchdb.git"
+    url "https://git-wip-us.apache.org/repos/asf/couchdb.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Library/Formula/cppi.rb
+++ b/Library/Formula/cppi.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Cppi < Formula
-  homepage 'http://www.gnu.org/software/cppi/'
+  homepage 'https://www.gnu.org/software/cppi/'
   url 'http://ftpmirror.gnu.org/cppi/cppi-1.18.tar.xz'
-  mirror 'http://ftp.gnu.org/cppi/cppi-1.18.tar.xz'
+  mirror 'https://ftp.gnu.org/cppi/cppi-1.18.tar.xz'
   sha1 '5f46d04041fc6e3413d5312db5b99329143a7c33'
 
   def install

--- a/Library/Formula/cppunit.rb
+++ b/Library/Formula/cppunit.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Cppunit < Formula
-  homepage "http://www.freedesktop.org/wiki/Software/cppunit/"
+  homepage "https://wiki.freedesktop.org/www/Software/cppunit/"
   url "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
   sha1 "0eaf8bb1dcf4d16b12bec30d0732370390d35e6f"
 

--- a/Library/Formula/cronolog.rb
+++ b/Library/Formula/cronolog.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Cronolog < Formula
   homepage "http://web.archive.org/web/20140209202032/http://cronolog.org/"
-  url "http://fossies.org/linux/www/cronolog-1.6.2.tar.gz"
+  url "https://fossies.org/linux/www/cronolog-1.6.2.tar.gz"
   sha1 "6422b7c5e87241eb31d76809a2e0eea77ae4c64e"
 
   def install

--- a/Library/Formula/csshx.rb
+++ b/Library/Formula/csshx.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Csshx < Formula
-  homepage 'http://code.google.com/p/csshx/'
+  homepage 'https://code.google.com/p/csshx/'
   url 'https://csshx.googlecode.com/files/csshX-0.74.tgz'
   sha1 'aa686b71161d6144d539d077b960da10d7b96993'
 

--- a/Library/Formula/csvprintf.rb
+++ b/Library/Formula/csvprintf.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Csvprintf < Formula
-  homepage 'http://code.google.com/p/csvprintf/'
+  homepage 'https://code.google.com/p/csvprintf/'
   url 'https://csvprintf.googlecode.com/files/csvprintf-1.0.3.tar.gz'
   sha1 'ee5ee6728a44cc7d0961b0960c7a444372752931'
 

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -1,6 +1,6 @@
 class DBus < Formula
   # releases: even (1.8.x) = stable, odd (1.9.x) = development
-  homepage "http://www.freedesktop.org/wiki/Software/dbus"
+  homepage "https://wiki.freedesktop.org/www/Software/dbus"
   url "http://dbus.freedesktop.org/releases/dbus/dbus-1.8.14.tar.gz"
   sha1 "d0b84d6d7af47b8cad7f55befee8e9001daefe01"
 

--- a/Library/Formula/darkice.rb
+++ b/Library/Formula/darkice.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Darkice < Formula
-  homepage 'http://code.google.com/p/darkice/'
+  homepage 'https://code.google.com/p/darkice/'
   url 'https://darkice.googlecode.com/files/darkice-1.2.tar.gz'
   sha1 '508eb0560a7cdf0990a8793f4b8d324ae74bc343'
 

--- a/Library/Formula/datamash.rb
+++ b/Library/Formula/datamash.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Datamash < Formula
-  homepage "http://www.gnu.org/software/datamash"
+  homepage "https://www.gnu.org/software/datamash"
   url "http://ftpmirror.gnu.org/datamash/datamash-1.0.6.tar.gz"
   sha1 "2423314727dfe1750a8f0c6dbc131458a6a67ca6"
 

--- a/Library/Formula/debianutils.rb
+++ b/Library/Formula/debianutils.rb
@@ -1,5 +1,5 @@
 class Debianutils < Formula
-  homepage "http://anonscm.debian.org/gitweb/?p=users/clint/debianutils.git"
+  homepage "https://anonscm.debian.org/gitweb/?p=users/clint/debianutils.git"
   url "http://ftp.de.debian.org/debian/pool/main/d/debianutils/debianutils_4.4.tar.gz"
   sha1 "019b969ab698c83117254b50fc8f469f10a5d8d6"
 

--- a/Library/Formula/diff-pdf.rb
+++ b/Library/Formula/diff-pdf.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class DiffPdf < Formula
-  homepage "http://vslavik.github.io/diff-pdf/"
+  homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha1 "308ea8e92ac609ca88303dce6a6e8403c6b9f11f"
 

--- a/Library/Formula/dircproxy.rb
+++ b/Library/Formula/dircproxy.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Dircproxy < Formula
-  homepage 'http://code.google.com/p/dircproxy/'
+  homepage 'https://code.google.com/p/dircproxy/'
   url 'https://dircproxy.googlecode.com/files/dircproxy-1.2.0-RC1.tar.gz'
   sha1 '7dc4b3aa2e10222f74e280de69c41f571335a96b'
 

--- a/Library/Formula/dirmngr.rb
+++ b/Library/Formula/dirmngr.rb
@@ -1,7 +1,7 @@
 class Dirmngr < Formula
   homepage "http://www.gnupg.org"
   url "ftp://ftp.gnupg.org/gcrypt/dirmngr/dirmngr-1.1.1.tar.bz2"
-  mirror "http://ftp.debian.org/debian/pool/main/d/dirmngr/dirmngr_1.1.1.orig.tar.bz2"
+  mirror "https://ftp.debian.org/debian/pool/main/d/dirmngr/dirmngr_1.1.1.orig.tar.bz2"
   sha1 "e708d4aa5ce852f4de3f4b58f4e4f221f5e5c690"
   revision 1
 

--- a/Library/Formula/distcc.rb
+++ b/Library/Formula/distcc.rb
@@ -10,7 +10,7 @@ class PythonWithoutPPC < Requirement
 end
 
 class Distcc < Formula
-  homepage 'http://code.google.com/p/distcc/'
+  homepage 'https://code.google.com/p/distcc/'
   url 'https://distcc.googlecode.com/files/distcc-3.2rc1.tar.gz'
   sha1 '7cd46fe0926a3a859a516274e6ae59fa8ba0262d'
 

--- a/Library/Formula/dnscrypt-wrapper.rb
+++ b/Library/Formula/dnscrypt-wrapper.rb
@@ -1,5 +1,5 @@
 class DnscryptWrapper < Formula
-  homepage "http://cofyc.github.io/dnscrypt-wrapper/"
+  homepage "https://cofyc.github.io/dnscrypt-wrapper/"
   url "https://github.com/Cofyc/dnscrypt-wrapper/releases/download/v0.1.15/dnscrypt-wrapper-v0.1.15.tar.bz2"
   sha256 "d486f3f923c6809c830e9db39290b0f44b1683f63f8bd3aeaa6225c64af232c1"
   head "https://github.com/Cofyc/dnscrypt-wrapper.git"

--- a/Library/Formula/dnsmap.rb
+++ b/Library/Formula/dnsmap.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Dnsmap < Formula
-  homepage 'http://code.google.com/p/dnsmap/'
+  homepage 'https://code.google.com/p/dnsmap/'
   url 'https://dnsmap.googlecode.com/files/dnsmap-0.30.tar.gz'
   sha1 'a9a8a17102825510d16c1f8af33ca74407c18c70'
 

--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -3,7 +3,7 @@ require "formula"
 class Dovecot < Formula
   homepage "http://dovecot.org/"
   url "http://dovecot.org/releases/2.2/dovecot-2.2.15.tar.gz"
-  mirror "http://fossies.org/linux/misc/dovecot-2.2.15.tar.gz"
+  mirror "https://fossies.org/linux/misc/dovecot-2.2.15.tar.gz"
   sha1 "10c90f1f08797b5931703d52a871437e6561d76f"
 
   bottle do

--- a/Library/Formula/dpkg.rb
+++ b/Library/Formula/dpkg.rb
@@ -1,7 +1,7 @@
 class Dpkg < Formula
   homepage "https://wiki.debian.org/Teams/Dpkg"
   url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
-  mirror "http://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
+  mirror "https://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
   sha256 "07019d38ae98fb107c79dbb3690cfadff877f153b8c4970e3a30d2e59aa66baa"
 
   bottle do

--- a/Library/Formula/dtc.rb
+++ b/Library/Formula/dtc.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Dtc < Formula
   homepage "http://www.devicetree.org/"
-  url "http://ftp.debian.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
+  url "https://ftp.debian.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
   sha1 "2f9697aa7dbc3036f43524a454bdf28bf7e0f701"
 
   def install

--- a/Library/Formula/dvdrtools.rb
+++ b/Library/Formula/dvdrtools.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Dvdrtools < Formula
-  homepage 'http://savannah.nongnu.org/projects/dvdrtools/'
-  url 'http://savannah.nongnu.org/download/dvdrtools/dvdrtools-0.2.1.tar.gz'
+  homepage 'https://savannah.nongnu.org/projects/dvdrtools/'
+  url 'https://savannah.nongnu.org/download/dvdrtools/dvdrtools-0.2.1.tar.gz'
   sha1 'b8b889f73953c121acd85ce1b4ba988ef7ef6bfc'
 
   conflicts_with 'cdrtools',

--- a/Library/Formula/enscript.rb
+++ b/Library/Formula/enscript.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Enscript < Formula
-  homepage 'http://www.gnu.org/software/enscript/'
+  homepage 'https://www.gnu.org/software/enscript/'
   url 'http://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz'
   sha1 '1f1e97a2ebb3d77f48c57487fe39e64139fb2beb'
 
   head 'git://git.savannah.gnu.org/enscript.git'

--- a/Library/Formula/es.rb
+++ b/Library/Formula/es.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Es < Formula
-  homepage "http://wryun.github.io/es-shell/"
+  homepage "https://wryun.github.io/es-shell/"
   url "https://github.com/downloads/wryun/es-shell/es-0.9.tar.gz"
   sha1 "40b0b3838c07a434b4cccca9a8bb173c71eda7d8"
 

--- a/Library/Formula/esound.rb
+++ b/Library/Formula/esound.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Esound < Formula
   homepage 'http://www.tux.org/~ricdude/EsounD.html'
-  url 'http://ftp.gnome.org/pub/gnome/sources/esound/0.2/esound-0.2.41.tar.bz2'
+  url 'https://ftp.gnome.org/pub/gnome/sources/esound/0.2/esound-0.2.41.tar.bz2'
   sha1 '6c343483b3789f439277935eaad7e478bee685ea'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/exempi.rb
+++ b/Library/Formula/exempi.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Exempi < Formula
-  homepage "http://libopenraw.freedesktop.org/wiki/Exempi"
+  homepage "https://wiki.freedesktop.org/libopenraw/Exempi"
   url "http://libopenraw.freedesktop.org/download/exempi-2.2.2.tar.bz2"
   sha1 "c0a0014e18f05aa7fac210c84788ef073718a9d8"
 

--- a/Library/Formula/exim.rb
+++ b/Library/Formula/exim.rb
@@ -27,7 +27,7 @@ class Exim < Formula
       s.gsub! '/usr/exim/configure', etc/'exim.conf'
       s.gsub! '/usr/exim', prefix
       s.gsub! '/var/spool/exim', var/'spool/exim'
-      # http://trac.macports.org/ticket/38654
+      # https://trac.macports.org/ticket/38654
       s.gsub! 'TMPDIR="/tmp"', 'TMPDIR=/tmp'
       s << "SUPPORT_MAILDIR=yes\n" if build.include? 'support-maildir'
       s << "AUTH_PLAINTEXT=yes\n"

--- a/Library/Formula/fakeroot.rb
+++ b/Library/Formula/fakeroot.rb
@@ -1,7 +1,7 @@
 class Fakeroot < Formula
   homepage "https://tracker.debian.org/pkg/fakeroot"
   url "https://mirrors.kernel.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
-  mirror "http://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
+  mirror "https://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
   sha1 "367040df07043edb630942b21939e493f3fad888"
 
   bottle do

--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ffmpegthumbnailer < Formula
-  homepage 'http://code.google.com/p/ffmpegthumbnailer/'
+  homepage 'https://code.google.com/p/ffmpegthumbnailer/'
   url 'https://ffmpegthumbnailer.googlecode.com/files/ffmpegthumbnailer-2.0.8.tar.gz'
   sha1 '2c54ca16efd953f46547e22799cfc40bd9c24533'
   bottle do

--- a/Library/Formula/findutils.rb
+++ b/Library/Formula/findutils.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Findutils < Formula
-  homepage "http://www.gnu.org/software/findutils/"
+  homepage "https://www.gnu.org/software/findutils/"
   url "http://ftpmirror.gnu.org/findutils/findutils-4.4.2.tar.gz"
   mirror "https://ftp.gnu.org/gnu/findutils/findutils-4.4.2.tar.gz"
   sha1 "e8dd88fa2cc58abffd0bfc1eddab9020231bb024"

--- a/Library/Formula/fltk.rb
+++ b/Library/Formula/fltk.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Fltk < Formula
   homepage "http://www.fltk.org/"
-  url "http://fossies.org/linux/misc/fltk-1.3.3-source.tar.gz"
+  url "https://fossies.org/linux/misc/fltk-1.3.3-source.tar.gz"
   sha1 "873aac49b277149e054b9740378e2ca87b0bd435"
 
   bottle do

--- a/Library/Formula/fop.rb
+++ b/Library/Formula/fop.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Fop < Formula
-  homepage "http://xmlgraphics.apache.org/fop/index.html"
-  url "http://www.apache.org/dyn/closer.cgi?path=/xmlgraphics/fop/binaries/fop-1.1-bin.tar.gz"
+  homepage "https://xmlgraphics.apache.org/fop/index.html"
+  url "https://www.apache.org/dyn/closer.cgi?path=/xmlgraphics/fop/binaries/fop-1.1-bin.tar.gz"
   sha1 '6b96c3f3fd5efe9f2b6b54bfa96161ec3f6a1dbc'
 
   # http://offo.sourceforge.net/hyphenation/
@@ -12,7 +12,7 @@ class Fop < Formula
   end
 
   # fixes broken default java path as in
-  # http://svn.apache.org/viewvc/ant/core/trunk/src/script/ant?r1=1238725&r2=1434680&pathrev=1434680&view=patch
+  # https://svn.apache.org/viewvc/ant/core/trunk/src/script/ant?r1=1238725&r2=1434680&pathrev=1434680&view=patch
   patch :DATA
 
   def install

--- a/Library/Formula/fsw.rb
+++ b/Library/Formula/fsw.rb
@@ -1,5 +1,5 @@
 class Fsw < Formula
-  homepage "http://emcrisostomo.github.io/fsw/"
+  homepage "https://emcrisostomo.github.io/fsw/"
   url "https://github.com/emcrisostomo/fsw/releases/download/1.3.9/fsw-1.3.9.tar.gz"
   sha1 "bd2b230dc800946941d89512ce9ae8669365d21a"
 

--- a/Library/Formula/fuse4x-kext.rb
+++ b/Library/Formula/fuse4x-kext.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Fuse4xKext < Formula
-  homepage "http://fuse4x.github.io"
+  homepage "https://fuse4x.github.io"
   url "https://github.com/fuse4x/kext/archive/fuse4x_0_9_2.tar.gz"
   sha1 "4222c14b38325d9e41fb0925d2681dda3e73e861"
 

--- a/Library/Formula/fuse4x.rb
+++ b/Library/Formula/fuse4x.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Fuse4x < Formula
-  homepage "http://fuse4x.github.io"
+  homepage "https://fuse4x.github.io"
   url "https://github.com/fuse4x/fuse/archive/fuse4x_0_9_2.tar.gz"
   sha1 "3a9700f716eff930dcd2426772c642a09adcc73a"
 

--- a/Library/Formula/fuseki.rb
+++ b/Library/Formula/fuseki.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Fuseki < Formula
-  homepage 'http://jena.apache.org/documentation/serving_data/'
-  url 'http://www.apache.org/dist/jena/binaries/jena-fuseki-1.1.1-distribution.tar.gz'
+  homepage 'https://jena.apache.org/documentation/serving_data/'
+  url 'https://www.apache.org/dist/jena/binaries/jena-fuseki-1.1.1-distribution.tar.gz'
   version '1.1.1'
   sha1 '12453d3e3de1a01d3413e94712c9219d065c55ad'
 
@@ -49,7 +49,7 @@ class Fuseki < Formula
     Quick-start guide:
 
     * See the Fuseki documentation for instructions on using an in-memory database:
-      http://jena.apache.org/documentation/serving_data/#fuseki-server-starting-with-an-empty-dataset
+      https://jena.apache.org/documentation/serving_data/#fuseki-server-starting-with-an-empty-dataset
 
     * Running from the LaunchAgent is different the standard configuration and
       uses traditional Unix paths: please inspect the settings here first:

--- a/Library/Formula/g2.rb
+++ b/Library/Formula/g2.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class G2 < Formula
-  homepage 'http://orefalo.github.io/g2/'
+  homepage 'https://orefalo.github.io/g2/'
   url 'https://github.com/orefalo/g2/archive/v1.1.tar.gz'
   sha1 'e225d21623e6884a9e99a92f43cdd750068ad211'
 

--- a/Library/Formula/garmintools.rb
+++ b/Library/Formula/garmintools.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Garmintools < Formula
-  homepage 'http://code.google.com/p/garmintools/'
+  homepage 'https://code.google.com/p/garmintools/'
   url 'https://garmintools.googlecode.com/files/garmintools-0.10.tar.gz'
   sha1 'f59a761b09575d27abbf5d76811f7ec25a1cbd26'
 

--- a/Library/Formula/gawk.rb
+++ b/Library/Formula/gawk.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Gawk < Formula
-  homepage "http://www.gnu.org/software/gawk/"
+  homepage "https://www.gnu.org/software/gawk/"
   url "http://ftpmirror.gnu.org/gawk/gawk-4.1.1.tar.xz"
-  mirror "http://ftp.gnu.org/gnu/gawk/gawk-4.1.1.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gawk/gawk-4.1.1.tar.xz"
   sha1 "547feb48d20e923aff58daccee97c94e047fdc18"
 
   bottle do

--- a/Library/Formula/gcab.rb
+++ b/Library/Formula/gcab.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gcab < Formula
   homepage 'https://wiki.gnome.org/msitools'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gcab/0.4/gcab-0.4.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gcab/0.4/gcab-0.4.tar.xz'
   sha1 'd81dfe35125e611e3a94c0d4def37ebf62b9187c'
 
   depends_on 'intltool' => :build

--- a/Library/Formula/gcal.rb
+++ b/Library/Formula/gcal.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Gcal < Formula
-  homepage 'http://www.gnu.org/software/gcal/'
+  homepage 'https://www.gnu.org/software/gcal/'
   url 'http://ftpmirror.gnu.org/gcal/gcal-3.6.3.tar.xz'
-  mirror 'http://ftp.gnu.org/gnu/gcal/gcal-3.6.3.tar.xz'
+  mirror 'https://ftp.gnu.org/gnu/gcal/gcal-3.6.3.tar.xz'
   sha1 'a5d68216d8b0735c9b095fb81a08d6dbf5cdeedd'
 
   def install

--- a/Library/Formula/gconf.rb
+++ b/Library/Formula/gconf.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Gconf < Formula
-  homepage 'http://projects.gnome.org/gconf/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/GConf/3.2/GConf-3.2.6.tar.xz'
+  homepage 'https://projects.gnome.org/gconf/'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/GConf/3.2/GConf-3.2.6.tar.xz'
   sha256 '1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class GdkPixbuf < Formula
   homepage 'http://gtk.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz'
   sha256 '4853830616113db4435837992c0aebd94cbb993c44dc55063cee7f72a7bef8be'
 
   bottle do

--- a/Library/Formula/gforth.rb
+++ b/Library/Formula/gforth.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Gforth < Formula
-  homepage 'http://www.gnu.org/software/gforth/'
+  homepage 'https://www.gnu.org/software/gforth/'
   url 'http://www.complang.tuwien.ac.at/forth/gforth/gforth-0.7.3.tar.gz'
   sha256 '2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0'
 

--- a/Library/Formula/git-cola.rb
+++ b/Library/Formula/git-cola.rb
@@ -1,5 +1,5 @@
 class GitCola < Formula
-  homepage "http://git-cola.github.io/"
+  homepage "https://git-cola.github.io/"
   url "https://github.com/git-cola/git-cola/archive/v2.1.0.tar.gz"
   sha1 "c93e74b021e6e5df92a46a3d05ac8a6377571fa8"
 

--- a/Library/Formula/git-integration.rb
+++ b/Library/Formula/git-integration.rb
@@ -12,7 +12,7 @@ class SufficientlyRecentGit < Requirement
 end
 
 class GitIntegration < Formula
-  homepage "http://johnkeeping.github.io/git-integration/"
+  homepage "https://johnkeeping.github.io/git-integration/"
   url "https://github.com/johnkeeping/git-integration/archive/v0.3.tar.gz"
   sha1 "fc64f987a2a6b73c61c8a5278d06bcaa46ee9312"
 

--- a/Library/Formula/git-multipush.rb
+++ b/Library/Formula/git-multipush.rb
@@ -1,5 +1,5 @@
 class GitMultipush < Formula
-  homepage 'http://code.google.com/p/git-multipush/'
+  homepage 'https://code.google.com/p/git-multipush/'
   url 'https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2'
   sha1 'a53f171af5e794afe9b1de6ccd9bd0661db6fd91'
 

--- a/Library/Formula/git-url-sub.rb
+++ b/Library/Formula/git-url-sub.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class GitUrlSub < Formula
-  homepage 'http://gosuri.github.io/git-url-sub'
+  homepage 'https://gosuri.github.io/git-url-sub'
   url 'https://github.com/gosuri/git-url-sub/archive/1.0.1.tar.gz'
   sha1 '294631d898a4263285f7a2ac0ce93ff494dadbf8'
 

--- a/Library/Formula/glib-networking.rb
+++ b/Library/Formula/glib-networking.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class GlibNetworking < Formula
   homepage "https://launchpad.net/glib-networking"
-  url "http://ftp.gnome.org/pub/GNOME/sources/glib-networking/2.42/glib-networking-2.42.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/glib-networking/2.42/glib-networking-2.42.0.tar.xz"
   sha256 "304dd9e4c0ced69094300e0b9e66cd2eaae7161b9fc3186536d11458677d820d"
 
   def pour_bottle?

--- a/Library/Formula/glib.rb
+++ b/Library/Formula/glib.rb
@@ -1,6 +1,6 @@
 class Glib < Formula
   homepage "https://developer.gnome.org/glib/"
-  url "http://ftp.gnome.org/pub/gnome/sources/glib/2.44/glib-2.44.0.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/glib/2.44/glib-2.44.0.tar.xz"
   sha256 "f2d362b106a08fa801770d41829a06fcfe287a00421018869eebf5efc796f5b9"
 
   bottle do

--- a/Library/Formula/gmediaserver.rb
+++ b/Library/Formula/gmediaserver.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Gmediaserver < Formula
-  homepage 'http://www.gnu.org/software/gmediaserver/'
+  homepage 'https://www.gnu.org/software/gmediaserver/'
   url 'http://download.savannah.gnu.org/releases/gmediaserver/gmediaserver-0.13.0.tar.gz'
   sha1 '5b868bc3c3d3bf0c2c550a4fc618c586a2640799'
 

--- a/Library/Formula/gmime.rb
+++ b/Library/Formula/gmime.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gmime < Formula
   homepage 'http://spruce.sourceforge.net/gmime/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gmime/2.6/gmime-2.6.20.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gmime/2.6/gmime-2.6.20.tar.xz'
   sha256 'e0a170fb264c2ae4cecd852f4e7aaddb8d58e8f3f0b569ce2d2a4704f55bdf65'
 
   bottle do

--- a/Library/Formula/gnome-common.rb
+++ b/Library/Formula/gnome-common.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class GnomeCommon < Formula
-  homepage "http://git.gnome.org/browse/gnome-common/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gnome-common/3.14/gnome-common-3.14.0.tar.xz"
+  homepage "https://git.gnome.org/browse/gnome-common/"
+  url "https://ftp.gnome.org/pub/gnome/sources/gnome-common/3.14/gnome-common-3.14.0.tar.xz"
   sha256 "4c00242f781bb441289f49dd80ed1d895d84de0c94bfc2c6818a104c9e39262c"
 
   def install

--- a/Library/Formula/gnome-doc-utils.rb
+++ b/Library/Formula/gnome-doc-utils.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class GnomeDocUtils < Formula
   homepage 'https://live.gnome.org/GnomeDocUtils'
-  url 'http://ftp.gnome.org/pub/gnome/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz'
+  url 'https://ftp.gnome.org/pub/gnome/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz'
   sha256 'cb0639ffa9550b6ddf3b62f3b1add92fb92ab4690d351f2353cffe668be8c4a6'
 
   bottle do

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -1,6 +1,6 @@
 class GnomeIconTheme < Formula
   homepage "https://developer.gnome.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.14/adwaita-icon-theme-3.14.1.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.14/adwaita-icon-theme-3.14.1.tar.xz"
   sha1 "e1d603d9cc4e4b7f83f749ba20934832d4321dd2"
 
   bottle do

--- a/Library/Formula/gnu-apl.rb
+++ b/Library/Formula/gnu-apl.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class GnuApl < Formula
-  homepage "http://www.gnu.org/software/apl/"
+  homepage "https://www.gnu.org/software/apl/"
   url "http://ftpmirror.gnu.org/apl/apl-1.4.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/apl/apl-1.4.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/apl/apl-1.4.tar.gz"
   sha1 "ee5dab7f7c0f5d79c435a20f3ddcafbda85ac22e"
 
   bottle do

--- a/Library/Formula/gnu-smalltalk.rb
+++ b/Library/Formula/gnu-smalltalk.rb
@@ -3,7 +3,7 @@ require 'formula'
 class GnuSmalltalk < Formula
   homepage 'http://smalltalk.gnu.org/'
   url 'http://ftpmirror.gnu.org/smalltalk/smalltalk-3.2.5.tar.xz'
-  mirror 'http://ftp.gnu.org/gnu/smalltalk/smalltalk-3.2.5.tar.xz'
+  mirror 'https://ftp.gnu.org/gnu/smalltalk/smalltalk-3.2.5.tar.xz'
   sha1 '0eb5895b9b5bebe4f75308efbe34f8721fc2fd6b'
   revision 1
 

--- a/Library/Formula/gnu-tar.rb
+++ b/Library/Formula/gnu-tar.rb
@@ -1,7 +1,7 @@
 class GnuTar < Formula
-  homepage "http://www.gnu.org/software/tar/"
+  homepage "https://www.gnu.org/software/tar/"
   url "http://ftpmirror.gnu.org/tar/tar-1.28.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/tar/tar-1.28.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/tar/tar-1.28.tar.gz"
   sha1 "cd30a13bbfefb54b17e039be7c43d2592dd3d5d0"
 
   option "with-default-names", "Do not prepend 'g' to the binary"

--- a/Library/Formula/gnu-time.rb
+++ b/Library/Formula/gnu-time.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class GnuTime < Formula
-  homepage 'http://www.gnu.org/software/time/'
+  homepage 'https://www.gnu.org/software/time/'
   url 'http://ftpmirror.gnu.org/time/time-1.7.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/time/time-1.7.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/time/time-1.7.tar.gz'
   sha1 'dde0c28c7426960736933f3e763320680356cc6a'
 
   bottle do
@@ -16,8 +16,8 @@ class GnuTime < Formula
   option "with-default-names", "Do not prepend 'g' to the binary"
 
   # Fixes issue with main returning void rather than int
-  # http://trac.macports.org/ticket/32860
-  # http://trac.macports.org/browser/trunk/dports/sysutils/gtime/files/patch-time.c.diff?rev=88924
+  # https://trac.macports.org/ticket/32860
+  # https://trac.macports.org/browser/trunk/dports/sysutils/gtime/files/patch-time.c.diff?rev=88924
   patch :DATA
 
   def install

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -1,6 +1,6 @@
 class GobjectIntrospection < Formula
   homepage "https://live.gnome.org/GObjectIntrospection"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/1.44/gobject-introspection-1.44.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/1.44/gobject-introspection-1.44.0.tar.xz"
   sha256 "6f0c2c28aeaa37b5037acbf21558098c4f95029b666db755d3a12c2f1e1627ad"
 
   bottle do

--- a/Library/Formula/goocanvas.rb
+++ b/Library/Formula/goocanvas.rb
@@ -1,6 +1,6 @@
 class Goocanvas < Formula
   homepage "https://live.gnome.org/GooCanvas"
-  url "http://ftp.gnome.org/pub/GNOME/sources/goocanvas/2.0/goocanvas-2.0.2.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/goocanvas/2.0/goocanvas-2.0.2.tar.xz"
   sha256 "f20e5fbef8d1a2633033edbd886dd13146a1b948d1813a9c353a80a29295d1d0"
 
   bottle do

--- a/Library/Formula/griffon.rb
+++ b/Library/Formula/griffon.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Griffon < Formula
   homepage 'http://griffon.codehaus.org/'
-  url 'http://dl.bintray.com/content/aalmiray/Griffon/griffon-1.5.0-bin.tgz'
+  url 'https://dl.bintray.com/content/aalmiray/Griffon/griffon-1.5.0-bin.tgz'
   sha1 'de28b792c37cf103b5745f2f323403ec6990c58a'
 
   def install

--- a/Library/Formula/groovysdk.rb
+++ b/Library/Formula/groovysdk.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Groovysdk < Formula
   homepage "http://groovy.codehaus.org/"
-  url "http://dl.bintray.com/groovy/maven/groovy-sdk-2.4.3.zip"
+  url "https://dl.bintray.com/groovy/maven/groovy-sdk-2.4.3.zip"
   sha1 "a3aa1161422132dc116f8b8171914b36668b3839"
 
   def install

--- a/Library/Formula/gsasl.rb
+++ b/Library/Formula/gsasl.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Gsasl < Formula
-  homepage 'http://www.gnu.org/software/gsasl/'
+  homepage 'https://www.gnu.org/software/gsasl/'
   url 'http://ftpmirror.gnu.org/gsasl/gsasl-1.8.0.tar.gz'
   bottle do
     cellar :any
@@ -11,7 +11,7 @@ class Gsasl < Formula
     sha1 "bf3355e1963568a4282ec50bb3d2dfebb5f6b190" => :mountain_lion
   end
 
-  mirror 'http://ftp.gnu.org/gsasl/gsasl-1.8.0.tar.gz'
+  mirror 'https://ftp.gnu.org/gsasl/gsasl-1.8.0.tar.gz'
   sha1 '343fd97ae924dc406986c02fb9b889f4114239ae'
 
   def install

--- a/Library/Formula/gsettings-desktop-schemas.rb
+++ b/Library/Formula/gsettings-desktop-schemas.rb
@@ -1,6 +1,6 @@
 class GsettingsDesktopSchemas < Formula
-  homepage "http://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/3.14/gsettings-desktop-schemas-3.14.0.tar.xz"
+  homepage "https://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/"
+  url "https://ftp.gnome.org/pub/GNOME/sources/gsettings-desktop-schemas/3.14/gsettings-desktop-schemas-3.14.0.tar.xz"
   sha256 "cf3ba58f6257155080b1872b4a6ce4a2424bb7af3f08e607b428cb47b065f2d7"
 
   bottle do

--- a/Library/Formula/gsl.rb
+++ b/Library/Formula/gsl.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Gsl < Formula
-  homepage 'http://www.gnu.org/software/gsl/'
+  homepage 'https://www.gnu.org/software/gsl/'
   url 'http://ftpmirror.gnu.org/gsl/gsl-1.16.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/gsl/gsl-1.16.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/gsl/gsl-1.16.tar.gz'
   sha1 '210af9366485f149140973700d90dc93a4b6213e'
 
   bottle do

--- a/Library/Formula/gssdp.rb
+++ b/Library/Formula/gssdp.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gssdp < Formula
   homepage 'https://wiki.gnome.org/GUPnP/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gssdp/0.14/gssdp-0.14.8.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gssdp/0.14/gssdp-0.14.8.tar.xz'
   sha256 '4c3ffa01435e84dc31c954e669e1ca0749b962f76a333e74f5c2cb0de5803a13'
 
   bottle do

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,6 +1,6 @@
 class Gtkx3 < Formula
   homepage "http://gtk.org/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gtk+/3.16/gtk+-3.16.2.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/gtk+/3.16/gtk+-3.16.2.tar.xz"
   sha256 "a03963a61c9f5253a8d4003187190be165d92f95acf97ca783735071a8781cfa"
 
   bottle do

--- a/Library/Formula/gtk-doc.rb
+++ b/Library/Formula/gtk-doc.rb
@@ -1,6 +1,6 @@
 class GtkDoc < Formula
   homepage "http://www.gtk.org/gtk-doc/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gtk-doc/1.21/gtk-doc-1.21.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/gtk-doc/1.21/gtk-doc-1.21.tar.xz"
   sha256 "5d934d012ee08edd1585544792efa80da271652587ba5b843d2cea8e8b80ee3e"
 
   bottle do

--- a/Library/Formula/gtk-engines.rb
+++ b/Library/Formula/gtk-engines.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class GtkEngines < Formula
-  homepage 'http://git.gnome.org/browse/gtk-engines/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/gtk-engines/2.20/gtk-engines-2.20.2.tar.bz2'
+  homepage 'https://git.gnome.org/browse/gtk-engines/'
+  url 'https://ftp.gnome.org/pub/gnome/sources/gtk-engines/2.20/gtk-engines-2.20.2.tar.bz2'
   sha1 '574c7577d70eaacecd2ffa14e288ef88fdcb6c2a'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/gtk-murrine-engine.rb
+++ b/Library/Formula/gtk-murrine-engine.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class GtkMurrineEngine < Formula
   homepage 'https://github.com/GNOME/murrine'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/murrine/0.98/murrine-0.98.2.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/murrine/0.98/murrine-0.98.2.tar.xz'
   sha1 'ddaca56b6e10736838572014ae9d20b814242615'
 
   depends_on 'intltool' => :build

--- a/Library/Formula/gtkglarea.rb
+++ b/Library/Formula/gtkglarea.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Gtkglarea < Formula
   homepage 'https://github.com/GNOME/gtkglarea'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/gtkglarea-2.0.1.tar.gz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/gtkglarea-2.0.1.tar.gz'
   sha1 'db12f2bb9a3d28d69834832e2e04a255acfd8a6d'
 
   depends_on :x11

--- a/Library/Formula/gtkglext.rb
+++ b/Library/Formula/gtkglext.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Gtkglext < Formula
-  homepage 'http://projects.gnome.org/gtkglext/'
+  homepage 'https://projects.gnome.org/gtkglext/'
   url 'https://downloads.sourceforge.net/gtkglext/gtkglext-1.2.0.tar.gz'
   sha1 'db9ce38ee555fd14f55083ec7f4ae30e5338d5cc'
 
@@ -20,7 +20,7 @@ class Gtkglext < Formula
   depends_on :x11
 
   # fixes an incompatibility with recent GTK versions
-  # patch from: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=585155
+  # patch from: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=585155
   patch :DATA
 
   def install

--- a/Library/Formula/gtkmm3.rb
+++ b/Library/Formula/gtkmm3.rb
@@ -1,6 +1,6 @@
 class Gtkmm3 < Formula
   homepage "http://www.gtkmm.org/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.16/gtkmm-3.16.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.16/gtkmm-3.16.0.tar.xz"
   sha256 "9b8d4af5e1bb64e52b53bc8ef471ef43e1b9d11a829f16ef54c3a92985b0dd0c"
 
   bottle do

--- a/Library/Formula/gtksourceview.rb
+++ b/Library/Formula/gtksourceview.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Gtksourceview < Formula
-  homepage 'http://projects.gnome.org/gtksourceview/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gtksourceview/2.10/gtksourceview-2.10.5.tar.gz'
+  homepage 'https://projects.gnome.org/gtksourceview/'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/gtksourceview/2.10/gtksourceview-2.10.5.tar.gz'
   sha1 '1bb784d1e9d9966232928cf91b1ded20e8339670'
 
   bottle do

--- a/Library/Formula/gtksourceview3.rb
+++ b/Library/Formula/gtksourceview3.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Gtksourceview3 < Formula
-  homepage "http://projects.gnome.org/gtksourceview/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gtksourceview/3.14/gtksourceview-3.14.2.tar.xz"
+  homepage "https://projects.gnome.org/gtksourceview/"
+  url "https://ftp.gnome.org/pub/gnome/sources/gtksourceview/3.14/gtksourceview-3.14.2.tar.xz"
   sha256 "b3c4a4f464fdb23ecc708a61c398aa3003e05adcd7d7223d48d9c04fe87524ad"
 
   bottle do

--- a/Library/Formula/guile.rb
+++ b/Library/Formula/guile.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Guile < Formula
-  homepage "http://www.gnu.org/software/guile/"
+  homepage "https://www.gnu.org/software/guile/"
   url "http://ftpmirror.gnu.org/guile/guile-2.0.11.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz"
   sha1 "3cdd1c4956414bffadea13e5a1ca08949016a802"
   revision 1
 

--- a/Library/Formula/gupnp-av.rb
+++ b/Library/Formula/gupnp-av.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class GupnpAv < Formula
   homepage "https://wiki.gnome.org/GUPnP/"
-  url "http://ftp.gnome.org/pub/gnome/sources/gupnp-av/0.12/gupnp-av-0.12.6.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/gupnp-av/0.12/gupnp-av-0.12.6.tar.xz"
   sha1 "8ea44b3b9bd1dcb2ad56d56943fc1cd235570d00"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/hadoop.rb
+++ b/Library/Formula/hadoop.rb
@@ -1,6 +1,6 @@
 class Hadoop < Formula
   homepage "https://hadoop.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz"
   mirror "https://archive.apache.org/dist/hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz"
   sha1 "5b5fb72445d2e964acaa62c60307168c009d57c5"
 

--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -22,7 +22,7 @@ class Hbase < Formula
     to reflect your environment.
 
     For more details:
-      http://wiki.apache.org/hadoop/Hbase
+      https://wiki.apache.org/hadoop/Hbase
     EOS
   end
 end

--- a/Library/Formula/hive.rb
+++ b/Library/Formula/hive.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Hive < Formula
-  homepage 'http://hive.apache.org'
-  url 'http://www.apache.org/dyn/closer.cgi?path=hive/hive-1.0.0/apache-hive-1.0.0-bin.tar.gz'
+  homepage 'https://hive.apache.org'
+  url 'https://www.apache.org/dyn/closer.cgi?path=hive/hive-1.0.0/apache-hive-1.0.0-bin.tar.gz'
   sha1 '8e24c451ebab1333352a2f0407d5fe847759fbd2'
 
   depends_on 'hadoop'

--- a/Library/Formula/hostdb.rb
+++ b/Library/Formula/hostdb.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Hostdb < Formula
-  homepage 'http://code.google.com/p/hostdb/'
+  homepage 'https://code.google.com/p/hostdb/'
   url 'https://hostdb.googlecode.com/files/hostdb-1.004.tgz'
   sha1 '65ec59c2c88b763813fa611d8fd28a45cd9d5278'
 

--- a/Library/Formula/hqx.rb
+++ b/Library/Formula/hqx.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Hqx < Formula
-  homepage 'http://code.google.com/p/hqx/'
+  homepage 'https://code.google.com/p/hqx/'
   url 'https://hqx.googlecode.com/files/hqx-1.1.tar.gz'
   sha1 'bf08ae10db6cce4d29c84524ec13a3101d31db6b'
 

--- a/Library/Formula/htmlcompressor.rb
+++ b/Library/Formula/htmlcompressor.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Htmlcompressor < Formula
-  homepage 'http://code.google.com/p/htmlcompressor/'
+  homepage 'https://code.google.com/p/htmlcompressor/'
   url 'https://htmlcompressor.googlecode.com/files/htmlcompressor-1.5.3.jar'
   sha1 '57db73b92499e018b2f2978f1c7aa7b1238c7a39'
 

--- a/Library/Formula/hubflow.rb
+++ b/Library/Formula/hubflow.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 # Note: pull from git tag to get submodules
 class Hubflow < Formula
-  homepage 'http://datasift.github.io/gitflow/'
+  homepage 'https://datasift.github.io/gitflow/'
   url 'https://github.com/datasift/gitflow.git', :tag => '1.5.2'
   head 'https://github.com/datasift/gitflow.git'
 

--- a/Library/Formula/icoutils.rb
+++ b/Library/Formula/icoutils.rb
@@ -1,6 +1,6 @@
 class Icoutils < Formula
   homepage "http://www.nongnu.org/icoutils/"
-  url "http://savannah.nongnu.org/download/icoutils/icoutils-0.31.0.tar.bz2"
+  url "https://savannah.nongnu.org/download/icoutils/icoutils-0.31.0.tar.bz2"
   sha1 "2712acd33c611588793562310077efd2ff35dca5"
   revision 1
 

--- a/Library/Formula/ievms.rb
+++ b/Library/Formula/ievms.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Ievms < Formula
-  homepage "http://xdissent.github.io/ievms/"
+  homepage "https://xdissent.github.io/ievms/"
   url "https://github.com/xdissent/ievms/archive/v0.2.1.tar.gz"
   sha1 "2379b323f3c5986a4a7a519ad2a158a0aa62a271"
 

--- a/Library/Formula/innotop.rb
+++ b/Library/Formula/innotop.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Innotop < Formula
-  homepage "http://code.google.com/p/innotop/"
+  homepage "https://code.google.com/p/innotop/"
   url "https://innotop.googlecode.com/files/innotop-1.9.1.tar.gz"
   sha1 "6b0b5f492e7188152727f6c157043be180ba516a"
 

--- a/Library/Formula/iphotoexport.rb
+++ b/Library/Formula/iphotoexport.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Iphotoexport < Formula
-  homepage 'http://code.google.com/p/iphotoexport/'
+  homepage 'https://code.google.com/p/iphotoexport/'
   url 'https://iphotoexport.googlecode.com/files/iphotoexport-1.6.4.zip'
   sha1 '50fa0916cf9689efdfd33cd4680424234b4e9023'
 

--- a/Library/Formula/iprint.rb
+++ b/Library/Formula/iprint.rb
@@ -3,7 +3,7 @@ require "formula"
 class Iprint < Formula
 
   homepage "http://www.samba.org/ftp/unpacked/junkcode/i.c"
-  url "http://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  url "https://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
   sha1 "1b423107cf6b1e5c2257648047ff91f5c6ac2249"
   version "1.3-9"
 
@@ -15,7 +15,7 @@ class Iprint < Formula
   end
 
   patch do
-    url "http://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    url "https://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
     sha1 "6164e8e9bd0e08542de34bbf386cd1f0193f17c5"
   end
 

--- a/Library/Formula/ivy.rb
+++ b/Library/Formula/ivy.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Ivy < Formula
-  homepage 'http://ant.apache.org/ivy/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz'
+  homepage 'https://ant.apache.org/ivy/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz'
   sha1 '97a206e3b6ec2ce9793d2ee151fa997a12647c7f'
 
   def install

--- a/Library/Formula/jasper.rb
+++ b/Library/Formula/jasper.rb
@@ -26,7 +26,7 @@ class Jasper < Formula
   # The following patch fixes a bug (still in upstream as of jasper 1.900.1)
   # where an assertion fails when Jasper is fed certain JPEG-2000 files with
   # an alpha channel. See:
-  # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=469786
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=469786
   patch :DATA
 
   def install

--- a/Library/Formula/jcal.rb
+++ b/Library/Formula/jcal.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Jcal < Formula
-  homepage 'http://savannah.nongnu.org/projects/jcal/'
+  homepage 'https://savannah.nongnu.org/projects/jcal/'
   url 'http://download.savannah.gnu.org/releases/jcal/jcal-0.4.1.tar.gz'
   sha1 '23710a685515e1e824494890d6befac9edf04143'
 

--- a/Library/Formula/jena.rb
+++ b/Library/Formula/jena.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Jena < Formula
-  homepage 'http://jena.apache.org/'
-  url 'http://archive.apache.org/dist/jena/binaries/apache-jena-2.12.1.tar.gz'
+  homepage 'https://jena.apache.org/'
+  url 'https://archive.apache.org/dist/jena/binaries/apache-jena-2.12.1.tar.gz'
   sha1 '4493a893b12b119d89d991d6d9c1f11f0700139b'
 
   def shim_script target

--- a/Library/Formula/jigdo.rb
+++ b/Library/Formula/jigdo.rb
@@ -17,7 +17,7 @@ class Jigdo < Formula
 
   # Use MacPorts patch for compilation on 10.9; this software is no longer developed.
   patch :p0 do
-    url "http://trac.macports.org/export/113020/trunk/dports/net/jigdo/files/patch-src-compat.hh.diff"
+    url "https://trac.macports.org/export/113020/trunk/dports/net/jigdo/files/patch-src-compat.hh.diff"
     sha1 "3318ecbe8b2bb20e8e36c70dc10ff366df2009f3"
   end
 

--- a/Library/Formula/jing.rb
+++ b/Library/Formula/jing.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Jing < Formula
-  homepage 'http://code.google.com/p/jing-trang/'
+  homepage 'https://code.google.com/p/jing-trang/'
   url 'https://jing-trang.googlecode.com/files/jing-20091111.zip'
   sha1 '2e8eacf399249d226ad4f6ca1d6907ff69430118'
 

--- a/Library/Formula/jq.rb
+++ b/Library/Formula/jq.rb
@@ -1,6 +1,6 @@
 class Jq < Formula
   homepage "https://stedolan.github.io/jq/"
-  url "http://stedolan.github.io/jq/download/source/jq-1.4.tar.gz"
+  url "https://stedolan.github.io/jq/download/source/jq-1.4.tar.gz"
   sha1 "71da3840839ec74ae65241e182ccd46f6251c43e"
 
   bottle do

--- a/Library/Formula/jrnl.rb
+++ b/Library/Formula/jrnl.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Jrnl < Formula
-  homepage "http://maebert.github.io/jrnl/"
+  homepage "https://maebert.github.io/jrnl/"
   url "https://github.com/maebert/jrnl/archive/1.9.7.tar.gz"
   sha1 "65914c66762ded186201a526b19e702dd35b0939"
 

--- a/Library/Formula/js-test-driver.rb
+++ b/Library/Formula/js-test-driver.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class JsTestDriver < Formula
-  homepage 'http://code.google.com/p/js-test-driver/'
+  homepage 'https://code.google.com/p/js-test-driver/'
   url 'https://js-test-driver.googlecode.com/files/JsTestDriver-1.3.5.jar'
   sha1 '7a29ace71b9d5a82f5f0abe0ea22b73d7fd07826'
 

--- a/Library/Formula/jsdoc-toolkit.rb
+++ b/Library/Formula/jsdoc-toolkit.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class JsdocToolkit < Formula
-  homepage 'http://code.google.com/p/jsdoc-toolkit/'
+  homepage 'https://code.google.com/p/jsdoc-toolkit/'
   url 'https://jsdoc-toolkit.googlecode.com/files/jsdoc_toolkit-2.4.0.zip'
   sha1 'bd276ec58dbd419326760226174eba09810d26ee'
 

--- a/Library/Formula/jslint4java.rb
+++ b/Library/Formula/jslint4java.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Jslint4java < Formula
-  homepage "http://code.google.com/p/jslint4java/"
+  homepage "https://code.google.com/p/jslint4java/"
   url "https://jslint4java.googlecode.com/files/jslint4java-2.0.5-dist.zip"
   sha1 "30a75ce48b64d2c8f0b2b86e20c0d98e6441827d"
 

--- a/Library/Formula/json-glib.rb
+++ b/Library/Formula/json-glib.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class JsonGlib < Formula
-  homepage "http://live.gnome.org/JsonGlib"
-  url "http://ftp.gnome.org/pub/gnome/sources/json-glib/1.0/json-glib-1.0.2.tar.xz"
+  homepage "https://live.gnome.org/JsonGlib"
+  url "https://ftp.gnome.org/pub/gnome/sources/json-glib/1.0/json-glib-1.0.2.tar.xz"
   sha256 "887bd192da8f5edc53b490ec51bf3ffebd958a671f5963e4f3af32c22e35660a"
 
   bottle do

--- a/Library/Formula/jsonpp.rb
+++ b/Library/Formula/jsonpp.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Jsonpp < Formula
-  homepage 'http://jmhodges.github.io/jsonpp/'
+  homepage 'https://jmhodges.github.io/jsonpp/'
   url 'https://github.com/jmhodges/jsonpp/releases/v1.2.0/715/jsonpp-1.2.0-osx-x86_64.tar.gz'
   version '1.2.0'
   sha1 '422d5b2cefa92923d2fbef9afe1324d72134509e'

--- a/Library/Formula/jsvc.rb
+++ b/Library/Formula/jsvc.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Jsvc < Formula
-  homepage 'http://commons.apache.org/daemon/jsvc.html'
-  url 'http://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-native-src.tar.gz'
+  homepage 'https://commons.apache.org/daemon/jsvc.html'
+  url 'https://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-native-src.tar.gz'
   version '1.0.15'
   sha1 'f99fa9bcbc3faf6660e760af099eb003e2553b39'
 

--- a/Library/Formula/kawa.rb
+++ b/Library/Formula/kawa.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Kawa < Formula
-  homepage 'http://www.gnu.org/software/kawa/'
+  homepage 'https://www.gnu.org/software/kawa/'
   url 'http://ftpmirror.gnu.org/kawa/kawa-2.0.jar'
-  mirror 'http://ftp.gnu.org/gnu/kawa/kawa-2.0.jar'
+  mirror 'https://ftp.gnu.org/gnu/kawa/kawa-2.0.jar'
   sha1 '150dacc0b1dbf55c5493da022a590d9d8549b3b6'
 
   def install

--- a/Library/Formula/kestrel.rb
+++ b/Library/Formula/kestrel.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Kestrel < Formula
-  homepage 'http://robey.github.io/kestrel/'
+  homepage 'https://robey.github.io/kestrel/'
   url 'http://robey.github.com/kestrel/download/kestrel-2.4.1.zip'
   sha1 'd6e6dabf1848fea306419c19ada0b89b6d1ad571'
 

--- a/Library/Formula/kjell.rb
+++ b/Library/Formula/kjell.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Kjell < Formula
-  homepage 'http://karlll.github.io/kjell/'
+  homepage 'https://karlll.github.io/kjell/'
   url 'https://github.com/karlll/kjell.git', :tag => '0.2.2'
   sha1 '514fc79b62093edd4149b9d1ab54874d4e9e3fae'
 

--- a/Library/Formula/l-smash.rb
+++ b/Library/Formula/l-smash.rb
@@ -1,5 +1,5 @@
 class LSmash < Formula
-  homepage "http://l-smash.github.io/l-smash/"
+  homepage "https://l-smash.github.io/l-smash/"
   url "https://github.com/l-smash/l-smash.git", :tag => "v1.13.2", :shallow => false
   head "https://github.com/l-smash/l-smash.git"
 

--- a/Library/Formula/lastfmlib.rb
+++ b/Library/Formula/lastfmlib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lastfmlib < Formula
-  homepage 'http://code.google.com/p/lastfmlib/'
+  homepage 'https://code.google.com/p/lastfmlib/'
   url 'https://lastfmlib.googlecode.com/files/lastfmlib-0.4.0.tar.gz'
   sha1 'b9e15e4eb42a9ccd9b3c5373054b0bd51a406fdd'
 

--- a/Library/Formula/lcrack.rb
+++ b/Library/Formula/lcrack.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lcrack < Formula
-  homepage 'http://packages.debian.org/sid/lcrack'
+  homepage 'https://packages.debian.org/sid/lcrack'
   url 'http://ftp.de.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz'
   sha1 'e2a3439ab7574f5d1dd345f34f8e244723c42770'
 

--- a/Library/Formula/lhasa.rb
+++ b/Library/Formula/lhasa.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Lhasa < Formula
-  homepage "http://fragglet.github.io/lhasa/"
+  homepage "https://fragglet.github.io/lhasa/"
   url "https://github.com/fragglet/lhasa/archive/v0.2.0.tar.gz"
   sha1 "95dae252410648f629b275dedef218f81b835b3b"
   head "https://github.com/fragglet/lhasa.git"

--- a/Library/Formula/libart.rb
+++ b/Library/Formula/libart.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libart < Formula
   homepage 'http://freshmeat.net/projects/libart/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libart_lgpl/2.3/libart_lgpl-2.3.20.tar.bz2'
+  url 'https://ftp.gnome.org/pub/gnome/sources/libart_lgpl/2.3/libart_lgpl-2.3.20.tar.bz2'
   sha1 '40aa6c6c5fb27a8a45cd7aaa302a835ff374d13a'
 
   bottle do

--- a/Library/Formula/libcaca.rb
+++ b/Library/Formula/libcaca.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libcaca < Formula
   homepage 'http://caca.zoy.org/wiki/libcaca'
-  url 'http://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz'
+  url 'https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz'
   version '0.99b19'
   sha1 'ed138f3717648692113145b99a80511178548010'
 

--- a/Library/Formula/libcdio.rb
+++ b/Library/Formula/libcdio.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Libcdio < Formula
-  homepage "http://www.gnu.org/software/libcdio/"
+  homepage "https://www.gnu.org/software/libcdio/"
   url "http://ftpmirror.gnu.org/libcdio/libcdio-0.93.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libcdio/libcdio-0.93.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libcdio/libcdio-0.93.tar.gz"
   sha1 "bc3f599b0b77d8d186c0afc66495f721747c5293"
 
   bottle do

--- a/Library/Formula/libcroco.rb
+++ b/Library/Formula/libcroco.rb
@@ -1,6 +1,6 @@
 class Libcroco < Formula
   homepage "http://www.linuxfromscratch.org/blfs/view/svn/general/libcroco.html"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libcroco/0.6/libcroco-0.6.8.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/libcroco/0.6/libcroco-0.6.8.tar.xz"
   sha256 "ea6e1b858c55219cefd7109756bff5bc1a774ba7a55f7d3ccd734d6b871b8570"
 
   bottle do

--- a/Library/Formula/libewf.rb
+++ b/Library/Formula/libewf.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Libewf < Formula
-  homepage "http://code.google.com/p/libewf/"
+  homepage "https://code.google.com/p/libewf/"
   url "https://googledrive.com/host/0B3fBvzttpiiSMTdoaVExWWNsRjg/libewf-20140608.tar.gz"
   sha1 "c17384a3d2c1d63bd5b1aaa2aead6ee3c82a2368"
   revision 1

--- a/Library/Formula/libextractor.rb
+++ b/Library/Formula/libextractor.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Libextractor < Formula
-  homepage "http://www.gnu.org/software/libextractor/"
+  homepage "https://www.gnu.org/software/libextractor/"
   url "http://ftpmirror.gnu.org/libextractor/libextractor-1.3.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libextractor/libextractor-1.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libextractor/libextractor-1.3.tar.gz"
   sha1 "613d0b80e83c79c3e05e073bcda0d0d0bd1f3336"
 
   bottle do

--- a/Library/Formula/libffi.rb
+++ b/Library/Formula/libffi.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libffi < Formula
   homepage 'http://sourceware.org/libffi/'
-  url 'http://mirrors.kernel.org/sources.redhat.com/libffi/libffi-3.0.13.tar.gz'
+  url 'https://mirrors.kernel.org/sources.redhat.com/libffi/libffi-3.0.13.tar.gz'
   mirror 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'
   sha1 'f5230890dc0be42fb5c58fbf793da253155de106'
 

--- a/Library/Formula/libgcrypt.rb
+++ b/Library/Formula/libgcrypt.rb
@@ -17,7 +17,7 @@ class Libgcrypt < Formula
   option :universal
 
   resource "config.h.ed" do
-    url "http://trac.macports.org/export/113198/trunk/dports/devel/libgcrypt/files/config.h.ed"
+    url "https://trac.macports.org/export/113198/trunk/dports/devel/libgcrypt/files/config.h.ed"
     version "113198"
     sha1 "136f636673b5c9d040f8a55f59b430b0f1c97d7a"
   end

--- a/Library/Formula/libgda.rb
+++ b/Library/Formula/libgda.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libgda < Formula
   homepage 'http://www.gnome-db.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libgda/5.2/libgda-5.2.0.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/libgda/5.2/libgda-5.2.0.tar.xz'
   sha256 '41bd14aaaf50efc7b80d7279c69ed9c90d3a1894cb5123385d86883a1d7d5f30'
   bottle do
     sha1 "446acb6ebf7b20f8adb7e270a1de64815dc397c3" => :yosemite

--- a/Library/Formula/libgee.rb
+++ b/Library/Formula/libgee.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Libgee < Formula
   homepage "https://wiki.gnome.org/Projects/Libgee"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libgee/0.16/libgee-0.16.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/libgee/0.16/libgee-0.16.0.tar.xz"
   sha1 "d67e718138fb5788d6a1aea7f344e670adb77375"
 
   bottle do

--- a/Library/Formula/libgit2-glib.rb
+++ b/Library/Formula/libgit2-glib.rb
@@ -1,6 +1,6 @@
 class Libgit2Glib < Formula
   homepage "https://github.com/GNOME/libgit2-glib"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libgit2-glib/0.22/libgit2-glib-0.22.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/libgit2-glib/0.22/libgit2-glib-0.22.0.tar.xz"
   sha256 "8ae19e1dd2a6b37dd81843182d96dc5f8d439013c26658670a08287abfedaee2"
 
   bottle do

--- a/Library/Formula/libglade.rb
+++ b/Library/Formula/libglade.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Libglade < Formula
-  homepage 'http://glade.gnome.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.gz'
+  homepage 'https://glade.gnome.org'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.gz'
   sha256 'c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3'
 
   bottle do

--- a/Library/Formula/libglademm.rb
+++ b/Library/Formula/libglademm.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Libglademm < Formula
-  homepage 'http://gnome.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2'
+  homepage 'https://gnome.org'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2'
   sha1 'd7c0138c80ea337d2e9ae55f74a6953ce2eb9f5d'
 
   bottle do

--- a/Library/Formula/libgnomecanvas.rb
+++ b/Library/Formula/libgnomecanvas.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Libgnomecanvas < Formula
-  homepage 'http://developer.gnome.org/libgnomecanvas/2.30/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.bz2'
+  homepage 'https://developer.gnome.org/libgnomecanvas/2.30/'
+  url 'https://ftp.gnome.org/pub/gnome/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.bz2'
   sha256 '859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40'
 
   bottle do

--- a/Library/Formula/libgnomecanvasmm.rb
+++ b/Library/Formula/libgnomecanvasmm.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libgnomecanvasmm < Formula
   homepage 'https://launchpad.net/libgnomecanvasmm'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2'
+  url 'https://ftp.gnome.org/pub/gnome/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2'
   sha1 'c2f20c75f6eedbaf4a3299e0e3fda2ef775092e8'
 
   bottle do

--- a/Library/Formula/libgtop.rb
+++ b/Library/Formula/libgtop.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Libgtop < Formula
-  homepage 'http://library.gnome.org/devel/libgtop/stable/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libgtop/2.28/libgtop-2.28.5.tar.xz'
+  homepage 'https://library.gnome.org/devel/libgtop/stable/'
+  url 'https://ftp.gnome.org/pub/gnome/sources/libgtop/2.28/libgtop-2.28.5.tar.xz'
   sha1 '7104a7546252e3fb26d162e9b34e1f7df42236d1'
 
   bottle do

--- a/Library/Formula/libgxps.rb
+++ b/Library/Formula/libgxps.rb
@@ -1,6 +1,6 @@
 class Libgxps < Formula
   homepage "https://live.gnome.org/libgxps"
-  url "http://ftp.gnome.org/pub/gnome/sources/libgxps/0.2/libgxps-0.2.2.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/libgxps/0.2/libgxps-0.2.2.tar.xz"
   sha256 "39d104739bf0db43905c315de1d8002460f1a098576f4418f69294013a5820be"
 
   bottle do

--- a/Library/Formula/libidl.rb
+++ b/Library/Formula/libidl.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libidl < Formula
   homepage 'http://ftp.acc.umu.se/pub/gnome/sources/libIDL/0.8/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libIDL/0.8/libIDL-0.8.14.tar.bz2'
+  url 'https://ftp.gnome.org/pub/gnome/sources/libIDL/0.8/libIDL-0.8.14.tar.bz2'
   sha1 'abedf091bef0c7e65162111baf068dcb739ffcd3'
 
   bottle do

--- a/Library/Formula/libkml.rb
+++ b/Library/Formula/libkml.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libkml < Formula
-  homepage 'http://code.google.com/p/libkml/'
+  homepage 'https://code.google.com/p/libkml/'
 
   stable do
     url "https://libkml.googlecode.com/files/libkml-1.2.0.tar.gz"
@@ -48,7 +48,7 @@ class Libkml < Formula
   def install
     if build.head?
       # The inreplace line below is only required until the patch in #issue 186
-      # is applied. http://code.google.com/p/libkml/issues/detail?id=186
+      # is applied. https://code.google.com/p/libkml/issues/detail?id=186
       # If the patch is applied, this find and replace will be unnecessary, but also
       # harmless
       inreplace 'configure.ac', '-Werror', ''

--- a/Library/Formula/liblockfile.rb
+++ b/Library/Formula/liblockfile.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Liblockfile < Formula
   homepage 'http://packages.qa.debian.org/libl/liblockfile.html'
-  url 'http://mirrors.kernel.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz'
+  url 'https://mirrors.kernel.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz'
   mirror 'http://ftp.us.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz'
   sha1 '6f3f170bc4c303435ab5b46a6aa49669e16a5a7d'
 

--- a/Library/Formula/libltc.rb
+++ b/Library/Formula/libltc.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Libltc < Formula
-  homepage "http://x42.github.io/libltc/"
+  homepage "https://x42.github.io/libltc/"
   url "https://github.com/x42/libltc/releases/download/v1.1.4/libltc-1.1.4.tar.gz"
   sha1 "b8ff317dc15807aaa7142366b4d13c0c9aa26959"
 

--- a/Library/Formula/liblunar.rb
+++ b/Library/Formula/liblunar.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Liblunar < Formula
-  homepage 'http://code.google.com/p/liblunar/'
+  homepage 'https://code.google.com/p/liblunar/'
   url 'https://liblunar.googlecode.com/files/liblunar-2.2.5.tar.gz'
   sha1 'c149dc32776667ed8d53124eec414ab15ace0981'
 

--- a/Library/Formula/libmicrohttpd.rb
+++ b/Library/Formula/libmicrohttpd.rb
@@ -1,9 +1,9 @@
 require "formula"
 
 class Libmicrohttpd < Formula
-  homepage "http://www.gnu.org/software/libmicrohttpd/"
+  homepage "https://www.gnu.org/software/libmicrohttpd/"
   url "http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.38.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.38.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.38.tar.gz"
   sha1 "1d0a6685b984b022a6be565f7b179c449944b3f1"
 
   option "with-ssl", "Enable SSL support"

--- a/Library/Formula/libnice.rb
+++ b/Library/Formula/libnice.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Libnice < Formula
-  homepage "http://nice.freedesktop.org/wiki/"
+  homepage "https://wiki.freedesktop.org/nice/"
   url "http://nice.freedesktop.org/releases/libnice-0.1.7.tar.gz"
   sha1 "94d459fc409da9cf5e4ac30d680ee6c0ded2cb64"
 

--- a/Library/Formula/liboil.rb
+++ b/Library/Formula/liboil.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Liboil < Formula
-  homepage 'http://liboil.freedesktop.org/'
+  homepage 'https://wiki.freedesktop.org/liboil'
   url 'http://liboil.freedesktop.org/download/liboil-0.3.17.tar.gz'
   sha1 'f9d7103a3a4a4089f56197f81871ae9129d229ed'
 

--- a/Library/Formula/libosip.rb
+++ b/Library/Formula/libosip.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Libosip < Formula
-  homepage 'http://www.gnu.org/software/osip/'
+  homepage 'https://www.gnu.org/software/osip/'
   url 'http://ftpmirror.gnu.org/osip/libosip2-4.1.0.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/osip/libosip2-4.1.0.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/osip/libosip2-4.1.0.tar.gz'
   sha1 '61459c9052ca2f5e77a6936c9b369e2b0602c080'
 
   bottle do

--- a/Library/Formula/libpgm.rb
+++ b/Library/Formula/libpgm.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libpgm < Formula
-  homepage 'http://code.google.com/p/openpgm/'
+  homepage 'https://code.google.com/p/openpgm/'
   url 'https://openpgm.googlecode.com/files/libpgm-5.2.122%7Edfsg.tar.gz'
   sha1 '788efcb223a05bb68b304bcdd3c37bb54fe4de28'
   version '5.2.122'

--- a/Library/Formula/libsecret.rb
+++ b/Library/Formula/libsecret.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Libsecret < Formula
   homepage "https://wiki.gnome.org/Projects/Libsecret"
-  url "http://ftp.gnome.org/pub/gnome/sources/libsecret/0.18/libsecret-0.18.tar.xz"
+  url "https://ftp.gnome.org/pub/gnome/sources/libsecret/0.18/libsecret-0.18.tar.xz"
   sha1 "af62de3958bbe0ccf59a02101a6704e036378a6f"
 
   bottle do

--- a/Library/Formula/libsigc++.rb
+++ b/Library/Formula/libsigc++.rb
@@ -1,6 +1,6 @@
 class Libsigcxx < Formula
   homepage "http://libsigc.sourceforge.net"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.4/libsigc++-2.4.1.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.4/libsigc++-2.4.1.tar.xz"
   sha256 "540443492a68e77e30db8d425f3c0b1299c825bf974d9bfc31ae7efafedc19ec"
 
   bottle do

--- a/Library/Formula/libsigsegv.rb
+++ b/Library/Formula/libsigsegv.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Libsigsegv < Formula
-  homepage 'http://www.gnu.org/software/libsigsegv/'
+  homepage 'https://www.gnu.org/software/libsigsegv/'
   url 'http://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.10.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz'
   sha256 '8460a4a3dd4954c3d96d7a4f5dd5bc4d9b76f5754196aa245287553b26d2199a'
 
   bottle do

--- a/Library/Formula/libsoup.rb
+++ b/Library/Formula/libsoup.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Libsoup < Formula
   homepage 'https://live.gnome.org/LibSoup'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libsoup/2.48/libsoup-2.48.1.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/libsoup/2.48/libsoup-2.48.1.tar.xz'
   sha256 '9b0d14b36e36a3131a06c6e3aa7245716e6904e3e636df81c0b6c8bd3f646f9a'
 
   bottle do

--- a/Library/Formula/libvpx.rb
+++ b/Library/Formula/libvpx.rb
@@ -28,7 +28,7 @@ class Libvpx < Formula
     args << "--enable-postproc-visualizer" if build.include? "visualizer"
 
     # configure misdetects 32-bit 10.6
-    # http://code.google.com/p/webm/issues/detail?id=401
+    # https://code.google.com/p/webm/issues/detail?id=401
     if MacOS.version == "10.6" && Hardware.is_32_bit?
       args << "--target=x86-darwin10-gcc"
     end

--- a/Library/Formula/libxmi.rb
+++ b/Library/Formula/libxmi.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Libxmi < Formula
-  homepage 'http://www.gnu.org/software/libxmi/'
+  homepage 'https://www.gnu.org/software/libxmi/'
   url 'http://ftpmirror.gnu.org/libxmi/libxmi-1.2.tar.gz'
-  mirror 'http://ftp.gnu.org/libxmi/libxmi-1.2.tar.gz'
+  mirror 'https://ftp.gnu.org/libxmi/libxmi-1.2.tar.gz'
   sha1 '62fa13ec4c8b706729c2553122e44f81715f3c0b'
 
   bottle do

--- a/Library/Formula/libxml++.rb
+++ b/Library/Formula/libxml++.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Libxmlxx < Formula
   homepage "http://libxmlplusplus.sourceforge.net"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libxml++/2.36/libxml++-2.36.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/libxml++/2.36/libxml++-2.36.0.tar.xz"
   sha256 "bfdf327bf9ebd12946b7aa6a152045f209d5c9fecd06ebfcdf9b3e7c1af6e2e1"
 
   bottle do

--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -69,7 +69,7 @@ index 0eeadd3..5e85821 100755
 -	echo
 -	echo "You must have libtool installed to compile libxslt."
 -	echo "Download the appropriate package for your distribution,"
--	echo "or see http://www.gnu.org/software/libtool"
+-	echo "or see https://www.gnu.org/software/libtool"
 -	DIE=1
 -}
 -
@@ -78,7 +78,7 @@ index 0eeadd3..5e85821 100755
 -	DIE=1
 -	echo "You must have automake installed to compile libxslt."
 -	echo "Download the appropriate package for your distribution,"
--	echo "or see http://www.gnu.org/software/automake"
+-	echo "or see https://www.gnu.org/software/automake"
 -}
 -
  if test "$DIE" -eq 1; then

--- a/Library/Formula/libyubikey.rb
+++ b/Library/Formula/libyubikey.rb
@@ -1,5 +1,5 @@
 class Libyubikey < Formula
-  homepage "http://yubico.github.io/yubico-c/"
+  homepage "https://yubico.github.io/yubico-c/"
   url "https://developers.yubico.com/yubico-c/Releases/libyubikey-1.12.tar.gz"
   sha1 "6a73d548e61f0b622a9447917f03c78686ab386d"
 

--- a/Library/Formula/lightning.rb
+++ b/Library/Formula/lightning.rb
@@ -28,7 +28,7 @@ class Lightning < Formula
   end
 
   test do
-    # from http://www.gnu.org/software/lightning/manual/lightning.html#incr
+    # from https://www.gnu.org/software/lightning/manual/lightning.html#incr
     (testpath/"test.c").write <<-EOS.undent
       #include <stdio.h>
       #include <lightning.h>

--- a/Library/Formula/lldpd.rb
+++ b/Library/Formula/lldpd.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lldpd < Formula
-  homepage 'http://vincentbernat.github.io/lldpd/'
+  homepage 'https://vincentbernat.github.io/lldpd/'
   url 'http://media.luffy.cx/files/lldpd/lldpd-0.7.12.tar.gz'
   sha1 '2d602aaaad01d1f76f8e1c87e48dca1c6725ba78'
 

--- a/Library/Formula/log4cxx.rb
+++ b/Library/Formula/log4cxx.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Log4cxx < Formula
-  homepage 'http://logging.apache.org/log4cxx/index.html'
-  url 'http://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz'
+  homepage 'https://logging.apache.org/log4cxx/index.html'
+  url 'https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz'
   sha1 'd79c053e8ac90f66c5e873b712bb359fd42b648d'
 
   depends_on "autoconf" => :build

--- a/Library/Formula/logrotate.rb
+++ b/Library/Formula/logrotate.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Logrotate < Formula
-  homepage 'http://packages.debian.org/testing/admin/logrotate'
+  homepage 'https://packages.debian.org/testing/admin/logrotate'
   url 'https://fedorahosted.org/releases/l/o/logrotate/logrotate-3.8.3.tar.gz'
   sha1 '19d70e2cfb97c1cee32e0d709da990856311022a'
 

--- a/Library/Formula/logstalgia.rb
+++ b/Library/Formula/logstalgia.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Logstalgia < Formula
-  homepage "http://code.google.com/p/logstalgia/"
+  homepage "https://code.google.com/p/logstalgia/"
   url "https://github.com/acaudwell/Logstalgia/releases/download/logstalgia-1.0.6/logstalgia-1.0.6.tar.gz"
   sha1 "92b2b037d289840517d6648bf72f09afbf3f09d5"
 

--- a/Library/Formula/lorem.rb
+++ b/Library/Formula/lorem.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Lorem < Formula
-  homepage 'http://code.google.com/p/lorem/'
+  homepage 'https://code.google.com/p/lorem/'
   url 'http://lorem.googlecode.com/svn-history/r4/trunk/lorem', :using => :curl
   version '0.6.1'
   sha1 'aa6ef66e5ee1151397f19b358d772af316cf333b'

--- a/Library/Formula/marst.rb
+++ b/Library/Formula/marst.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Marst < Formula
-  homepage "http://www.gnu.org/software/marst"
+  homepage "https://www.gnu.org/software/marst"
   url "http://ftpmirror.gnu.org/marst/marst-2.7.tar.gz"
   sha1 "a55ef653887c09045f04e00a179309463546f548"
 

--- a/Library/Formula/mat.rb
+++ b/Library/Formula/mat.rb
@@ -100,7 +100,7 @@ class Mat < Formula
 
   test do
     system "#{bin}/mat", "-l"
-    system "touch", "foo"
+    touch "foo"
     system "tar", "cf", "foo.tar", "foo"
     system "#{bin}/mat", "-c", "foo.tar"
   end

--- a/Library/Formula/maven.rb
+++ b/Library/Formula/maven.rb
@@ -31,8 +31,8 @@ class Maven < Formula
   test do
     (testpath/"pom.xml").write <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>
-      <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
         <modelVersion>4.0.0</modelVersion>
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>

--- a/Library/Formula/memcache-top.rb
+++ b/Library/Formula/memcache-top.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class MemcacheTop < Formula
-  homepage 'http://code.google.com/p/memcache-top/'
+  homepage 'https://code.google.com/p/memcache-top/'
   url 'https://memcache-top.googlecode.com/files/memcache-top-v0.6'
   version '0.6'
   sha1 'eaac357e13ac2a531c28081783fdcc3ddbe98ede'

--- a/Library/Formula/mfcuk.rb
+++ b/Library/Formula/mfcuk.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mfcuk < Formula
-  homepage 'http://code.google.com/p/mfcuk/'
+  homepage 'https://code.google.com/p/mfcuk/'
   url 'https://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz'
   sha1 '2a8259440ac5bed8516c8d771a945b713dacd2bc'
 

--- a/Library/Formula/mfoc.rb
+++ b/Library/Formula/mfoc.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mfoc < Formula
-  homepage 'http://code.google.com/p/mfoc/'
+  homepage 'https://code.google.com/p/mfoc/'
   url 'https://mfoc.googlecode.com/files/mfoc-0.10.7.tar.bz2'
   sha1 '162a464baf6498926a72383c6b0040654321012d'
 

--- a/Library/Formula/mimms.rb
+++ b/Library/Formula/mimms.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mimms < Formula
-  homepage 'http://savannah.nongnu.org/projects/mimms'
+  homepage 'https://savannah.nongnu.org/projects/mimms'
   url 'https://launchpad.net/mimms/trunk/3.2.1/+download/mimms-3.2.1.tar.bz2'
   sha1 '279eee76dd4032cd2c1dddf1d49292a952c57b80'
 
@@ -9,7 +9,7 @@ class Mimms < Formula
   depends_on 'libmms'
 
   # Switch shared library loading to Mach-O naming convention (.dylib)
-  # Matching upstream bug report: http://savannah.nongnu.org/bugs/?29684
+  # Matching upstream bug report: https://savannah.nongnu.org/bugs/?29684
   patch :DATA
 
   def install

--- a/Library/Formula/minicom.rb
+++ b/Library/Formula/minicom.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Minicom < Formula
-  homepage 'http://alioth.debian.org/projects/minicom/'
+  homepage 'https://alioth.debian.org/projects/minicom/'
   url 'http://ftp.de.debian.org/debian/pool/main/m/minicom/minicom_2.7.orig.tar.gz'
   sha1 '939eef8ca1bda82ee801b087d9db4f16a19fbe6e'
 

--- a/Library/Formula/mkcue.rb
+++ b/Library/Formula/mkcue.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mkcue < Formula
-  homepage 'http://packages.debian.org/source/stable/mkcue'
+  homepage 'https://packages.debian.org/source/stable/mkcue'
   url 'http://ftp.de.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz'
   version '1'
   sha1 'd9a69718ba3d862b589588bdf61796f755200f9d'

--- a/Library/Formula/mm-common.rb
+++ b/Library/Formula/mm-common.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class MmCommon < Formula
   homepage "http://www.gtkmm.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.7.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.7.tar.xz"
   sha256 "78f47336f3bdf034a384c59a39cc9f0d566e69e36aa7c9ee3ec0bb6a94bf8b3e"
 
   def install

--- a/Library/Formula/mogenerator.rb
+++ b/Library/Formula/mogenerator.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mogenerator < Formula
-  homepage 'http://rentzsch.github.io/mogenerator/'
+  homepage 'https://rentzsch.github.io/mogenerator/'
   url 'https://github.com/rentzsch/mogenerator/archive/1.28.tar.gz'
   sha1 '2c92204c76cbe88091494d0730cf986efab8ef1a'
 

--- a/Library/Formula/movgrab.rb
+++ b/Library/Formula/movgrab.rb
@@ -13,7 +13,7 @@ class Movgrab < Formula
     # Makefile itself doesn't declare INSTALL as a phony target, we
     # just remove the INSTALL instructions file so we can actually
     # just make install
-    system 'rm INSTALL'
+    rm 'INSTALL'
     system 'make install'
   end
 end

--- a/Library/Formula/mp3check.rb
+++ b/Library/Formula/mp3check.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Mp3check < Formula
-  homepage 'http://code.google.com/p/mp3check/'
+  homepage 'https://code.google.com/p/mp3check/'
   url 'https://mp3check.googlecode.com/files/mp3check-0.8.7.tgz'
   sha1 '31fe95bb7949343f6ebc04fcaa2faffd2b738264'
 

--- a/Library/Formula/mp3fs.rb
+++ b/Library/Formula/mp3fs.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Mp3fs < Formula
-  homepage "http://khenriks.github.io/mp3fs/"
+  homepage "https://khenriks.github.io/mp3fs/"
   url "https://github.com/khenriks/mp3fs/releases/download/v0.91/mp3fs-0.91.tar.gz"
   sha1 "a9e65b8453f4444ec6faba045120e7efb18da20e"
 

--- a/Library/Formula/mp4v2.rb
+++ b/Library/Formula/mp4v2.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Mp4v2 < Formula
-  homepage "http://code.google.com/p/mp4v2/"
+  homepage "https://code.google.com/p/mp4v2/"
   url "https://mp4v2.googlecode.com/files/mp4v2-2.0.0.tar.bz2"
   sha1 "193260cfb7201e6ec250137bcca1468d4d20e2f0"
 

--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -63,7 +63,7 @@ class Mplayer < Formula
     # Specify our compiler to stop ffmpeg from defaulting to gcc.
     # Disable openjpeg because it defines int main(), which hides mplayer's main().
     # This issue was reported upstream against openjpeg 1.5.0:
-    # http://code.google.com/p/openjpeg/issues/detail?id=152
+    # https://code.google.com/p/openjpeg/issues/detail?id=152
     args = %W[
       --prefix=#{prefix}
       --cc=#{ENV.cc}

--- a/Library/Formula/msitools.rb
+++ b/Library/Formula/msitools.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Msitools < Formula
   homepage 'https://wiki.gnome.org/msitools'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/msitools/0.93/msitools-0.93.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/msitools/0.93/msitools-0.93.tar.xz'
   sha1 'b8dcf394a1aeddd8404ae1702ce42af623f54101'
 
   depends_on 'intltool' => :build

--- a/Library/Formula/mtools.rb
+++ b/Library/Formula/mtools.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Mtools < Formula
-  homepage 'http://www.gnu.org/software/mtools/'
+  homepage 'https://www.gnu.org/software/mtools/'
   url 'http://ftpmirror.gnu.org/mtools/mtools-4.0.17.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/mtools/mtools-4.0.17.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/mtools/mtools-4.0.17.tar.gz'
   sha1 'eebfab51148c4ab20a6aca3cea8057da5a11bdc8'
 
   conflicts_with 'multimarkdown', :because => 'both install `mmd` binaries'

--- a/Library/Formula/mvnvm.rb
+++ b/Library/Formula/mvnvm.rb
@@ -20,8 +20,8 @@ class Mvnvm < Formula
     EOS
     (testpath/"pom.xml").write <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>
-      <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
         <modelVersion>4.0.0</modelVersion>
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>

--- a/Library/Formula/netcat6.rb
+++ b/Library/Formula/netcat6.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Netcat6 < Formula
   homepage "http://www.deepspace6.net/projects/netcat6.html"
-  url "http://ftp.debian.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
+  url "https://ftp.debian.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
   sha1 "50b1a3f7bfa610a2016727e5741791ad3a88bd07"
 
   option "silence-patch", "Use silence patch from Debian"

--- a/Library/Formula/normalize.rb
+++ b/Library/Formula/normalize.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Normalize < Formula
   homepage 'http://normalize.nongnu.org/'
-  url 'http://savannah.nongnu.org/download/normalize/normalize-0.7.7.tar.gz'
+  url 'https://savannah.nongnu.org/download/normalize/normalize-0.7.7.tar.gz'
   sha1 '1509ca998703aacc15f6098df58650b3c83980c7'
 
   option 'without-mad', 'Compile without MP3 support'

--- a/Library/Formula/open-vcdiff.rb
+++ b/Library/Formula/open-vcdiff.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class OpenVcdiff < Formula
-  homepage 'http://code.google.com/p/open-vcdiff/'
+  homepage 'https://code.google.com/p/open-vcdiff/'
   url 'https://open-vcdiff.googlecode.com/files/open-vcdiff-0.8.3.tar.gz'
   sha1 'fd14e8d46edac14988f1a6cab479bc07677d487c'
 

--- a/Library/Formula/opencc.rb
+++ b/Library/Formula/opencc.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Opencc < Formula
   homepage "https://github.com/BYVoid/OpenCC"
-  url "http://dl.bintray.com/byvoid/opencc/opencc-1.0.2.tar.gz"
+  url "https://dl.bintray.com/byvoid/opencc/opencc-1.0.2.tar.gz"
   sha1 "101b9f46aca95d2039a955572c394ca6bdb2d88d"
 
   bottle do

--- a/Library/Formula/openwsman.rb
+++ b/Library/Formula/openwsman.rb
@@ -1,5 +1,5 @@
 class Openwsman < Formula
-  homepage "http://openwsman.github.io"
+  homepage "https://openwsman.github.io"
   url "https://github.com/Openwsman/openwsman/archive/v2.4.12.tar.gz"
   sha1 "15fbe4454c3d48ab229036b09400afd5037f4ef2"
 

--- a/Library/Formula/orbit.rb
+++ b/Library/Formula/orbit.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Orbit < Formula
-  homepage 'http://projects.gnome.org/ORBit2/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/ORBit2/2.14/ORBit2-2.14.19.tar.bz2'
+  homepage 'https://projects.gnome.org/ORBit2/'
+  url 'https://ftp.gnome.org/pub/gnome/sources/ORBit2/2.14/ORBit2-2.14.19.tar.bz2'
   sha256 '55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/oscats.rb
+++ b/Library/Formula/oscats.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Oscats < Formula
-  homepage 'http://code.google.com/p/oscats/'
+  homepage 'https://code.google.com/p/oscats/'
   url 'https://oscats.googlecode.com/files/oscats-0.6.tar.gz'
   sha1 'f57fa06ee0d842ed4c547dd7ab599fd5090d7550'
 

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Pango < Formula
   homepage "http://www.pango.org/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz"
   sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
 
   head do

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Pangomm < Formula
   homepage 'http://www.pango.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.34/pangomm-2.34.0.tar.xz'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.34/pangomm-2.34.0.tar.xz'
   sha256 '0e82bbff62f626692a00f3772d8b17169a1842b8cc54d5f2ddb1fec2cede9e41'
 
   bottle do

--- a/Library/Formula/pangox-compat.rb
+++ b/Library/Formula/pangox-compat.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class PangoxCompat < Formula
   homepage 'http://pango.org'
-  url 'http://ftp.gnome.org/pub/gnome/sources/pangox-compat/0.0/pangox-compat-0.0.2.tar.xz'
+  url 'https://ftp.gnome.org/pub/gnome/sources/pangox-compat/0.0/pangox-compat-0.0.2.tar.xz'
   sha256 '552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/pdf2htmlex.rb
+++ b/Library/Formula/pdf2htmlex.rb
@@ -54,7 +54,7 @@ class Pdf2htmlex < Formula
               "--disable-python-extension",
       ]
 
-      # Fix linker error; see: http://trac.macports.org/ticket/25012
+      # Fix linker error; see: https://trac.macports.org/ticket/25012
       ENV.append "LDFLAGS", "-lintl"
 
       # Reset ARCHFLAGS to match how we build

--- a/Library/Formula/pgbadger.rb
+++ b/Library/Formula/pgbadger.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Pgbadger < Formula
-  homepage "http://dalibo.github.io/pgbadger/"
+  homepage "https://dalibo.github.io/pgbadger/"
   url "https://downloads.sourceforge.net/project/pgbadger/6.2/pgbadger-6.2.tar.gz"
   sha1 "46f6935ff746f8b2002009ebbcae60d23aaff8b3"
 

--- a/Library/Formula/picoc.rb
+++ b/Library/Formula/picoc.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Picoc < Formula
-  homepage 'http://code.google.com/p/picoc/'
+  homepage 'https://code.google.com/p/picoc/'
   url 'https://picoc.googlecode.com/files/picoc-2.1.tar.bz2'
   sha1 '24fdc3c8302915d663fcaefaf878ab5ad5a2d69b'
 

--- a/Library/Formula/picocom.rb
+++ b/Library/Formula/picocom.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Picocom < Formula
-  homepage 'http://code.google.com/p/picocom/'
+  homepage 'https://code.google.com/p/picocom/'
   url 'https://picocom.googlecode.com/files/picocom-1.7.tar.gz'
   sha1 'bde6e36af71db845913f9d61f28dee1b485218fa'
 

--- a/Library/Formula/pig.rb
+++ b/Library/Formula/pig.rb
@@ -1,6 +1,6 @@
 class Pig < Formula
   homepage "https://pig.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=pig/pig-0.14.0/pig-0.14.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=pig/pig-0.14.0/pig-0.14.0.tar.gz"
   mirror "https://archive.apache.org/dist/pig/pig-0.14.0/pig-0.14.0.tar.gz"
   sha256 "6aea66dda4791f82bad9654ec5290efc6179d333077b0ce9f07624c9c8b071a0"
 

--- a/Library/Formula/pkg-config.rb
+++ b/Library/Formula/pkg-config.rb
@@ -1,7 +1,7 @@
 class PkgConfig < Formula
   homepage "http://pkgconfig.freedesktop.org"
   url "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
-  mirror "http://fossies.org/linux/misc/pkg-config-0.28.tar.gz"
+  mirror "https://fossies.org/linux/misc/pkg-config-0.28.tar.gz"
   sha256 "6b6eb31c6ec4421174578652c7e141fdaae2dabad1021f420d8713206ac1f845"
 
   bottle do

--- a/Library/Formula/plotutils.rb
+++ b/Library/Formula/plotutils.rb
@@ -1,7 +1,7 @@
 class Plotutils < Formula
-  homepage "http://www.gnu.org/software/plotutils/"
+  homepage "https://www.gnu.org/software/plotutils/"
   url "http://ftpmirror.gnu.org/plotutils/plotutils-2.6.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/plotutils/plotutils-2.6.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/plotutils/plotutils-2.6.tar.gz"
   sha1 "7921301d9dfe8991e3df2829bd733df6b2a70838"
   revision 1
 

--- a/Library/Formula/pmccabe.rb
+++ b/Library/Formula/pmccabe.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Pmccabe < Formula
-  homepage 'http://packages.debian.org/stable/pmccabe'
+  homepage 'https://packages.debian.org/stable/pmccabe'
   url 'http://ftp.de.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz'
   sha1 '6e1378b28faf822339780829f3cb9e2d897c5c4d'
 

--- a/Library/Formula/poster.rb
+++ b/Library/Formula/poster.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Poster < Formula
-  homepage 'http://schrfr.github.io/poster/'
+  homepage 'https://schrfr.github.io/poster/'
   url 'https://github.com/schrfr/poster/archive/1.0.0.tar.gz'
   sha1 '20846c17fc0c266caecf82b24cbe7906999a410c'
 

--- a/Library/Formula/primesieve.rb
+++ b/Library/Formula/primesieve.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Primesieve < Formula
   homepage "http://primesieve.org/"
-  url "http://dl.bintray.com/kimwalisch/primesieve/primesieve-5.4.tar.gz"
+  url "https://dl.bintray.com/kimwalisch/primesieve/primesieve-5.4.tar.gz"
   sha1 "1309e444bde3822cdc3e953757b46750d384cc00"
 
   bottle do

--- a/Library/Formula/protobuf.rb
+++ b/Library/Formula/protobuf.rb
@@ -61,7 +61,7 @@ class Protobuf < Formula
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
-    # http://code.google.com/p/protobuf/source/browse/trunk/configure.ac#61
+    # https://code.google.com/p/protobuf/source/browse/trunk/configure.ac#61
     ENV.prepend "CXXFLAGS", "-DNDEBUG"
     ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?

--- a/Library/Formula/psgrep.rb
+++ b/Library/Formula/psgrep.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Psgrep < Formula
-  homepage 'http://code.google.com/p/psgrep/'
+  homepage 'https://code.google.com/p/psgrep/'
   url 'https://psgrep.googlecode.com/files/psgrep-1.0.6.tar.bz2'
   sha1 'fe1102546971358a5eff2cff613d70ee63395444'
 

--- a/Library/Formula/pth.rb
+++ b/Library/Formula/pth.rb
@@ -1,7 +1,7 @@
 class Pth < Formula
-  homepage "http://www.gnu.org/software/pth/"
+  homepage "https://www.gnu.org/software/pth/"
   url "http://ftpmirror.gnu.org/pth/pth-2.0.7.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/pth/pth-2.0.7.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/pth/pth-2.0.7.tar.gz"
   sha1 "9a71915c89ff2414de69fe104ae1016d513afeee"
 
   bottle do

--- a/Library/Formula/pulledpork.rb
+++ b/Library/Formula/pulledpork.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Pulledpork < Formula
-  homepage 'http://code.google.com/p/pulledpork/'
+  homepage 'https://code.google.com/p/pulledpork/'
   url 'https://pulledpork.googlecode.com/files/pulledpork-0.7.0.tar.gz'
   sha1 'fd7f2b195b473ba80826c4f06dd6ef2dd445814e'
 

--- a/Library/Formula/pygobject.rb
+++ b/Library/Formula/pygobject.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Pygobject < Formula
   homepage 'https://live.gnome.org/PyGObject'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2'
   sha1 '4eda7d2b97f495a2ad7d4cdc234d08ca5408d9d5'
 
   bottle do
@@ -19,7 +19,7 @@ class Pygobject < Formula
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=668522
   patch do
-    url "http://git.gnome.org/browse/pygobject/patch/gio/gio-types.defs?id=42d01f060c5d764baa881d13c103d68897163a49"
+    url "https://git.gnome.org/browse/pygobject/patch/gio/gio-types.defs?id=42d01f060c5d764baa881d13c103d68897163a49"
     sha1 "66411f0251ac036f33239591cf3c4c0a50ccab30"
   end
 

--- a/Library/Formula/pygobject3.rb
+++ b/Library/Formula/pygobject3.rb
@@ -1,6 +1,6 @@
 class Pygobject3 < Formula
   homepage "https://live.gnome.org/PyGObject"
-  url "http://ftp.gnome.org/pub/GNOME/sources/pygobject/3.14/pygobject-3.14.0.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/pygobject/3.14/pygobject-3.14.0.tar.xz"
   sha256 "779effa93f4b59cdb72f4ab0128fb3fd82900bf686193b570fd3a8ce63392d54"
 
   option 'with-tests', 'run tests'

--- a/Library/Formula/pygtk.rb
+++ b/Library/Formula/pygtk.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Pygtk < Formula
   homepage 'http://www.pygtk.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2'
+  url 'https://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2'
   sha1 '344e6a32a5e8c7e0aaeb807e0636a163095231c2'
 
   bottle do

--- a/Library/Formula/pygtkglext.rb
+++ b/Library/Formula/pygtkglext.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Pygtkglext < Formula
-  homepage 'http://projects.gnome.org/gtkglext/download.html#pygtkglext'
+  homepage 'https://projects.gnome.org/gtkglext/download.html#pygtkglext'
   url 'https://downloads.sourceforge.net/gtkglext/pygtkglext-1.1.0.tar.gz'
   sha1 '2ae3e87e8cdfc3318d8ff0e33b344377cb3df7cb'
 

--- a/Library/Formula/pygtksourceview.rb
+++ b/Library/Formula/pygtksourceview.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Pygtksourceview < Formula
-  homepage 'http://projects.gnome.org/gtksourceview/pygtksourceview.html'
-  url 'http://ftp.gnome.org/pub/gnome/sources/pygtksourceview/2.10/pygtksourceview-2.10.0.tar.bz2'
+  homepage 'https://projects.gnome.org/gtksourceview/pygtksourceview.html'
+  url 'https://ftp.gnome.org/pub/gnome/sources/pygtksourceview/2.10/pygtksourceview-2.10.0.tar.bz2'
   sha256 'bfdde2ce4f61d461fb34dece9433cf81a73a9c9de6b62d4eb06177b8c9cec9c7'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/pylucene.rb
+++ b/Library/Formula/pylucene.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Pylucene < Formula
-  homepage "http://lucene.apache.org/pylucene/index.html"
-  url "http://www.apache.org/dyn/closer.cgi?path=lucene/pylucene/pylucene-4.10.1-1-src.tar.gz"
+  homepage "https://lucene.apache.org/pylucene/index.html"
+  url "https://www.apache.org/dyn/closer.cgi?path=lucene/pylucene/pylucene-4.10.1-1-src.tar.gz"
   sha1 "650709590f4443ed711f100cc6e4f6850245899b"
 
   option "with-shared", "build jcc as a shared library"

--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -122,7 +122,7 @@ class Python < Formula
     system "./configure", *args
 
     # HAVE_POLL is "broken" on OS X. See:
-    # http://trac.macports.org/ticket/18376
+    # https://trac.macports.org/ticket/18376
     # http://bugs.python.org/issue5154
     if build.without? "poll"
       inreplace "pyconfig.h", /.*?(HAVE_POLL[_A-Z]*).*/, '#undef \1'

--- a/Library/Formula/quilt.rb
+++ b/Library/Formula/quilt.rb
@@ -1,5 +1,5 @@
 class Quilt < Formula
-  homepage "http://savannah.nongnu.org/projects/quilt"
+  homepage "https://savannah.nongnu.org/projects/quilt"
   url "http://download.savannah.gnu.org/releases/quilt/quilt-0.63.tar.gz"
   sha1 "19f2ba0384521eb3d8269b8a1097b16b07339be5"
 

--- a/Library/Formula/rdiff-backup.rb
+++ b/Library/Formula/rdiff-backup.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class RdiffBackup < Formula
   homepage 'http://rdiff-backup.nongnu.org/'
-  url 'http://savannah.nongnu.org/download/rdiff-backup/rdiff-backup-1.2.8.tar.gz'
+  url 'https://savannah.nongnu.org/download/rdiff-backup/rdiff-backup-1.2.8.tar.gz'
   sha1 '14ffe4f5b46a8a96ded536c1d03ae5e85faae318'
 
   depends_on 'librsync'

--- a/Library/Formula/reaver.rb
+++ b/Library/Formula/reaver.rb
@@ -1,12 +1,12 @@
 require 'formula'
 
 class Reaver < Formula
-  homepage 'http://code.google.com/p/reaver-wps/'
+  homepage 'https://code.google.com/p/reaver-wps/'
   url 'https://reaver-wps.googlecode.com/files/reaver-1.4.tar.gz'
   sha1 '2ebec75c3979daa7b576bc54adedc60eb0e27a21'
 
   # Adds general support for Mac OS X in reaver:
-  # http://code.google.com/p/reaver-wps/issues/detail?id=245
+  # https://code.google.com/p/reaver-wps/issues/detail?id=245
   patch do
     url "https://gist.githubusercontent.com/syndicut/6134996/raw/16f1b4336c104375ff93a88858809eced53c1171/reaver-osx.diff"
     sha1 "9b5c77a167fdc34627a7ff3e15f8e5b5a67226a4"

--- a/Library/Formula/recutils.rb
+++ b/Library/Formula/recutils.rb
@@ -1,7 +1,7 @@
 class Recutils < Formula
-  homepage "http://www.gnu.org/software/recutils/"
+  homepage "https://www.gnu.org/software/recutils/"
   url "http://ftpmirror.gnu.org/recutils/recutils-1.7.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/recutils/recutils-1.7.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/recutils/recutils-1.7.tar.gz"
   sha1 "20d265aecb05ca4e4072df9cfac08b1392da6919"
 
   bottle do

--- a/Library/Formula/rlog.rb
+++ b/Library/Formula/rlog.rb
@@ -14,7 +14,7 @@ class Rlog < Formula
 end
 
 # This patch solves an OSX build issue, should not be necessary for the next release according to
-# http://code.google.com/p/rlog/issues/detail?id=7
+# https://code.google.com/p/rlog/issues/detail?id=7
 __END__
 --- orig/rlog/common.h.in	2008-06-14 20:10:13.000000000 -0700
 +++ new/rlog/common.h.in	2009-05-18 16:05:04.000000000 -0700

--- a/Library/Formula/roundup.rb
+++ b/Library/Formula/roundup.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Roundup < Formula
-  homepage 'http://bmizerany.github.io/roundup'
+  homepage 'https://bmizerany.github.io/roundup'
   url 'https://github.com/bmizerany/roundup/archive/v0.0.5.tar.gz'
   sha1 '76ad889ed8e4c32d24847ba2848a8515199e0966'
 

--- a/Library/Formula/rp.rb
+++ b/Library/Formula/rp.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Rp < Formula
-  homepage 'http://0vercl0k.github.io/rp/'
+  homepage 'https://0vercl0k.github.io/rp/'
   head 'https://github.com/0vercl0k/rp.git'
   url 'https://github.com/0vercl0k/rp/archive/v1.tar.gz'
   version '1.0'

--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -4,7 +4,7 @@ require 'formula'
 # http://livestreamer.tanuki.se/en/latest/issues.html#installed-rtmpdump-does-not-support-jtv-argument
 class Rtmpdump < Formula
   homepage 'http://rtmpdump.mplayerhq.hu'
-  url 'http://ftp.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20150115.gita107cef.orig.tar.gz'
+  url 'https://ftp.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20150115.gita107cef.orig.tar.gz'
   version '2.4+20150115'
   sha256 'd47ef3a07815079bf73eb5d053001c4341407fcbebf39f34e6213c4b772cb29a'
 

--- a/Library/Formula/s3fs.rb
+++ b/Library/Formula/s3fs.rb
@@ -32,7 +32,7 @@ class S3fs < Formula
     that have been created by other tools. See the following issue for
     details:
 
-      http://code.google.com/p/s3fs/issues/detail?id=73
+      https://code.google.com/p/s3fs/issues/detail?id=73
     EOS
   end
 end

--- a/Library/Formula/sam2p.rb
+++ b/Library/Formula/sam2p.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Sam2p < Formula
-  homepage 'http://code.google.com/p/sam2p/'
+  homepage 'https://code.google.com/p/sam2p/'
   url 'https://sam2p.googlecode.com/files/sam2p-0.49.2.tar.gz'
   sha1 'a26db7408dfa42ab615d087774128cc5b20ab61d'
 

--- a/Library/Formula/sane-backends.rb
+++ b/Library/Formula/sane-backends.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class SaneBackends < Formula
   homepage "http://www.sane-project.org/"
-  url "http://fossies.org/linux/misc/sane-backends-1.0.24.tar.gz"
+  url "https://fossies.org/linux/misc/sane-backends-1.0.24.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.24.orig.tar.gz"
   sha1 "c10bcb30a1b092b2c2fe5a86d6a5efc29123ccf9"
   bottle do

--- a/Library/Formula/scrub.rb
+++ b/Library/Formula/scrub.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Scrub < Formula
-  homepage 'http://code.google.com/p/diskscrub/'
+  homepage 'https://code.google.com/p/diskscrub/'
   url 'https://diskscrub.googlecode.com/files/scrub-2.5.2.tar.bz2'
   sha1 '863e5894e6acb3f922cb25f58e260f9c59b55c14'
 

--- a/Library/Formula/shared-mime-info.rb
+++ b/Library/Formula/shared-mime-info.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class SharedMimeInfo < Formula
-  homepage 'http://www.freedesktop.org/wiki/Software/shared-mime-info'
+  homepage 'https://wiki.freedesktop.org/www/Software/shared-mime-info'
   url 'http://freedesktop.org/~hadess/shared-mime-info-1.3.tar.xz'
   sha1 'dfc8f2724df2172be2f2782be0c40c23e1d8f54f'
 

--- a/Library/Formula/shocco.rb
+++ b/Library/Formula/shocco.rb
@@ -7,7 +7,7 @@ class MarkdownProvider < Requirement
 end
 
 class Shocco < Formula
-  homepage "http://rtomayko.github.io/shocco/"
+  homepage "https://rtomayko.github.io/shocco/"
   url "https://github.com/rtomayko/shocco/archive/1.0.tar.gz"
   sha1 "e29d58fb8109040b4fb4a816f330bb1c67064f6d"
 

--- a/Library/Formula/signing-party.rb
+++ b/Library/Formula/signing-party.rb
@@ -1,6 +1,6 @@
 class SigningParty < Formula
   homepage "http://pgp-tools.alioth.debian.org/"
-  url "http://ftp.debian.org/debian/pool/main/s/signing-party/signing-party_1.1.10.orig.tar.gz"
+  url "https://ftp.debian.org/debian/pool/main/s/signing-party/signing-party_1.1.10.orig.tar.gz"
   sha256 "b8d6fca8b7a64938436b3d825052513d9b22317241d134707ec5d1d48c0642fd"
 
   bottle do

--- a/Library/Formula/simple-tiles.rb
+++ b/Library/Formula/simple-tiles.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class SimpleTiles < Formula
-  homepage 'http://propublica.github.io/simple-tiles/'
+  homepage 'https://propublica.github.io/simple-tiles/'
   url 'https://github.com/propublica/simple-tiles/archive/v0.5.0.tar.gz'
   sha1 'dde1359132f29e56e01596cbab58b1ed85d2de08'
 

--- a/Library/Formula/skipfish.rb
+++ b/Library/Formula/skipfish.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Skipfish < Formula
-  homepage 'http://code.google.com/p/skipfish/'
+  homepage 'https://code.google.com/p/skipfish/'
   url 'https://skipfish.googlecode.com/files/skipfish-2.10b.tgz'
   sha1 '2564162a13d02f8310eef5edcbaf74ed6043be99'
 

--- a/Library/Formula/sleepwatcher.rb
+++ b/Library/Formula/sleepwatcher.rb
@@ -20,7 +20,7 @@ class Sleepwatcher < Formula
 
     # Build and install binary
     cd "sources" do
-      system "mv", "../sleepwatcher.8", "."
+      mv "../sleepwatcher.8", "."
       system "make", "install", "PREFIX=#{prefix}"
     end
 

--- a/Library/Formula/spatialindex.rb
+++ b/Library/Formula/spatialindex.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Spatialindex < Formula
-  homepage 'http://libspatialindex.github.io'
+  homepage 'https://libspatialindex.github.io'
   url "http://download.osgeo.org/libspatialindex/spatialindex-src-1.8.5.tar.gz"
   sha1 "08af1fefd0a30c895d7d714056c2a8f021f46eb4"
 

--- a/Library/Formula/sqoop.rb
+++ b/Library/Formula/sqoop.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Sqoop < Formula
-  homepage 'http://sqoop.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.5/sqoop-1.4.5.bin__hadoop-2.0.4-alpha.tar.gz'
+  homepage 'https://sqoop.apache.org/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.5/sqoop-1.4.5.bin__hadoop-2.0.4-alpha.tar.gz'
   version '1.4.5'
   sha1 'cb1831d0da2b6f508f62b144d405d859e371e111'
 

--- a/Library/Formula/srmio.rb
+++ b/Library/Formula/srmio.rb
@@ -16,7 +16,7 @@ class Srmio < Formula
 
   def install
     if build.head?
-       system "chmod u+x genautomake.sh"
+      chmod "u+x", "genautomake.sh"
       system "./genautomake.sh"
     end
     system "./configure", "--disable-dependency-tracking",

--- a/Library/Formula/sshfs.rb
+++ b/Library/Formula/sshfs.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Sshfs < Formula
-  homepage 'http://osxfuse.github.io/'
+  homepage 'https://osxfuse.github.io/'
   url 'https://github.com/osxfuse/sshfs/archive/osxfuse-sshfs-2.5.0.tar.gz'
   sha1 '34d81a2f6b4150bff5ee55978b98df50c0bd3152'
 

--- a/Library/Formula/taglib.rb
+++ b/Library/Formula/taglib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Taglib < Formula
-  homepage 'http://taglib.github.io/'
+  homepage 'https://taglib.github.io/'
   url 'https://github.com/taglib/taglib/archive/v1.9.1.tar.gz'
   sha1 '44165eda04d49214a0c4de121a4d99ae18b9670b'
 

--- a/Library/Formula/telepathy-gabble.rb
+++ b/Library/Formula/telepathy-gabble.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class TelepathyGabble < Formula
-  homepage "http://telepathy.freedesktop.org/wiki/Components/"
+  homepage "https://wiki.freedesktop.org/telepathy/Components/"
   url "http://telepathy.freedesktop.org/releases/telepathy-gabble/telepathy-gabble-0.18.3.tar.gz"
   sha1 "1c71c5acf2c506788aa4b1604390f38979d88887"
   revision 1

--- a/Library/Formula/telepathy-glib.rb
+++ b/Library/Formula/telepathy-glib.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class TelepathyGlib < Formula
-  homepage "http://telepathy.freedesktop.org/wiki/"
+  homepage "https://wiki.freedesktop.org/telepathy/"
   url "http://telepathy.freedesktop.org/releases/telepathy-glib/telepathy-glib-0.24.0.tar.gz"
   sha1 "43a3e9f3e08725b689aba3baa487c9711d436888"
 

--- a/Library/Formula/telepathy-idle.rb
+++ b/Library/Formula/telepathy-idle.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class TelepathyIdle < Formula
-  homepage "http://telepathy.freedesktop.org/wiki/Components/"
+  homepage "https://wiki.freedesktop.org/telepathy/Components/"
   url "http://telepathy.freedesktop.org/releases/telepathy-idle/telepathy-idle-0.2.0.tar.gz"
   sha1 "932c11e7c131cc106ef0a6670158535925d9ca9e"
 

--- a/Library/Formula/telepathy-mission-control.rb
+++ b/Library/Formula/telepathy-mission-control.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class TelepathyMissionControl < Formula
-  homepage "http://telepathy.freedesktop.org/wiki/Mission_Control/"
+  homepage "https://wiki.freedesktop.org/telepathy/Mission_Control/"
   url "http://telepathy.freedesktop.org/releases/telepathy-mission-control/telepathy-mission-control-5.16.2.tar.gz"
   sha1 "4c15d20b5f06f083a60bcd9b08141e99092863a3"
 

--- a/Library/Formula/tesseract.rb
+++ b/Library/Formula/tesseract.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Tesseract < Formula
-  homepage 'http://code.google.com/p/tesseract-ocr/'
+  homepage 'https://code.google.com/p/tesseract-ocr/'
   url 'https://tesseract-ocr.googlecode.com/files/tesseract-ocr-3.02.02.tar.gz'
   sha1 'a950acf7b75cf851de2de787e9abb62c58ca1827'
   revision 3

--- a/Library/Formula/texinfo.rb
+++ b/Library/Formula/texinfo.rb
@@ -1,7 +1,7 @@
 class Texinfo < Formula
-  homepage "http://www.gnu.org/software/texinfo/"
+  homepage "https://www.gnu.org/software/texinfo/"
   url "http://ftpmirror.gnu.org/texinfo/texinfo-5.2.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/texinfo/texinfo-5.2.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/texinfo/texinfo-5.2.tar.gz"
   sha1 "dc54edfbb623d46fb400576b3da181f987e63516"
 
   bottle do

--- a/Library/Formula/thrift.rb
+++ b/Library/Formula/thrift.rb
@@ -1,10 +1,10 @@
 require "formula"
 
 class Thrift < Formula
-  homepage "http://thrift.apache.org"
+  homepage "https://thrift.apache.org"
 
   stable do
-    url "http://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz"
+    url "https://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz"
     sha1 "02f78b158da795ea89a26ce41964fbe562cc4235"
 
     # Apply any necessary patches (none currently required)

--- a/Library/Formula/tika.rb
+++ b/Library/Formula/tika.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Tika < Formula
-  homepage 'http://tika.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.7.jar'
+  homepage 'https://tika.apache.org/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.7.jar'
   sha1 'd9516b1964be8775edbe0d6d167234c2967fea7a'
 
   resource 'server' do

--- a/Library/Formula/tomee-jax-rs.rb
+++ b/Library/Formula/tomee-jax-rs.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class TomeeJaxRs < Formula
-  homepage "http://tomee.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-jaxrs.tar.gz"
+  homepage "https://tomee.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-jaxrs.tar.gz"
   version "1.7.1"
   sha1 "5abce8176d034fefc19eb6c81fd5d64bc888d0a9"
 

--- a/Library/Formula/tomee-plume.rb
+++ b/Library/Formula/tomee-plume.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class TomeePlume < Formula
-  homepage "http://tomee.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-plume.tar.gz"
+  homepage "https://tomee.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-plume.tar.gz"
   version "1.7.1"
   sha1 "b27386dd16df4cc936283dd3739012a5eed3224a"
 

--- a/Library/Formula/tomee-plus.rb
+++ b/Library/Formula/tomee-plus.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class TomeePlus < Formula
-  homepage "http://tomee.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-plus.tar.gz"
+  homepage "https://tomee.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-plus.tar.gz"
   version "1.7.1"
   sha1 "c957652b205ec2395dfc30004e88088d4fb41aa5"
 

--- a/Library/Formula/tomee-webprofile.rb
+++ b/Library/Formula/tomee-webprofile.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class TomeeWebprofile < Formula
-  homepage "http://tomee.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-webprofile.tar.gz"
+  homepage "https://tomee.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.1/apache-tomee-1.7.1-webprofile.tar.gz"
   version "1.7.1"
   sha1 "cc86efe41390e61247fd46706f84a9b011f1cd5e"
 

--- a/Library/Formula/tpl.rb
+++ b/Library/Formula/tpl.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Tpl < Formula
-  homepage "http://troydhanson.github.io/tpl/"
+  homepage "https://troydhanson.github.io/tpl/"
   url "https://github.com/troydhanson/tpl/archive/v1.6.1.tar.gz"
   sha1 "2ee92627e8f67400061d8fc606b601988ed90217"
   head "https://github.com/troydhanson/tpl.git"

--- a/Library/Formula/trang.rb
+++ b/Library/Formula/trang.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Trang < Formula
-  homepage 'http://code.google.com/p/jing-trang/'
+  homepage 'https://code.google.com/p/jing-trang/'
   url 'https://jing-trang.googlecode.com/files/trang-20091111.zip'
   sha1 'b5f1fd4b63f347c8d0575bd1922f94316240cb29'
 

--- a/Library/Formula/ttf2eot.rb
+++ b/Library/Formula/ttf2eot.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Ttf2eot < Formula
-  homepage 'http://code.google.com/p/ttf2eot/'
+  homepage 'https://code.google.com/p/ttf2eot/'
   url 'https://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz'
   sha1 'c9a64216e7a090cb50f7a5074865218623dea75d'
 

--- a/Library/Formula/uchardet.rb
+++ b/Library/Formula/uchardet.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Uchardet < Formula
-  homepage 'http://code.google.com/p/uchardet/'
+  homepage 'https://code.google.com/p/uchardet/'
   url 'https://uchardet.googlecode.com/files/uchardet-0.0.1.tar.gz'
   sha1 'c81264cca67f3e7c46e284288f8cab7a34b3f386'
 

--- a/Library/Formula/uim.rb
+++ b/Library/Formula/uim.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Uim < Formula
-  homepage 'http://code.google.com/p/uim/'
+  homepage 'https://code.google.com/p/uim/'
   url 'https://uim.googlecode.com/files/uim-1.6.0.tar.bz2'
   sha1 'd27f2ca8136da0702c82f0522911d06b2b8f8ea7'
 

--- a/Library/Formula/unac.rb
+++ b/Library/Formula/unac.rb
@@ -3,7 +3,7 @@
 require 'formula'
 
 class Unac < Formula
-  homepage 'http://savannah.nongnu.org/projects/unac'
+  homepage 'https://savannah.nongnu.org/projects/unac'
   url 'http://ftp.de.debian.org/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz'
   sha1 '3e779bb7f3b505880ac4f43b48ee2f935ef8aa36'
 
@@ -15,12 +15,12 @@ class Unac < Formula
   patch :DATA
 
   patch :p0 do
-    url "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340"
+    url "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340"
     sha1 "5b273127609b98092b8f3bb1b4c3e9f137968151"
   end
 
   patch :p0 do
-    url "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=10;filename=patch-unaccent.c.txt;att=1;bug=623340"
+    url "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=10;filename=patch-unaccent.c.txt;att=1;bug=623340"
     sha1 "689a1f32cdf08e3dab04bef1605666e4288ae64e"
   end
 
@@ -61,4 +61,4 @@ index 4a4eab6..9f25d50 100644
 +LIBS="$LIBS -liconv"
  AC_CHECK_FUNCS(iconv_open,,AC_MSG_ERROR([
  iconv_open not found try to install replacement from
- http://www.gnu.org/software/libiconv/
+ https://www.gnu.org/software/libiconv/

--- a/Library/Formula/unrtf.rb
+++ b/Library/Formula/unrtf.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Unrtf < Formula
-  homepage 'http://www.gnu.org/software/unrtf/'
+  homepage 'https://www.gnu.org/software/unrtf/'
   url 'http://ftpmirror.gnu.org/unrtf/unrtf-0.21.5.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/unrtf/unrtf-0.21.5.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/unrtf/unrtf-0.21.5.tar.gz'
   sha1 '73d22805eb7a83edf5c3c27fe036e3c33248902d'
 
   # Per MacPorts, add a return value to fix compiling with clang, and fix

--- a/Library/Formula/urlview.rb
+++ b/Library/Formula/urlview.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Urlview < Formula
-  homepage 'http://packages.debian.org/unstable/misc/urlview'
-  url 'http://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz'
+  homepage 'https://packages.debian.org/unstable/misc/urlview'
+  url 'https://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz'
   mirror 'http://ftp.us.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz'
   sha1 '323af9ba30ba87ec600531629f5dd84c720984b6'
 

--- a/Library/Formula/vala.rb
+++ b/Library/Formula/vala.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Vala < Formula
   homepage "https://live.gnome.org/Vala"
-  url "http://ftp.gnome.org/pub/GNOME/sources/vala/0.26/vala-0.26.1.tar.xz"
+  url "https://ftp.gnome.org/pub/GNOME/sources/vala/0.26/vala-0.26.1.tar.xz"
   sha256 "8407abb19ab3a58bbfc0d288abb47666ef81f76d0540258c03965e7545f59e6b"
 
   bottle do
@@ -12,7 +12,7 @@ class Vala < Formula
   end
 
   devel do
-    url "http://ftp.gnome.org/pub/GNOME/sources/vala/0.27/vala-0.27.1.tar.xz"
+    url "https://ftp.gnome.org/pub/GNOME/sources/vala/0.27/vala-0.27.1.tar.xz"
     sha256 "0bce939c011c34478da840f869b3c24d02e8f1c92691c587c1fe289a5533cd77"
   end
 

--- a/Library/Formula/vcdimager.rb
+++ b/Library/Formula/vcdimager.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Vcdimager < Formula
-  homepage 'http://www.gnu.org/software/vcdimager/'
+  homepage 'https://www.gnu.org/software/vcdimager/'
   url 'http://ftpmirror.gnu.org/vcdimager/vcdimager-0.7.24.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/vcdimager/vcdimager-0.7.24.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/vcdimager/vcdimager-0.7.24.tar.gz'
   sha1 '8c245555c3e21dcbc3d4dbb2ecca74f609545424'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/vert.x.rb
+++ b/Library/Formula/vert.x.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class VertX < Formula
   homepage 'http://vertx.io/'
-  url 'http://dl.bintray.com/vertx/downloads/vert.x-2.1.5.tar.gz'
+  url 'https://dl.bintray.com/vertx/downloads/vert.x-2.1.5.tar.gz'
   sha1 'bac58701858462f13c0b01de99e2ada0a4df8431'
 
   def install

--- a/Library/Formula/vim.rb
+++ b/Library/Formula/vim.rb
@@ -1,8 +1,8 @@
 class Vim < Formula
   homepage "http://www.vim.org/"
   head "https://vim.googlecode.com/hg/"
-  # This package tracks debian-unstable: http://packages.debian.org/unstable/vim
-  url "http://ftp.debian.org/debian/pool/main/v/vim/vim_7.4.488.orig.tar.gz"
+  # This package tracks debian-unstable: https://packages.debian.org/unstable/vim
+  url "https://ftp.debian.org/debian/pool/main/v/vim/vim_7.4.488.orig.tar.gz"
   sha256 "5b58ef7d4ce2c2eb84af2f3dbb3b5d6919adc97f12de1509a13681fa58936faf"
 
   # We only have special support for finding depends_on :python, but not yet for
@@ -95,7 +95,7 @@ class Vim < Formula
     system "make"
     # If stripping the binaries is not enabled, vim will segfault with
     # statically-linked interpreters like ruby
-    # http://code.google.com/p/vim/issues/detail?id=114&thanks=114&ts=1361483471
+    # https://code.google.com/p/vim/issues/detail?id=114&thanks=114&ts=1361483471
     system "make", "install", "prefix=#{prefix}", "STRIP=true"
     bin.install_symlink "vim" => "vi" if build.include? "override-system-vi"
   end

--- a/Library/Formula/visualnetkit.rb
+++ b/Library/Formula/visualnetkit.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Visualnetkit < Formula
-  homepage 'http://code.google.com/p/visual-netkit/'
+  homepage 'https://code.google.com/p/visual-netkit/'
   url 'https://visual-netkit.googlecode.com/files/visualnetkit-1.4.tar.bz'
   version '1.4'
   sha1 '17dbc3a6b7e62b1b2183f2a4426b9021781e4ec4'

--- a/Library/Formula/vpnc.rb
+++ b/Library/Formula/vpnc.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Vpnc < Formula
   homepage "http://www.unix-ag.uni-kl.de/~massar/vpnc/"
-  url "http://ftp.debian.org/debian/pool/main/v/vpnc/vpnc_0.5.3r512.orig.tar.gz"
+  url "https://ftp.debian.org/debian/pool/main/v/vpnc/vpnc_0.5.3r512.orig.tar.gz"
   version "0.5.3r512"
   sha256 "d421ac20b6c65d22d2ee88066e487f740f4d367f9143b6045bcb8fa177b384fe"
   revision 2

--- a/Library/Formula/vte.rb
+++ b/Library/Formula/vte.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Vte < Formula
-  homepage 'http://developer.gnome.org/vte/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/vte/0.28/vte-0.28.0.tar.bz2'
+  homepage 'https://developer.gnome.org/vte/'
+  url 'https://ftp.gnome.org/pub/gnome/sources/vte/0.28/vte-0.28.0.tar.bz2'
   sha1 '49b66a0346da09c72f59e5c544cc5b50e7de9bc1'
 
   depends_on 'pkg-config' => :build

--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Vte3 < Formula
-  homepage "http://developer.gnome.org/vte/"
-  url "http://ftp.gnome.org/pub/gnome/sources/vte/0.36/vte-0.36.3.tar.xz"
+  homepage "https://developer.gnome.org/vte/"
+  url "https://ftp.gnome.org/pub/gnome/sources/vte/0.36/vte-0.36.3.tar.xz"
   sha1 "a7acc1594eb6fa249edccb059c21132b3aa2657b"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/wdiff.rb
+++ b/Library/Formula/wdiff.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Wdiff < Formula
-  homepage 'http://www.gnu.org/software/wdiff/'
+  homepage 'https://www.gnu.org/software/wdiff/'
   url 'http://ftpmirror.gnu.org/wdiff/wdiff-1.2.2.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/wdiff/wdiff-1.2.2.tar.gz'
+  mirror 'https://ftp.gnu.org/gnu/wdiff/wdiff-1.2.2.tar.gz'
   sha1 'c93b5cb593257d814212e15fc371ff6c6b952c3d'
 
   depends_on 'gettext' => :optional

--- a/Library/Formula/whereami.rb
+++ b/Library/Formula/whereami.rb
@@ -1,5 +1,5 @@
 class Whereami < Formula
-  homepage "http://victor.github.io/whereami/"
+  homepage "https://victor.github.io/whereami/"
   url "https://github.com/victor/whereami/archive/v1.0.tar.gz"
   sha1 "2f81e4b05af5f6806590d7212c0dbfbea00a75e0"
   head "https://github.com/victor/whereami.git", :branch => "swift"

--- a/Library/Formula/whirr.rb
+++ b/Library/Formula/whirr.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Whirr < Formula
-  homepage 'http://whirr.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=whirr/whirr-0.8.2/whirr-0.8.2.tar.gz'
+  homepage 'https://whirr.apache.org/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=whirr/whirr-0.8.2/whirr-0.8.2.tar.gz'
   sha1 'd5bd127bc396795e4c512c1584a8c73abde5a78c'
 
   def install

--- a/Library/Formula/wla-dx.rb
+++ b/Library/Formula/wla-dx.rb
@@ -11,8 +11,8 @@ class WlaDx < Formula
   def install
     %w{CFLAGS CXXFLAGS CPPFLAGS}.each { |e| ENV.delete(e) }
     ENV.append_to_cflags '-c -O3 -ansi -pedantic -Wall'
-    system "chmod +x unix.sh"
-    system "chmod +x opcode_table_generator/create_tables.sh"
+    chmod "+x", "unix.sh"
+    chmod "+x", "opcode_table_generator/create_tables.sh"
     system "./unix.sh", ENV.make_jobs
     bin.install Dir['./binaries/*']
   end

--- a/Library/Formula/xml-security-c.rb
+++ b/Library/Formula/xml-security-c.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class XmlSecurityC < Formula
-  homepage 'http://santuario.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.2.tar.gz'
+  homepage 'https://santuario.apache.org/'
+  url 'https://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.2.tar.gz'
   sha1 'fee59d5347ff0666802c8e5aa729e0304ee492bc'
 
   bottle do

--- a/Library/Formula/zookeeper.rb
+++ b/Library/Formula/zookeeper.rb
@@ -5,7 +5,7 @@ class Zookeeper < Formula
   revision 1
 
   stable do
-    url "http://www.apache.org/dyn/closer.cgi?path=zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?path=zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz"
     sha1 "2a9e53f5990dfe0965834a525fbcad226bf93474"
 
     # To resolve Yosemite build errors.


### PR DESCRIPTION
Fixed a number of ``brew audit`` warnings.

* Switch to ``https`` urls
* Switch to ruby versions of ``mv``, ``rm``, ``touch``, ``chmod``
* Fix wiki.freedesktop.org urls

Before:

``Error: 304 problems in 238 formulae``

After:

``Error: 38 problems in 36 formulae``