### PR TITLE
Add support for installing fish completions

### DIFF
--- a/Library/Formula/pass.rb
+++ b/Library/Formula/pass.rb
@@ -22,6 +22,7 @@ class Pass < Formula
     share.install "contrib"
     zsh_completion.install "src/completion/pass.zsh-completion" => "_pass"
     bash_completion.install "src/completion/pass.bash-completion" => "password-store"
+    fish_completion.install "src/completion/pass.fish-completion" => "pass.fish"
   end
 
   test do

--- a/Library/Formula/task.rb
+++ b/Library/Formula/task.rb
@@ -18,6 +18,7 @@ class Task < Formula
     system "make", "install"
     bash_completion.install "scripts/bash/task.sh"
     zsh_completion.install "scripts/zsh/_task"
+    fish_completion.install "scripts/fish/task.fish"
   end
 
   test do

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -48,7 +48,7 @@ class Caveats
   end
 
   def fish_completion_caveats
-    if keg and keg.completion_installed? :fish then <<-EOS.undent
+    if keg and keg.completion_installed? :fish and which("fish") then <<-EOS.undent
       fish completion has been installed to:
         #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
       EOS

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -12,6 +12,7 @@ class Caveats
     caveats << f.keg_only_text if f.keg_only? && f.respond_to?(:keg_only_text)
     caveats << bash_completion_caveats
     caveats << zsh_completion_caveats
+    caveats << fish_completion_caveats
     caveats << plist_caveats
     caveats << python_caveats
     caveats << app_caveats
@@ -42,6 +43,14 @@ class Caveats
     if keg and keg.completion_installed? :zsh then <<-EOS.undent
       zsh completion has been installed to:
         #{HOMEBREW_PREFIX}/share/zsh/site-functions
+      EOS
+    end
+  end
+
+  def fish_completion_caveats
+    if keg and keg.completion_installed? :fish then <<-EOS.undent
+      fish completion has been installed to:
+        #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
       EOS
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -397,13 +397,19 @@ class Formula
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
-  def bash_completion; prefix+'etc/bash_completion.d' end
+  def bash_completion; prefix+'etc/bash_completion.d'    end
 
   # The directory where the formula's ZSH completion files should be
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
-  def zsh_completion;  share+'zsh/site-functions'     end
+  def zsh_completion;  share+'zsh/site-functions'        end
+
+  # The directory where the formula's fish completion files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def fish_completion; share+'fish/vendor_completions.d' end
 
   # The directory used for as the prefix for {#etc} and {#var} files on
   # installation so, despite not being in `HOMEBREW_CELLAR`, they are installed

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -218,6 +218,7 @@ class Keg
     dir = case shell
           when :bash then path.join("etc", "bash_completion.d")
           when :zsh  then path.join("share", "zsh", "site-functions")
+          when :fish then path.join("share", "fish", "vendor_completions.d")
           end
     dir && dir.directory? && dir.children.any?
   end


### PR DESCRIPTION
This pull request introduces support for installing completions for the fish shell comparable to bash and zsh completions. I have adapted formulae where I know about existing fish completions accordingly. Would be glad if this was accepted.