### PR TITLE
sysdig 0.1.99

### DIFF
--- a/Library/Formula/sysdig.rb
+++ b/Library/Formula/sysdig.rb
@@ -1,11 +1,8 @@
-require "formula"
-
 class Sysdig < Formula
   homepage "http://www.sysdig.org/"
-  url "https://github.com/draios/sysdig/archive/0.1.98.tar.gz"
-  sha1 "a184272b9ab34a644027a699e1e7dbb1676b5265"
-
-  head "https://github.com/draios/sysdig.git"
+  url "https://github.com/draios/sysdig/archive/0.1.99.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/s/sysdig/sysdig_0.1.99.orig.tar.gz"
+  sha256 "e6f00493feaa42f05720c708ab87b7150b465306dae18f9b97f2c40334e2ca09"
 
   bottle do
     sha1 "a84b9e27e74e38c3f25c1880f0834523c8be1ba8" => :yosemite
@@ -14,18 +11,25 @@ class Sysdig < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "luajit"
 
   # More info on https://gist.github.com/juniorz/9986999
   resource "sample_file" do
     url "https://gist.githubusercontent.com/juniorz/9986999/raw/a3556d7e93fa890a157a33f4233efaf8f5e01a6f/sample.scap"
-    sha1 "0aa3c30b954f9fb0d7320d900d3a103ade6b1cec"
+    sha256 "efe287e651a3deea5e87418d39e0fe1e9dc55c6886af4e952468cd64182ee7ef"
   end
 
   def install
     ENV.libcxx if MacOS.version < :mavericks
 
     mkdir "build" do
-      system "cmake", "..", "-DSYSDIG_VERSION=#{version}", *std_cmake_args
+      args = %W[
+        -DSYSDIG_VERSION=#{version}
+        -DUSE_BUNDLED_LUAJIT=OFF
+        -DUSE_BUNDLED_ZLIB=OFF
+      ] + std_cmake_args
+
+      system "cmake", "..", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
Looks like cmake is downloading zlib and luajit during the build: https://gist.github.com/dunn/240f50f717d7ad62190d

Should we try to vendor zlib and use brewed luajit?