### PR TITLE
gdal 1.11.2_2 java swig bindings #39105

### DIFF
--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -71,8 +71,8 @@ class Gdal < Formula
     depends_on "json-c"
   end
 
+  depends_on :java => ["1.7+", :optional, :build]
   if build.with? "swig-java"
-    depends_on :java => "1.7+"
     depends_on 'swig'
   end
 
@@ -293,9 +293,7 @@ class Gdal < Formula
     if build.with? "swig-java"
       cd 'swig/java' do
         inreplace "java.opt", "linux", "darwin"
-        inreplace "java.opt", "#JA", "JA"
-        # The following line uses ' + ' to split the replace argument so it passes the brew audit checks
-        inreplace "java.opt", "/usr/lib/jvm/java-6-openjdk/", '$(shell echo $$JAVA' + '_HOME)'
+        inreplace "java.opt", "#JAVA_HOME = /usr/lib/jvm/java-6-openjdk/", 'JAVA_HOME=$(shell echo $$JAVA_HOME)'
         system "make"
         system "make", "install"
       end

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -72,9 +72,7 @@ class Gdal < Formula
   end
 
   depends_on :java => ["1.7+", :optional, :build]
-  if build.with? "swig-java"
-    depends_on 'swig'
-  end
+  depends_on "swig" if build.with? "swig-java"
 
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -321,4 +321,3 @@ class Gdal < Formula
     system "#{bin}/ogrinfo", "--formats"
   end
 end
-

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -2,7 +2,7 @@ class Gdal < Formula
   homepage 'http://www.gdal.org/'
   url "http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz"
   sha1 "6f3ccbe5643805784812072a33c25be0bbff00db"
-  revision 2
+  revision 1
 
   bottle do
     sha256 "a0fd2413588bac1b4705349796cf1a93a20770ee16ae0044e56bc93ceaa18a72" => :yosemite
@@ -71,7 +71,10 @@ class Gdal < Formula
     depends_on "json-c"
   end
 
-  depends_on 'swig'
+  if build.include? 'with-swig-java'
+     depends_on :java => "1.7+"
+     depends_on 'swig'
+  end
 
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455
@@ -289,12 +292,15 @@ class Gdal < Formula
 
     if 'with-swig-java'
       cd 'swig/java' do
-        system "echo 'JAVA_HOME='`/usr/libexec/java_home -v 1.7` > java.opt"
-        system "echo 'JAVADOC=$(JAVA_HOME)/bin/javadoc' >> java.opt"
-        system "echo 'JAVAC=$(JAVA_HOME)/bin/javac' >> java.opt"
-        system "echo 'JAVA=$(JAVA_HOME)/bin/java' >> java.opt"
-        system "echo 'JAR=$(JAVA_HOME)/bin/jar' >> java.opt"
-        system "echo 'JAVA_INCLUDE=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin' >> java.opt"
+        File.open("java.opt", "w"){|file| file.write <<-EOS.undent
+JAVA_HOME=$(shell /usr/libexec/java_home -v 1.7)
+JAVADOC=$(JAVA_HOME)/bin/javadoc
+JAVAC=$(JAVA_HOME)/bin/javac
+JAVA=$(JAVA_HOME)/bin/java
+JAR=$(JAVA_HOME)/bin/jar
+JAVA_INCLUDE=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin
+        EOS
+        }
         system "make"
         system "make install"
       end
@@ -324,3 +330,4 @@ class Gdal < Formula
     system "#{bin}/ogrinfo", "--formats"
   end
 end
+

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -71,9 +71,9 @@ class Gdal < Formula
     depends_on "json-c"
   end
 
-  if build.include? 'with-swig-java'
-     depends_on :java => "1.7+"
-     depends_on 'swig'
+  if build.with? "swig-java"
+    depends_on :java => "1.7+"
+    depends_on 'swig'
   end
 
   # Extra linking libraries in configure test of armadillo may throw warning
@@ -275,7 +275,7 @@ class Gdal < Formula
 
     system "./configure", *get_configure_args
     system "make"
-    system "make install"
+    system "make", "install"
 
     # `python-config` may try to talk us into building bindings for more
     # architectures than we really should.
@@ -290,19 +290,14 @@ class Gdal < Formula
       bin.install Dir['scripts/*']
     end
 
-    if 'with-swig-java'
+    if build.with? "swig-java"
       cd 'swig/java' do
-        File.open("java.opt", "w"){|file| file.write <<-EOS.undent
-JAVA_HOME=$(shell /usr/libexec/java_home -v 1.7)
-JAVADOC=$(JAVA_HOME)/bin/javadoc
-JAVAC=$(JAVA_HOME)/bin/javac
-JAVA=$(JAVA_HOME)/bin/java
-JAR=$(JAVA_HOME)/bin/jar
-JAVA_INCLUDE=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin
-        EOS
-        }
+        inreplace "java.opt", "linux", "darwin"
+        inreplace "java.opt", "#JA", "JA"
+        # The following line uses ' + ' to split the replace argument so it passes the brew audit checks
+        inreplace "java.opt", "/usr/lib/jvm/java-6-openjdk/", '$(shell echo $$JAVA' + '_HOME)'
         system "make"
-        system "make install"
+        system "make", "install"
       end
     end
 

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -2,7 +2,7 @@ class Gdal < Formula
   homepage 'http://www.gdal.org/'
   url "http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz"
   sha1 "6f3ccbe5643805784812072a33c25be0bbff00db"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "a0fd2413588bac1b4705349796cf1a93a20770ee16ae0044e56bc93ceaa18a72" => :yosemite
@@ -21,6 +21,7 @@ class Gdal < Formula
   option 'enable-unsupported', "Allow configure to drag in any library it can find. Invoke this at your own risk."
   option 'enable-mdb', 'Build with Access MDB driver (requires Java 1.6+ JDK/JRE, from Apple or Oracle).'
   option "with-libkml", "Build with Google's libkml driver (requires libkml --HEAD or >= 1.3)"
+  option 'with-swig-java', 'Build the swig java bindings'
 
   depends_on :python => :optional
   if build.with? "python"
@@ -69,6 +70,8 @@ class Gdal < Formula
     depends_on "poppler"
     depends_on "json-c"
   end
+
+  depends_on 'swig'
 
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455
@@ -282,6 +285,19 @@ class Gdal < Formula
     cd 'swig/python' do
       system "python", "setup.py", "install", "--prefix=#{prefix}", "--record=installed.txt", "--single-version-externally-managed"
       bin.install Dir['scripts/*']
+    end
+
+    if 'with-swig-java'
+      cd 'swig/java' do
+        system "echo 'JAVA_HOME='`/usr/libexec/java_home -v 1.7` > java.opt"
+        system "echo 'JAVADOC=$(JAVA_HOME)/bin/javadoc' >> java.opt"
+        system "echo 'JAVAC=$(JAVA_HOME)/bin/javac' >> java.opt"
+        system "echo 'JAVA=$(JAVA_HOME)/bin/java' >> java.opt"
+        system "echo 'JAR=$(JAVA_HOME)/bin/jar' >> java.opt"
+        system "echo 'JAVA_INCLUDE=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin' >> java.opt"
+        system "make"
+        system "make install"
+      end
     end
 
     system 'make', 'man' if build.head?


### PR DESCRIPTION
Added the --with-swig-java option to enable compilation of the swig
java bindings for gdal. Added the code to create the required
java config file for java 1.7 and run make on swig java binding.