### PR TITLE
pdksh: patches + fix install name

### DIFF
--- a/Library/Formula/pdksh.rb
+++ b/Library/Formula/pdksh.rb
@@ -1,25 +1,32 @@
-require 'formula'
-
 class Pdksh < Formula
-  homepage 'http://www.cs.mun.ca/~michael/pdksh/'
-  url 'http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14.tar.gz'
-  sha1 '8b022e45de7691ef330f13b0981f0cff30b4047d'
+  homepage "http://www.cs.mun.ca/~michael/pdksh/"
+  url "http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14.tar.gz"
+  sha256 "ab15bcdd50f291edc632bca351b2edce5405d4f2ce3854d3d548d721ab9bbfa6"
 
-  # Use a sort command that works with Leopard and up
+  patch :p2 do # Upstream patches
+    url "http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.1"
+    sha256 "b4adfc47e4d78eb8718ee10f7ffafc218b0e9d453413456fab263985ae02d356"
+  end
+
   patch :p0 do
-    url "https://trac.macports.org/export/90549/trunk/dports/shells/pdksh/files/patch-siglist.sh.diff"
-    sha1 "009830f37b7be86d1a1a2f187c82c25da6d9b418"
+    url "http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.2"
+    sha256 "82041113e0b3aeca57bb9b161257b43d9f8eba95fd450d2287666e77e6209afd"
+  end
+
+  patch :p0 do # Use `sort -k 3n -k 1` instead of `sort +2n +0n`.
+    url "https://trac.macports.org/raw-attachment/ticket/13165/patch-siglist.sh"
+    sha256 "23a3b4cbf67886c358a26818a95f9b39304d0aab82dead78d5438b633a0917bc"
   end
 
   def install
-    # --mandir does not work for this
-    inreplace "Makefile.in",
-                "$(prefix)/man/man$(manext)",
-                "$(prefix)/share/man/man1"
+    system "./configure", "--prefix=#{prefix}", "--program-prefix=pd"
+    system "make", "install"
 
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make"
-    system "make install"
+    share.install prefix/"man" # Avoid an inreplace this way.
+    prefix.install buildpath/"etc"
+  end
+
+  test do
+    assert_equal "Hello World!", pipe_output("#{bin}/pdksh -c 'echo Hello World!'").chomp
   end
 end


### PR DESCRIPTION
- Add important patches from upstream.
- Install as `pdksh` instead of `ksh`, which conflicts with [AT&T] ksh.
- Install template .kshrc and .profile files in `etc`.
- Cleanup, add test.