### PR TITLE
fpp 0.5.6

### DIFF
--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,7 +1,7 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  url "https://github.com/facebook/PathPicker/releases/download/0.5.5/fpp.0.5.5.tar.gz"
-  sha256 "416e8f8d5979947239db89a9e327e8d3e731a5feb08f1d9c05b1ee90768cdbf7"
+  url "https://github.com/facebook/PathPicker/releases/download/0.5.6/fpp.0.5.6.tar.gz"
+  sha256 "c06a8733471074104099a21957f1f391e1d68969c4671443f4a0518314ecc509"
   head "https://github.com/facebook/pathpicker.git"
 
   bottle do


### PR DESCRIPTION
Small sha256 and url update for the fpp 0.5.6 release. Release notes here:
https://github.com/facebook/PathPicker/releases/tag/0.5.6

We won't be sending new recipes every few days, we're just clearing out a backlog of issues from our big announcement on thursday :D i expected release stability fairly soon. `brew audit --strict` passes!