### PR TITLE
fontforge: add option to install extra tools

### DIFF
--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -11,6 +11,7 @@ class Fontforge < Formula
   end
 
   option "with-giflib", "Build with GIF support"
+  option "with-extra-tools", "Build with additional font tools"
 
   deprecated_option "with-x" => "with-x11"
   deprecated_option "with-gif" => "with-giflib"
@@ -85,6 +86,14 @@ class Fontforge < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
+
+    if build.with? "extra-tools"
+      cd "contrib/fonttools" do
+        system "make"
+        bin.install Dir["*"].select { |f| File.executable? f }
+      end
+    end
+
     # The name is case-sensitive. Don't downcase it when linking.
     ln_s "#{share}/fontforge/osx/FontForge.app", prefix if build.with? "x11"
   end


### PR DESCRIPTION
Adds an option to install the extra Font tools. These used to be part of Fontforge by default but were moved to an optional location last year. I believe they are still packaged if you do `make dist` but obviously, we don't.

Upstream requested we add the option, and it's potentially quite useful, so here's a PR.