### PR TITLE
audit: Check if a 'url' value is reused as 'mirror'

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -321,6 +321,11 @@ class FormulaAuditor
       problem "\"http://ftpmirror.gnu.org\" is preferred for GNU software (url is #{u})."
     end
 
+    # Check if main url is used again as a mirror
+    if (urls & :mirrors).length
+      problem "Url should not be reused as a mirror: #{(urls & :mirrors)[0]}"
+    end
+
     # the rest of the checks apply to mirrors as well.
     urls.concat(@specs.map(&:mirrors).flatten)
 


### PR DESCRIPTION
Please verify me.

Example for this kind of problem:
https://github.com/Homebrew/homebrew/blob/5cda0af3b97ecdd78412952ab161eb85a1aca8be/Library/Formula/signing-party.rb#L44-L45