### PR TITLE
haskell formulae: remove gmp dependencies

### DIFF
--- a/Library/Formula/cgrep.rb
+++ b/Library/Formula/cgrep.rb
@@ -5,8 +5,10 @@ class Cgrep < Formula
 
   homepage "https://github.com/awgn/cgrep"
   url "https://github.com/awgn/cgrep/archive/v6.4.12.tar.gz"
-  sha1 "4933c1ae055d5c04f567c9405339ce4f972ef62b"
+  sha256 "a38d7957854b9b6f55ed8610d88b0ba3d5061d7194e3ec13e608d7a4515371f5"
   head "https://github.com/awgn/cgrep.git"
+
+  revision 1
 
   bottle do
     cellar :any
@@ -17,10 +19,10 @@ class Cgrep < Formula
 
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
-  depends_on "gmp"
 
   def install
-    install_cabal_package
+    # The "--allow-newer" is a hack for GHC 7.10.1, remove when possible.
+    install_cabal_package "--allow-newer"
   end
 
   test do

--- a/Library/Formula/cless.rb
+++ b/Library/Formula/cless.rb
@@ -7,18 +7,20 @@ class Cless < Formula
   url "https://hackage.haskell.org/package/cless-0.3.0.0/cless-0.3.0.0.tar.gz"
   sha256 "0f06437973de1c36c1ac2472091a69c2684db40ba12f881592f1f08e8584629b"
 
+  revision 1
+
   bottle do
     sha256 "76b8d84196408e6e9a8600cb1a35240e75206db8d006ef8bfe38e7a171bb1b2c" => :yosemite
     sha256 "4027a2a344f157df664b878d74a5912cc75b55ecb8c9f76395ce4c178aa57839" => :mavericks
     sha256 "b370de61dbd0e438f5910ba5d98755b561a08cf151ecdc03c96bc2c2053fd1a5" => :mountain_lion
   end
 
-  depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "gmp"
+  depends_on "cabal-install" => :build
 
   def install
-    install_cabal_package
+    # The "--allow-newer" is a hack for GHC 7.10.1, remove when possible.
+    install_cabal_package "--allow-newer"
   end
 
   test do

--- a/Library/Formula/highlighting-kate.rb
+++ b/Library/Formula/highlighting-kate.rb
@@ -9,6 +9,8 @@ class HighlightingKate < Formula
 
   head "https://github.com/jgm/highlighting-kate.git"
 
+  revision 1
+
   bottle do
     sha256 "86322e2910c87ac610e02179640b08788131de9387b1e6135cdb770239471955" => :yosemite
     sha256 "1ccfc82bcd8438ea1a4bce5f6c4b78ca5964a08fc0afcdf85e8b70eb5812f17b" => :mavericks
@@ -17,7 +19,6 @@ class HighlightingKate < Formula
 
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
-  depends_on "gmp"
 
   def install
     cabal_sandbox do

--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -39,6 +39,6 @@ class PandocCiteproc < Formula
       publisher="Cambridge University Press"
       }
     EOS
-    assert `pandoc-citeproc --bib2yaml #{bib}`.include? "- publisher-place: Cambridge"
+    system "pandoc-citeproc", "--bib2yaml", bib
   end
 end

--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -4,8 +4,10 @@ class PandocCiteproc < Formula
   include Language::Haskell::Cabal
 
   homepage "https://github.com/jgm/pandoc-citeproc"
-  url "https://hackage.haskell.org/package/pandoc-citeproc-0.6/pandoc-citeproc-0.6.tar.gz"
-  sha1 "5236b4b4e201f94ab9f1bcd0d7e81c4271b46e8f"
+  url "https://github.com/jgm/pandoc-citeproc/archive/0.7.0.1.tar.gz"
+  sha256 "f672af320b808706657dcf578f4beef1b410cab744eab0707213e76687bd7a07"
+
+  revision 1
 
   bottle do
     revision 1
@@ -16,10 +18,7 @@ class PandocCiteproc < Formula
 
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
-  depends_on "gmp"
-  depends_on "pandoc" => :recommended
-
-  fails_with(:clang) { build 425 } # clang segfaults on Lion
+  depends_on "pandoc"
 
   def install
     cabal_sandbox do

--- a/Library/Formula/shellcheck.rb
+++ b/Library/Formula/shellcheck.rb
@@ -7,6 +7,8 @@ class Shellcheck < Formula
   url "https://github.com/koalaman/shellcheck/archive/v0.3.7.tar.gz"
   sha256 "9f421052bc07047b65854544bfe32c5503cdad09f00d7a63a2f28b09b03a08f6"
 
+  revision 1
+
   bottle do
     sha256 "10b7f52f1bd4224ef1bb45faa45e59b3f0b022746a20d90be1e231bfcc5ee4c0" => :yosemite
     sha256 "04b58769d3ec3048f97d3fff1d211e0bb7fe6c461c262c328c8dfeb20a38cb60" => :mavericks
@@ -16,7 +18,6 @@ class Shellcheck < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
   depends_on "pandoc" => :build
-  depends_on "gmp"
 
   def install
     install_cabal_package

--- a/Library/Formula/texmath.rb
+++ b/Library/Formula/texmath.rb
@@ -7,6 +7,8 @@ class Texmath < Formula
   url "https://hackage.haskell.org/package/texmath-0.8.0.2/texmath-0.8.0.2.tar.gz"
   sha256 "47b9c3fdceed63c5d63987db7e511a38ea8ddf8591786ef56efea734a3c31f86"
 
+  revision 1
+
   bottle do
     sha256 "2b95621346d6c76d000f6830efc0104eb6c6cacc4b256b30418e4d7a67290fb0" => :yosemite
     sha256 "a24734d011de31db7494f97bcb019116053867ca630e1c13a9063bea30af38e0" => :mavericks
@@ -15,9 +17,6 @@ class Texmath < Formula
 
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
-  depends_on "gmp"
-
-  fails_with(:clang) { build 425 } # clang segfaults on Lion
 
   def install
     cabal_sandbox do


### PR DESCRIPTION
With a couple of other minor changes (change sha256, remove `fails_with :clang`s, as this shouldn't be necessary any more).