### PR TITLE
Fix funcoeszz when using apple's sed

### DIFF
--- a/Library/Formula/funcoeszz.rb
+++ b/Library/Formula/funcoeszz.rb
@@ -5,8 +5,18 @@ class Funcoeszz < Formula
   url 'http://funcoeszz.net/download/funcoeszz-13.2.sh'
   sha1 '33d6950dc83fd2118bc45a752c4a77be3b112573'
 
+  depends_on "gnu-sed"
+
   def install
-    prefix.install "funcoeszz-#{version}.sh" => "funcoeszz.sh"
+    # This program needs gnu sed to work, insted of forcing users
+    # to change their paths, we just change the sed callings to gsed
+    original_path = "funcoeszz-#{version}.sh"
+
+    inreplace original_path do |s|
+      s.gsub! /\bsed\b/, "gsed"
+    end
+
+    prefix.install original_path => "funcoeszz.sh"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
This software requires gnu-sed, so I've changed it to use explicitly gsed instead of apple's sed. With this you don't have to force users changing their paths to make gnu-sed default.