### PR TITLE
audit: Don't complain about untapped conflicts

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -217,7 +217,9 @@ class FormulaAuditor
       begin
         Formulary.factory(c.name)
       rescue FormulaUnavailableError
-        problem "Can't find conflicting formula #{c.name.inspect}."
+        unless c.name =~ HOMEBREW_TAP_FORMULA_REGEX
+          problem "Can't find conflicting formula #{c.name.inspect}."
+        end
       end
     end
   end


### PR DESCRIPTION
If a formula conflicts with a formula that lives in a tap, but the user doesn't have that tap tapped, then `audit` will complain that it can't find the conflicting formula.  It shouldn't do that.