### PR TITLE
hive 1.1.0

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -5,11 +5,13 @@ class ApacheSpark < Formula
   head "https://github.com/apache/spark.git"
   url "https://d3kbcqa49mib13.cloudfront.net/spark-1.3.1-bin-hadoop2.6.tgz"
   version "1.3.1"
+  revision 1
   sha1 "86911b6c8964230a93691bd45589f491c10d36c0"
 
-  conflicts_with 'hive', :because => 'both install `beeline` binaries'
-
   def install
+    # Rename beeline to distinguish it from hive's beeline
+    mv "bin/beeline", "bin/spark-beeline"
+
     rm_f Dir["bin/*.cmd"]
     libexec.install Dir["*"]
     bin.write_exec_script Dir["#{libexec}/bin/*"]

--- a/Library/Formula/hive.rb
+++ b/Library/Formula/hive.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Hive < Formula
-  homepage 'http://hive.apache.org'
+  homepage 'https://hive.apache.org'
   url 'https://www.apache.org/dyn/closer.cgi?path=hive/hive-1.1.0/apache-hive-1.1.0-bin.tar.gz'
   sha1 'bf7e4752fa7208c3eda09f7a8aeba0f341239952'
 

--- a/Library/Formula/hive.rb
+++ b/Library/Formula/hive.rb
@@ -2,11 +2,10 @@ require 'formula'
 
 class Hive < Formula
   homepage 'http://hive.apache.org'
-  url 'http://www.apache.org/dyn/closer.cgi?path=hive/hive-1.0.0/apache-hive-1.0.0-bin.tar.gz'
-  sha1 '8e24c451ebab1333352a2f0407d5fe847759fbd2'
+  url 'http://www.apache.org/dyn/closer.cgi?path=hive/hive-1.1.0/apache-hive-1.1.0-bin.tar.gz'
+  sha1 'bf7e4752fa7208c3eda09f7a8aeba0f341239952'
 
   depends_on 'hadoop'
-  conflicts_with 'apache-spark', :because => 'both install `beeline` binaries'
 
   def install
     rm_f Dir["bin/ext/*.cmd", "bin/ext/util/*.cmd"]

--- a/Library/Formula/hive.rb
+++ b/Library/Formula/hive.rb
@@ -2,10 +2,11 @@ require 'formula'
 
 class Hive < Formula
   homepage 'http://hive.apache.org'
-  url 'http://www.apache.org/dyn/closer.cgi?path=hive/hive-1.1.0/apache-hive-1.1.0-bin.tar.gz'
+  url 'https://www.apache.org/dyn/closer.cgi?path=hive/hive-1.1.0/apache-hive-1.1.0-bin.tar.gz'
   sha1 'bf7e4752fa7208c3eda09f7a8aeba0f341239952'
 
   depends_on 'hadoop'
+  depends_on :java
 
   def install
     rm_f Dir["bin/ext/*.cmd", "bin/ext/util/*.cmd"]


### PR DESCRIPTION
also removed conflict with spark’s beeline binary by renaming spark’s
version to spark-beeline