### PR TITLE
highlighting-kate 0.5.15 (new formula)

### DIFF
--- a/Library/Formula/highlighting-kate.rb
+++ b/Library/Formula/highlighting-kate.rb
@@ -1,0 +1,31 @@
+require "language/haskell"
+
+class HighlightingKate < Formula
+  include Language::Haskell::Cabal
+
+  homepage "https://github.com/jgm/highlighting-kate"
+  url "https://hackage.haskell.org/package/highlighting-kate-0.5.15/highlighting-kate-0.5.15.tar.gz"
+  sha256 "e4e52471dcef0771109d1f748ca9989a32eac8a31971b7e09e1c81c6cef7e945"
+
+  head "https://github.com/jgm/highlighting-kate.git"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+  depends_on "gmp"
+
+  def install
+    cabal_sandbox do
+      cabal_install "--only-dependencies"
+      cabal_install "--prefix=#{prefix}", "-fexecutable"
+    end
+    cabal_clean_lib
+  end
+
+  test do
+    test_input = "*hello, world*\n"
+    test_output = `/bin/echo -n "#{test_input}" | #{bin}/highlighting-kate -s markdown`
+    test_output_last_line = test_output.split("\n")[-1]
+    expected_last_line = '</style></head><body><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode">*hello, world*</code></pre></div></body>'
+    assert_equal expected_last_line, test_output_last_line
+  end
+end


### PR DESCRIPTION
[highlighting-kate](https://github.com/jgm/highlighting-kate) is a syntax highlighting library written in Haskell, with support for over a hundred languages. It has been actively maintained since 2008 (latest release 9 days ago), and its maintainer John MacFarlane, aka jgm, is also known for Pandoc and CommonMark, among other things. The project currently has 69 stars and 39 forks on GitHub — not sure if it satisfies the notability criterion. Anyway, I've experimented with it for a while and found it very useful, and once merged I can take the responsibility of maintaining this formula.