### PR TITLE
Updated the naming of objective-caml to just ocaml everywhere

### DIFF
--- a/Library/Aliases/ocaml
+++ b/Library/Aliases/ocaml
@@ -1,1 +1,0 @@
-../Formula/objective-caml.rb

--- a/Library/Formula/bibtex2html.rb
+++ b/Library/Formula/bibtex2html.rb
@@ -10,7 +10,7 @@ class Bibtex2html < Formula
     sha1 "32377bea1f584fedf5d2abb604a1d46e5e92ac5c" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "hevea"
   depends_on :tex => :optional
 

--- a/Library/Formula/camlp4.rb
+++ b/Library/Formula/camlp4.rb
@@ -12,7 +12,7 @@ class Camlp4 < Formula
     sha1 "68c208492b208b060b66418e77dedc059796c2b2" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     # this build fails if jobs are parallelized

--- a/Library/Formula/camlp5.rb
+++ b/Library/Formula/camlp5.rb
@@ -12,7 +12,7 @@ class Camlp5 < Formula
     sha1 "73d8bd3f7848902360e171b425a8e807a512d449" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   option "strict", "Compile in strict mode"
 

--- a/Library/Formula/coccinelle.rb
+++ b/Library/Formula/coccinelle.rb
@@ -11,7 +11,7 @@ class Coccinelle < Formula
     sha1 "ef567b84ce5bd101e3993e162855e4e88d1f3600" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4"
 
   def install

--- a/Library/Formula/compcert.rb
+++ b/Library/Formula/compcert.rb
@@ -5,7 +5,7 @@ class Compcert < Formula
   url "http://compcert.inria.fr/release/compcert-2.4.tgz"
   sha1 "065eef31d1a59547fb3275ba7566867757b176f6"
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "coq" => :build
   depends_on "menhir" => :build
 

--- a/Library/Formula/coq.rb
+++ b/Library/Formula/coq.rb
@@ -21,7 +21,7 @@ class Coq < Formula
   head "git://scm.gforge.inria.fr/coq/coq.git"
 
   depends_on TransitionalMode
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp5"
 
   def install

--- a/Library/Formula/flow.rb
+++ b/Library/Formula/flow.rb
@@ -13,7 +13,7 @@ class Flow < Formula
     sha256 "237e13f65416acef0cf106bd1774cb0d2490491c271d37956c5a91a9afcf2971" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     system "make"

--- a/Library/Formula/haxe.rb
+++ b/Library/Formula/haxe.rb
@@ -20,7 +20,7 @@ class Haxe < Formula
     url "https://github.com/HaxeFoundation/haxe.git", :branch => "development"
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "camlp4" => :build
   depends_on "neko" => :optional
 

--- a/Library/Formula/hevea.rb
+++ b/Library/Formula/hevea.rb
@@ -9,7 +9,7 @@ class Hevea < Formula
     sha256 "1777a109ad7bf3693bd3cb0c09ec99846fbb73611e705eba4a7a48cf195c7ce4" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "ghostscript" => :optional
 
   def install

--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -14,7 +14,7 @@ class Lablgtk < Formula
   depends_on 'pkg-config' => :build
   depends_on 'camlp4' => :build
   depends_on :x11
-  depends_on 'objective-caml'
+  depends_on 'ocaml'
   depends_on 'gtk+'
   depends_on 'librsvg'
 

--- a/Library/Formula/ledit.rb
+++ b/Library/Formula/ledit.rb
@@ -10,7 +10,7 @@ class Ledit < Formula
     sha256 "338e160cde4ece1c167ec07e8b202f599ba0267ac5c3b6ca896b569067cb2e20" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp5"
 
   def install

--- a/Library/Formula/menhir.rb
+++ b/Library/Formula/menhir.rb
@@ -9,7 +9,7 @@ class Menhir < Formula
     sha1 "7ab625d14199153fac46742c684e623e68590469" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     ENV.deparallelize

--- a/Library/Formula/mldonkey.rb
+++ b/Library/Formula/mldonkey.rb
@@ -8,7 +8,7 @@ class Mldonkey < Formula
   deprecated_option "with-x" => "with-x11"
 
   depends_on 'pkg-config' => :build
-  depends_on 'objective-caml'
+  depends_on 'ocaml'
   depends_on 'gd'
   depends_on 'libpng'
   depends_on :x11 => :optional

