### PR TITLE
dpkg: fix md5 issue

### DIFF
--- a/Library/Formula/dpkg.rb
+++ b/Library/Formula/dpkg.rb
@@ -1,8 +1,9 @@
 class Dpkg < Formula
   homepage "https://wiki.debian.org/Teams/Dpkg"
   url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
-  mirror "http://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dpkg/dpkg_1.17.25.tar.xz"
   sha256 "07019d38ae98fb107c79dbb3690cfadff877f153b8c4970e3a30d2e59aa66baa"
+  revision 1
 
   bottle do
     revision 1
@@ -17,8 +18,9 @@ class Dpkg < Formula
 
   def install
     # Fix for OS X checksum utility names.
+    # The quotation marks look weird, but don't "fix" them, it's intentional.
     inreplace "scripts/Dpkg/Checksums.pm" do |s|
-      s.gsub! "md5sum", "md5"
+      s.gsub! "md5sum", "md5', '-q"
       s.gsub! "sha1sum", "shasum"
       s.gsub! "sha256sum", "shasum', '-a', '256"
     end


### PR DESCRIPTION
This deals the final blow to #38990, closing it for good.

"My bad" on this one - I forgot that Debian's MD5 utility places filename first, checksum second. OS X's Shasum utility and Linux's SHA1SUM/SHA256SUM utilities share the same common output, but for whatever reason, OS X's MD5 utility does not share the same common output and instead flips around the filename and checksum, causing the errors seen in the referenced issue. Sigh.

Revision because this is a fairly major hiccup, and to be honest https://github.com/Homebrew/homebrew/commit/4928364d746f53ed64b89aebdc8cba8cf9a78b7a probably should have caused a revision as well given the major fixes there.

Long live `dpkg`.