### PR TITLE
sassc and libsass 3.2.1

### DIFF
--- a/Library/Formula/libsass.rb
+++ b/Library/Formula/libsass.rb
@@ -1,7 +1,6 @@
 class Libsass < Formula
   homepage "https://github.com/sass/libsass"
-  url "https://github.com/sass/libsass/archive/3.1.0.tar.gz"
-  sha1 "858c41405f5ff8b4186c7111e08f29893f4e51a1"
+  url "https://github.com/sass/libsass.git", :tag => "3.2.1", :revision => "e716caa918d86b3b8598e8ad639943fe6ec8e0ec"
   head "https://github.com/sass/libsass.git"
 
   bottle do
@@ -18,15 +17,10 @@ class Libsass < Formula
 
   def install
     ENV.cxx11
-    ENV["LIBSASS_VERSION"] = "HEAD" if build.head?
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"
     system "make", "install"
-    # The header below is deprecated and should not be used outside of test do.
-    # We only install it here for backward compatibility and so brew test works.
-    # https://github.com/sass/libsass/wiki/API-Documentation
-    include.install "sass_interface.h" if build.devel?
   end
 
   test do
@@ -37,11 +31,12 @@ class Libsass < Formula
 
       int main()
       {
-        char* source_string = "a { color:blue; &:hover { color:red; } }";
-        struct Sass_Data_Context* data_ctx = sass_make_data_context(source_string);
+        const char* source_string = "a { color:blue; &:hover { color:red; } }";
+        struct Sass_Data_Context* data_ctx = sass_make_data_context(strdup(source_string));
         struct Sass_Options* options = sass_data_context_get_options(data_ctx);
-        sass_option_set_precision(options, SASS_STYLE_NESTED);
-        sass_option_set_source_comments(options, 0);
+        sass_option_set_precision(options, 1);
+        sass_option_set_source_comments(options, false);
+        sass_data_context_set_options(data_ctx, options);
         sass_compile_data_context(data_ctx);
         struct Sass_Context* ctx = sass_data_context_get_context(data_ctx);
         int err = sass_context_get_error_status(ctx);

--- a/Library/Formula/sassc.rb
+++ b/Library/Formula/sassc.rb
@@ -2,8 +2,7 @@ require "formula"
 
 class Sassc < Formula
   homepage "https://github.com/sass/sassc"
-  url "https://github.com/sass/sassc/archive/3.1.0.tar.gz"
-  sha1 "573224ad922b46ea1a568807ddcbc7de41a4254d"
+  url "https://github.com/sass/sassc.git", :tag => "3.2.1", :revision => "a88dd098143a1297d68a509f6dd99be25487197a"
   head "https://github.com/sass/sassc.git"
 
   bottle do
@@ -20,7 +19,6 @@ class Sassc < Formula
   depends_on "libsass"
 
   def install
-    ENV["SASSC_VERSION"] = "3.1.0"
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
                           "--disable-dependency-tracking"


### PR DESCRIPTION
Update SassC to ~~3.2.0~~ 3.2.1.

~~The Libsass dependency update has been PR  in https://github.com/Homebrew/homebrew/pull/39164~~