### PR TITLE
pound: remove overly-paranoid LDFLAGS append

### DIFF
--- a/Library/Formula/pound.rb
+++ b/Library/Formula/pound.rb
@@ -14,9 +14,6 @@ class Pound < Formula
   depends_on "google-perftools" => :recommended
 
   def install
-    # find Homebrew's libpcre
-    ENV.append "LDFLAGS", "-L#{Formula["pcre"].lib}"
-
     system "./configure", "--prefix=#{prefix}", "--disable-tcmalloc"
     system "make"
     # Manual install to get around group issues


### PR DESCRIPTION
I have tested this and found that the brewed pcre library will be linked even without appending to the value of `LDFLAGS`.