### PR TITLE
freetds: upgrade to 0.91.112; style changes for `brew audit --strict`; other configuration changes

### DIFF
--- a/Library/Formula/freetds.rb
+++ b/Library/Formula/freetds.rb
@@ -1,10 +1,7 @@
-require "formula"
-
 class Freetds < Formula
   homepage "http://www.freetds.org/"
-  url "http://mirrors.ibiblio.org/freetds/stable/freetds-0.91.tar.gz"
-  sha1 "3ab06c8e208e82197dc25d09ae353d9f3be7db52"
-  revision 2
+  url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-0.91.112.tar.gz"
+  sha256 "be4f04ee57328c32e7e7cd7e2e1483e535071cec6101e46b9dd15b857c5078ed"
 
   bottle do
     sha1 "7f98f1313e932185398c72237b7ac0d408cea986" => :mavericks
@@ -13,7 +10,7 @@ class Freetds < Formula
   end
 
   head do
-    url "https://git.gitorious.org/freetds/freetds.git"
+    url "https://github.com/FreeTDS/freetds.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -21,43 +18,44 @@ class Freetds < Formula
   end
 
   option :universal
-  option "enable-msdblib", "Enable Microsoft behavior in the DB-Library API where it diverges from Sybase's"
-  option "enable-sybase-compat", "Enable close compatibility with Sybase's ABI, at the expense of other features"
-  option "enable-odbc-wide", "Enable odbc wide, prevent unicode - MemoryError's"
-  option "enable-krb", "Enable Kerberos support"
+  option "with-msdblib", "Enable Microsoft behavior in the DB-Library API where it diverges from Sybase's"
+  option "with-sybase-compat", "Enable close compatibility with Sybase's ABI, at the expense of other features"
+  option "with-odbc-wide", "Enable odbc wide, prevent unicode - MemoryError's"
+  option "with-krb5", "Enable Kerberos support"
+  option "without-openssl", "Build without OpenSSL support (default is to use brewed OpenSSL)"
+
+  deprecated_option "enable-msdblib" => "with-msdblib"
+  deprecated_option "enable-sybase-compat" => "with-sybase-compat"
+  deprecated_option "enable-odbc-wide" => "with-odbc-wide"
+  deprecated_option "enable-krb" => "with-krb5"
 
   depends_on "pkg-config" => :build
   depends_on "unixodbc" => :optional
-  depends_on "openssl"
+  depends_on "openssl" => :recommended
 
   def install
-    system "autoreconf -i" if build.head?
+    system "autoreconf", "-i" if build.head?
 
     args = %W[
       --prefix=#{prefix}
-      --with-openssl=#{Formula["openssl"].opt_prefix}
       --with-tdsver=7.1
       --mandir=#{man}
     ]
+
+    if build.with? "openssl"
+      args << "--with-openssl=#{Formula["openssl"].opt_prefix}"
+    end
 
     if build.with? "unixodbc"
       args << "--with-unixodbc=#{Formula["unixodbc"].prefix}"
     end
 
-    if build.include? "enable-msdblib"
-      args << "--enable-msdblib"
-    end
-
-    if build.include? "enable-sybase-compat"
-      args << "--enable-sybase-compat"
-    end
-
-    if build.include? "enable-odbc-wide"
-      args << "--enable-odbc-wide"
-    end
-
-    if build.include? "enable-krb"
-      args << "--enable-krb5"
+    # Translate formula's "--with" options to configuration script's "--enable"
+    # options
+    %w[msdblib sybase-compat odbc-wide krb5].each do |option|
+      if build.with? option
+        args << "--enable-#{option}"
+      end
     end
 
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
I broke this up into two commits, but can merge them into one once everyone is satisfied with the changes.

The first one is a straightforward upgrade to a new version with style changes to pass `brew audit --strict`. Only one potentially controversial item: I had to specify the `version`. Even though the tarball being downloaded rolls up all of the latest patches, they don't name it with the version number used in the code (but it is evident within the tarball's file structure and in the source code).

The second commit is mainly to migrate all of the `--enable-*` options to `--with-*` options. Two important things of note in this one:
* I turned the dependency on OpenSSL into a `:recommended` dependency (thus, `--without-openssl` is a new option). To respect all open-source licenses, I think this should really be an `:optional` dependency, but I made it `:recommended` to minimize the potential for surprise. (I say this because the FreeTDS docs make the assertion that linking with OpenSSL introduces a license conflict, yet it _is_ still an option.)
* I added a clause that checks for `HOMEBREW_DEVELOPER` and enables the configuration option `--enable-option-checking=fatal` accordingly. This gave me peace of mind while I was migrating the formula options, so I decided to leave it in; if anyone hates it, I can take it out. :smile_cat: 
