### PR TITLE
libswift (new formula)

### DIFF
--- a/Library/Formula/libswift.rb
+++ b/Library/Formula/libswift.rb
@@ -1,0 +1,19 @@
+class Libswift < Formula
+  homepage "http://libswift.org/"
+  url "https://github.com/libswift/libswift/archive/v0.1-beta.tar.gz"
+  version "0.1-beta"
+  sha256 "ba7869e0a4e1ec4b6b8f526ffc53137d9f39b5da1562b3bac1454a60f4ceb88b"
+  head "https://github.com/libswift/libswift.git", :branch => :devel
+
+  depends_on "libevent"
+
+  def install
+    system "make"
+    bin.install "swift" => "libswift"
+  end
+
+  test do
+    # make a merkle tree hash from an arbitrary file
+    system "#{bin}/libswift", "-f", "#{bin}/libswift"
+  end
+end


### PR DESCRIPTION
- re-submission of libswift after upstream tags the repo https://github.com/libswift/libswift/issues/46
- viz https://github.com/Homebrew/homebrew/pull/30764 discussion
- resulting binary is called `libswift`, which doesn't conflict with the similarly named recipe `libswiften` (a library without a corresponding executable)
- passes brew audit & test fine

