### PR TITLE
Debian - Various

### DIFF
--- a/Library/Formula/debianutils.rb
+++ b/Library/Formula/debianutils.rb
@@ -1,7 +1,8 @@
 class Debianutils < Formula
-  homepage "http://anonscm.debian.org/gitweb/?p=users/clint/debianutils.git"
-  url "http://ftp.de.debian.org/debian/pool/main/d/debianutils/debianutils_4.4.tar.gz"
-  sha1 "019b969ab698c83117254b50fc8f469f10a5d8d6"
+  homepage "https://packages.debian.org/unstable/utils/debianutils"
+  url "https://mirrors.kernel.org/debian/pool/main/d/debianutils/debianutils_4.5.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.5.tar.gz"
+  sha256 "7cfaa53caaaaf36dad16fa69b30dd2b78b8dafebd766aacd53a3c7c78a9d441f"
 
   bottle do
     cellar :any

--- a/Library/Formula/dtc.rb
+++ b/Library/Formula/dtc.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Dtc < Formula
   homepage "http://www.devicetree.org/"
-  url "http://ftp.debian.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
-  sha1 "2f9697aa7dbc3036f43524a454bdf28bf7e0f701"
+  url "https://mirrors.kernel.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
+  sha256 "f5f9a1aea478ee6dbcece8907fd4551058fe72fc2c2a7be972e3d0b7eec4fa43"
 
   def install
     system "make"
@@ -12,7 +11,7 @@ class Dtc < Formula
   end
 
   test do
-    (testpath/'test.dts').write <<-EOS.undent
+    (testpath/"test.dts").write <<-EOS.undent
       /dts-v1/;
       / {
       };

--- a/Library/Formula/iprint.rb
+++ b/Library/Formula/iprint.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Iprint < Formula
-
-  homepage "http://www.samba.org/ftp/unpacked/junkcode/i.c"
-  url "http://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  sha1 "1b423107cf6b1e5c2257648047ff91f5c6ac2249"
+  homepage "https://www.samba.org/ftp/unpacked/junkcode/i.c"
+  url "https://mirrors.kernel.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
   version "1.3-9"
 
   bottle do
@@ -15,8 +13,8 @@ class Iprint < Formula
   end
 
   patch do
-    url "http://ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
-    sha1 "6164e8e9bd0e08542de34bbf386cd1f0193f17c5"
+    url "https://mirrors.kernel.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    sha256 "3a1ff260e6d639886c005ece754c2c661c0d3ad7f1f127ddb2943c092e18ab74"
   end
 
   def install
@@ -29,5 +27,4 @@ class Iprint < Formula
   test do
     assert_equal shell_output("#{bin}/i 1234"), "1234 0x4D2 02322 0b10011010010\n"
   end
-
 end

--- a/Library/Formula/lcrack.rb
+++ b/Library/Formula/lcrack.rb
@@ -1,14 +1,31 @@
-require 'formula'
-
 class Lcrack < Formula
-  homepage 'http://packages.debian.org/sid/lcrack'
-  url 'http://ftp.de.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz'
-  sha1 'e2a3439ab7574f5d1dd345f34f8e244723c42770'
+  homepage "https://packages.debian.org/sid/lcrack"
+  url "https://mirrors.kernel.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
+  version "20040914"
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure"
     system "make"
     bin.install "lcrack"
+
+    # This prevents installing slightly generic names (regex)
+    # and also mimics Debian's installation of lcrack.
+    %w[mktbl mkword regex].each do |prog|
+      bin.install prog => "lcrack_#{prog}"
+    end
+  end
+
+  test do
+    (testpath/"secrets.txt").write <<-EOS.undent
+      root:5ebe2294ecd0e0f08eab7690d2a6ee69:SECRET
+    EOS
+
+    (testpath/"dict.txt").write <<-EOS.undent
+      secret
+    EOS
+
+    assert_match /Found: 1/, pipe_output("#{bin}/lcrack -m md5 -d dict.txt -xf+ -s a-z -l 1-8 secrets.txt 2>&1")
   end
 end

--- a/Library/Formula/le.rb
+++ b/Library/Formula/le.rb
@@ -1,18 +1,14 @@
-require 'formula'
-
 class Le < Formula
-  homepage 'http://freecode.com/projects/leeditor'
-  # url 'http://ftp.yar.ru/pub/source/le/le-1.14.9.tar.xz'
-  # upstream not responding, source from debian
-  url 'http://ftp.de.debian.org/debian/pool/main/l/le/le_1.14.9.orig.tar.gz'
-  sha1 'ce85cbefb30cf1f5a7e8349dbb24ffa0f65b1fd7'
+  homepage "https://github.com/lavv17/le"
+  url "http://lav.yar.ru/download/le/le-1.15.1.tar.xz"
+  sha256 "d9895ef82c89ae9cf30946bd43fa18b294f645e6a2bacd3ed9d39a3ccf324a4f"
 
-  conflicts_with 'logentries', :because => 'both install a le binary'
+  conflicts_with "logentries", :because => "both install a le binary"
 
   def install
     ENV.j1
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 end

