### PR TITLE
Revert "llvm: enable RTTI when building libc++"

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -112,7 +112,7 @@ class Llvm < Formula
       -DLLVM_OPTIMIZED_TABLEGEN=On
     ]
 
-    args << "-DLLVM_ENABLE_RTTI=On" if build.with?("rtti") || build.with?("clang")
+    args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
 
     args << "-DBUILD_SHARED_LIBS=Off" if build.without? "shared"
 


### PR DESCRIPTION
`brew install llvm --with-clang` works without rtti. Why was this added to begin with?