### PR TITLE
yelp-tools and yelp-xsl new formulas

### DIFF
--- a/Library/Formula/yelp-tools.rb
+++ b/Library/Formula/yelp-tools.rb
@@ -1,0 +1,23 @@
+class YelpTools < Formula
+  homepage "https://github.com/GNOME/yelp-tools"
+  desc "Tools that help create and edit Mallard or DocBook documentation."
+  url "https://download.gnome.org/sources/yelp-tools/3.16/yelp-tools-3.16.1.tar.xz"
+  sha256 "b4f66c145af1c6448dc51037d305d6844da13dc31d07729b8e29005ee4fef89c"
+
+  depends_on "itstool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libxslt" => :build
+  depends_on "libxml2" => :build
+  depends_on "yelp-xsl"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/yelp-new", "task", "ducksinarow"
+    system "#{bin}/yelp-build", "html", "ducksinarow.page"
+    system "#{bin}/yelp-check", "validate", "ducksinarow.page"
+  end
+end

--- a/Library/Formula/yelp-xsl.rb
+++ b/Library/Formula/yelp-xsl.rb
@@ -1,0 +1,32 @@
+class YelpXsl < Formula
+  homepage "https://github.com/GNOME/yelp-xsl"
+  desc "Yelp's universal stylesheets for Mallard and DocBook"
+  url "https://download.gnome.org/sources/yelp-xsl/3.16/yelp-xsl-3.16.1.tar.xz"
+  sha256 "3295eecc4b03d2a239f7a1bdf4a1311d34c46c3055e6535c1f72bb5a49b4174a"
+
+  depends_on "libxslt"
+  depends_on "libxml2"
+  depends_on "itstool" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext" => :build
+  depends_on "gtk+3"=> :run
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def post_install
+    system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+  end
+
+  test do
+    assert (share/"yelp-xsl/xslt/mallard/html/mal2html-links.xsl").exist?
+    assert (share/"yelp-xsl/js/jquery.syntax.brush.smalltalk.js").exist?
+    assert (share/"yelp-xsl/icons/hicolor/24x24/status/yelp-note-warning.png").exist?
+    assert (share/"pkgconfig/yelp-xsl.pc").exist?
+  end
+end


### PR DESCRIPTION
needed these packages to autogen glade, which I will update when gtk2
becomes quartz-backend-only and when the new gtk-mac-integration release
is out