### PR TITLE
Fixed audit complaints for Sphinx about system OpenSSL if built with --mysql flag

### DIFF
--- a/Library/Formula/sphinx.rb
+++ b/Library/Formula/sphinx.rb
@@ -2,6 +2,7 @@ require 'formula'
 
 class Sphinx < Formula
   homepage 'http://www.sphinxsearch.com'
+  revision 1
 
   stable do
     url 'http://sphinxsearch.com/files/sphinx-2.2.9-release.tar.gz'
@@ -21,13 +22,18 @@ class Sphinx < Formula
     sha256 "a71c292f774b8e449cf8775d21e7a6f41a85497e178ea6ba678b80a2f33b4ebd" => :mountain_lion
   end
 
-  option 'mysql', 'Force compiling against MySQL'
-  option 'pgsql', 'Force compiling against PostgreSQL'
-  option 'id64',  'Force compiling with 64-bit ID support'
+  option 'with-mysql',      'Force compiling against MySQL'
+  option 'with-postgresql', 'Force compiling against PostgreSQL'
+  option 'with-id64',       'Force compiling with 64-bit ID support'
+
+  deprecated_option 'mysql' => 'with-mysql'
+  deprecated_option 'pgsql' => 'with-postgresql'
+  deprecated_option 'id64'  => 'with-id64'
 
   depends_on "re2" => :optional
-  depends_on :mysql if build.include? 'mysql'
-  depends_on :postgresql if build.include? 'pgsql'
+  depends_on :mysql => :optional
+  depends_on :postgresql => :optional
+  depends_on 'openssl' if build.with?('mysql')
 
   resource 'stemmer' do
     url "https://github.com/snowballstem/snowball.git",
@@ -55,15 +61,19 @@ class Sphinx < Formula
               --localstatedir=#{var}
               --with-libstemmer]
 
-    args << "--enable-id64" if build.include? 'id64'
+    args << "--enable-id64" if build.with? 'id64'
     args << "--with-re2" if build.with? 're2'
 
-    %w{mysql pgsql}.each do |db|
-      if build.include? db
-        args << "--with-#{db}"
-      else
-        args << "--without-#{db}"
-      end
+    if build.with? 'mysql'
+      args << '--with-mysql'
+    else
+      args << '--without-mysql'
+    end
+
+    if build.with? 'postgresql'
+      args << '--with-pgsql'
+    else
+      args << '--without-pgsql'
     end
 
     system "./configure", *args


### PR DESCRIPTION
When Sphinx installed with `--mysql` flag `brew audit sphinx` message was:

    sphinx:
     * object files were linked against system openssl
    These object files were linked against the deprecated system OpenSSL.
    Adding `depends_on "openssl"` to the formula may help.
      /usr/local/Cellar/sphinx/2.2.9/bin/indexer
      /usr/local/Cellar/sphinx/2.2.9/bin/indextool
      /usr/local/Cellar/sphinx/2.2.9/bin/searchd
      /usr/local/Cellar/sphinx/2.2.9/bin/spelldump
      /usr/local/Cellar/sphinx/2.2.9/bin/wordbreaker

    Error: 1 problems in 1 formulae

Brew bot doesn't detect this as it does not build (and therefore audit) Sphinx with `--mysql` or `--pgsql` flags. But one (or both) of these flags are used in most installations (IMO). So it's essential to make CI to check installation for them. But I don't know how to do that.