### PR TITLE
commonmark 0.19.0

### DIFF
--- a/Library/Formula/commonmark.rb
+++ b/Library/Formula/commonmark.rb
@@ -1,7 +1,7 @@
 class Commonmark < Formula
   homepage "http://commonmark.org"
-  url "https://github.com/jgm/cmark/archive/0.18.3.tar.gz"
-  sha256 "493a29765b6b72b7cac9acca9b5be1e34828345068a1b1c17f8e004b786d55de"
+  url "https://github.com/jgm/cmark/archive/0.19.0.tar.gz"
+  sha256 "25547326e24595da0ec3be5b8d2b2d1fff9d9943ab68ae1cc0dc4cc79d2c22e4"
 
   bottle do
     cellar :any


### PR DESCRIPTION
[cmark 0.19.0 release](https://github.com/jgm/cmark/releases/tag/0.19.0).