### PR TITLE
ruby-build 20150502

### DIFF
--- a/Library/Formula/ruby-build.rb
+++ b/Library/Formula/ruby-build.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class RubyBuild < Formula
   homepage "https://github.com/sstephenson/ruby-build"
-  url "https://github.com/sstephenson/ruby-build/archive/v20150413.tar.gz"
-  sha256 "a07e1b31df730be9a7be64036fe89a06f0ce41dc6c1cd79c69f7aef08091d140"
+  url "https://github.com/sstephenson/ruby-build/archive/v20150502.tar.gz"
+  sha256 "e37e8d4390e34987b3270a161d9cafbd185741f11f9e40035d3ab1ee0bad559d"
 
   head "https://github.com/sstephenson/ruby-build.git"
 


### PR DESCRIPTION
* [Add Rubinius 2.5.3](https://github.com/sstephenson/ruby-build/commit/3e519f1b14108300bd709261263a2726682c00e9)
* [Add JRuby 9.0.0.0.pre2](https://github.com/sstephenson/ruby-build/commit/a18d1661320b4ebf6be770f0de4befdd9cbda1e5)
* [Specify inet protocol](https://github.com/sstephenson/ruby-build/commit/8ff2af4224513fb88ba838adb946d46552aca8d7)
* [Remove needless build flag for some Ruby 2.1 versions](https://github.com/sstephenson/ruby-build/commit/97b999976727c89b7987393d57c81013c6077ec1)
* [Update canonical MagLev 1.0.0 download location](https://github.com/sstephenson/ruby-build/commit/78cda70ac750a7bcc0d5f2c609e878587d6d784a)