### PR TITLE
audit: enforce SSL/TLS MetaCPAN urls

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -863,6 +863,8 @@ class ResourceAuditor
         problem "Bintray urls should be https://, not http (url is #{p})."
       when %r[^http://tools\.ietf\.org/]
         problem "ietf urls should be https://, not http (url is #{p})."
+      when %r[^http://search\.mcpan\.org/CPAN/(.*)]i
+        problem "MetaCPAN url should be `https://cpan.metacpan.org/#{$1}` (url is #{p})."
       end
     end
 


### PR DESCRIPTION
It is SSL/TLS from this point; it isn't redirected to plaintext.