### PR TITLE
pull: warning if we are not in master

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -94,6 +94,10 @@ module Homebrew
       revision = `git rev-parse --short HEAD`.strip
       branch = `git symbolic-ref --short HEAD`.strip
 
+      unless branch == "master"
+        opoo "Current branch is #{branch}: do you need to pull inside master? "
+      end
+
       pull_url url
 
       changed_formulae = []


### PR DESCRIPTION
I just accidentally push wrong branch into Homebrew core as I didn't realize I was not in master branch. :cry: Thankfully, the result is creating a new branch in Homebrew instead of something worse.

So here am I, adding a new warning in `brew pull` command.