### PR TITLE
audit: tweak ftp.gnu.org language for clarity

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -332,7 +332,7 @@ class FormulaAuditor
 
       case p
       when %r[^http://ftp\.gnu\.org/]
-        problem "ftp.gnu.org urls should be https://, not http:// (url is #{p})."
+        problem "ftp.gnu.org mirrors should be https://, not http:// (mirror is #{p})."
       when %r[^http://[^/]*\.apache\.org/]
         problem "Apache urls should be https://, not http (url is #{p})."
       when %r[^http://code\.google\.com/]


### PR DESCRIPTION
Re https://github.com/Homebrew/homebrew/pull/39306#issuecomment-99269170.

We already fire off an audit warning when the `ftpmirror` URL isn't the main URL for GNU formulae, so there's no real harm to changing the language on this line if it makes people a little happier on the clarity.