### PR TITLE
Fix `creduce --HEAD`

### DIFF
--- a/Library/Formula/creduce.rb
+++ b/Library/Formula/creduce.rb
@@ -94,6 +94,6 @@ class Creduce < Formula
     EOS
 
     chmod 0755, testpath/"test1.sh"
-    system "#{bin}/creduce", "test1.sh", "test1.c"
+    system "creduce", "test1.sh", "test1.c"
   end
 end


### PR DESCRIPTION
When installing HEAD, `bin` doesn't refer to the correct location.