### PR TITLE
xml-security-c: fix system openssl linkage

### DIFF
--- a/Library/Formula/xml-security-c.rb
+++ b/Library/Formula/xml-security-c.rb
@@ -1,9 +1,8 @@
-require 'formula'
-
 class XmlSecurityC < Formula
-  homepage 'http://santuario.apache.org/'
-  url 'http://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.2.tar.gz'
-  sha1 'fee59d5347ff0666802c8e5aa729e0304ee492bc'
+  homepage "https://santuario.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.2.tar.gz"
+  sha256 "d576b07bb843eaebfde3be01301db40504ea8e8e477c0ad5f739b07022445452"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,11 +11,17 @@ class XmlSecurityC < Formula
     sha1 "2ca2c2af28a4d7e45bb54110054323a7e220c47b" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'xerces-c'
+  depends_on "pkg-config" => :build
+  depends_on "xerces-c"
+  depends_on "openssl"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
-    system "make install"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+    system "make", "install"
+  end
+
+  test do
+    assert_match /All tests passed/, pipe_output("#{bin}/xtest 2>&1")
   end
 end


### PR DESCRIPTION
Fixes system OpenSSL linkage, bumps revision, adds test, rolls SSL/TLS, removes redundant configure option.

Re: https://github.com/Homebrew/homebrew/pull/38759#issuecomment-94099350