### PR TITLE
Upgrade task to version 2.4.3

### DIFF
--- a/Library/Formula/task.rb
+++ b/Library/Formula/task.rb
@@ -1,8 +1,8 @@
 class Task < Formula
   homepage "http://www.taskwarrior.org/"
-  url "http://taskwarrior.org/download/task-2.4.2.tar.gz"
-  sha1 "94699f518150e736e8d5ad2b5b7ccf8c988ed4d0"
-  head "https://git.tasktools.org/scm/tm/task.git", :branch => "2.4.3", :shallow => false
+  url "http://taskwarrior.org/download/task-2.4.3.tar.gz"
+  sha1 "2a0c1519b1b572c91f8d6ee489b1250a993a3e86"
+  head "https://git.tasktools.org/scm/tm/task.git", :branch => "2.4.4", :shallow => false
 
   bottle do
     sha256 "d70d69485365a3b0a576df29a7ff00bc95dbe21824d37b97ae12facc2ac510c2" => :yosemite


### PR DESCRIPTION
Updates release and head version. Removes bottle ids since they probably
don't exist.