### PR TITLE
android-platform-tools: update 22.0.0 bottle

### DIFF
--- a/Library/Formula/android-platform-tools.rb
+++ b/Library/Formula/android-platform-tools.rb
@@ -1,7 +1,7 @@
 class AndroidPlatformTools < Formula
   homepage "https://developer.android.com/sdk"
   # the url is from:
-  # https://dl.google.com/android/repository/repository-8.xml
+  # https://dl.google.com/android/repository/repository-10.xml
   url "https://dl.google.com/android/repository/platform-tools_r22-macosx.zip"
   version "22.0.0"
   sha256 "c06721ff66a1a3f70e489325f06474e28cd0efd5352f097ee2ff58167b4f6564"


### PR DESCRIPTION
Updated URL for android-platform-tools, and upgraded version to r22.