### PR TITLE
heroku-toolbelt 3.36.4

### DIFF
--- a/Library/Formula/heroku-toolbelt.rb
+++ b/Library/Formula/heroku-toolbelt.rb
@@ -1,13 +1,17 @@
 class HerokuToolbelt < Formula
   homepage "https://toolbelt.heroku.com/other"
-  url "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-3.32.0.tgz"
-  sha256 "bae8e899dbc0f2e341171e10270faa347b1d4e9dda31167b091d6a4e6dfd2695"
+  url "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-3.36.4.tgz"
+  sha256 "b57a991828663e3587e07a66b796bf56bf8f4610a618241195bd760a4cf29319"
   head "https://github.com/heroku/heroku.git"
 
   depends_on :ruby => "1.9"
 
   def install
     libexec.install Dir["*"]
+    # turn off autoupdates (off by default in HEAD)
+    if build.stable?
+      inreplace libexec/"bin/heroku", "Heroku::Updater.inject_libpath", "Heroku::Updater.disable(\"Use `brew upgrade heroku-toolbelt` to update\")"
+    end
     bin.write_exec_script libexec/"bin/heroku"
   end
 


### PR DESCRIPTION
Autoupdates are turned off for Keybase and I think a few other formula so I figure that's the thing to do here too.

There's a "Next Gen" version at <https://github.com/heroku/heroku-cli>, but I don't see a deprecation notice or anything on the 3.x.x repository so I wasn't sure whether to switch over.