### PR TITLE
bullet: 2.83

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,7 +1,7 @@
 class Bullet < Formula
   homepage "http://bulletphysics.org/wordpress/"
-  url "https://github.com/bulletphysics/bullet3/archive/2.82.tar.gz"
-  sha256 "93ffcdfdd7aa67159fc18d336456945538a6602e3cd318eed9963280620b55bd"
+  url "https://github.com/bulletphysics/bullet3/archive/2.83.tar.gz"
+  sha256 "14a425225f96f4e16ccef8e4029622d6ceb363f98dc5463bb8126c21bf6fb17b"
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do
@@ -44,7 +44,25 @@ class Bullet < Formula
 
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
-    args << "-DBUILD_DEMOS=OFF" if build.without? "demo"
+    with_demo = build.with? "demo"
+    if with_demo && (OS.mac? && MacOS.version < :mavericks)
+      opoo "Demos don't work on versions older than Mavericks"
+      puts <<-EOS.undent
+      Demos will be disabled due to lack of OpenGL3 support.
+      See https://github.com/bulletphysics/bullet3/issues/371 for more information.
+      EOS
+      with_demo = false
+    elsif with_demo && build.with? "shared"
+      # Related to the following warnings when building --with-shared --with-demo
+      # https://gist.github.com/scpeters/6afc44f0cf916b11a226
+      opoo "Demos don't work with shared libraries"
+      puts <<-EOS.undent
+      Demos will be disabled due to the use of shared libraries.
+      Static libraries are required for demos installed by homebrew.
+      EOS
+      with_demo = false
+    end
+    args << "-DBUILD_BULLET2_DEMOS=OFF" unless with_demo
 
     # Demos require extras, see:
     # https://code.google.com/p/bullet/issues/detail?id=767&thanks=767&ts=1384333052
@@ -58,7 +76,7 @@ class Bullet < Formula
     system "make"
     system "make", "install"
 
-    prefix.install "Demos" if build.with? "demo"
+    prefix.install "examples" if build.with? "demo"
     prefix.install "Extras" if build.with? "extra"
   end
 


### PR DESCRIPTION
The cmake variable for building demos changed
from BUILD_DEMOS to BUILD_BULLET2_DEMOS.
The demos are now in the examples folder
instead of the Demos folder.

Also, demos are disabled for 10.8 and less
or if shared libraries are specified.

My first attempt was #39366. The CI jobs helped me find out about the incompatibility of demos with 10.8 ([failed job](http://bot.brew.sh/job/Homebrew%20Pull%20Requests/25445/version=mountain_lion/console) which I [reported upstream](https://github.com/bulletphysics/bullet3/issues/371)). Also, if you try to install `--with-demo` and `--with-shared` the demos won't work (see [console warnings here](https://gist.github.com/scpeters/6afc44f0cf916b11a226) if you are so inclined). The demos do work with static libraries.