### PR TITLE
llvm: install python bindings only if specified

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -140,8 +140,10 @@ class Llvm < Formula
     end
 
     # install llvm python bindings
-    (lib+"python2.7/site-packages").install buildpath/"bindings/python/llvm"
-    (lib+"python2.7/site-packages").install buildpath/"tools/clang/bindings/python/clang" if build.with? "clang"
+    if build.with? "python"
+      (lib+"python2.7/site-packages").install buildpath/"bindings/python/llvm"
+      (lib+"python2.7/site-packages").install buildpath/"tools/clang/bindings/python/clang" if build.with? "clang"
+    end
   end
 
   test do


### PR DESCRIPTION
The `--with-python` doesn't do anything right now =/