### PR TITLE
Update calabash to 1.1.0-95

### DIFF
--- a/Library/Formula/calabash.rb
+++ b/Library/Formula/calabash.rb
@@ -1,7 +1,7 @@
 class Calabash < Formula
   homepage "http://xmlcalabash.com"
-  url "http://xmlcalabash.com/download/calabash-1.0.24-95.zip"
-  sha1 "e5443324147891728277880046e5466aef74a8ad"
+  url "https://github.com/ndw/xmlcalabash1/releases/download/1.1.0-95/xmlcalabash-1.1.0-95.zip"
+  sha256 "d75a8699ec496fb854761d8e375015732ac51047aad5d7bec57ea3a5349feae7"
 
   depends_on "saxon"
 

--- a/Library/Formula/calabash.rb
+++ b/Library/Formula/calabash.rb
@@ -7,7 +7,7 @@ class Calabash < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.write_jar_script libexec/"calabash.jar", "calabash", "-Xmx1024m"
+    bin.write_jar_script libexec/"xmlcalabash-#{version}.jar", "calabash", "-Xmx1024m"
   end
 
   test do


### PR DESCRIPTION
The `-95` in the version is significant.  Calabash offers 2 releases—(`x.x.x-95`, and `x.x.x-96`)—each of which is built to run with a specific version of the `saxon` dependency.  

Since Homebrew currently offers only the Saxon 9.5 dependency, that’s why this commit uses the `-95` suffix on the release.  If Homebrew ever offers Saxon 9.6, this formula should be updated accordingly.