### PR TITLE
audit: flag incorrect automake/autoconf/libtool dep handling

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -586,6 +586,10 @@ class FormulaAuditor
       problem "\"#{$1}\" should be \"\#{#{$2}}\""
     end
 
+    if line =~ %r[depends_on :(automake|autoconf|libtool)]
+      problem ":#{$1} is deprecated. Usage should be \"#{$1}\""
+    end
+
     # Commented-out depends_on
     if line =~ /#\s*depends_on\s+(.+)\s*$/
       problem "Commented-out dep #{$1}"


### PR DESCRIPTION
Just makes the audit cough out this:
```
 * :libtool is deprecated. Usage should be "libtool"
 * :autoconf is deprecated. Usage should be "autoconf"
 * :automake is deprecated. Usage should be "automake"
```

Closes #39303.