### PR TITLE
Update to the latest release of F#

### DIFF
--- a/Library/Formula/fsharp.rb
+++ b/Library/Formula/fsharp.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Fsharp < Formula
   homepage "http://fsharp.org/"
-  url "https://github.com/fsharp/fsharp.git", :tag => "3.1.1.31",
-    :revision => "1f79c0455fb8b5ec816985f922413894ce19359a"
+  url "https://github.com/fsharp/fsharp.git", :tag => "3.1.1.32",
+    :revision => "a4e1f7111a6d1410df3f33e7205ee34617006b94"
 
   bottle do
     sha256 "2369c57d4accee52b300d4f729941c4371e2632e3d9c52581c98176640ef9a03" => :yosemite


### PR DESCRIPTION
There are various fixes for the latest mono in this revision which not does not include .Net2.0, 3.5, 4.0 reference assemblies