### PR TITLE
dfu-util: style fixes and hosting changes

### DIFF
--- a/Library/Formula/dfu-util.rb
+++ b/Library/Formula/dfu-util.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class DfuUtil < Formula
-  homepage "https://gitorious.org/dfu-util/community"
-  # upstream moved, no releases yet, using debian mirror until then.  see #34047
+  homepage "http://dfu-util.sourceforge.net/"
+  # Upstream moved, no releases yet, using debian mirror until then.
+  # (see #34047 and #39181)
   url "http://ftp.de.debian.org/debian/pool/main/d/dfu-util/dfu-util_0.8.orig.tar.gz"
-  sha1 "164551ca40f0c569eb7ae3263a9945a1ef3fed4d"
+  sha256 "55cbde9be12a212bd84bce9d1e63941d9a16139ed0d4912401367eba1502f058"
 
   bottle do
     cellar :any
@@ -14,7 +13,7 @@ class DfuUtil < Formula
   end
 
   head do
-    url "git://gitorious.org/dfu-util/dfu-util.git"
+    url "git://git.code.sf.net/p/dfu-util/dfu-util"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
@@ -27,6 +26,12 @@ class DfuUtil < Formula
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"dfu-util", "-V"
+    system bin/"dfu-prefix", "-V"
+    system bin/"dfu-suffix", "-V"
   end
 end


### PR DESCRIPTION
* Remove `require "formula"`
* Replace Gitorious URLs with Sourceforge URLs (Gitorious closing at end of May)
* Replace SHA-1 hash with SHA-2(256) hash
* Break up arguments to `system` call
* Add test block for basic validation