### PR TITLE
couchdb: bump revision for icu4c

### DIFF
--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Couchdb < Formula
-  homepage "http://couchdb.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
-  sha1 "6275f3818579d7b307052e9735c42a8a64313229"
-  revision 1
+  homepage "https://couchdb.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
+  sha256 "5a601b173733ce3ed31b654805c793aa907131cd70b06d03825f169aa48c8627"
+  revision 2
 
   bottle do
     sha1 "5de6d96453578bcb65a89dd68128efb856f8e99d" => :mavericks
@@ -13,7 +11,7 @@ class Couchdb < Formula
   end
 
   head do
-    url "http://git-wip-us.apache.org/repos/asf/couchdb.git"
+    url "https://git-wip-us.apache.org/repos/asf/couchdb.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -36,7 +34,7 @@ class Couchdb < Formula
       s.gsub! "%version%", "%version%-1"
     end
 
-    if build.devel? or build.head?
+    if build.devel? || build.head?
       # workaround for the auto-generation of THANKS file which assumes
       # a developer build environment incl access to git sha
       touch "THANKS"
@@ -51,7 +49,7 @@ class Couchdb < Formula
                           "--with-js-include=#{HOMEBREW_PREFIX}/include/js",
                           "--with-js-lib=#{HOMEBREW_PREFIX}/lib"
     system "make"
-    system "make install"
+    system "make", "install"
 
     # Use our plist instead to avoid faffing with a new system user.
     (prefix+"Library/LaunchDaemons/org.apache.couchdb.plist").delete


### PR DESCRIPTION
Looks like there's runtime issues again. CouchDB needs bumping with each icu4c update that changes icu4c dylib versioning.

See: https://github.com/Homebrew/homebrew/issues/19641#issuecomment-98247080