### PR TITLE
ctags: removing merged patch

### DIFF
--- a/Library/Formula/ctags.rb
+++ b/Library/Formula/ctags.rb
@@ -19,6 +19,15 @@ class Ctags < Formula
   # fixes http://sourceforge.net/tracker/?func=detail&aid=3247256&group_id=6556&atid=106556
   patch :p2, :DATA
 
+  stable do
+    # also fixes http://sourceforge.net/tracker/?func=detail&aid=3247256&group_id=6556&atid=106556
+    # merged upstream but not yet in stable
+    patch :p2 do
+      url "https://gist.githubusercontent.com/naegelejd/9a0f3af61954ae5a77e7/raw/16d981a3d99628994ef0f73848b6beffc70b5db8/Ctags%20r782"
+      sha256 "26d196a75fa73aae6a9041c1cb91aca2ad9d9c1de8192fce8cdc60e4aaadbcbb"
+    end
+  end
+
   def install
     if build.head?
       system "autoheader"
@@ -103,26 +112,3 @@ diff -ur a/ctags-5.8/read.h b/ctags-5.8/read.h
  
  /*
  *   FUNCTION PROTOTYPES
-
-
-Bugfix: Don't use strcpy on overlapping buffers
-Upstream commit (not in release yet): http://sourceforge.net/p/ctags/code/782/
-diff -ur a/ctags-5.8/routines.c b/ctags-5.8/routines.c
---- a/ctags-5.8/routines.c	2007-06-07 00:35:21.000000000 -0400
-+++ b/ctags-5.8/routines.c	2015-03-07 20:38:58.000000000 -0500
-@@ -757,13 +757,13 @@
- 				else if (cp [0] != PATH_SEPARATOR)
- 					cp = slashp;
- #endif
--				strcpy (cp, slashp + 3);
-+				memmove (cp, slashp + 3, strlen (slashp + 3) + 1);
- 				slashp = cp;
- 				continue;
- 			}
- 			else if (slashp [2] == PATH_SEPARATOR  ||  slashp [2] == '\0')
- 			{
--				strcpy (slashp, slashp + 2);
-+				memmove (slashp, slashp + 2, strlen (slashp + 2) + 1);
- 				continue;
- 			}
- 		}


### PR DESCRIPTION
The patch to `routines.c` has been merged upstream. Fixes #39351.