### PR TITLE
rethinkdb: explicitly set cache size to auto

### DIFF
--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -47,6 +47,8 @@ class Rethinkdb < Formula
           <string>#{opt_bin}/rethinkdb</string>
           <string>-d</string>
           <string>#{var}/rethinkdb</string>
+          <string>--cache-size</string>
+          <string>auto</string>
       </array>
       <key>WorkingDirectory</key>
       <string>#{HOMEBREW_PREFIX}</string>


### PR DESCRIPTION
@coffeemug @AtnNn 

Cache size on my MBA was being automatically set without this flag to just 100MB and with the `auto` flag it goes up to 1GB which seems to perform better. Disregard if this is intentionally left out. 