### PR TITLE
osquery 1.4.5

### DIFF
--- a/Library/Formula/osquery.rb
+++ b/Library/Formula/osquery.rb
@@ -3,7 +3,7 @@ require "formula"
 class Osquery < Formula
   homepage "http://osquery.io"
   # pull from git tag to get submodules
-  url "https://github.com/facebook/osquery.git", :tag => "1.4.4", :revision => "800dc7745e2ee81c645ca3cda7c8ca2f4c535ca4"
+  url "https://github.com/facebook/osquery.git", :tag => "1.4.5", :revision => "3131a97d9511ed92d65afadf1a049a6425ec6eca"
 
   bottle do
     sha256 "7987f024819b8d44d06772c1d5de2a44a34215669536ed8580f57897caa43506" => :yosemite
@@ -17,9 +17,11 @@ class Osquery < Formula
 
   depends_on "cmake" => :build
   depends_on "boost" => :build
+  depends_on "doxygen" => :build
   depends_on "gflags" => :build
   depends_on "rocksdb" => :build
   depends_on "thrift" => :build
+  depends_on "yara" => :build
   depends_on "openssl"
 
   resource "markupsafe" do


### PR DESCRIPTION
Updating the version of osquery to 1.4.5, which was just released today.