### PR TITLE
gdk-pixbuf 2.31.4

### DIFF
--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class GdkPixbuf < Formula
-  homepage 'http://gtk.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz'
-  sha256 '4853830616113db4435837992c0aebd94cbb993c44dc55063cee7f72a7bef8be'
+  homepage "http://gtk.org"
+  url "https://download.gnome.org/sources/gdk-pixbuf/2.31/gdk-pixbuf-2.31.4.tar.xz"
+  sha256 "e5d9977493f8188baa6f432c5015c9937f0f67d29e0b6bccd3fae23126a47a15"
 
   bottle do
     revision 1
@@ -22,7 +20,7 @@ class GdkPixbuf < Formula
   depends_on "gobject-introspection"
 
   # 'loaders.cache' must be writable by other packages
-  skip_clean 'lib/gdk-pixbuf-2.0'
+  skip_clean "lib/gdk-pixbuf-2.0"
 
   def install
     ENV.universal_binary if build.universal?
@@ -38,10 +36,10 @@ class GdkPixbuf < Formula
 
     # Other packages should use the top-level modules directory
     # rather than dumping their files into the gdk-pixbuf keg.
-    inreplace lib/'pkgconfig/gdk-pixbuf-2.0.pc' do |s|
-      libv = s.get_make_var 'gdk_pixbuf_binary_version'
-      s.change_make_var! 'gdk_pixbuf_binarydir',
-        HOMEBREW_PREFIX/'lib/gdk-pixbuf-2.0'/libv
+    inreplace lib/"pkgconfig/gdk-pixbuf-2.0.pc" do |s|
+      libv = s.get_make_var "gdk_pixbuf_binary_version"
+      s.change_make_var! "gdk_pixbuf_binarydir",
+        HOMEBREW_PREFIX/"lib/gdk-pixbuf-2.0"/libv
     end
   end
 
@@ -57,5 +55,38 @@ class GdkPixbuf < Formula
     If you need to manually update the query loader cache, set GDK_PIXBUF_MODULEDIR then run
       #{bin}/gdk-pixbuf-query-loaders --update-cache
     EOS
+  end
+
+  test do
+    system "#{bin}/gdk-pixbuf-csource", "--version"
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gdk-pixbuf/gdk-pixbuf.h>
+
+      int main(int argc, char *argv[]) {
+        GSList *list = gdk_pixbuf_get_formats();
+        return 0;
+      }
+    EOS
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    libpng = Formula["libpng"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/gdk-pixbuf-2.0
+      -I#{libpng.opt_include}/libpng16
+      -D_REENTRANT
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -lgdk_pixbuf-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lintl
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end


### PR DESCRIPTION
version bump
officially I think this is the development version but everybody
(Macports, Ubuntu...) appears
to be using this instead of the 2.30.x series, which hasn't seen an
update for a long time.
audit --strict compliance