### PR TITLE
doctor: add homebrew_temp sticky bit check

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -419,6 +419,16 @@ def check_access_usr_local
   end
 end
 
+def check_tmpdir_sticky_bit
+  world_writable = HOMEBREW_TEMP.stat.mode & 0777 == 0777
+  if world_writable && !HOMEBREW_TEMP.sticky? then <<-EOS.undent
+    #{HOMEBREW_TEMP} is world-writable but does not have the sticky bit set.
+    Please run "Repair Disk Permissions" in Disk Utility.
+  EOS
+  end
+end
+
+
 (Keg::TOP_LEVEL_DIRECTORIES + ["lib/pkgconfig"]).each do |d|
   define_method("check_access_#{d.sub("/", "_")}") do
     dir = HOMEBREW_PREFIX.join(d)


### PR DESCRIPTION
Adds a small check to the Doctor command to ensure HOMEBREW_TEMP has a sticky bit set. This has become a significant issue lately.

Closes #39735
Original issue: #39170