--- a/Library/Formula/logcheck.rb
+++ b/Library/Formula/logcheck.rb
@@ -1,7 +1,8 @@
 class Logcheck < Formula
   homepage "https://logcheck.alioth.debian.org/"
-  url "http://ftp.de.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
-  sha1 "adb54e75f8a17e3aff4abb3066122c0dfdde21e3"
+  url "https://mirrors.kernel.org/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
+  sha256 "c2d3fc323e8c6555e91d956385dbfd0f67b55872ed0f6a7ad8ad2526a9faf03a"
 
   bottle do
     cellar :any
@@ -11,11 +12,10 @@ class Logcheck < Formula
   end
 
   def install
-    system "make", "install",
-                   "--always-make",
-                   "DESTDIR=#{prefix}",
-                   "SBINDIR=sbin",
-                   "BINDIR=bin"
+    inreplace "Makefile", "$(DESTDIR)/$(CONFDIR)", "$(CONFDIR)"
+
+    system "make", "install", "--always-make", "DESTDIR=#{prefix}",
+                   "SBINDIR=sbin", "BINDIR=bin", "CONFDIR=#{etc}/logcheck"
   end
 
   test do

--- a/Library/Formula/mdf2iso.rb
+++ b/Library/Formula/mdf2iso.rb
@@ -1,13 +1,16 @@
-require 'formula'
-
 class Mdf2iso < Formula
-  homepage 'http://mdf2iso.berlios.de/'
-  url 'http://ftp.de.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.0.orig.tar.gz'
-  sha1 '949d4fa0bb1e40ca17842a265d8ed813bac4917a'
+  homepage "https://packages.debian.org/sid/mdf2iso"
+  url "https://mirrors.kernel.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  sha256 "906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    assert_match /#{version}/, shell_output("#{bin}/mdf2iso --help")
   end
 end

--- a/Library/Formula/mkcue.rb
+++ b/Library/Formula/mkcue.rb
@@ -1,6 +1,7 @@
 class Mkcue < Formula
   homepage "https://packages.debian.org/source/stable/mkcue"
-  url "http://ftp.de.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  url "https://mirrors.kernel.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
   version "1"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
 

--- a/Library/Formula/pmccabe.rb
+++ b/Library/Formula/pmccabe.rb
@@ -1,16 +1,18 @@
-require 'formula'
-
 class Pmccabe < Formula
-  homepage 'http://packages.debian.org/stable/pmccabe'
-  url 'http://ftp.de.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz'
-  sha1 '6e1378b28faf822339780829f3cb9e2d897c5c4d'
+  homepage "https://packages.debian.org/sid/pmccabe"
+  url "https://mirrors.kernel.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  sha256 "e490fe7c9368fec3613326265dd44563dc47182d142f579a40eca0e5d20a7028"
 
   def install
-    ENV.append_to_cflags '-D__unix'
+    ENV.append_to_cflags "-D__unix"
 
     system "make"
+    bin.install "pmccabe", "codechanges", "decomment", "vifn"
+    man1.install Dir["*.1"]
+  end
 
-    bin.install 'pmccabe', 'codechanges', 'decomment', 'vifn'
-    man1.install Dir['*.1']
+  test do
+    assert_match /pmccabe #{version}/, shell_output("#{bin}/pmccabe -V")
   end
 end

--- a/Library/Formula/urlview.rb
+++ b/Library/Formula/urlview.rb
@@ -1,25 +1,23 @@
-require 'formula'
-
 class Urlview < Formula
-  homepage 'http://packages.debian.org/unstable/misc/urlview'
-  url 'http://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz'
-  mirror 'http://ftp.us.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz'
-  sha1 '323af9ba30ba87ec600531629f5dd84c720984b6'
+  homepage "https://packages.debian.org/sid/misc/urlview"
+  url "https://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  sha256 "746ff540ccf601645f500ee7743f443caf987d6380e61e5249fc15f7a455ed42"
 
   patch do
-    url "http://ftp.aarnet.edu.au/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
-    sha1 "96bd07bbb7cfc3416dc0ce8fa914160356f95c41"
+    url "https://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
+    sha256 "056883c17756f849fb9235596d274fbc5bc0d944fcc072bdbb13d1e828301585"
   end
 
   def install
-    inreplace 'urlview.man', '/etc/urlview/url_handler.sh', 'open'
-    inreplace 'urlview.c',
+    inreplace "urlview.man", "/etc/urlview/url_handler.sh", "open"
+    inreplace "urlview.c",
       '#define DEFAULT_COMMAND "/etc/urlview/url_handler.sh %s"',
       '#define DEFAULT_COMMAND "open %s"'
 
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
     man1.mkpath
-    system "make install"
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
It's all in the commit messages, but essentially the root cause of this PR is to move things over from plaintext Debian mirrors to SSL/TLS protected Debian mirrors.

I've been meaning to start shoving things across for a while. 10 formulae every few days shouldn't be too odious to users updating, or maintainers, hopefully.

There's a couple of version bumps in there as well, added tests and style fixes, one build tweak and `le` has its official homepage & url back.