### PR TITLE
[RFC] Facebook Path Picker

### DIFF
--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -7,7 +7,6 @@ class Fpp < Formula
   depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    puts buildpath
     # we need to copy the bash file and source python files
     libexec.install Dir["*"]
     # and then symlink the bash file

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,6 +1,5 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  # TODO -- change away from gh-pages link
   url "https://facebook.github.io/PathPicker/dist/fpp.0.5.0.tar.gz"
   sha256 "634cbd2f501639186561418bf2036529d3995676836378b5865e7130d34733e8"
   head "https://github.com/facebook/pathpicker.git"

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,8 +1,8 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  # To be changed -- just a sample tar for now
-  url "https://github.com/pcottle/example_for_pip/raw/master/dist/pcottleexample.0.0.4.tar.gz"
-  sha256 "25f3edddc28b7a353c407d48a74a92f9a364160de790122357a3785d9d9e8aeb"
+  # TODO -- change away from gh-pages link
+  url "https://facebook.github.io/PathPicker/dist/fpp.0.5.0.tar.gz"
+  sha256 "634cbd2f501639186561418bf2036529d3995676836378b5865e7130d34733e8"
   head "https://github.com/facebook/pathpicker.git"
 
   depends_on :python if MacOS.version <= :snow_leopard
@@ -12,11 +12,11 @@ class Fpp < Formula
     # we need to copy the bash file and source python files
     libexec.install Dir["*"]
     # and then symlink the bash file
-    bin.install_symlink libexec/"example"
+    bin.install_symlink libexec/"fpp"
   end
 
   test do
-    system "example --help"
+    system "fpp --help"
   end
 
 end

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -16,7 +16,6 @@ class Fpp < Formula
   end
 
   test do
-    system "fpp --help"
+    system bin/"fpp", "--help"
   end
-
 end

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,7 +1,7 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  url "https://facebook.github.io/PathPicker/dist/fpp.0.5.0.tar.gz"
-  sha256 "634cbd2f501639186561418bf2036529d3995676836378b5865e7130d34733e8"
+  url "https://facebook.github.io/PathPicker/dist/fpp.0.5.3.tar.gz"
+  sha256 "94b77ef10a128a694f6302ce578a2d07a3fd2892299d341b22be9496abd7277d"
   head "https://github.com/facebook/pathpicker.git"
 
   depends_on :python if MacOS.version <= :snow_leopard

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -15,7 +15,7 @@ class Fpp < Formula
     bin.install_symlink libexec/"example"
   end
 
-  def test
+  test do
     system "example --help"
   end
 

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,23 +1,18 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  head "https://github.com/facebook/pathpicker/"
-  version "0.0.3"
   # To be changed -- just a sample tar for now
-  url "https://github.com/pcottle/example_for_pip/raw/master/dist/pcottleexample.tar.gz"
-  sha256 "038753f944edf7b3d6b0dbcf0056350eead1e14db4a3c70fafb711e9a31be3d4"
+  url "https://github.com/pcottle/example_for_pip/raw/master/dist/pcottleexample.0.0.4.tar.gz"
+  sha256 "25f3edddc28b7a353c407d48a74a92f9a364160de790122357a3785d9d9e8aeb"
+  head "https://github.com/facebook/pathpicker.git"
 
-  # I have a dependency on python 2.7 -- is this ok?
-  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+  depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    puts 'Unpacking PathPicker'
-    # obviously a total hack -- my two questions:
-    # -- how can I correctly access the destination of where url was downloaded?
-    # -- how can I extract this tar correctly to somewhere permanent?
-    system "tar xopf /Library/Caches/Homebrew/fpp-0.0.3.tar.gz -C /Users/pcottle/Desktop/"
-    puts 'Symlinking bash script'
-    # and this is a hack as well -- but basically i just want to symlink one file from the tar
-    ln_sf '/Users/pcottle/Desktop/example', '/usr/local/bin/fpp'
+    puts buildpath
+    # we need to copy the bash file and source python files
+    libexec.install Dir["*"]
+    # and then symlink the bash file
+    bin.install_symlink libexec/"example"
   end
 
 end

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,0 +1,23 @@
+class Fpp < Formula
+  homepage "https://facebook.github.io/PathPicker/"
+  head "https://github.com/facebook/pathpicker/"
+  version "0.0.3"
+  # To be changed -- just a sample tar for now
+  url "https://github.com/pcottle/example_for_pip/raw/master/dist/pcottleexample.tar.gz"
+  sha256 "038753f944edf7b3d6b0dbcf0056350eead1e14db4a3c70fafb711e9a31be3d4"
+
+  # I have a dependency on python 2.7 -- is this ok?
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
+
+  def install
+    puts 'Unpacking PathPicker'
+    # obviously a total hack -- my two questions:
+    # -- how can I correctly access the destination of where url was downloaded?
+    # -- how can I extract this tar correctly to somewhere permanent?
+    system "tar xopf /Library/Caches/Homebrew/fpp-0.0.3.tar.gz -C /Users/pcottle/Desktop/"
+    puts 'Symlinking bash script'
+    # and this is a hack as well -- but basically i just want to symlink one file from the tar
+    ln_sf '/Users/pcottle/Desktop/example', '/usr/local/bin/fpp'
+  end
+
+end

--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -15,4 +15,8 @@ class Fpp < Formula
     bin.install_symlink libexec/"example"
   end
 
+  def test
+    system "example --help"
+  end
+
 end


### PR DESCRIPTION
Hey everyone! This is an RFC (request for comments) for a project that Facebook is going to open source soon. I wish I could put this up in a better state but I'm entirely new to homebrew recipes and ruby, so apologies in advance.

Some real quick context:
* We are open sourcing a project called "PathPicker", aliased to "fpp" for short. Best context is here: http://facebook.github.io/PathPicker/
* The project is a Python **application**, aka not going to be imported at all in code but simply run from the command line.
* It has no external dependencies besides python -- it's just:
    * One bash script
    * ~10 python files that uses standard ~2.7 libraries

Installing it theoretically is quite easy. It would essentially just be:
* Unarchive the provided tar file to somewhere permanent
* Symlink the bash script into `/usr/bin/local` or wherever `$PATH` includes

The following recipe attempts to do the above but with some obvious uncommitable hacks. Hopefully some feedback can be provided -- almost all the python recipes I found were using `setup.py` and other things that were not as simple.

Anyways sorry for the low quality PR but hopefully this is easy to improve!