### PR TITLE
abcm2ps 8.7.8 (devel)

### DIFF
--- a/Library/Formula/abcm2ps.rb
+++ b/Library/Formula/abcm2ps.rb
@@ -10,8 +10,8 @@ class Abcm2ps < Formula
   end
 
   devel do
-    url "http://moinejf.free.fr/abcm2ps-8.7.4.tar.gz"
-    sha256 "c81ada90810f7f70aff08c5962edc209c78e1aed34892ff871ba85765274dc17"
+    url "http://moinejf.free.fr/abcm2ps-8.7.8.tar.gz"
+    sha256 "f9120e8ffd8e9eba3095fc800c7cceca5017eadeedcc2e1e19d7c59082201cbc"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Unfortunately, I couldn’t convert the download URLs to `https`; the site
doesn’t seem to support it.  :(