### PR TITLE
rtl-sdr 0.5.3: migrate from head-only (releases now provided on GitHub)

### DIFF
--- a/Library/Formula/rtl-sdr.rb
+++ b/Library/Formula/rtl-sdr.rb
@@ -1,0 +1,22 @@
+class RtlSdr < Formula
+  homepage "http://sdr.osmocom.org/trac/wiki/rtl-sdr"
+  url "https://github.com/steve-m/librtlsdr/archive/v0.5.3.tar.gz"
+  sha256 "98fb5c34ac94d6f2235a0bb41a08f8bed7949e1d1b91ea57a7c1110191ea58de"
+  head "git://git.osmocom.org/rtl-sdr.git"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    assert_match(
+      %r{^rtl_sdr, an I/Q recorder for RTL2832 }m,
+      shell_output("#{bin}/rtl_sdr 2>&1", 1)
+    )
+  end
+end


### PR DESCRIPTION
From the [rtl-sdr home page](http://sdr.osmocom.org/trac/wiki/rtl-sdr):

> The rtl-sdr code can be checked out with:
> 
>     git clone git://git.osmocom.org/rtl-sdr.git
>
> It can also be browsed via [​cgit](http://cgit.osmocom.org/cgit/rtl-sdr/), and there's an official [​mirror on github](https://github.com/steve-m/librtlsdr) that also provides ​[packaged releases](https://github.com/steve-m/librtlsdr/releases).

In light of the mirror's "official" status and its holding of versioned releases, I thought maybe this formula could graduate to core.