### PR TITLE
Fix homepage for evas

### DIFF
--- a/Library/Formula/evas.rb
+++ b/Library/Formula/evas.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Evas < Formula
-  homepage "http://trac.enlightenment.org/e/wiki/Evas"
+  homepage "https://docs.enlightenment.org/auto/eet/evas_main.html"
   url "http://download.enlightenment.org/releases/evas-1.7.10.tar.gz"
   sha1 "ad1002eded75ea0e90d80b3b6813b3278d9f4228"
 


### PR DESCRIPTION
- Old subdomain no longer in use. Updated to correct URL