--- a/Library/Formula/ocaml.rb
+++ b/Library/Formula/ocaml.rb
@@ -1,4 +1,4 @@
-class ObjectiveCaml < Formula
+class OCaml < Formula
   homepage "http://ocaml.org"
   url "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
   sha1 "6af8c67f2badece81d8e1d1ce70568a16e42313e"

--- a/Library/Formula/ocamlsdl.rb
+++ b/Library/Formula/ocamlsdl.rb
@@ -16,7 +16,7 @@ class Ocamlsdl < Formula
   depends_on "sdl_image" => :recommended
   depends_on "sdl_gfx" => :recommended
   depends_on "sdl_ttf" => :recommended
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Library/Formula/one-ml.rb
+++ b/Library/Formula/one-ml.rb
@@ -11,7 +11,7 @@ class OneMl < Formula
     sha256 "d9cc9f66611ddf1d255a3090886d84f76ecd90c82fc1b6833a9c736f372dc484" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     system "make"

--- a/Library/Formula/opam.rb
+++ b/Library/Formula/opam.rb
@@ -14,7 +14,7 @@ class Opam < Formula
     sha256 "00971c8f7ead433bdac2731715380aef7635847c8f899be6dcf08a9d6d162455" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4" => :recommended
 
   # aspcud has a fairly large buildtime dep tree, and uses gringo,

--- a/Library/Formula/orpie.rb
+++ b/Library/Formula/orpie.rb
@@ -10,7 +10,7 @@ class Orpie < Formula
   end
 
   depends_on "gsl"
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4" => :build
 
   def install

--- a/Library/Formula/polygen.rb
+++ b/Library/Formula/polygen.rb
@@ -5,7 +5,7 @@ class Polygen < Formula
   url 'http://www.polygen.org/dist/polygen-1.0.6-20040628-src.zip'
   sha1 'a9b397f32f22713c0a98b20c9421815e0a4e1293'
 
-  depends_on 'objective-caml' => :build
+  depends_on 'ocaml' => :build
 
   def install
     cd 'src' do

--- a/Library/Formula/ssreflect.rb
+++ b/Library/Formula/ssreflect.rb
@@ -5,7 +5,7 @@ class Ssreflect < Formula
   url "http://ssr.msr-inria.inria.fr/FTP/ssreflect-1.5.tar.gz"
   sha1 "131f4e2746b4a97627ae91a9f980f61ec42a00c9"
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "coq"
 
   option "with-doc", "Install HTML documents"

--- a/Library/Formula/unison.rb
+++ b/Library/Formula/unison.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Unison < Formula
   homepage 'http://www.cis.upenn.edu/~bcpierce/unison/'
-  url 'http://www.seas.upenn.edu/~bcpierce/unison//download/releases/stable/unison-2.48.3.tar.gz'
+  url 'http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/unison-2.48.3.tar.gz'
   sha1 '74f1c087ee49dc1db4680ad779280f7333d5c968'
 
   bottle do
@@ -12,7 +12,7 @@ class Unison < Formula
     sha1 "0d83d72a11c558eec59ae9aa20476165dc56cb85" => :mountain_lion
   end
 
-  depends_on 'objective-caml' => :build
+  depends_on 'ocaml' => :build
 
   def install
     ENV.j1

--- a/Library/Formula/why3.rb
+++ b/Library/Formula/why3.rb
@@ -9,7 +9,7 @@ class Why3 < Formula
     sha1 "a6b08c8f3b78fd3c0bba978ef59a03dd701f85f3" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "coq" => :optional
   depends_on "lablgtk" => :optional
   depends_on "hevea" => [:build, :optional]

--- a/Library/Formula/wyrd.rb
+++ b/Library/Formula/wyrd.rb
@@ -10,7 +10,7 @@ class Wyrd < Formula
   end
 
   depends_on "remind"
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "camlp4" => :build
 
   def install


### PR DESCRIPTION
OCaml's name is not objective-caml but actually just OCaml, http://caml.inria.fr/ocaml/name.en.html. 

(This confusion of naming is an unnecessary stumbling block for ocaml beginners.)

Brew should reflect that, this pull request does that. 
I followed the trail of all the things that `brew uses ocaml` showed. If this pull request goes through then I will finish the 3 leftover ones that are in homebrew-science and in homebrew-versions.

