### PR TITLE
Update links to GitHub's personal access token

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -27,7 +27,7 @@ module Homebrew
       auth = :AUTH_TOKEN
 
       unless HOMEBREW_GITHUB_API_TOKEN
-        puts 'You can create an API token: https://github.com/settings/applications'
+        puts 'You can create a personal access token: https://github.com/settings/tokens'
         puts 'and then set HOMEBREW_GITHUB_API_TOKEN as authentication method.'
         puts
 

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -554,8 +554,8 @@ can take several different forms:
     editors will do strange things in this case.
 
   * HOMEBREW\_GITHUB\_API\_TOKEN:
-    A personal GitHub API Access token, which you can create at
-    <https://github.com/settings/applications>. If set, GitHub will allow you a
+    A personal access token for the GitHub API, which you can create at
+    <https://github.com/settings/tokens>. If set, GitHub will allow you a
     greater number of API requests. See
     <https://developer.github.com/v3/#rate-limiting> for more information.
     Homebrew uses the GitHub API for features such as `brew search`.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -332,7 +332,7 @@ module GitHub extend self
       super <<-EOS.undent
         GitHub #{error}
         HOMEBREW_GITHUB_API_TOKEN may be invalid or expired, check:
-          https://github.com/settings/applications
+          https://github.com/settings/tokens
         EOS
     end
   end

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "April 2015" "Homebrew" "brew"
+.TH "BREW" "1" "May 2015" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for OS X
@@ -579,7 +579,7 @@ If set, Homebrew will use this editor when editing a single formula, or several 
 .
 .TP
 HOMEBREW_GITHUB_API_TOKEN
-A personal GitHub API Access token, which you can create at \fIhttps://github\.com/settings/applications\fR\. If set, GitHub will allow you a greater number of API requests\. See \fIhttps://developer\.github\.com/v3/#rate\-limiting\fR for more information\. Homebrew uses the GitHub API for features such as \fBbrew search\fR\.
+A personal access token for the GitHub API, which you can create at \fIhttps://github\.com/settings/tokens\fR\. If set, GitHub will allow you a greater number of API requests\. See \fIhttps://developer\.github\.com/v3/#rate\-limiting\fR for more information\. Homebrew uses the GitHub API for features such as \fBbrew search\fR\.
 .
 .TP
 HOMEBREW_MAKE_JOBS


### PR DESCRIPTION
The link for the page that allows creation of API tokens has changed from `/settings/applications` to `/settings/tokens`. Also the wording on that page calls them "personal access tokens", so update Homebrew to be consistent with that.