### PR TITLE
bullet: use github tarball instead of google code

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,8 +1,7 @@
 class Bullet < Formula
   homepage "http://bulletphysics.org/wordpress/"
-  url "https://bullet.googlecode.com/files/bullet-2.82-r2704.tgz"
-  version "2.82"
-  sha256 "67e4c9eb76f7adf99501d726d8ad5e9b525dfd0843fbce9ca73aaca4ba9eced2"
+  url "https://github.com/bulletphysics/bullet3/archive/2.82.tar.gz"
+  sha256 "93ffcdfdd7aa67159fc18d336456945538a6602e3cd318eed9963280620b55bd"
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do


### PR DESCRIPTION
bullet has migrated to from [google code (svn)](https://code.google.com/p/bullet/) to a [github repo](https://github.com/bulletphysics/bullet3), though it only recently has had a tag for 2.82 applied to its git repository (https://github.com/bulletphysics/bullet3/issues/339). This points homebrew to github for the tarball.