### PR TITLE
Fix tcpflow HEAD build

### DIFF
--- a/Library/Formula/tcpflow.rb
+++ b/Library/Formula/tcpflow.rb
@@ -16,10 +16,12 @@ class Tcpflow < Formula
   depends_on 'sqlite' if MacOS.version < :lion
   depends_on "openssl"
 
-  # Upstream fix for 10.6; can be removed in next release
-  patch do
-    url "https://github.com/simsong/tcpflow/commit/1cd5a9168c2ebf72c1fadcd64634398bd8470bce.diff"
-    sha1 "5264d287a5e62b647da0aa6f2bfa237bc8171c3a"
+  stable do
+    # Upstream fix for 10.6; can be removed in next release
+    patch do
+      url "https://github.com/simsong/tcpflow/commit/1cd5a9168c2ebf72c1fadcd64634398bd8470bce.diff"
+      sha1 "5264d287a5e62b647da0aa6f2bfa237bc8171c3a"
+    end
   end
 
   def install


### PR DESCRIPTION
Tcpflow install isn't work since tcpflow download location is down now.
I reported to upstream:
https://github.com/simsong/tcpflow/issues/97

I tried to use the release tarball on Github also.
But the SHA-1 isn't the same.
Maybe it's just because autotools release tarball contains more files but I'm not 100% sure.

I then tried to do a HEAD build.
It also fails.
But this is caused by the fact that the current formula apply the patch unconditionally.
I guess it applies to stable build only since it is from the Git repo anyway.

So I created this pull request :) 

