### PR TITLE
knot: Workaround for compiler bug

### DIFF
--- a/Library/Formula/knot.rb
+++ b/Library/Formula/knot.rb
@@ -30,6 +30,7 @@ class Knot < Formula
     system "autoreconf", "-i", "-f" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
+                          "--disable-fastparser",
                           "--disable-silent-rules",
                           "--with-configdir=#{etc}",
                           "--with-storage=#{var}/knot",
@@ -39,6 +40,7 @@ class Knot < Formula
     inreplace "samples/Makefile", "install-data-local:", "disable-install-data-local:"
 
     system "make"
+    system "make", "check"
     system "make", "install"
 
     (buildpath/"knot.conf").write(knot_conf)


### PR DESCRIPTION
1. Disable the fast parser because it breaks zone loading. See this bug for details: https://gitlab.labs.nic.cz/labs/knot/issues/351
2. The package provides a "check" target, so use it; it would have caught this bug earlier