### PR TITLE
Default HOMEBREW_TEMP to Dir.tmpdir

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -49,7 +49,7 @@ end
 
 HOMEBREW_LOGS = Pathname.new(ENV['HOMEBREW_LOGS'] || '~/Library/Logs/Homebrew/').expand_path
 
-HOMEBREW_TEMP = Pathname.new(ENV.fetch('HOMEBREW_TEMP', '/tmp'))
+HOMEBREW_TEMP = Pathname.new(ENV["HOMEBREW_TEMP"] || Dir.tmpdir)
 
 if not defined? HOMEBREW_LIBRARY_PATH
   HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent.join("Homebrew")


### PR DESCRIPTION
`Dir.tmpdir` will try a number of locations, starting with `$TMPDIR`, `$TMP`, and `$TEMP`, eventually falling back to `/tmp`. On OS X, `$TMPDIR` is set to a per-user temporary directory, so I think this is a better default.