### PR TITLE
audit: enforce SSL/TLS MetaCPAN urls

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -345,6 +345,8 @@ class FormulaAuditor
         problem "Bintray urls should be https://, not http (url is #{p})."
       when %r[^http://tools\.ietf\.org/]
         problem "ietf urls should be https://, not http (url is #{p})."
+       when %r[^http://search\.mcpan\.org/CPAN/(.*)]i
+        problem "MetaCPAN url should be `https://cpan.metacpan.org/#{$1}` (url is #{p})."
       end
     end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -345,7 +345,7 @@ class FormulaAuditor
         problem "Bintray urls should be https://, not http (url is #{p})."
       when %r[^http://tools\.ietf\.org/]
         problem "ietf urls should be https://, not http (url is #{p})."
-       when %r[^http://search\.mcpan\.org/CPAN/(.*)]i
+      when %r[^http://search\.mcpan\.org/CPAN/(.*)]i
         problem "MetaCPAN url should be `https://cpan.metacpan.org/#{$1}` (url is #{p})."
       end
     end


### PR DESCRIPTION
It is "real" SSL/TLS, it doesn't redirect to plaintext.