### PR TITLE
stlviewer: use sha256

### DIFF
--- a/Library/Formula/stlviewer.rb
+++ b/Library/Formula/stlviewer.rb
@@ -1,12 +1,14 @@
-require 'formula'
-
 class Stlviewer < Formula
-  homepage 'https://github.com/vishpat/stlviewer#readme'
-  url 'https://github.com/vishpat/stlviewer/archive/release-0.1.tar.gz'
-  sha1 '2ceeee6e36de4b9e95002940d893819fb9e09120'
+  homepage "https://github.com/vishpat/stlviewer#readme"
+  url "https://github.com/vishpat/stlviewer/archive/release-0.1.tar.gz"
+  sha256 "55c1969537a7c663273d0d3ab242f0bf61b93d83a7a5ea0786436a2041ecdb8b"
 
   def install
-    system './compile.py'
-    bin.install 'stlviewer'
+    system "./compile.py"
+    bin.install "stlviewer"
+  end
+
+  test do
+    shell_output("#{bin}/stlviewer 2>&1", 1)
   end
 end


### PR DESCRIPTION
I couldn’t add a better test because `stlviewer` starts a GUI and doesn’t accept any option.