### PR TITLE
boost-python: don't link a Python framework

### DIFF
--- a/Library/Formula/boost-python.rb
+++ b/Library/Formula/boost-python.rb
@@ -1,41 +1,14 @@
-class UniversalPython < Requirement
-  satisfy(:build_env => false) { archs_for_command("python").universal? }
-
-  def message; <<-EOS.undent
-    A universal build was requested, but Python is not a universal build
-
-    Boost compiles against the Python it finds in the path; if this Python
-    is not a universal build then linking will likely fail.
-    EOS
-  end
-end
-
-class UniversalPython3 < Requirement
-  satisfy(:build_env => false) { archs_for_command("python3").universal? }
-
-  def message; <<-EOS.undent
-    A universal build was requested, but Python 3 is not a universal build
-
-    Boost compiles against the Python 3 it finds in the path; if this Python
-    is not a universal build then linking will likely fail.
-    EOS
-  end
-end
-
 class BoostPython < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
   sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
-
   head "https://github.com/boostorg/boost.git"
 
   option :universal
   option :cxx11
 
-  depends_on :python => :recommended
+  option "without-python", "Build without python 2 support"
   depends_on :python3 => :optional
-  depends_on UniversalPython if build.universal? && build.with?("python")
-  depends_on UniversalPython3 if build.universal? && build.with?("python3")
 
   if build.cxx11?
     depends_on "boost" => "c++11"
@@ -46,6 +19,15 @@ class BoostPython < Formula
   fails_with :llvm do
     build 2335
     cause "Dropped arguments to functions when linking with boost"
+  end
+
+  stable do
+    # don't explicitly link a Python framework
+    # https://github.com/boostorg/build/pull/78
+    patch do
+      url "https://gist.githubusercontent.com/tdsmith/9026da299ac1bfd3f419/raw/b73a919c38af08941487ca37d46e711864104c4d/boost-python.diff"
+      sha256 "9f374761ada11eecd082e7f9d5b80efeb387039d3a290f45b61f0730bce3801a"
+    end
   end
 
   def install

--- a/Library/Formula/ledger.rb
+++ b/Library/Formula/ledger.rb
@@ -39,6 +39,13 @@ class Ledger < Formula
       url "https://github.com/ledger/ledger/commit/5f08e27.diff"
       sha256 "064b0e64d211224455511cd7b82736bb26e444c3af3b64936bec1501ed14c547"
     end
+
+    # boost 1.58 compatibility
+    # https://github.com/ledger/ledger/pull/417
+    patch do
+      url "https://github.com/ledger/ledger/commit/2e02e0.diff"
+      sha256 "c1438cbf989995dd0b4bfa426578a8763544f28788ae76f9ff5d23f1b8b17add"
+    end
   end
 
   needs :cxx11

--- a/Library/Formula/ledger.rb
+++ b/Library/Formula/ledger.rb
@@ -3,6 +3,7 @@ class Ledger < Formula
   url "https://github.com/ledger/ledger/archive/v3.1.tar.gz"
   sha1 "549aa375d4802e9dd4fd153c45ab64d8ede94afc"
   head "https://github.com/ledger/ledger.git"
+  revision 1
 
   bottle do
     revision 3
@@ -33,12 +34,16 @@ class Ledger < Formula
   depends_on "boost-python" => boost_opts if build.with? "python"
 
   stable do
-    # don't explicitly link a python framework
+    # library shouldn't explicitly link a python framework
     # https://github.com/ledger/ledger/pull/415
     patch do
       url "https://github.com/ledger/ledger/commit/5f08e27.diff"
       sha256 "064b0e64d211224455511cd7b82736bb26e444c3af3b64936bec1501ed14c547"
     end
+
+    # but the executable should
+    # https://github.com/ledger/ledger/pull/416
+    patch :DATA
 
     # boost 1.58 compatibility
     # https://github.com/ledger/ledger/pull/417
@@ -94,3 +99,18 @@ class Ledger < Formula
     end
   end
 end
+__END__
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a368d37..570a659 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -273,6 +273,9 @@ if (BUILD_LIBRARY)
+ 
+   add_executable(ledger main.cc global.cc)
+   target_link_libraries(ledger libledger)
++  if (APPLE AND HAVE_BOOST_PYTHON)
++    target_link_libraries(ledger ${PYTHON_LIBRARIES})
++  endif()
+ 
+   install(TARGETS libledger DESTINATION ${CMAKE_INSTALL_LIBDIR})
+   install(FILES ${LEDGER_INCLUDES}


### PR DESCRIPTION
Allows bottling. Closes #38738.