### PR TITLE
clipsafe: use SSL/TLS mirrors, pass strict audit

### DIFF
--- a/Library/Formula/clipsafe.rb
+++ b/Library/Formula/clipsafe.rb
@@ -3,26 +3,26 @@ require "formula"
 class Clipsafe < Formula
   homepage "http://waxandwane.org/clipsafe.html"
   url "http://waxandwane.org/download/clipsafe-1.1.tar.gz"
-  sha1 "5e940a3f89821bfb3315ff9b1be4256db27e5f6a"
+  sha256 "7a70b4f467094693a58814a42d272e98387916588c6337963fa7258bda7a3e48"
 
   depends_on :macos => :mountain_lion
 
   resource "Crypt::Twofish" do
     url "http://search.cpan.org/CPAN/authors/id/A/AM/AMS/Crypt-Twofish-2.17.tar.gz"
-    mirror "http://search.mcpan.org/CPAN/authors/id/A/AM/AMS/Crypt-Twofish-2.17.tar.gz"
-    sha1 "f2659d7b9e7d7daadb3b2414174bd6ec8ac68eda"
+    mirror "https://cpan.metacpan.org/authors/id/A/AM/AMS/Crypt-Twofish-2.17.tar.gz"
+    sha256 "eed502012f0c63927a1a32e3154071cc81175d1992a893ec41f183b6e3e5d758"
   end
 
   resource "Digest::SHA" do
     url "http://search.cpan.org/CPAN/authors/id/M/MS/MSHELOR/Digest-SHA-5.85.tar.gz"
-    mirror "http://search.mcpan.org/CPAN/authors/id/M/MS/MSHELOR/Digest-SHA-5.85.tar.gz"
-    sha1 "a603cfba95afcd0266c9482c0c93e84241fe0ce0"
+    mirror "https://cpan.metacpan.org/authors/id/M/MS/MSHELOR/Digest-SHA-5.85.tar.gz"
+    sha256 "57eaa26fb2d2ccfd31af2fd312992272439d561c17e34274e8c7aa93e427ca49"
   end
 
   resource "DateTime" do
     url "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/DateTime-1.03.tar.gz"
-    mirror "http://search.mcpan.org/CPAN/authors/id/D/DR/DROLSKY/DateTime-1.03.tar.gz"
-    sha1 "23cad043140988ea95ad8dcb3095cc5aded0464e"
+    mirror "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-1.03.tar.gz"
+    sha256 "384f97c73da02492d771d6b5c3b37f6b18c2e12f4db3246b1d61ff19c6d6ad6d"
   end
 
   def install

--- a/Library/Formula/clipsafe.rb
+++ b/Library/Formula/clipsafe.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Clipsafe < Formula
   homepage "http://waxandwane.org/clipsafe.html"
   url "http://waxandwane.org/download/clipsafe-1.1.tar.gz"


### PR DESCRIPTION
Old plaintext mirror URLs are automatically redirected to these new, SSL/TLS ones:
http://search.mcpan.org/CPAN/{PATH}
https://cpan.metacpan.org/{PATH}
It's better to use the SSL/TLS ones natively.