### PR TITLE
bullet: 2.83.4

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -44,18 +44,12 @@ class Bullet < Formula
 
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
-    with_demo = build.with? "demo"
-    if with_demo && (build.with?("shared") || build.with?("framework"))
-      # Related to the following warnings when building --with-shared --with-demo
-      # https://gist.github.com/scpeters/6afc44f0cf916b11a226
-      opoo "Installed demos don't work with shared libraries"
-      puts <<-EOS.undent
-        Demos will be disabled due to the use of shared libraries.
-        Static libraries are required for demos installed by homebrew.
-      EOS
-      with_demo = false
+    # Related to the following warnings when building --with-shared --with-demo
+    # https://gist.github.com/scpeters/6afc44f0cf916b11a226
+    if build.with?("demo") && (build.with?("shared") || build.with?("framework"))
+      raise "Demos cannot be installed with shared libraries or framework."
     end
-    args << "-DBUILD_BULLET2_DEMOS=OFF" unless with_demo
+    args << "-DBUILD_BULLET2_DEMOS=OFF" if build.without? "demo"
 
     if build.with?("extra")
       args << "-DINSTALL_EXTRA_LIBS=ON"

--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,7 +1,7 @@
 class Bullet < Formula
   homepage "http://bulletphysics.org/wordpress/"
-  url "https://github.com/bulletphysics/bullet3/archive/2.82.tar.gz"
-  sha256 "93ffcdfdd7aa67159fc18d336456945538a6602e3cd318eed9963280620b55bd"
+  url "https://github.com/bulletphysics/bullet3/archive/2.83.4.tar.gz"
+  sha256 "2cf287cead9a116c56f6d6f15f73dc8b3ed1fe407ef2ca894027d585fab07341"
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do
@@ -44,11 +44,20 @@ class Bullet < Formula
 
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
-    args << "-DBUILD_DEMOS=OFF" if build.without? "demo"
+    with_demo = build.with? "demo"
+    if with_demo && build.with?("shared")
+      # Related to the following warnings when building --with-shared --with-demo
+      # https://gist.github.com/scpeters/6afc44f0cf916b11a226
+      opoo "Installed demos don't work with shared libraries"
+      puts <<-EOS.undent
+      Demos will be disabled due to the use of shared libraries.
+      Static libraries are required for demos installed by homebrew.
+      EOS
+      with_demo = false
+    end
+    args << "-DBUILD_BULLET2_DEMOS=OFF" unless with_demo
 
-    # Demos require extras, see:
-    # https://code.google.com/p/bullet/issues/detail?id=767&thanks=767&ts=1384333052
-    if build.with?("extra") || build.with?("demo")
+    if build.with?("extra")
       args << "-DINSTALL_EXTRA_LIBS=ON"
     else
       args << "-DBUILD_EXTRAS=OFF"
@@ -58,7 +67,7 @@ class Bullet < Formula
     system "make"
     system "make", "install"
 
-    prefix.install "Demos" if build.with? "demo"
+    prefix.install "examples" if with_demo
     prefix.install "Extras" if build.with? "extra"
   end
 

--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -61,7 +61,7 @@ class Bullet < Formula
     system "make"
     system "make", "install"
 
-    prefix.install "examples" if with_demo
+    prefix.install "examples" if build.with? "demo"
     prefix.install "Extras" if build.with? "extra"
   end
 

--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -45,13 +45,13 @@ class Bullet < Formula
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
 
     with_demo = build.with? "demo"
-    if with_demo && build.with?("shared")
+    if with_demo && (build.with?("shared") || build.with?("framework"))
       # Related to the following warnings when building --with-shared --with-demo
       # https://gist.github.com/scpeters/6afc44f0cf916b11a226
       opoo "Installed demos don't work with shared libraries"
       puts <<-EOS.undent
-      Demos will be disabled due to the use of shared libraries.
-      Static libraries are required for demos installed by homebrew.
+        Demos will be disabled due to the use of shared libraries.
+        Static libraries are required for demos installed by homebrew.
       EOS
       with_demo = false
     end


### PR DESCRIPTION
A few changes in 2.83.4:

* The cmake variable for building demos changed from `BUILD_DEMOS` to `BUILD_BULLET2_DEMOS`.
* The demos are now in the examples folder instead of the Demos folder.
* Demos no longer require extras.
* Also, demos are disabled if shared libraries are specified due to a [linking problem](https://gist.github.com/scpeters/6afc44f0cf916b11a226) during installation.

Previous attempts: #39366 #39436 #39458 (sorry for the noise).