### PR TITLE
Allow HOMEBREW_CELLAR environment variable to override cellar path

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -39,9 +39,13 @@ HOMEBREW_REPOSITORY = Pathname.new(HOMEBREW_BREW_FILE).realpath.dirname.parent
 HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY/"Library"
 HOMEBREW_CONTRIB = HOMEBREW_REPOSITORY/"Library/Contributions"
 
-# Where we store built products; /usr/local/Cellar if it exists,
-# otherwise a Cellar relative to the Repository.
-HOMEBREW_CELLAR = if (HOMEBREW_PREFIX+"Cellar").exist?
+# Where we store built products; in decreasing order of precedence:
+#   * value of ENV["HOMEBREW_CELLAR"], if set
+#   * the Cellar subdirectory relative to Homebrew, if it exists
+#   * the Cellar subdirectory relative to the current repository
+HOMEBREW_CELLAR = if ENV["HOMEBREW_CELLAR"]
+  Pathname.new(ENV["HOMEBREW_CELLAR"])
+elsif (HOMEBREW_PREFIX+"Cellar").exist?
   HOMEBREW_PREFIX+"Cellar"
 else
   HOMEBREW_REPOSITORY+"Cellar"

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -438,7 +438,7 @@ Note that these flags should only appear after a command.
     Display the file or directory used to cache <formula>.
 
   * `--cellar`:
-    Display Homebrew's Cellar path. *Default:* `/usr/local/Cellar`
+    Display Homebrew's Cellar path. *Default:* See `HOMEBREW_CELLAR`.
 
   * `--cellar` <formula>:
     Display the location in the cellar where <formula> would be installed,
@@ -524,6 +524,13 @@ can take several different forms:
 
     *Default:* `~/Library/Caches/Homebrew` if it exists; otherwise,
     `/Library/Caches/Homebrew`.
+
+  * HOMEBREW\_CELLAR:
+    If set, Homebrew will use this as the path to the cellar.
+
+    *Default:*
+    `$(brew --prefix)/Cellar` if it exists; otherwise the `Cellar` subdirectory
+    of the current repo.
 
   * HOMEBREW\_CURL\_VERBOSE:
     If set, Homebrew will pass `--verbose` when invoking `curl`(1).


### PR DESCRIPTION
I made this change because I wanted to be able to have a development copy of Homebrew checked out while still having it use my regular system cellar (outside of the checked-out repo).

Perhaps there is a better way to do this that doesn't involve making this change.
