### PR TITLE
Gems,-Eggs-and-Perl-Modules: link to MetaCPAN

### DIFF
--- a/share/doc/homebrew/Gems,-Eggs-and-Perl-Modules.md
+++ b/share/doc/homebrew/Gems,-Eggs-and-Perl-Modules.md
@@ -107,14 +107,14 @@ Perl CPAN Modules without sudo
 The Perl module local::lib works similarly to rbenv/RVM (although for
 modules only, not perl installations). A simple solution that only
 pollutes your /Library/Perl a little is to install
-[local::lib](http://search.cpan.org/search?query=local::lib) with sudo:
+[local::lib](https://metacpan.org/pod/local::lib) with sudo:
 
 `sudo cpan local::lib`
 
 Note that will install some other dependencies like `Module::Install`.
 Then put the appropriate incantation in your shell’s startup, e.g. for
 `.bash_profile` you insert the below, for others see the
-[local::lib](http://search.cpan.org/search?query=local::lib) docs.
+[local::lib](https://metacpan.org/pod/local::lib) docs.
 
 `eval $(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)`
 


### PR DESCRIPTION
Link to MetaCPAN.org instead of search.cpan.org. MetaCPAN is the community-maintained web portal to CPAN, while search.cpan.org is the historic but proprietary one.