### PR TITLE
yubico-pam: add alias for pam_yubico

### DIFF
--- a/Library/Aliases/yubico-pam
+++ b/Library/Aliases/yubico-pam
@@ -1,0 +1,1 @@
+../Formula/pam_yubico.rb


### PR DESCRIPTION
It is the name used by author:
https://github.com/Yubico/yubico-pam/
https://developers.yubico.com/yubico-pam/
