### PR TITLE
Show the android-sdk opt prefix instead of keg path in the logs

### DIFF
--- a/Library/Formula/android-sdk.rb
+++ b/Library/Formula/android-sdk.rb
@@ -83,8 +83,7 @@ class AndroidSdk < Formula
   def caveats; <<-EOS.undent
     Now run the 'android' tool to install the actual SDK stuff.
 
-    The Android-SDK location for IDEs such as Eclipse, IntelliJ etc is:
-      #{prefix}
+    The Android-SDK is available at #{opt_prefix}
 
     You will have to install the platform-tools and docs EVERY time this formula
     updates. If you want to try and fix this then see the comment in this formula.


### PR DESCRIPTION
I haven't seen any IDE yet that does not follow symlinks, so there doesn't seem to be any valid reason to provide the keg path that will change with each upgrade instead of the static opt prefix. If someone knows of some actual workflow that requires the real path, then we can add a line about that.