### PR TITLE
tinyproxy: revert 6e87b7f2d2fdbab1b69670ab2524066313b45138

### DIFF
--- a/Library/Formula/tinyproxy.rb
+++ b/Library/Formula/tinyproxy.rb
@@ -53,28 +53,6 @@ class Tinyproxy < Formula
     (var/"run/tinyproxy").mkpath
   end
 
-  test do
-    pid = fork do
-      exec "#{sbin}/tinyproxy"
-    end
-    sleep 2
-
-    begin
-      assert_match /tinyproxy/, shell_output("curl localhost:8888")
-    ensure
-      Process.kill("SIGINT", pid)
-      Process.wait(pid)
-    end
-  end
-
-  def post_install
-    log = prefix/"var/log/tinyproxy"
-    log.mkpath
-
-    run = prefix/"var/run/tinyproxy"
-    run.mkpath
-  end
-
   plist_options :manual => "tinyproxy"
 
   def plist; <<-EOS.undent
@@ -97,5 +75,19 @@ class Tinyproxy < Formula
       </dict>
     </plist>
     EOS
+  end
+
+  test do
+    pid = fork do
+      exec "#{sbin}/tinyproxy"
+    end
+    sleep 2
+
+    begin
+      assert_match /tinyproxy/, shell_output("curl localhost:8888")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
   end
 end


### PR DESCRIPTION
This partially reverts https://github.com/Homebrew/homebrew/commit/6e87b7f2d2fdbab1b69670ab2524066313b45138, which conflicts with the prior merge of https://github.com/Homebrew/homebrew/commit/b71ee671d395bb54fbcf864f85c2b95e18d896ea.

Merging the second PR added a second `post_install` stage underneath the prior existing one, and the new `post_install` stage created directories which aren't compatible with correct placement of the `var` directories.