### PR TITLE
dirac: avoid compiling with new GCCs (work in progress)

### DIFF
--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -11,6 +11,10 @@ class Dirac < Formula
     build 2334
   end
 
+  fails_with :clang do
+    cause "build uses compiler flags not known to clang"
+  end
+
   patch :DATA
 
   def install

--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -1,20 +1,18 @@
-require 'formula'
-
 class Dirac < Formula
-  homepage 'http://diracvideo.org/'
-  url 'http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz'
-  sha1 '895aaad832a54b754e58f77c87d38c0c37752b0b'
+  homepage "http://diracvideo.org/"
+  url "http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz"
+  sha256 "816b16f18d235ff8ccd40d95fc5b4fad61ae47583e86607932929d70bf1f00fd"
 
   fails_with :llvm do
     build 2334
   end
 
   def install
-    # BSD cp doesn't have '-d'
-    inreplace 'doc/Makefile.in', 'cp -dR', 'cp -R'
+    # BSD cp doesn't have "-d"
+    inreplace "doc/Makefile.in", "cp -dR", "cp -R"
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 end

--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -3,16 +3,37 @@ class Dirac < Formula
   url "http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz"
   sha256 "816b16f18d235ff8ccd40d95fc5b4fad61ae47583e86607932929d70bf1f00fd"
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   fails_with :llvm do
     build 2334
   end
+
+  patch :DATA
 
   def install
     # BSD cp doesn't have "-d"
     inreplace "doc/Makefile.in", "cp -dR", "cp -R"
 
+    system "./bootstrap"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 end
+__END__
+diff --git a/bootstrap b/bootstrap
+index 61f7c11..812148d 100755
+--- a/bootstrap
++++ b/bootstrap
+@@ -11,7 +11,7 @@ rm -rf autom4te.cache
+ 
+ set -x
+ aclocal -I m4
+-libtoolize --force --copy
++glibtoolize --force --copy
+ automake --foreign --copy --add-missing
+ if [ $? -ne 0 ]; 
+ then

--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -15,11 +15,12 @@ class Dirac < Formula
     cause "build uses compiler flags not known to clang"
   end
 
-  patch :DATA
-
   def install
     # BSD cp doesn't have "-d"
     inreplace "doc/Makefile.in", "cp -dR", "cp -R"
+
+    # Homebrew's libtool package installs names with "g" prefixes
+    inreplace "bootstrap", /\blibtool/, "glibtool"
 
     system "./bootstrap"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
@@ -27,17 +28,3 @@ class Dirac < Formula
     system "make", "install"
   end
 end
-__END__
-diff --git a/bootstrap b/bootstrap
-index 61f7c11..812148d 100755
---- a/bootstrap
-+++ b/bootstrap
-@@ -11,7 +11,7 @@ rm -rf autom4te.cache
- 
- set -x
- aclocal -I m4
--libtoolize --force --copy
-+glibtoolize --force --copy
- automake --foreign --copy --add-missing
- if [ $? -ne 0 ]; 
- then

--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -15,6 +15,12 @@ class Dirac < Formula
     cause "build uses compiler flags not known to clang"
   end
 
+  ("4.5".."4.9").each do |gcc_version|
+    fails_with :gcc => gcc_version do
+      cause "multiple compilation errors in quant_chooser.cpp"
+    end
+  end
+
   def install
     # BSD cp doesn't have "-d"
     inreplace "doc/Makefile.in", "cp -dR", "cp -R"


### PR DESCRIPTION
dirac is a GNU-style build that hasn't been updated in so long that it may be a lost cause now. But I've made a branch with my attempts to make it work again.

The pull request is mainly for code-reviewing purposes; it is _NOT_ by any means ready to merge at this writing.
