### PR TITLE
pull: fetch source checksum if no bottle added/updated

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -181,6 +181,9 @@ module Homebrew
         else
           opoo "You must set BINTRAY_USER and BINTRAY_KEY to add or update bottles on Bintray!"
         end
+      else
+        formula = changed_formulae.first
+        safe_system "brew", "fetch", "--retry", "-fs", formula.name if ARGV.include? "--check-sha"
       end
 
       ohai 'Patch changed:'


### PR DESCRIPTION
The thinking here is that it's useful to quickly glance & check on SHA1 => SHA256 updates (nested within URL updates, plaintext to SSL/TLS updates, etc) that the SHA1 hasn't changed, which the SHA256 change would otherwise mask.

It's also potentially useful to check the expected checksum matches on maintainer local machines prior to push on the things we don't bottle.

Opt-in for now, because the change has the potential to catch people who aren't watching the pull file for changes like a hawk off-guard.

Re discussion in #39412.