### PR TITLE
ENV: Add gcc-5 to compilers support C++11

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -275,7 +275,7 @@ module Stdenv
     if compiler == :clang
       append 'CXX', '-std=c++11'
       append 'CXX', '-stdlib=libc++'
-    elsif compiler =~ /gcc-4\.(8|9)/
+    elsif compiler =~ /gcc-(4\.(8|9)|5)/
       append 'CXX', '-std=c++11'
     else
       raise "The selected compiler doesn't support C++11: #{compiler}"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -293,7 +293,7 @@ module Superenv
     when "clang"
       append 'HOMEBREW_CCCFG', "x", ''
       append 'HOMEBREW_CCCFG', "g", ''
-    when /gcc-4\.(8|9)/
+    when /gcc-(4\.(8|9)|5)/
       append 'HOMEBREW_CCCFG', "x", ''
     else
       raise "The selected compiler doesn't support C++11: #{homebrew_cc}"


### PR DESCRIPTION
The PR marks gcc-5 as compiler support C++11.