### PR TITLE
mr: Git repo on official homepage is off

### DIFF
--- a/Library/Formula/mr.rb
+++ b/Library/Formula/mr.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Mr < Formula
   homepage 'http://myrepos.branchable.com/'
-  url 'git://myrepos.branchable.com/', :tag => '1.20141024'
+  url 'https://github.com/joeyh/myrepos.git', :tag => '1.20141024'
 
   def install
     system "make"


### PR DESCRIPTION
Git repository on official homepage is off (git://myrepos.branchable.com/)