### PR TITLE
jdnssec-tools 0.12

### DIFF
--- a/Library/Formula/jdnssec-tools.rb
+++ b/Library/Formula/jdnssec-tools.rb
@@ -15,7 +15,15 @@ class JdnssecTools < Formula
   end
 
   test do
-    (testpath/"powerdns.com.key").write("powerdns.com.   10773 IN  DNSKEY  257 3 8 AwEAAb/+pXOZWYQ8mv9WM5dFva8WU9jcIUdDuEjldbyfnkQ/xlrJC5zA EfhYhrea3SmIPmMTDimLqbh3/4SMTNPTUF+9+U1vpNfIRTFadqsmuU9F ddz3JqCcYwEpWbReg6DJOeyu+9oBoIQkPxFyLtIXEPGlQzrynKubn04C x83I6NfzDTraJT3jLHKeW5PVc1ifqKzHz5TXdHHTA7NkJAa0sPcZCoNE 1LpnJI/wcUpRUiuQhoLFeT1E432GuPuZ7y+agElGj0NnBxEgnHrhrnZW UbULpRa/il+Cr5Taj988HqX9Xdm6FjcP4Lbuds/44U7U8du224Q8jTrZ 57Yvj4VDQKc=")
-    assert_match /D4C3D5552B8679FAEEBC317E5F048B614B2E5F607DC57F1553182D49AB2179F7/, shell_output("#{bin}/jdnssec-dstool -d 2 powerdns.com.key")
+    (testpath/"powerdns.com.key").write(
+      "powerdns.com.   10773 IN  DNSKEY  257 3 8 (AwEAAb/+pXOZWYQ8mv9WM5dFva8
+      WU9jcIUdDuEjldbyfnkQ/xlrJC5zA EfhYhrea3SmIPmMTDimLqbh3/4SMTNPTUF+9+U1vp
+      NfIRTFadqsmuU9F ddz3JqCcYwEpWbReg6DJOeyu+9oBoIQkPxFyLtIXEPGlQzrynKubn04
+      Cx83I6NfzDTraJT3jLHKeW5PVc1ifqKzHz5TXdHHTA7NkJAa0sPcZCoNE 1LpnJI/wcUpRU
+      iuQhoLFeT1E432GuPuZ7y+agElGj0NnBxEgnHrhrnZW UbULpRa/il+Cr5Taj988HqX9Xdm
+      6FjcP4Lbuds/44U7U8du224Q8jTrZ 57Yvj4VDQKc=)")
+
+    assert_match /D4C3D5552B8679FAEEBC317E5F048B614B2E5F607DC57F1553182D49AB2179F7/,
+      shell_output("#{bin}/jdnssec-dstool -d 2 powerdns.com.key")
   end
 end

--- a/Library/Formula/jdnssec-tools.rb
+++ b/Library/Formula/jdnssec-tools.rb
@@ -1,0 +1,21 @@
+class JdnssecTools < Formula
+  desc "Java command-line tools for DNSSEC"
+  homepage "http://www.verisignlabs.com/jdnssec-tools/"
+  url "http://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.12.tar.gz"
+  sha256 "3fa0bfe062051d9048c5186adbb04d8f5e176e50da3cdcf9b0d97e1c558efc22"
+
+  depends_on :java
+
+  def install
+    inreplace Dir["bin/*"] do |s|
+      s.gsub! /basedir=.*/, "basedir=#{libexec}"
+    end
+    bin.install Dir["bin/*"]
+    (libexec/"lib").install Dir["lib/*"]
+  end
+
+  test do
+    (testpath/"powerdns.com.key").write("powerdns.com.   10773 IN  DNSKEY  257 3 8 AwEAAb/+pXOZWYQ8mv9WM5dFva8WU9jcIUdDuEjldbyfnkQ/xlrJC5zA EfhYhrea3SmIPmMTDimLqbh3/4SMTNPTUF+9+U1vpNfIRTFadqsmuU9F ddz3JqCcYwEpWbReg6DJOeyu+9oBoIQkPxFyLtIXEPGlQzrynKubn04C x83I6NfzDTraJT3jLHKeW5PVc1ifqKzHz5TXdHHTA7NkJAa0sPcZCoNE 1LpnJI/wcUpRUiuQhoLFeT1E432GuPuZ7y+agElGj0NnBxEgnHrhrnZW UbULpRa/il+Cr5Taj988HqX9Xdm6FjcP4Lbuds/44U7U8du224Q8jTrZ 57Yvj4VDQKc=")
+    assert_match /D4C3D5552B8679FAEEBC317E5F048B614B2E5F607DC57F1553182D49AB2179F7/, shell_output("#{bin}/jdnssec-dstool -d 2 powerdns.com.key")
+  end
+end


### PR DESCRIPTION
This is a binary (jar) formula - I tried building from source but this project uses ant instead of maven so that would mean also packaging up two dependencies which seemed like overkill to me - and to make it worse, the author forked those dependencies in an incompatible way to their originals.
