### PR TITLE
add audit check for explicit Python linkage

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -127,7 +127,7 @@ module FormulaCellarChecks
   end
 
   def check_easy_install_pth lib
-    pth_found = Dir["#{lib}/python{2.7,3.4}/site-packages/easy-install.pth"].map { |f| File.dirname(f) }
+    pth_found = Dir["#{lib}/python{2.7,3}*/site-packages/easy-install.pth"].map { |f| File.dirname(f) }
     return if pth_found.empty?
 
     <<-EOS.undent

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -156,6 +156,23 @@ module FormulaCellarChecks
     EOS
   end
 
+  def check_python_framework_links lib
+    python_modules = Pathname.glob lib/"python*/site-packages/**/*.so"
+    framework_links = python_modules.select do |obj|
+      dlls = obj.dynamically_linked_libraries
+      dlls.any? { |dll| /Python\.framework/.match dll }
+    end
+    return if framework_links.empty?
+
+    <<-EOS.undent
+      python modules have explicit framework links
+      These python extension modules were linked directly to a Python
+      framework binary. They should be linked with -undefined dynamic_lookup
+      instead of -lpython or -framework Python.
+        #{framework_links * "\n        "}
+    EOS
+  end
+
   def audit_installed
     audit_check_output(check_manpages)
     audit_check_output(check_infopages)
@@ -168,6 +185,7 @@ module FormulaCellarChecks
     audit_check_output(check_shadowed_headers)
     audit_check_output(check_easy_install_pth(formula.lib))
     audit_check_output(check_openssl_links)
+    audit_check_output(check_python_framework_links(formula.lib))
   end
 
   private


### PR DESCRIPTION
Verifies that CPython extension modules are not explicitly linked to a
Python framework, which should never be necessary.

Python's distutils uses -undefined dynamic_lookup, as seen here:
https://github.com/python/cpython/blob/9a77656/configure.ac#L2214-L2245

I'm more confident that this is always wrong in site-packages and always fixable.