### PR TITLE
Update to Riak 2.1.1.

### DIFF
--- a/Library/Formula/riak.rb
+++ b/Library/Formula/riak.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Riak < Formula
   homepage "http://basho.com/riak/"
-  url "https://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.0.4/osx/10.8/riak-2.0.4-OSX-x86_64.tar.gz"
-  version "2.0.4"
-  sha256 "023627c038833765141f6af0006622dd76e3b9f42495ea796f24e40fc76edba0"
+  url "https://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.1/osx/10.8/riak-2.1.1-OSX-x86_64.tar.gz"
+  version "2.1.1"
+  sha256 "ee06193b5fc4bb56746f8f648794b732b96879369835a94f22235e0561d652d7"
 
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64


### PR DESCRIPTION
Incidentally, [Basho's OS X installation instructions](http://docs.basho.com/riak/latest/ops/building/installing/mac-osx/) already imply 2.1.1 will be installed by Homebrew (but notes this community-maintained package may not be up-to-date).