### PR TITLE
fileutils: use rm_rf to clean temp dir.

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -19,7 +19,7 @@ module FileUtils
         cd(prev)
       end
     ensure
-      ignore_interrupts { rm_r(tmp) }
+      ignore_interrupts { rm_rf(tmp) }
     end
   end
   module_function :mktemp


### PR DESCRIPTION
Honestly, I don't know why git is broken under sandbox. But this seems
fix the problem.

Closes ##38978.

cc @DomT4, @jacknagel to confirm it does fix the problem.