### PR TITLE
bullet: 2.83.1

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,7 +1,7 @@
 class Bullet < Formula
   homepage "http://bulletphysics.org/wordpress/"
-  url "https://github.com/bulletphysics/bullet3/archive/2.82.tar.gz"
-  sha256 "93ffcdfdd7aa67159fc18d336456945538a6602e3cd318eed9963280620b55bd"
+  url "https://github.com/bulletphysics/bullet3/archive/2.83.1.tar.gz"
+  sha256 "e5f22dc834cb47f9cbeab7b5d164f8c32b64a60e9842ec0afddb3aaf9ee02c8c"
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do
@@ -44,7 +44,18 @@ class Bullet < Formula
 
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
-    args << "-DBUILD_DEMOS=OFF" if build.without? "demo"
+    with_demo = build.with? "demo"
+    if with_demo && build.with?("shared")
+      # Related to the following warnings when building --with-shared --with-demo
+      # https://gist.github.com/scpeters/6afc44f0cf916b11a226
+      opoo "Demos don't work with shared libraries"
+      puts <<-EOS.undent
+      Demos will be disabled due to the use of shared libraries.
+      Static libraries are required for demos installed by homebrew.
+      EOS
+      with_demo = false
+    end
+    args << "-DBUILD_BULLET2_DEMOS=OFF" unless with_demo
 
     # Demos require extras, see:
     # https://code.google.com/p/bullet/issues/detail?id=767&thanks=767&ts=1384333052
@@ -58,7 +69,7 @@ class Bullet < Formula
     system "make"
     system "make", "install"
 
-    prefix.install "Demos" if build.with? "demo"
+    prefix.install "examples" if build.with? "demo"
     prefix.install "Extras" if build.with? "extra"
   end
 


### PR DESCRIPTION
The cmake variable for building demos changed
from BUILD_DEMOS to BUILD_BULLET2_DEMOS.
The demos are now in the examples folder
instead of the Demos folder.

Also, demos are disabled if shared libraries
are specified due to a linking problem.

Previous attempts: #39366, #39436.