### PR TITLE
add Formulary::path method

### DIFF
--- a/Library/Homebrew/cmd/create.rb
+++ b/Library/Homebrew/cmd/create.rb
@@ -40,7 +40,7 @@ module Homebrew
       stem = Pathname.new(url).stem
       print "Formula name [#{stem}]: "
       fc.name = __gets || stem
-      fc.path = Formula.path(fc.name)
+      fc.path = Formulary.path(fc.name)
     end
 
     # Don't allow blacklisted formula, or names that shadow aliases,
@@ -84,9 +84,9 @@ class FormulaCreator
       @name ||= $1
       /(.*?)[-_.]?#{path.version}/.match path.basename
       @name ||= $1
-      @path = Formula.path @name unless @name.nil?
+      @path = Formulary.path @name unless @name.nil?
     else
-      @path = Formula.path name
+      @path = Formulary.path name
     end
     if @version
       @version = Version.new(@version)

--- a/Library/Homebrew/cmd/edit.rb
+++ b/Library/Homebrew/cmd/edit.rb
@@ -26,13 +26,11 @@ module Homebrew
     else
       # Don't use ARGV.formulae as that will throw if the file doesn't parse
       paths = ARGV.named.map do |name|
-        name = Formulary.canonical_name(name)
-        Formula.path(name)
-      end
-      unless ARGV.force?
-        paths.each do |path|
-          raise FormulaUnavailableError, path.basename('.rb').to_s unless path.file?
+        path = Formulary.path(name)
+        unless path.file? || ARGV.force?
+          raise FormulaUnavailableError, name
         end
+        path
       end
       exec_editor(*paths)
     end

--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -1,15 +1,12 @@
+require "formula"
+
 module Homebrew
   def log
     if ARGV.named.empty?
       cd HOMEBREW_REPOSITORY
       exec "git", "log", *ARGV.options_only
     else
-      begin
-        path = ARGV.formulae.first.path
-      rescue FormulaUnavailableError
-        # Maybe the formula was deleted
-        path = Formula.path(ARGV.named.first)
-      end
+      path = Formulary.path(ARGV.named.first)
       cd path.dirname # supports taps
       exec "git", "log", *ARGV.options_only + ["--", path]
     end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -46,7 +46,7 @@ module Homebrew
       begin
         Formulary.factory(n)
       rescue Exception => e
-        onoe "problem in #{Formula.path(n)}"
+        onoe "problem in #{Formulary.path(n)}"
         puts e
         Homebrew.failed = true
       end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -183,6 +183,7 @@ class Formulary
   class NullLoader < FormulaLoader
     def initialize(name)
       @name = name
+      @path = Formula.path(name)
     end
 
     def get_formula(spec)
@@ -202,6 +203,10 @@ class Formulary
 
   def self.canonical_name(ref)
     loader_for(ref).name
+  end
+
+  def self.path(ref)
+    loader_for(ref).path
   end
 
   def self.loader_for(ref)


### PR DESCRIPTION
This is a little code refactoring splited from #36753

The idea is to eliminate `Formula#path` outside of formulary. And I indent to deprecate `Formula#path` method when I reimplement symlink free tap function.