### PR TITLE
sqsh: correct homepage, test

### DIFF
--- a/Library/Formula/sqsh.rb
+++ b/Library/Formula/sqsh.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class Sqsh < Formula
-  homepage 'http://www.cs.washington.edu/~rose/sqsh/sqsh.html'
-  url 'https://downloads.sourceforge.net/project/sqsh/sqsh/sqsh-2.5/sqsh-2.5.16.1.tgz'
-  sha1 '1bdbab03ab96f53d0a0a279ba2518643225c6460'
+  homepage "https://sourceforge.net/projects/sqsh/"
+  url "https://downloads.sourceforge.net/project/sqsh/sqsh/sqsh-2.5/sqsh-2.5.16.1.tgz"
+  sha256 "d6641f365ace60225fc0fa48f82b9dbed77a4e506a0e497eb6889e096b8320f2"
 
   deprecated_option "enable-x" => "with-x11"
 
   depends_on :x11 => :optional
-  depends_on 'freetds'
-  depends_on 'readline'
+  depends_on "freetds"
+  depends_on "readline"
 
-  # this patch fixes detection of freetds being instaled, it was reported
+  # this patch fixes detection of freetds being installed, it was reported
   # upstream via email and should be fixed in the next release
   patch :DATA
 
@@ -23,8 +21,8 @@ class Sqsh < Formula
     ]
 
     readline = Formula["readline"]
-    ENV['LIBDIRS'] = readline.opt_lib
-    ENV['INCDIRS'] = readline.opt_include
+    ENV["LIBDIRS"] = readline.opt_lib
+    ENV["INCDIRS"] = readline.opt_include
 
     if build.with? "x11"
       args << "--with-x"
@@ -32,10 +30,14 @@ class Sqsh < Formula
       args << "--x-includes=#{MacOS::X11.include}"
     end
 
-    ENV['SYBASE'] = Formula["freetds"].opt_prefix
+    ENV["SYBASE"] = Formula["freetds"].opt_prefix
     system "./configure", *args
     system "make", "install"
     system "make", "install.man"
+  end
+
+  test do
+    assert_equal "sqsh-#{version}", shell_output("#{bin}/sqsh -v").chomp
   end
 end
 


### PR DESCRIPTION
The current homepage 404s and from an email to the page owner it seems he's no longer the maintainer of sqsh, if he ever was—it might have just been a how-to page he wrote.