### PR TITLE
heroku-toolbelt: check OSX version for ruby dep

### DIFF
--- a/Library/Formula/heroku-toolbelt.rb
+++ b/Library/Formula/heroku-toolbelt.rb
@@ -4,7 +4,7 @@ class HerokuToolbelt < Formula
   sha256 "008393132b6422982221245f50cf28792f9f7a298d0ae13e34273d80976e0e77"
   head "https://github.com/heroku/heroku.git"
 
-  depends_on :ruby => "1.9"
+  depends_on :ruby => "1.9" if MacOS.version < :mavericks
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
This pull request removes the ruby dependency for heroku-toolbelt for OS X versions ≥ Mavericks.

The dependency is needed because heroku-toolbelt needs Ruby ≥1.9, but starting with Mavericks, OS X ships with Ruby 2.0 anyway, thereby making this dependency obsolete for newer OS X versions.