### PR TITLE
pcre1: add symlink to pcre

### DIFF
--- a/Library/Aliases/pcre1
+++ b/Library/Aliases/pcre1
@@ -1,0 +1,1 @@
+../Formula/pcre.rb


### PR DESCRIPTION
`pcre1` is the new canonical name after the release of `pcre2`.

Restart of https://github.com/Homebrew/homebrew/pull/39381
