### PR TITLE
gtk-doc 1.23

### DIFF
--- a/Library/Formula/gtk-doc.rb
+++ b/Library/Formula/gtk-doc.rb
@@ -1,7 +1,7 @@
 class GtkDoc < Formula
   homepage "http://www.gtk.org/gtk-doc/"
-  url "https://download.gnome.org/sources/gtk-doc/1.22/gtk-doc-1.22.tar.xz"
-  sha256 "932865c912ce0d81c9480bf957d3908bae6e18c0cf2ee33014d63b920047fca8"
+  url "https://download.gnome.org/sources/gtk-doc/1.23/gtk-doc-1.23.tar.xz"
+  sha256 "0b5c23711166c10ff5c74603db80ac26c2b9a382ce778b0e795db821d50718c4"
 
   bottle do
     sha256 "654ae76d5e15f8461dbfd0be4ed8c52d67e7cc2dd4e8f4fc893fc9e5feedcd2f" => :yosemite


### PR DESCRIPTION
version bump
audit --strict reports that this is a development release but this is not true!