### PR TITLE
npth: add mirror

### DIFF
--- a/Library/Formula/npth.rb
+++ b/Library/Formula/npth.rb
@@ -1,6 +1,7 @@
 class Npth < Formula
   homepage "https://gnupg.org/index.html"
   url "ftp://ftp.gnupg.org/gcrypt/npth/npth-1.2.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/npth/npth-1.2.tar.bz2"
   sha256 "6ddbdddb2cf49a4723f9d1ad6563c480d6760dcb63cb7726b8fc3bc2e1b6c08a"
 
   bottle do


### PR DESCRIPTION
FTP can tend to be firewalled to death. A mirror that uses port 443 instead is nicer.