### PR TITLE
Gtk+ goes quartz-only

### DIFF
--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -1,11 +1,10 @@
-require "formula"
-
 class Cairo < Formula
   desc "Vector graphics library with cross-device output support"
   homepage "http://cairographics.org/"
   url "http://cairographics.org/releases/cairo-1.14.2.tar.xz"
   mirror "http://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/cairo-1.14.2.tar.xz"
   sha256 "c919d999ddb1bbbecd4bbe65299ca2abd2079c7e13d224577895afa7005ecceb"
+  revision 1
 
   bottle do
     sha256 "86672344ecd86346a890952f6038e943d95080d15d9eafc06e417fd6dc301791" => :yosemite
@@ -23,7 +22,6 @@ class Cairo < Formula
   depends_on "libpng"
   depends_on "pixman"
   depends_on "glib"
-  depends_on :x11 => :recommended
 
   def install
     ENV.universal_binary if build.universal?
@@ -34,18 +32,49 @@ class Cairo < Formula
       --enable-gobject=yes
       --enable-svg=yes
       --enable-tee=yes
-      --with-x
+      --enable-xlib=no
+      --enable-xlib-xrender=no
+      --enable-quartz-image
     ]
-
-    if build.without? "x11"
-      args.delete "--with-x"
-      args << "--enable-xlib=no" << "--enable-xlib-xrender=no"
-      args << "--enable-quartz-image"
-    end
 
     args << "--enable-xcb=no" if MacOS.version <= :leopard
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <cairo.h>
+
+      int main(int argc, char *argv[]) {
+
+        cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 600, 400);
+        cairo_t *context = cairo_create(surface);
+
+        return 0;
+      }
+    EOS
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    libpng = Formula["libpng"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/cairo
+      -I#{libpng.opt_include}/libpng16
+      -I#{pixman.opt_include}/pixman-1
+      -L#{lib}
+      -lcairo
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/cairomm.rb
+++ b/Library/Formula/cairomm.rb
@@ -3,6 +3,7 @@ class Cairomm < Formula
   homepage "http://cairographics.org/cairomm/"
   url "http://cairographics.org/releases/cairomm-1.11.2.tar.gz"
   sha256 "ccf677098c1e08e189add0bd146f78498109f202575491a82f1815b6bc28008d"
+  revision 1
 
   bottle do
     sha256 "0de6d6e44c5e25a7c74cf8e7e0a57f96354603b57ef81550f2862cf44f2826d5" => :yosemite
@@ -11,8 +12,6 @@ class Cairomm < Formula
   end
 
   option :cxx11
-
-  deprecated_option "without-x" => "without-x11"
 
   depends_on "pkg-config" => :build
   if build.cxx11?
@@ -23,7 +22,6 @@ class Cairomm < Formula
 
   depends_on "libpng"
   depends_on "cairo"
-  depends_on :x11 => :recommended
 
   def install
     ENV.cxx11 if build.cxx11?

--- a/Library/Formula/cogl.rb
+++ b/Library/Formula/cogl.rb
@@ -3,6 +3,7 @@ class Cogl < Formula
   homepage "https://developer.gnome.org/cogl/"
   url "https://download.gnome.org/sources/cogl/1.20/cogl-1.20.0.tar.xz"
   sha256 "729e35495829e7d31fafa3358e47b743ba21a2b08ff9b6cd28fb74c0de91192b"
+  revision 1
 
   bottle do
     sha256 "16b476d5d5d34c5dadd575e7ae9e6b526043083d574eadb92ae11f1642dc6fab" => :yosemite
@@ -23,9 +24,6 @@ class Cogl < Formula
   depends_on "gobject-introspection"
   depends_on "gtk-doc"
   depends_on "pango"
-
-  depends_on :x11 => ["2.5.1", :recommended]
-  deprecated_option "without-x" => "without-x11"
 
   # Lion's grep fails, which later results in compilation failures:
   # libtool: link: /usr/bin/grep -E -e [really long regexp] ".libs/libcogl.exp" > ".libs/libcogl.expT"
@@ -59,8 +57,8 @@ class Cogl < Formula
       --enable-cogl-pango=yes
       --enable-introspection=yes
       --disable-glx
+      --without-x
     ]
-    args << "--without-x" if build.without? "x11"
 
     if build.head?
       system "./autogen.sh", *args

--- a/Library/Formula/diffuse.rb
+++ b/Library/Formula/diffuse.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Diffuse < Formula
   desc "Graphical tool for merging and comparing text files"
   homepage "http://diffuse.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/diffuse/diffuse/0.4.8/diffuse-0.4.8.tar.bz2"
-  sha1 "473f7e82f57cc3a5ce0378eea8aede19a3f2a9df"
+  sha256 "c1d3b79bba9352fcb9aa4003537d3fece248fb824781c5e21f3fcccafd42df2b"
 
   depends_on "pygtk"
 

--- a/Library/Formula/etl.rb
+++ b/Library/Formula/etl.rb
@@ -1,14 +1,30 @@
-require "formula"
-
 class Etl < Formula
   desc "Extensible Template Library"
   homepage "http://synfig.org"
-  url "https://downloads.sourceforge.net/project/synfig/releases/0.64.3/source/ETL-0.04.17.tar.gz"
-  sha1 "cb7e83534274ef53ce841e8924f92048593e0cea"
+  url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/ETL-0.04.18.tar.gz"
+  sha256 "53953e477a37d2e870e3be4b22f519474c24537b0e6eb1633e3402273a684a98"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <ETL/misc>
+      int main(int argc, char *argv[])
+      {
+        int rv = etl::ceil_to_int(5.5);
+        return 6 - rv;
+      }
+    EOS
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{include}
+      -lpthread
+    ]
+    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -4,6 +4,7 @@ class Fontforge < Formula
   url "https://github.com/fontforge/fontforge/archive/20150430.tar.gz"
   sha256 "430c6d02611c7ca948df743e9241994efe37eda25f81a94aeadd9b6dd286ff37"
   head "https://github.com/fontforge/fontforge.git"
+  revision 1
 
   bottle do
     sha256 "db55b0a73b4851077da8dfd48c39675f05eaf437323acccf56602779b21cf414" => :yosemite
@@ -14,7 +15,6 @@ class Fontforge < Formula
   option "with-giflib", "Build with GIF support"
   option "with-extra-tools", "Build with additional font tools"
 
-  deprecated_option "with-x" => "with-x11"
   deprecated_option "with-gif" => "with-giflib"
 
   # Autotools are required to build from source in all releases.
@@ -32,7 +32,6 @@ class Fontforge < Formula
   depends_on "libtiff" => :recommended
   depends_on "giflib" => :optional
   depends_on "libspiro" => :optional
-  depends_on :x11 => :optional
   depends_on :python if MacOS.version <= :snow_leopard
 
   # This may be causing font-display glitches and needs further isolation & fixing.
@@ -47,9 +46,9 @@ class Fontforge < Formula
 
   def install
     if MacOS.version <= :snow_leopard || !build.bottle?
-      pydir = "#{%x(python-config --prefix).chomp}"
+      pydir = `python-config --prefix`.chomp
     else
-      pydir = "#{%x(/usr/bin/python-config --prefix).chomp}"
+      pydir = `/usr/bin/python-config --prefix`.chomp
     end
 
     args = %W[
@@ -57,13 +56,8 @@ class Fontforge < Formula
       --disable-silent-rules
       --disable-dependency-tracking
       --with-pythonbinary=#{pydir}/bin/python2.7
+      --without-x
     ]
-
-    if build.with? "x11"
-      args << "--with-x"
-    else
-      args << "--without-x"
-    end
 
     args << "--without-libpng" if build.without? "libpng"
     args << "--without-libjpeg" if build.without? "jpeg"
@@ -94,9 +88,6 @@ class Fontforge < Formula
         bin.install Dir["*"].select { |f| File.executable? f }
       end
     end
-
-    # The name is case-sensitive. Don't downcase it when linking.
-    ln_s "#{share}/fontforge/osx/FontForge.app", prefix if build.with? "x11"
   end
 
   test do

--- a/Library/Formula/gabedit.rb
+++ b/Library/Formula/gabedit.rb
@@ -1,11 +1,10 @@
-require "formula"
-
 class Gabedit < Formula
   desc "GUI to computational chemistry packages like Gamess-US, Gaussian, etc."
   homepage "http://gabedit.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/gabedit/gabedit/Gabedit248/GabeditSrc248.tar.gz"
   version "2.4.8"
-  sha1 "7a48f42c39258471faa0a3942890c16b6290de41"
+  sha256 "38d6437a18280387b46fd136f2201a73b33e45abde13fa802c64806b6b64e4d3"
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"
@@ -16,5 +15,9 @@ class Gabedit < Formula
     args << "OMPLIB=" << "OMPCFLAGS=" if ENV.compiler == :clang
     system "make", *args
     bin.install "gabedit"
+  end
+
+  test do
+    assert (bin/"gabedit").exist?
   end
 end

--- a/Library/Formula/gbdfed.rb
+++ b/Library/Formula/gbdfed.rb
@@ -1,21 +1,27 @@
-require 'formula'
-
 class Gbdfed < Formula
   desc "Bitmap Font Editor"
-  homepage 'http://sofia.nmsu.edu/~mleisher/Software/gbdfed/'
-  url 'http://sofia.nmsu.edu/~mleisher/Software/gbdfed/gbdfed-1.6.tar.gz'
-  sha1 '733afccc43273d3385f8b9bc9d6334bcaa4403ae'
+  homepage "http://sofia.nmsu.edu/~mleisher/Software/gbdfed/"
+  url "http://sofia.nmsu.edu/~mleisher/Software/gbdfed/gbdfed-1.6.tar.gz"
+  sha256 "8042575d23a55a3c38192e67fcb5eafd8f7aa8d723012c374acb2e0a36022943"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
 
   # Fixes compilation error with gtk+ per note on the project homepage.
   patch :DATA
 
   def install
+    # BDF_NO_X11 has to be defined to avoid X11 headers from being included
+    ENV["CPPFLAGS"] = "-DBDF_NO_X11"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make install"
+                          "--prefix=#{prefix}", "--without-x"
+    system "make", "install"
+  end
+
+  test do
+    assert (bin/"gbdfed").exist?
+    assert (share/"man/man1/gbdfed.1").exist?
   end
 end
 

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -5,6 +5,7 @@ class GdkPixbuf < Formula
   homepage 'http://gtk.org'
   url 'http://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz'
   sha256 '4853830616113db4435837992c0aebd94cbb993c44dc55063cee7f72a7bef8be'
+  revision 1
 
   bottle do
     revision 1

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -5,7 +5,6 @@ class GdkPixbuf < Formula
   homepage 'http://gtk.org'
   url 'http://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.30/gdk-pixbuf-2.30.8.tar.xz'
   sha256 '4853830616113db4435837992c0aebd94cbb993c44dc55063cee7f72a7bef8be'
-  revision 1
 
   bottle do
     revision 1

--- a/Library/Formula/gdmap.rb
+++ b/Library/Formula/gdmap.rb
@@ -1,33 +1,31 @@
-require 'formula'
-
 class Gdmap < Formula
   desc "Tool to inspect the used space of folders"
-  homepage 'http://sourceforge.net/projects/gdmap/'
-  url 'https://downloads.sourceforge.net/project/gdmap/gdmap/0.8.1/gdmap-0.8.1.tar.gz'
-  sha1 'd97cc7c107dbaf9f3f3ed22ee6cef6172c115295'
+  homepage "http://sourceforge.net/projects/gdmap/"
+  url "https://downloads.sourceforge.net/project/gdmap/gdmap/0.8.1/gdmap-0.8.1.tar.gz"
+  sha256 "a200c98004b349443f853bf611e49941403fce46f2335850913f85c710a2285b"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'gettext'
-  depends_on 'glib'
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gtk+"
 
-  #The code depends on some GTK macros that are flagged as deprecated in the brew version of GTK.
-  #I assume they're not deprecated in normal GTK, because the config file disables deprecated GDK calls.
-  #The first patch turns off this disablement, making the code work fine as intended
-  #The second patch is to remove an unused system header import on one of the files.
-  #This header file doesn't exist in OSX and the program compiles and runs fine without it.
+  # The code depends on some GTK macros that are flagged as deprecated in the brew version of GTK.
+  # I assume they're not deprecated in normal GTK, because the config file disables deprecated GDK calls.
+  # The first patch turns off this disablement, making the code work fine as intended
+  # The second patch is to remove an unused system header import on one of the files.
+  # This header file doesn't exist in OSX and the program compiles and runs fine without it.
   patch :DATA
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
 
-    system "make install"
+    system "make", "install"
   end
 
   test do
-    system "#{bin}/gdmap"
+    system "#{bin}/gdmap", "--help"
   end
 end
 

--- a/Library/Formula/gdmap.rb
+++ b/Library/Formula/gdmap.rb
@@ -15,6 +15,7 @@ class Gdmap < Formula
   # The first patch turns off this disablement, making the code work fine as intended
   # The second patch is to remove an unused system header import on one of the files.
   # This header file doesn't exist in OSX and the program compiles and runs fine without it.
+  # Filed bug upstream as https://sourceforge.net/p/gdmap/bugs/19/
   patch :DATA
 
   def install

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -3,6 +3,7 @@ class GnomeIconTheme < Formula
   homepage "https://developer.gnome.org"
   url "https://download.gnome.org/sources/adwaita-icon-theme/3.16/adwaita-icon-theme-3.16.2.1.tar.xz"
   sha256 "b4556dfbf555d4fac12d4d5c12f7519de0d43ec42a1b649611439a50bf7acb96"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -3,7 +3,6 @@ class GnomeIconTheme < Formula
   homepage "https://developer.gnome.org"
   url "https://download.gnome.org/sources/adwaita-icon-theme/3.16/adwaita-icon-theme-3.16.2.1.tar.xz"
   sha256 "b4556dfbf555d4fac12d4d5c12f7519de0d43ec42a1b649611439a50bf7acb96"
-  revision 1
 
   bottle do
     cellar :any
@@ -20,7 +19,6 @@ class GnomeIconTheme < Formula
   depends_on "librsvg"
 
   def install
-    ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "GTK_UPDATE_ICON_CACHE=#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache"

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -20,6 +20,7 @@ class GnomeIconTheme < Formula
   depends_on "librsvg"
 
   def install
+    ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "GTK_UPDATE_ICON_CACHE=#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache"

--- a/Library/Formula/goffice.rb
+++ b/Library/Formula/goffice.rb
@@ -3,6 +3,7 @@ class Goffice < Formula
   homepage "https://developer.gnome.org/goffice/"
   url "https://download.gnome.org/sources/goffice/0.10/goffice-0.10.22.tar.xz"
   sha256 "0206a87a323b52a874dc54491374245f9e1c5f62e93a2ce4a02fb444a26b0e28"
+  revision 1
 
   bottle do
     revision 2
@@ -39,7 +40,6 @@ class Goffice < Formula
   depends_on "librsvg"
   depends_on "pango"
   depends_on "pcre"
-  depends_on :x11
 
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]

--- a/Library/Formula/gqview.rb
+++ b/Library/Formula/gqview.rb
@@ -1,18 +1,21 @@
-require 'formula'
-
 class Gqview < Formula
   desc "GQview image browser"
-  homepage 'http://gqview.sourceforge.net'
-  url 'https://downloads.sourceforge.net/project/gqview/gqview/2.0.4/gqview-2.0.4.tar.gz'
-  sha1 'aae8f1cdae60441472a52d594cb42572d0d79eeb'
+  homepage "http://gqview.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/gqview/gqview/2.0.4/gqview-2.0.4.tar.gz"
+  sha256 "97e3b7ce5f17a315c56d6eefd7b3a60b40cc3d18858ca194c7e7262acce383cb"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/gqview", "--version"
   end
 end

--- a/Library/Formula/grsync.rb
+++ b/Library/Formula/grsync.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Grsync < Formula
   desc "GUI for rsync"
-  homepage "http://sourceforge.net/projects/grsync/"
+  homepage "http://www.opbyte.it/grsync/"
   url "https://downloads.sourceforge.net/project/grsync/grsync-1.2.5.tar.gz"
   sha256 "4f1443154f7c85ca7b0e93d5fea438e2709776005e7cfc97da89f4899b1c12e5"
+  revision 1
 
   bottle do
     sha1 "2f246934c2877a3afc7259676f24657f100e825c" => :mavericks
@@ -17,12 +16,17 @@ class Grsync < Formula
   depends_on "gettext"
   depends_on "gtk+"
 
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-unity",
                           "--prefix=#{prefix}"
 
     system "make", "install"
+  end
+
+  test do
+    # running the executable always produces the GUI, which is undesirable for the test
+    # so we'll just check if the executable exists
+    assert (bin/"grsync").exist?
   end
 end

--- a/Library/Formula/gst-python.rb
+++ b/Library/Formula/gst-python.rb
@@ -3,7 +3,6 @@ class GstPython < Formula
   homepage "http://gstreamer.freedesktop.org/modules/gst-python.html"
   url "http://gstreamer.freedesktop.org/src/gst-python/gst-python-1.4.0.tar.xz"
   sha256 "b1e40c29ceb41b03f08d38aca6056054f0341d0706276326dceeec6ac8d53d3e"
-  revision 1
 
   bottle do
     sha256 "e27ac3a525070e5e9dbbd1128c5913c0e35d10efbff18eb2f5777e30323c45a9" => :yosemite
@@ -12,7 +11,6 @@ class GstPython < Formula
   end
 
   depends_on "gst-plugins-base"
-  depends_on "pygtk"
   depends_on "pygobject3"
 
   def install

--- a/Library/Formula/gst-python.rb
+++ b/Library/Formula/gst-python.rb
@@ -3,6 +3,7 @@ class GstPython < Formula
   homepage "http://gstreamer.freedesktop.org/modules/gst-python.html"
   url "http://gstreamer.freedesktop.org/src/gst-python/gst-python-1.4.0.tar.xz"
   sha256 "b1e40c29ceb41b03f08d38aca6056054f0341d0706276326dceeec6ac8d53d3e"
+  revision 1
 
   bottle do
     sha256 "e27ac3a525070e5e9dbbd1128c5913c0e35d10efbff18eb2f5777e30323c45a9" => :yosemite

--- a/Library/Formula/gtk+.rb
+++ b/Library/Formula/gtk+.rb
@@ -11,13 +11,14 @@ class Gtkx < Formula
     sha256 "67af28491ac9622e5c19b0d37802c9569e95ab21342b83672de0b6aac98c5c72" => :mountain_lion
   end
 
+  option "with-quartz-relocation", "Build with quartz relocation support"
+
   depends_on "pkg-config" => :build
   depends_on "gdk-pixbuf"
   depends_on "jasper" => :optional
   depends_on "atk"
   depends_on "pango"
   depends_on "gobject-introspection"
-  option "with-quartz-relocation"
 
   fails_with :llvm do
     build 2326

--- a/Library/Formula/gtk+.rb
+++ b/Library/Formula/gtk+.rb
@@ -3,6 +3,7 @@ class Gtkx < Formula
   homepage "http://gtk.org/"
   url "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.28.tar.xz"
   sha256 "b2c6441e98bc5232e5f9bba6965075dcf580a8726398f7374d39f90b88ed4656"
+  revision 1
 
   bottle do
     sha256 "bbc0dc6e82ebed36acfecbd5216a7e05709ce54353fae2e88ae6dc89d02b4c49" => :yosemite
@@ -15,8 +16,8 @@ class Gtkx < Formula
   depends_on "jasper" => :optional
   depends_on "atk"
   depends_on "pango"
-  depends_on :x11 => ["2.3.6", :recommended]
   depends_on "gobject-introspection"
+  option "with-quartz-relocation"
 
   fails_with :llvm do
     build 2326
@@ -29,10 +30,10 @@ class Gtkx < Formula
             "--prefix=#{prefix}",
             "--disable-glibtest",
             "--enable-introspection=yes",
+            "--with-gdktarget=quartz",
             "--disable-visibility"]
 
-    args << "--with-gdktarget=quartz" if build.without?("x11")
-    args << "--enable-quartz-relocation" if build.without?("x11")
+    args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
     system "./configure", *args
     system "make", "install"
@@ -54,7 +55,6 @@ class Gtkx < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    harfbuzz = Formula["harfbuzz"]
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
@@ -68,7 +68,6 @@ class Gtkx < Formula
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include
-      -I#{harfbuzz.opt_include}/harfbuzz
       -I#{include}/gtk-2.0
       -I#{libpng.opt_include}/libpng16
       -I#{lib}/gtk-2.0/include
@@ -77,8 +76,6 @@ class Gtkx < Formula
       -D_REENTRANT
       -L#{atk.opt_lib}
       -L#{cairo.opt_lib}
-      -L#{fontconfig.opt_lib}
-      -L#{freetype.opt_lib}
       -L#{gdk_pixbuf.opt_lib}
       -L#{gettext.opt_lib}
       -L#{glib.opt_lib}
@@ -86,18 +83,15 @@ class Gtkx < Formula
       -L#{pango.opt_lib}
       -latk-1.0
       -lcairo
-      -lfontconfig
-      -lfreetype
-      -lgdk-x11-2.0
+      -lgdk-quartz-2.0
       -lgdk_pixbuf-2.0
       -lgio-2.0
       -lglib-2.0
       -lgobject-2.0
-      -lgtk-x11-2.0
+      -lgtk-quartz-2.0
       -lintl
       -lpango-1.0
       -lpangocairo-1.0
-      -lpangoft2-1.0
     ]
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Library/Formula/gtk-engines.rb
+++ b/Library/Formula/gtk-engines.rb
@@ -18,9 +18,9 @@ class GtkEngines < Formula
   end
 
   test do
-    ENV["GTK2_RC_FILES"] = "#{share}/themes/Clearlooks/gtk-2.0/gtkrc"
-    ENV["GTK_PATH"] = "#{HOMEBREW_PREFIX}/lib/gtk-2.0"
-    system "#{HOMEBREW_PREFIX}/bin/gtk-demo"
+    assert (share/"gtk-engines/clearlooks.xml").exist?
+    assert (lib/"gtk-2.0/2.10.0/engines/libhcengine.so").exist?
+    assert (share/"themes/Industrial/gtk-2.0/gtkrc").exist?
   end
 
   def caveats; <<-EOS.undent

--- a/Library/Formula/gtk-engines.rb
+++ b/Library/Formula/gtk-engines.rb
@@ -1,26 +1,25 @@
-require 'formula'
-
 class GtkEngines < Formula
   desc "Themes for GTK+"
-  homepage 'http://git.gnome.org/browse/gtk-engines/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/gtk-engines/2.20/gtk-engines-2.20.2.tar.bz2'
-  sha1 '574c7577d70eaacecd2ffa14e288ef88fdcb6c2a'
+  homepage "https://git.gnome.org/browse/gtk-engines/"
+  url "https://download.gnome.org/sources/gtk-engines/2.20/gtk-engines-2.20.2.tar.bz2"
+  sha256 "15b680abca6c773ecb85253521fa100dd3b8549befeecc7595b10209d62d66b5"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'gettext'
-  depends_on 'cairo'
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "cairo"
+  depends_on "gtk+"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 
   test do
-    ENV['GTK2_RC_FILES'] = "#{share}/themes/Clearlooks/gtk-2.0/gtkrc"
-    ENV['GTK_PATH'] = "#{HOMEBREW_PREFIX}/lib/gtk-2.0"
+    ENV["GTK2_RC_FILES"] = "#{share}/themes/Clearlooks/gtk-2.0/gtkrc"
+    ENV["GTK_PATH"] = "#{HOMEBREW_PREFIX}/lib/gtk-2.0"
     system "#{HOMEBREW_PREFIX}/bin/gtk-demo"
   end
 

--- a/Library/Formula/gtk-gnutella.rb
+++ b/Library/Formula/gtk-gnutella.rb
@@ -1,8 +1,8 @@
 class GtkGnutella < Formula
   desc "Share files in a peer-to-peer (P2P) network"
   homepage "http://gtk-gnutella.sourceforge.net/en/?page=news"
-  url "https://downloads.sourceforge.net/project/gtk-gnutella/gtk-gnutella/1.1.1/gtk-gnutella-1.1.1.tar.bz2"
-  sha1 "aa4f21fe758f7ac52c15ee0156247443ce8c7d6f"
+  url "https://downloads.sourceforge.net/project/gtk-gnutella/gtk-gnutella/1.1.3/gtk-gnutella-1.1.3.tar.bz2"
+  sha256 "2659ddb846f60d13789674e926a71bbb4a8b9d3ca98c6b034a95eaa073531405"
 
   bottle do
     revision 1
@@ -21,5 +21,9 @@ class GtkGnutella < Formula
     system "make", "install"
     rm_rf share+"pixmaps"
     rm_rf share+"applications"
+  end
+
+  test do
+    system "#{bin}/gtk-gnutella", "--version"
   end
 end

--- a/Library/Formula/gtk-mac-integration.rb
+++ b/Library/Formula/gtk-mac-integration.rb
@@ -1,0 +1,88 @@
+class GtkMacIntegration < Formula
+  homepage "https://wiki.gnome.org/Projects/GTK+/OSX/Integration"
+  url "https://download.gnome.org/sources/gtk-mac-integration/2.0/gtk-mac-integration-2.0.8.tar.xz"
+  sha256 "74fce9dbc5efe4e3d07a20b24796be1b1d6c3ac10a0ee6b1f1d685c809071b79"
+
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
+  depends_on "gtk+3" => :recommended
+
+  def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-gtk2
+      --enable-python=no
+      --enable-introspection=no
+    ]
+
+    args << ((build.without? "gtk+3") ? "--without-gtk3" : "--with-gtk3")
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtkosxapplication.h>
+
+      int main(int argc, char *argv[]) {
+        gchar *bundle = gtkosx_application_get_bundle_path();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/gtkmacintegration
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -DMAC_INTEGRATION
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkmacintegration-gtk2
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Library/Formula/gtk-mac-integration.rb
+++ b/Library/Formula/gtk-mac-integration.rb
@@ -1,4 +1,5 @@
 class GtkMacIntegration < Formula
+  desc "API to integrate GTK OS X applications with the Mac desktop"
   homepage "https://wiki.gnome.org/Projects/GTK+/OSX/Integration"
   url "https://download.gnome.org/sources/gtk-mac-integration/2.0/gtk-mac-integration-2.0.8.tar.xz"
   sha256 "74fce9dbc5efe4e3d07a20b24796be1b1d6c3ac10a0ee6b1f1d685c809071b79"

--- a/Library/Formula/gtk-murrine-engine.rb
+++ b/Library/Formula/gtk-murrine-engine.rb
@@ -1,20 +1,24 @@
-require 'formula'
-
 class GtkMurrineEngine < Formula
   desc "Murrine GTK+ engine"
-  homepage 'https://github.com/GNOME/murrine'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/murrine/0.98/murrine-0.98.2.tar.xz'
-  sha1 'ddaca56b6e10736838572014ae9d20b814242615'
+  homepage "https://github.com/GNOME/murrine"
+  url "https://download.gnome.org/sources/murrine/0.98/murrine-0.98.2.tar.xz"
+  sha256 "e9c68ae001b9130d0f9d1b311e8121a94e5c134b82553ba03971088e57d12c89"
+  revision 1
 
-  depends_on 'intltool' => :build
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
-  depends_on 'gettext'
+  depends_on "intltool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
+  depends_on "gettext"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-animation"
     system "make", "install"
+  end
+
+  test do
+    assert (lib/"gtk-2.0/2.10.0/engines/libmurrine.so").exist?
+    assert (share/"gtk-engines/murrine.xml").exist?
   end
 end

--- a/Library/Formula/gtkdatabox.rb
+++ b/Library/Formula/gtkdatabox.rb
@@ -1,14 +1,12 @@
-require 'formula'
-
 class Gtkdatabox < Formula
   desc "Widget for live display of large amounts of changing data"
-  homepage 'http://sourceforge.net/projects/gtkdatabox/'
-  url 'https://downloads.sourceforge.net/project/gtkdatabox/gtkdatabox/0.9.2.0/gtkdatabox-0.9.2.0.tar.gz'
-  sha1 'a2cb25c1aa1b817283a3da9598d6d1d6e702d58f'
+  homepage "http://sourceforge.net/projects/gtkdatabox/"
+  url "https://downloads.sourceforge.net/project/gtkdatabox/gtkdatabox/0.9.2.0/gtkdatabox-0.9.2.0.tar.gz"
+  sha256 "745a6843e8f790504a86ad1b8642e1a9e595d75586215e0d2cb2f0bf0a324040"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
-  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -16,9 +14,71 @@ class Gtkdatabox < Formula
     # We need to re-enable deprecated features of gtk
     # in order to build without errors
     # Will be fixed in the next upstream release
-    inreplace 'gtk/Makefile', '-DGTK_DISABLE_DEPRECATED', ''
-    inreplace 'examples/Makefile', '-DGTK_DISABLE_DEPRECATED', ''
+    inreplace "gtk/Makefile", "-DGTK_DISABLE_DEPRECATED", ""
+    inreplace "examples/Makefile", "-DGTK_DISABLE_DEPRECATED", ""
 
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtkdatabox.h>
+
+      int main(int argc, char *argv[]) {
+        GtkWidget *db = gtk_databox_new();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkdatabox
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/gtkextra.rb
+++ b/Library/Formula/gtkextra.rb
@@ -3,6 +3,7 @@ class Gtkextra < Formula
   homepage "http://gtkextra.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/gtkextra/3.1/gtkextra-3.1.3.tar.gz"
   sha256 "eb8bbfd31ec5d73face8939d19f9951293dd99183050aab4f781549964c2692f"
+  revision 1
 
   bottle do
     cellar :any
@@ -41,7 +42,6 @@ class Gtkextra < Formula
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     gtkx = Formula["gtk+"]
-    harfbuzz = Formula["harfbuzz"]
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
@@ -57,7 +57,6 @@ class Gtkextra < Formula
       -I#{glib.opt_lib}/glib-2.0/include
       -I#{gtkx.opt_include}/gtk-2.0
       -I#{gtkx.opt_lib}/gtk-2.0/include
-      -I#{harfbuzz.opt_include}/harfbuzz
       -I#{include}/gtkextra-3.0
       -I#{libpng.opt_include}/libpng16
       -I#{pango.opt_include}/pango-1.0
@@ -65,8 +64,6 @@ class Gtkextra < Formula
       -D_REENTRANT
       -L#{atk.opt_lib}
       -L#{cairo.opt_lib}
-      -L#{fontconfig.opt_lib}
-      -L#{freetype.opt_lib}
       -L#{gdk_pixbuf.opt_lib}
       -L#{gettext.opt_lib}
       -L#{glib.opt_lib}
@@ -75,19 +72,16 @@ class Gtkextra < Formula
       -L#{pango.opt_lib}
       -latk-1.0
       -lcairo
-      -lfontconfig
-      -lfreetype
-      -lgdk-x11-2.0
+      -lgdk-quartz-2.0
       -lgdk_pixbuf-2.0
       -lgio-2.0
       -lglib-2.0
       -lgobject-2.0
-      -lgtk-x11-2.0
-      -lgtkextra-x11-3.0
+      -lgtk-quartz-2.0
+      -lgtkextra-quartz-3.0
       -lintl
       -lpango-1.0
       -lpangocairo-1.0
-      -lpangoft2-1.0
     ]
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Library/Formula/gtkglext.rb
+++ b/Library/Formula/gtkglext.rb
@@ -18,6 +18,8 @@ class Gtkglext < Formula
   depends_on "gtk+"
   depends_on "pangox-compat"
 
+  # all these MacPorts patches have already been included upstream. A new release of gtkglext
+  # for gtk+2.0 remains uncertain though.
   patch :p0 do
     url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-configure.diff"
     sha256 "aca35cd6ae28613b375301068715f82b59bd066a32b2f4d046177478950ab026"

--- a/Library/Formula/gtkglext.rb
+++ b/Library/Formula/gtkglext.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Gtkglext < Formula
   desc "OpenGL extension to GTK+"
-  homepage 'http://projects.gnome.org/gtkglext/'
-  url 'https://downloads.sourceforge.net/gtkglext/gtkglext-1.2.0.tar.gz'
-  sha1 'db9ce38ee555fd14f55083ec7f4ae30e5338d5cc'
+  homepage "https://projects.gnome.org/gtkglext/"
+  url "https://download.gnome.org/sources/gtkglext/1.2/gtkglext-1.2.0.tar.gz"
+  sha256 "e5073f3c6b816e7fa67d359d9745a5bb5de94a628ac85f624c992925a46844f9"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,126 +13,133 @@ class Gtkglext < Formula
     sha1 "03c196737dbef40fef3bd51f7feba9040a039d3a" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'glib'
-  depends_on 'gtk+'
-  depends_on 'pangox-compat'
-  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "gtk+"
+  depends_on "pangox-compat"
 
-  # fixes an incompatibility with recent GTK versions
-  # patch from: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=585155
-  patch :DATA
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-configure.diff"
+    sha256 "aca35cd6ae28613b375301068715f82b59bd066a32b2f4d046177478950ab026"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-examples-pixmap-mixed.c.diff"
+    sha256 "d2fe00bfcf96b3c78dd4b01aa119a7860a34ca6080c57f0ccc7a8e2fc4a3c92b"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-examples-pixmap.c.diff"
+    sha256 "d955b18784d3e83c1f698e63875d98de5bad9eae1e84b66549dfe25d9ff94d51"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gdk-gdkglglext.h.diff"
+    sha256 "a1b6a97016013d5cda73760bbf2a970bae318153c2810291b81bd49ed67de80b"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gdk-gdkglquery.c.diff"
+    sha256 "a419b8d523f123d1ab59e4de1105cdfc72bf5a450db8031809dcbc84932b539f"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gdk-gdkglshapes.c.diff"
+    sha256 "bc01fccec833f7ede39ee06ecc2a2ad5d2b30cf703dc66d2a40a912104c6e1f5"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gdk-makefile.in.diff"
+    sha256 "d0bc857f258640bf4f423a79e8475e8cf86e24f9994c0a85475ce87f41bcded6"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gtk-gtkglwidget.c.diff"
+    sha256 "7f7918d5a83c8f36186026a92587117a94014e7b21203fe9eb96a1c751c3c317"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-gtk-makefile.in.diff"
+    sha256 "49f58421a12c2badd84ae6677752ba9cc23c249dac81987edf94abaf0d088ff6"
+  end
+
+  patch :p0 do
+    url "https://trac.macports.org/export/132848/trunk/dports/devel/gtkglext/files/patch-makefile.in.diff"
+    sha256 "0d112b417d6c51022e31701037aa49ea50f270d3a34c263599ac0ef64c2f6743"
+  end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make install"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--without-x"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtk/gtkgl.h>
+
+      int main(int argc, char *argv[]) {
+        int version_check = GTKGLEXT_CHECK_VERSION(1, 2, 0);
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/gtkglext-1.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{lib}/gtkglext-1.0/include
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgdkglext-quartz-1.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgmodule-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkglext-quartz-1.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -framework AppKit
+      -framework OpenGL
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end
-
-__END__
-diff --git a/examples/pixmap-mixed.c b/examples/pixmap-mixed.c
-index 2346afd..3e53f14 100644
---- a/examples/pixmap-mixed.c
-+++ b/examples/pixmap-mixed.c
-@@ -154,7 +154,7 @@ expose_event (GtkWidget      *widget,
-               gpointer        data)
- {
-   gdk_draw_drawable (widget->window,
--		     widget->style->fg_gc[GTK_WIDGET_STATE (widget)],
-+		     widget->style->fg_gc[gtk_widget_get_state (widget)],
- 		     pixmap,
- 		     event->area.x, event->area.y,
- 		     event->area.x, event->area.y,
-diff --git a/examples/pixmap.c b/examples/pixmap.c
-index 10e6fc1..a14a1b7 100644
---- a/examples/pixmap.c
-+++ b/examples/pixmap.c
-@@ -137,7 +137,7 @@ expose_event (GtkWidget      *widget,
-               gpointer        data)
- {
-   gdk_draw_drawable (widget->window,
--		     widget->style->fg_gc[GTK_WIDGET_STATE (widget)],
-+		     widget->style->fg_gc[gtk_widget_get_state (widget)],
- 		     pixmap,
- 		     event->area.x, event->area.y,
- 		     event->area.x, event->area.y,
-diff --git a/gtk/gtkglwidget.c b/gtk/gtkglwidget.c
-index 76a93d6..ca60626 100644
---- a/gtk/gtkglwidget.c
-+++ b/gtk/gtkglwidget.c
-@@ -129,7 +129,7 @@ gtk_gl_widget_size_allocate (GtkWidget       *widget,
-    * Synchronize OpenGL and window resizing request streams.
-    */
- 
--  if (GTK_WIDGET_REALIZED (widget) && private->is_realized)
-+  if (gtk_widget_get_realized (widget) && private->is_realized)
-     {
-       gldrawable = gdk_window_get_gl_drawable (widget->window);
-       gdk_gl_drawable_wait_gdk (gldrawable);
-@@ -156,7 +156,7 @@ gtk_gl_widget_unrealize (GtkWidget       *widget,
-    * Remove OpenGL-capability from widget->window.
-    */
- 
--  if (GTK_WIDGET_REALIZED (widget))
-+  if (gtk_widget_get_realized (widget))
-     gdk_window_unset_gl_capability (widget->window);
- 
-   private->is_realized = FALSE;
-@@ -176,7 +176,7 @@ gtk_gl_widget_parent_set (GtkWidget   *widget,
-    */
- 
-   toplevel = gtk_widget_get_toplevel (widget);
--  if (GTK_WIDGET_TOPLEVEL (toplevel) && !GTK_WIDGET_REALIZED (toplevel))
-+  if (gtk_widget_is_toplevel (toplevel) && !gtk_widget_get_realized (toplevel))
-     {
-       GTK_GL_NOTE (MISC,
-         g_message (" - Install colormap to the top-level window."));
-@@ -196,7 +196,7 @@ gtk_gl_widget_style_set (GtkWidget *widget,
-    * Set a background of "None" on window to avoid AIX X server crash.
-    */
- 
--  if (GTK_WIDGET_REALIZED (widget))
-+  if (gtk_widget_get_realized (widget))
-     {
-       GTK_GL_NOTE (MISC,
-         g_message (" - window->bg_pixmap = %p",
-@@ -252,8 +252,8 @@ gtk_widget_set_gl_capability (GtkWidget    *widget,
-   GTK_GL_NOTE_FUNC ();
- 
-   g_return_val_if_fail (GTK_IS_WIDGET (widget), FALSE);
--  g_return_val_if_fail (!GTK_WIDGET_NO_WINDOW (widget), FALSE);
--  g_return_val_if_fail (!GTK_WIDGET_REALIZED (widget), FALSE);
-+  g_return_val_if_fail (gtk_widget_get_has_window (widget), FALSE);
-+  g_return_val_if_fail (!gtk_widget_get_realized (widget), FALSE);
-   g_return_val_if_fail (GDK_IS_GL_CONFIG (glconfig), FALSE);
- 
-   /* 
-@@ -434,7 +434,7 @@ gtk_widget_create_gl_context (GtkWidget    *widget,
-   GTK_GL_NOTE_FUNC ();
- 
-   g_return_val_if_fail (GTK_IS_WIDGET (widget), NULL);
--  g_return_val_if_fail (GTK_WIDGET_REALIZED (widget), NULL);
-+  g_return_val_if_fail (gtk_widget_get_realized (widget), NULL);
- 
-   gldrawable = gdk_window_get_gl_drawable (widget->window);
-   if (gldrawable == NULL)
-@@ -476,7 +476,7 @@ gtk_widget_get_gl_context (GtkWidget *widget)
-   GLWidgetPrivate *private;
-
-   g_return_val_if_fail (GTK_IS_WIDGET (widget), NULL);
--  g_return_val_if_fail (GTK_WIDGET_REALIZED (widget), NULL);
-+  g_return_val_if_fail (gtk_widget_get_realized (widget), NULL);
- 
-   private = g_object_get_qdata (G_OBJECT (widget), quark_gl_private);
-   if (private == NULL)
-@@ -503,7 +503,7 @@ GdkGLWindow *
- gtk_widget_get_gl_window (GtkWidget *widget)
- {
-   g_return_val_if_fail (GTK_IS_WIDGET (widget), NULL);
--  g_return_val_if_fail (GTK_WIDGET_REALIZED (widget), NULL);
-+  g_return_val_if_fail (gtk_widget_get_realized (widget), NULL);
- 
-   return gdk_window_get_gl_window (widget->window);
- }
-

--- a/Library/Formula/gtkmm.rb
+++ b/Library/Formula/gtkmm.rb
@@ -3,6 +3,7 @@ class Gtkmm < Formula
   homepage "http://www.gtkmm.org/"
   url "https://download.gnome.org/sources/gtkmm/2.24/gtkmm-2.24.4.tar.xz"
   sha256 "443a2ff3fcb42a915609f1779000390c640a6d7fd19ad8816e6161053696f5ee"
+  revision 1
 
   bottle do
     revision 2
@@ -44,7 +45,6 @@ class Gtkmm < Formula
     glib = Formula["glib"]
     glibmm = Formula["glibmm"]
     gtkx = Formula["gtk+"]
-    harfbuzz = Formula["harfbuzz"]
     libpng = Formula["libpng"]
     libsigcxx = Formula["libsigc++"]
     pango = Formula["pango"]
@@ -70,7 +70,6 @@ class Gtkmm < Formula
       -I#{gtkx.opt_include}/gtk-2.0
       -I#{gtkx.opt_include}/gtk-unix-print-2.0
       -I#{gtkx.opt_lib}/gtk-2.0/include
-      -I#{harfbuzz.opt_include}/harfbuzz
       -I#{include}/gdkmm-2.4
       -I#{include}/gtkmm-2.4
       -I#{libpng.opt_include}/libpng16
@@ -87,8 +86,6 @@ class Gtkmm < Formula
       -L#{atkmm.opt_lib}
       -L#{cairo.opt_lib}
       -L#{cairomm.opt_lib}
-      -L#{fontconfig.opt_lib}
-      -L#{freetype.opt_lib}
       -L#{gdk_pixbuf.opt_lib}
       -L#{gettext.opt_lib}
       -L#{glib.opt_lib}
@@ -102,9 +99,7 @@ class Gtkmm < Formula
       -latkmm-1.6
       -lcairo
       -lcairomm-1.0
-      -lfontconfig
-      -lfreetype
-      -lgdk-x11-2.0
+      -lgdk-quartz-2.0
       -lgdk_pixbuf-2.0
       -lgdkmm-2.4
       -lgio-2.0
@@ -112,12 +107,11 @@ class Gtkmm < Formula
       -lglib-2.0
       -lglibmm-2.4
       -lgobject-2.0
-      -lgtk-x11-2.0
+      -lgtk-quartz-2.0
       -lgtkmm-2.4
       -lintl
       -lpango-1.0
       -lpangocairo-1.0
-      -lpangoft2-1.0
       -lpangomm-1.4
       -lsigc-2.0
     ]

--- a/Library/Formula/gtksourceview.rb
+++ b/Library/Formula/gtksourceview.rb
@@ -17,6 +17,10 @@ class Gtksourceview < Formula
   depends_on "gtk+"
   depends_on "gtk-mac-integration"
 
+  # patches added the ensure that gtk-mac-integration is supported properly instead
+  # of the old released called ige-mac-integration.
+  # These are already integrated upstream in their gnome-2-30 branch but a release of
+  # this remains highly unlikely
   patch :DATA
 
   def install

--- a/Library/Formula/gtksourceview.rb
+++ b/Library/Formula/gtksourceview.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Gtksourceview < Formula
   desc "Text view with syntax, undo/redo, and text marks"
-  homepage 'http://projects.gnome.org/gtksourceview/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/gtksourceview/2.10/gtksourceview-2.10.5.tar.gz'
-  sha1 '1bb784d1e9d9966232928cf91b1ded20e8339670'
+  homepage "https://projects.gnome.org/gtksourceview/"
+  url "https://download.gnome.org/sources/gtksourceview/2.10/gtksourceview-2.10.5.tar.gz"
+  sha256 "f5c3dda83d69c8746da78c1434585169dd8de1eecf2a6bcdda0d9925bf857c97"
+  revision 1
 
   bottle do
     sha1 "e776f4b2aa5a68f193d1f22352582cb923090614" => :yosemite
@@ -12,14 +11,166 @@ class Gtksourceview < Formula
     sha1 "466836536733808dfbbe8c874b02b3e9afa84006" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'gettext'
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "gtk+"
+  depends_on "gtk-mac-integration"
+
+  patch :DATA
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gtksourceview/gtksourceview.h>
+
+      int main(int argc, char *argv[]) {
+        GtkWidget *widget = gtk_source_view_new();
+        return 0;
+      }
+    EOS
+    ENV.libxml2
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/gtksourceview-2.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtksourceview-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end
+__END__
+diff --git a/configure b/configure
+index ed522e5..5f51d4f 100755
+--- a/configure
++++ b/configure
+@@ -11220,12 +11220,12 @@ if test -n "$IGE_MAC_CFLAGS"; then
+     pkg_cv_IGE_MAC_CFLAGS="$IGE_MAC_CFLAGS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"ige-mac-integration\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "ige-mac-integration") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integration-gtk2\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration-gtk2") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_IGE_MAC_CFLAGS=`$PKG_CONFIG --cflags "ige-mac-integration" 2>/dev/null`
++  pkg_cv_IGE_MAC_CFLAGS=`$PKG_CONFIG --cflags "gtk-mac-integration-gtk2" 2>/dev/null`
+ else
+   pkg_failed=yes
+ fi
+@@ -11236,12 +11236,12 @@ if test -n "$IGE_MAC_LIBS"; then
+     pkg_cv_IGE_MAC_LIBS="$IGE_MAC_LIBS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"ige-mac-integration\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "ige-mac-integration") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integration-gtk2\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration-gtk2") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_IGE_MAC_LIBS=`$PKG_CONFIG --libs "ige-mac-integration" 2>/dev/null`
++  pkg_cv_IGE_MAC_LIBS=`$PKG_CONFIG --libs "gtk-mac-integration-gtk2" 2>/dev/null`
+ else
+   pkg_failed=yes
+ fi
+@@ -11261,14 +11261,14 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        IGE_MAC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors "ige-mac-integration" 2>&1`
++	        IGE_MAC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors "gtk-mac-integration-gtk2" 2>&1`
+         else
+-	        IGE_MAC_PKG_ERRORS=`$PKG_CONFIG --print-errors "ige-mac-integration" 2>&1`
++	        IGE_MAC_PKG_ERRORS=`$PKG_CONFIG --print-errors "gtk-mac-integration-gtk2" 2>&1`
+         fi
+ 	# Put the nasty error message in config.log where it belongs
+ 	echo "$IGE_MAC_PKG_ERRORS" >&5
+ 
+-	as_fn_error $? "Package requirements (ige-mac-integration) were not met:
++	as_fn_error $? "Package requirements (gtk-mac-integration-gtk2) were not met:
+ 
+ $IGE_MAC_PKG_ERRORS
+ 
+diff --git a/gtksourceview/gtksourceview-i18n.c b/gtksourceview/gtksourceview-i18n.c
+index e4db3eb..70f8f2c 100644
+--- a/gtksourceview/gtksourceview-i18n.c
++++ b/gtksourceview/gtksourceview-i18n.c
+@@ -24,7 +24,7 @@
+ #endif
+ 
+ #ifdef OS_OSX
+-#include <ige-mac-bundle.h>
++#include <gtkosxapplication.h>
+ #endif
+ 
+ #include <string.h>
+@@ -45,12 +45,10 @@ get_locale_dir (void)
+ 
+ 	g_free (win32_dir);
+ #elif defined (OS_OSX)
+-	IgeMacBundle *bundle = ige_mac_bundle_get_default ();
+-
+-	if (ige_mac_bundle_get_is_app_bundle (bundle))
+-	{
+-		locale_dir = g_strdup (ige_mac_bundle_get_localedir (bundle));
+-	}
++        if(gtkosx_application_get_bundle_id () != NULL)  
++ 	{ 
++ 		locale_dir = g_strdup (gtkosx_application_get_resource_path ()); 
++ 	}
+ 	else
+ 	{
+ 		locale_dir = g_build_filename (DATADIR, "locale", NULL);
+

--- a/Library/Formula/gwyddion.rb
+++ b/Library/Formula/gwyddion.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Gwyddion < Formula
   desc "Scanning Probe Microscopy visualization and analysis tool"
-  homepage 'http://gwyddion.net/'
-  url 'http://gwyddion.net/download/2.40/gwyddion-2.40.tar.gz'
-  sha1 '3e914985e5cde6303e2c842605014a9c66a1c030'
+  homepage "http://gwyddion.net/"
+  url "http://gwyddion.net/download/2.40/gwyddion-2.40.tar.gz"
+  sha256 "b3838dab5a4ff8e1f62d2ab859fabb42c3a8c31f5dc4f72dc679a46de2b67bab"
+  revision 1
 
   bottle do
     sha1 "9e6ba00a543047c776d88ad1e3561247cdfacf05" => :yosemite
@@ -12,21 +11,110 @@ class Gwyddion < Formula
     sha1 "3c621ed8e56d52a4502bc9b7fc1641a86988a94f" => :mountain_lion
   end
 
-  depends_on :x11 => :optional
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
-  depends_on 'libxml2'
-  depends_on 'fftw'
-  depends_on 'gtkglext'
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
+  depends_on "gtk-mac-integration"
+  depends_on "libxml2"
+  depends_on "fftw"
+  depends_on "gtkglext"
   depends_on :python => :optional
-  depends_on 'pygtk' if build.with? 'python'
-  depends_on 'gtksourceview' if build.with? 'python'
+  depends_on "pygtk" if build.with? "python"
+  depends_on "gtksourceview" if build.with? "python"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-desktop-file-update",
                           "--prefix=#{prefix}",
                           "--with-html-dir=#{doc}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/gwyddion", "--version"
+    (testpath/"test.c").write <<-EOS.undent
+      #include <libgwyddion/gwyddion.h>
+
+      int main(int argc, char *argv[]) {
+        const gchar *string = gwy_version_string();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fftw = Formula["fftw"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    gtkglext = Formula["gtkglext"]
+    harfbuzz = Formula["harfbuzz"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fftw.opt_include}
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkglext.opt_include}/gtkglext-1.0
+      -I#{gtkglext.opt_lib}/gtkglext-1.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{harfbuzz.opt_include}/harfbuzz
+      -I#{include}/gwyddion
+      -I#{libpng.opt_include}/libpng16
+      -I#{lib}/gwyddion/include
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{fftw.opt_lib}
+      -L#{fontconfig.opt_lib}
+      -L#{freetype.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkglext.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lfftw3
+      -lfontconfig
+      -lfreetype
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgdkglext-quartz-1.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgmodule-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkglext-quartz-1.0
+      -lgwyapp2
+      -lgwyddion2
+      -lgwydgets2
+      -lgwydraw2
+      -lgwymodule2
+      -lgwyprocess2
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lpangoft2-1.0
+      -framework AppKit
+      -framework OpenGL
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/homebank.rb
+++ b/Library/Formula/homebank.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Homebank < Formula
   desc "Manage your personal accounts at home"
-  homepage 'http://homebank.free.fr'
-  url 'http://homebank.free.fr/public/homebank-5.0.3.tar.gz'
-  sha256 'eac04a19f5d7644a5bf254a22f737d562b41503f280e339192f39745bf0d7839'
+  homepage "http://homebank.free.fr"
+  url "http://homebank.free.fr/public/homebank-5.0.2.tar.gz"
+  sha256 "f2c3f9da0aa9af76cfed63a19104d99d33b1766cac89dd1586c378b9cf54a2ca"
+  revision 1
 
   bottle do
     sha256 "6f3e5c28cdcf4b4c3d38b179d85bcf2c975cd45733e1a4a0a055865dba0e732a" => :yosemite
@@ -12,23 +11,27 @@ class Homebank < Formula
     sha256 "3cc8e24062a1ec1795bacc7d99b3f42a215780e3bf6575190299b0d55fe9e8cc" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'gettext'
-  depends_on 'gtk+3'
-  depends_on 'gnome-icon-theme'
-  depends_on 'hicolor-icon-theme'
-  depends_on 'freetype'
-  depends_on 'fontconfig'
-  depends_on 'libofx' => :optional
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "gtk+3"
+  depends_on "gnome-icon-theme"
+  depends_on "hicolor-icon-theme"
+  depends_on "freetype"
+  depends_on "fontconfig"
+  depends_on "libofx" => :optional
 
   def install
     args = ["--disable-dependency-tracking",
             "--prefix=#{prefix}"]
-    args << "--with-ofx" if build.with? 'libofx'
+    args << "--with-ofx" if build.with? "libofx"
 
     system "./configure", *args
     chmod 0755, "./install-sh"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/homebank", "--version"
   end
 end

--- a/Library/Formula/jigdo.rb
+++ b/Library/Formula/jigdo.rb
@@ -2,8 +2,8 @@ class Jigdo < Formula
   desc "Tool to distribute very large files over the internet"
   homepage "http://atterer.org/jigdo/"
   url "http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-0.7.3.tar.bz2"
-  sha1 "7b83c35af71f908b31b9aa55b0dda9dfb4d224f0"
-  revision 1
+  sha256 "875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
+  revision 2
 
   bottle do
     sha1 "082410ddb96160d7dad904396e54c628e395efd6" => :yosemite
@@ -18,7 +18,7 @@ class Jigdo < Formula
 
   # Use MacPorts patch for compilation on 10.9; this software is no longer developed.
   patch :p0 do
-    url "http://trac.macports.org/export/113020/trunk/dports/net/jigdo/files/patch-src-compat.hh.diff"
+    url "https://trac.macports.org/export/113020/trunk/dports/net/jigdo/files/patch-src-compat.hh.diff"
     sha1 "3318ecbe8b2bb20e8e36c70dc10ff366df2009f3"
   end
 

--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -32,7 +32,7 @@ class Lablgtk < Formula
         GtkMain.Main.init ()
       let _ = main ()
     EOS
-    system "ocamlc", "-I", "+lablgtk2", "-o", "test", "lablgtk.cma", "gtkInit.cmo", "test.ml"
+    system "ocamlc", "-I", "#{Formula["lablgtk"].opt_lib}/ocaml/lablgtk2", "lablgtk.cma", "gtkInit.cmo", "test.ml", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -1,10 +1,8 @@
-require 'formula'
-
 class Lablgtk < Formula
   desc "Objective Caml interface to gtk+"
-  homepage 'http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgtk.html'
-  url 'http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/dist/lablgtk-2.14.2.tar.gz'
-  sha1 'fd184418ccbc542825748ca63fba75138d2ea561'
+  homepage "http://lablgtk.forge.ocamlcore.org"
+  url "https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
+  sha256 "975bebf2f9ca74dc3bf7431ebb640ff6a924bb80c8ee5f4467c475a7e4b0cbaf"
 
   bottle do
     sha1 "f17c4f647c272598eebde8a169be6cdac11e30e5" => :yosemite
@@ -12,12 +10,11 @@ class Lablgtk < Formula
     sha1 "d78c6d4a152d142372265af77e9ac95cfb9e92a8" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'camlp4' => :build
-  depends_on :x11
-  depends_on 'objective-caml'
-  depends_on 'gtk+'
-  depends_on 'librsvg'
+  depends_on "pkg-config" => :build
+  depends_on "camlp4" => :build
+  depends_on "objective-caml"
+  depends_on "gtk+"
+  depends_on "librsvg"
 
   def install
     system "./configure", "--bindir=#{bin}",
@@ -25,7 +22,17 @@ class Lablgtk < Formula
                           "--mandir=#{man}",
                           "--with-libdir=#{lib}/ocaml"
     ENV.j1
-    system "make world"
-    system "make install"
+    system "make", "world"
+    system "make", "old-install"
+  end
+
+  test do
+    (testpath/"test.ml").write <<-EOS.undent
+      let main () =
+        GtkMain.Main.init ()
+      let _ = main ()
+    EOS
+    system "ocamlc", "-I", "+lablgtk2", "-o", "test", "lablgtk.cma", "gtkInit.cmo", "test.ml"
+    system "./test"
   end
 end

--- a/Library/Formula/libglade.rb
+++ b/Library/Formula/libglade.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Libglade < Formula
   desc "RAD tool to help build GTK+ interfaces"
-  homepage 'http://glade.gnome.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.gz'
-  sha256 'c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3'
+  homepage "https://glade.gnome.org"
+  url "http://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.gz"
+  sha256 "c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3"
+  revision 1
 
   bottle do
     revision 1
@@ -13,15 +12,77 @@ class Libglade < Formula
     sha1 "f6777adb7998cd1de73f8a7f51c6b57786050872" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'libxml2'
-  depends_on 'gtk+'
-  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "libxml2"
+  depends_on "gtk+"
 
   def install
-    ENV.append 'LDFLAGS', '-lgmodule-2.0'
+    ENV.append "LDFLAGS", "-lgmodule-2.0"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <glade/glade.h>
+
+      int main(int argc, char *argv[]) {
+        glade_init();
+        return 0;
+      }
+    EOS
+    ENV.libxml2
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/libglade-2.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglade-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lxml2
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/libglade.rb
+++ b/Library/Formula/libglade.rb
@@ -1,7 +1,7 @@
 class Libglade < Formula
   desc "RAD tool to help build GTK+ interfaces"
   homepage "https://glade.gnome.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.gz"
+  url "https://download.gnome.org/sources/libglade/2.6/libglade-2.6.4.tar.gz"
   sha256 "c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3"
   revision 1
 

--- a/Library/Formula/libglademm.rb
+++ b/Library/Formula/libglademm.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Libglademm < Formula
   desc "C++ wrapper around libglade"
-  homepage 'http://gnome.org'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2'
-  sha1 'd7c0138c80ea337d2e9ae55f74a6953ce2eb9f5d'
+  homepage "https://gnome.org"
+  url "http://ftp.gnome.org/pub/GNOME/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2"
+  sha256 "38543c15acf727434341cc08c2b003d24f36abc22380937707fc2c5c687a2bc3"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,15 +12,122 @@ class Libglademm < Formula
     sha1 "ab0607b43ba9195b3f18fc38cdabd3a72d5c499c" => :mavericks
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtkmm'
-  depends_on 'libglade'
-  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "gtkmm"
+  depends_on "libglade"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <libglademm.h>
+
+      int main(int argc, char *argv[]) {
+        try {
+          throw Gnome::Glade::XmlError("this formula should die");
+        }
+        catch (Gnome::Glade::XmlError &e) {}
+        return 0;
+      }
+    EOS
+    ENV.libxml2
+    atk = Formula["atk"]
+    atkmm = Formula["atkmm"]
+    cairo = Formula["cairo"]
+    cairomm = Formula["cairomm"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    gtkx = Formula["gtk+"]
+    gtkmm = Formula["gtkmm"]
+    libglade = Formula["libglade"]
+    libpng = Formula["libpng"]
+    libsigcxx = Formula["libsigc++"]
+    pango = Formula["pango"]
+    pangomm = Formula["pangomm"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{atkmm.opt_include}/atkmm-1.6
+      -I#{cairo.opt_include}/cairo
+      -I#{cairomm.opt_include}/cairomm-1.0
+      -I#{cairomm.opt_lib}/cairomm-1.0/include
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/giomm-2.4
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/giomm-2.4/include
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{gtkmm.opt_include}/gdkmm-2.4
+      -I#{gtkmm.opt_include}/gtkmm-2.4
+      -I#{gtkmm.opt_lib}/gdkmm-2.4/include
+      -I#{gtkmm.opt_lib}/gtkmm-2.4/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_include}/gtk-unix-print-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/libglademm-2.4
+      -I#{libglade.opt_include}/libglade-2.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{lib}/libglademm-2.4/include
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pangomm.opt_include}/pangomm-1.4
+      -I#{pangomm.opt_lib}/pangomm-1.4/include
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{atkmm.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{cairomm.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{gtkmm.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{libglade.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -L#{pangomm.opt_lib}
+      -latk-1.0
+      -latkmm-1.6
+      -lcairo
+      -lcairomm-1.0
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgdkmm-2.4
+      -lgio-2.0
+      -lgiomm-2.4
+      -lglade-2.0
+      -lglademm-2.4
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkmm-2.4
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lpangomm-1.4
+      -lsigc-2.0
+      -lxml2
+    ]
+    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/libglademm.rb
+++ b/Library/Formula/libglademm.rb
@@ -1,7 +1,7 @@
 class Libglademm < Formula
   desc "C++ wrapper around libglade"
   homepage "https://gnome.org"
-  url "http://ftp.gnome.org/pub/GNOME/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2"
+  url "https://download.gnome.org/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2"
   sha256 "38543c15acf727434341cc08c2b003d24f36abc22380937707fc2c5c687a2bc3"
   revision 1
 

--- a/Library/Formula/libgnomecanvas.rb
+++ b/Library/Formula/libgnomecanvas.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Libgnomecanvas < Formula
   desc "Highlevel, structured graphics library"
-  homepage 'http://developer.gnome.org/libgnomecanvas/2.30/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.bz2'
-  sha256 '859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40'
+  homepage "https://developer.gnome.org/libgnomecanvas/2.30/"
+  url "https://download.gnome.org/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.bz2"
+  sha256 "859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,18 +12,87 @@ class Libgnomecanvas < Formula
     sha1 "bf225dfe17cf5c839547835517da067dcceb3479" => :mavericks
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'libglade'
-  depends_on 'libart'
-  depends_on 'gettext'
-  depends_on 'gtk+'
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "libglade"
+  depends_on "libart"
+  depends_on "gettext"
+  depends_on "gtk+"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-static",
                           "--prefix=#{prefix}",
                           "--enable-glade"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <libgnomecanvas/libgnomecanvas.h>
+
+      int main(int argc, char *argv[]) {
+        GnomeCanvasPoints *gcp = gnome_canvas_points_new(100);
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    harfbuzz = Formula["harfbuzz"]
+    libart = Formula["libart"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gail-1.0
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{harfbuzz.opt_include}/harfbuzz
+      -I#{include}/libgnomecanvas-2.0
+      -I#{libart.opt_include}/libart-2.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{libart.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -lart_lgpl_2
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgnomecanvas-2
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/libgnomecanvasmm.rb
+++ b/Library/Formula/libgnomecanvasmm.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Libgnomecanvasmm < Formula
   desc "C++ wrapper for libgnomecanvas"
-  homepage 'https://launchpad.net/libgnomecanvasmm'
-  url 'http://ftp.gnome.org/pub/gnome/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2'
-  sha1 'c2f20c75f6eedbaf4a3299e0e3fda2ef775092e8'
+  homepage "https://launchpad.net/libgnomecanvasmm"
+  url "https://download.gnome.org/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2"
+  sha256 "996577f97f459a574919e15ba7fee6af8cda38a87a98289e9a4f54752d83e918"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,14 +13,122 @@ class Libgnomecanvasmm < Formula
     sha1 "dcf3306ac9ab19171a2c3d05151fb8f020b96b4e" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'libgnomecanvas'
-  depends_on 'gtkmm'
+  depends_on "pkg-config" => :build
+  depends_on "libgnomecanvas"
+  depends_on "gtkmm"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <libgnomecanvasmm.h>
 
+      int main(int argc, char *argv[]) {
+        Gnome::Canvas::init();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    atkmm = Formula["atkmm"]
+    cairo = Formula["cairo"]
+    cairomm = Formula["cairomm"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    gtkx = Formula["gtk+"]
+    gtkmm = Formula["gtkmm"]
+    harfbuzz = Formula["harfbuzz"]
+    libart = Formula["libart"]
+    libgnomecanvas = Formula["libgnomecanvas"]
+    libpng = Formula["libpng"]
+    libsigcxx = Formula["libsigc++"]
+    pango = Formula["pango"]
+    pangomm = Formula["pangomm"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{atkmm.opt_include}/atkmm-1.6
+      -I#{cairo.opt_include}/cairo
+      -I#{cairomm.opt_include}/cairomm-1.0
+      -I#{cairomm.opt_lib}/cairomm-1.0/include
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/giomm-2.4
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/giomm-2.4/include
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{gtkmm.opt_include}/gdkmm-2.4
+      -I#{gtkmm.opt_include}/gtkmm-2.4
+      -I#{gtkmm.opt_lib}/gdkmm-2.4/include
+      -I#{gtkmm.opt_lib}/gtkmm-2.4/include
+      -I#{gtkx.opt_include}/gail-1.0
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_include}/gtk-unix-print-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{harfbuzz.opt_include}/harfbuzz
+      -I#{include}/libgnomecanvasmm-2.6
+      -I#{libart.opt_include}/libart-2.0
+      -I#{libgnomecanvas.opt_include}/libgnomecanvas-2.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{lib}/libgnomecanvasmm-2.6/include
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pangomm.opt_include}/pangomm-1.4
+      -I#{pangomm.opt_lib}/pangomm-1.4/include
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{atkmm.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{cairomm.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{gtkmm.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{libart.opt_lib}
+      -L#{libgnomecanvas.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -L#{pangomm.opt_lib}
+      -lart_lgpl_2
+      -latk-1.0
+      -latkmm-1.6
+      -lcairo
+      -lcairomm-1.0
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgdkmm-2.4
+      -lgio-2.0
+      -lgiomm-2.4
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgnomecanvas-2
+      -lgnomecanvasmm-2.6
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lgtkmm-2.4
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lpangomm-1.4
+      -lsigc-2.0
+    ]
+    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
 end

--- a/Library/Formula/librsvg.rb
+++ b/Library/Formula/librsvg.rb
@@ -3,6 +3,7 @@ class Librsvg < Formula
   homepage "https://live.gnome.org/LibRsvg"
   url "https://download.gnome.org/sources/librsvg/2.40/librsvg-2.40.9.tar.xz"
   sha256 "13964c5d35357552b47d365c34215eee0a63bf0e6059b689f048648c6bf5f43a"
+  revision 1
 
   bottle do
     sha256 "d5c5069f182b750a3060cca13a5c50f1546713115705af0bb9bc831b12b2f096" => :yosemite

--- a/Library/Formula/librsvg.rb
+++ b/Library/Formula/librsvg.rb
@@ -14,12 +14,10 @@ class Librsvg < Formula
   depends_on "cairo"
   depends_on "gdk-pixbuf"
   depends_on "glib"
-  depends_on "gtk+" => :recommended
   depends_on "gtk+3" => :optional
   depends_on "libcroco"
   depends_on "libgsf" => :optional
   depends_on "pango"
-  depends_on :x11 => :recommended
 
   def install
     args = ["--disable-dependency-tracking",

--- a/Library/Formula/mdk.rb
+++ b/Library/Formula/mdk.rb
@@ -3,7 +3,8 @@ class Mdk < Formula
   homepage "https://www.gnu.org/software/mdk/mdk.html"
   url "http://ftpmirror.gnu.org/mdk/v1.2.8/mdk-1.2.8.tar.gz"
   mirror "https://ftp.gnu.org/gnu/mdk/v1.2.8/mdk-1.2.8.tar.gz"
-  sha1 "43bd40a48f88b3458c3bb6ccfd62d254b85c5fb8"
+  sha256 "7bff1e10b829c6e1f3c278bfecbe82f0f658753ce80ea58b6f71c05f9490b0db"
+  revision 1
 
   bottle do
     sha1 "027992f17eb6d137af1b2c2fecd2ae58acb4c66d" => :yosemite
@@ -11,9 +12,9 @@ class Mdk < Formula
     sha1 "73dd16e090ff87bee664f4b45858462a8235c1ab" => :mountain_lion
   end
 
-  depends_on "gtk+3"
-  depends_on "glib"
+  depends_on "gtk+"
   depends_on "libglade"
+  depends_on "glib"
   depends_on "flex"
   depends_on "guile"
   depends_on "intltool" => :build

--- a/Library/Formula/minbif.rb
+++ b/Library/Formula/minbif.rb
@@ -1,29 +1,27 @@
-require 'formula'
-
-# Official download has untrusted SSL cert, so use Debian
-
 class Minbif < Formula
   desc "IRC-to-other-IM-networks gateway using Pidgin library"
-  homepage 'http://minbif.im/'
-  url 'http://ftp.de.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20120508.orig.tar.gz'
-  version '1.0.5'
-  sha1 '5827df8954e29df80d1e81ee5df354b76c5fd86a'
-  revision 1
+  homepage "http://minbif.im/"
+  url "http://ftp.de.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20120508.orig.tar.gz"
+  version "1.0.5"
+  sha256 "307bd98e367c1202cfa119ee8f33ff5b5a2a05d2544709f850a2d26b7919d697"
+  revision 2
 
-  option 'pam', 'Build with PAM support, patching for OSX PAM headers'
+  option "with-pam", "Build with PAM support, patching for OSX PAM headers"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'cmake' => :build
-  depends_on 'glib'
-  depends_on 'gettext'
-  depends_on 'pidgin'
-  depends_on 'gnutls'
-  depends_on 'imlib2' => :optional
-  depends_on 'libcaca' => :optional
+  deprecated_option "pam" => "with-pam"
+
+  depends_on "pkg-config" => :build
+  depends_on "cmake" => :build
+  depends_on "glib"
+  depends_on "gettext"
+  depends_on "pidgin"
+  depends_on "gnutls"
+  depends_on "imlib2" => :optional
+  depends_on "libcaca" => :optional
 
   # Problem:  Apple doesn't have <security/pam_misc.h> so don't ask for it.
   # Reported: https://symlink.me/issues/917
-  patch :DATA if build.include? 'pam'
+  patch :DATA if build.include? "pam"
 
   def install
     inreplace "minbif.conf" do |s|
@@ -38,12 +36,12 @@ class Minbif < Formula
       ENABLE_VIDEO=OFF
       ENABLE_TLS=ON
     ]
-    args << 'ENABLE_IMLIB=' + ((build.include? 'imlib2') ? 'ON' : 'OFF')
-    args << 'ENABLE_CACA=' + ((build.include? 'libcaca') ? 'ON' : 'OFF')
-    args << 'ENABLE_PAM=' + ((build.include? 'pam') ? 'ON' : 'OFF')
+    args << "ENABLE_IMLIB=" + ((build.include? "imlib2") ? "ON" : "OFF")
+    args << "ENABLE_CACA=" + ((build.include? "libcaca") ? "ON" : "OFF")
+    args << "ENABLE_PAM=" + ((build.include? "pam") ? "ON" : "OFF")
 
-    system 'make', *args
-    system 'make install'
+    system "make", *args
+    system "make", "install"
 
     (var + "lib/minbif/users").mkpath
   end
@@ -54,6 +52,10 @@ class Minbif < Formula
 
     Learn more about minbif: http://minbif.im/Quick_start
     EOS
+  end
+
+  test do
+    system "#{bin}/minbif", "--version"
   end
 end
 

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -34,6 +34,8 @@ class OpenSceneGraph < Formula
   depends_on "qt5" => :optional
   depends_on "qt" => :optional
 
+  # patch necessary to ensure support for gtkglext-quartz
+  # filed as an issue to the developers https://github.com/openscenegraph/osg/issues/34
   patch :DATA
 
   if build.with? "docs"

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -2,7 +2,8 @@ class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "http://www.openscenegraph.org/projects/osg"
   url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.3.3.zip"
-  sha1 "98697c3e3b3c6e7e2ec7a6a75ece8f790b709cd7"
+  sha256 "b81cda123ffb3bd108e0fe4be4fff1351d6636e6fb0a1475b2c4fb9618d3ae2b"
+  revision 1
 
   bottle do
     sha1 "2f7f0292cf0d66cc37f94ff9d769c7d397e4a19c" => :yosemite
@@ -32,6 +33,8 @@ class OpenSceneGraph < Formula
   depends_on "ffmpeg" => :optional
   depends_on "qt5" => :optional
   depends_on "qt" => :optional
+
+  patch :DATA
 
   if build.with? "docs"
     depends_on "doxygen" => :build
@@ -91,3 +94,17 @@ class OpenSceneGraph < Formula
     assert_equal `./test`.chomp, version.to_s
   end
 end
+__END__
+diff --git a/CMakeModules/FindGtkGl.cmake b/CMakeModules/FindGtkGl.cmake
+index 321cede..6497589 100644
+--- a/CMakeModules/FindGtkGl.cmake
++++ b/CMakeModules/FindGtkGl.cmake
+@@ -10,7 +10,7 @@ IF(PKG_CONFIG_FOUND)
+     IF(WIN32)
+         PKG_CHECK_MODULES(GTKGL gtkglext-win32-1.0)
+     ELSE()
+-        PKG_CHECK_MODULES(GTKGL gtkglext-x11-1.0)
++        PKG_CHECK_MODULES(GTKGL gtkglext-quartz-1.0)
+     ENDIF()
+ 
+ ENDIF()

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -1,7 +1,7 @@
 class Pango < Formula
   desc "Framework for layout and rendering of i18n text"
   homepage "http://www.pango.org/"
-  url "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz"
+  url "https://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz"
   sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
   revision 1
 
@@ -12,13 +12,6 @@ class Pango < Formula
     depends_on "autoconf" => :build
     depends_on "libtool" => :build
     depends_on "gtk-doc" => :build
-  end
-
-  bottle do
-    revision 1
-    sha1 "b30d81e5b4b90792e14aa02b273fcf93e9675fc7" => :yosemite
-    sha1 "eb30e96c1d896cd8fc7e1053513b3e298645c9af" => :mavericks
-    sha1 "ea288645c2ca58b4addf29c0140fb3ecec6ea3ab" => :mountain_lion
   end
 
   option :universal

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -1,18 +1,17 @@
-require 'formula'
-
 class Pango < Formula
   desc "Framework for layout and rendering of i18n text"
   homepage "http://www.pango.org/"
   url "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz"
   sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
+  revision 1
 
   head do
-    url 'https://git.gnome.org/browse/pango'
+    url "https://git.gnome.org/browse/pango"
 
-    depends_on 'automake' => :build
-    depends_on 'autoconf' => :build
-    depends_on 'libtool' => :build
-    depends_on 'gtk-doc' => :build
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+    depends_on "gtk-doc" => :build
   end
 
   bottle do
@@ -24,13 +23,12 @@ class Pango < Formula
 
   option :universal
 
-  depends_on 'pkg-config' => :build
-  depends_on 'glib'
-  depends_on 'cairo'
-  depends_on 'harfbuzz'
-  depends_on 'fontconfig'
-  depends_on :x11 => :recommended
-  depends_on 'gobject-introspection'
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "cairo"
+  depends_on "harfbuzz"
+  depends_on "fontconfig"
+  depends_on "gobject-introspection"
 
   fails_with :llvm do
     build 2326
@@ -47,21 +45,61 @@ class Pango < Formula
       --enable-man
       --with-html-dir=#{share}/doc
       --enable-introspection=yes
+      --without-xft
     ]
-
-    if build.without? "x11"
-      args << '--without-xft'
-    else
-      args << '--with-xft'
-    end
 
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make"
-    system "make install"
+    system "make", "install"
   end
 
   test do
     system "#{bin}/pango-querymodules", "--version"
+    (testpath/"test.c").write <<-EOS.undent
+      #include <pango/pangocairo.h>
+
+      int main(int argc, char *argv[]) {
+        PangoFontMap *fontmap;
+        int n_families;
+        PangoFontFamily **families;
+        fontmap = pango_cairo_font_map_get_default();
+        pango_font_map_list_families (fontmap, &families, &n_families);
+        g_free(families);
+        return 0;
+      }
+    EOS
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    libpng = Formula["libpng"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/pango-1.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{cairo.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -lcairo
+      -lglib-2.0
+      -lgobject-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -1,10 +1,8 @@
-require 'formula'
-
 class Pangomm < Formula
   desc "C++ interface to Pango"
   homepage 'http://www.pango.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.34/pangomm-2.34.0.tar.xz'
-  sha256 '0e82bbff62f626692a00f3772d8b17169a1842b8cc54d5f2ddb1fec2cede9e41'
+  url "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.36/pangomm-2.36.0.tar.xz"
+  sha256 "a8d96952c708d7726bed260d693cece554f8f00e48b97cccfbf4f5690b6821f0"
 
   bottle do
     revision 1
@@ -13,13 +11,23 @@ class Pangomm < Formula
     sha1 "3df791891b37c582cad8712fe5a93d6c067ca90e" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'pango'
-  depends_on 'glibmm'
-  depends_on 'cairomm'
+  depends_on "pkg-config" => :build
+  depends_on "glibmm"
+  depends_on "cairomm"
+  depends_on "pango"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <pangomm.h>
+      int main(int argc, char *argv[])
+      {
+        Pango::FontDescription fd;
+        return 0;
+      }
+    EOS
   end
 end

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -1,7 +1,7 @@
 class Pangomm < Formula
   desc "C++ interface to Pango"
   homepage 'http://www.pango.org/'
-  url "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.36/pangomm-2.36.0.tar.xz"
+  url "https://download.gnome.org/sources/pangomm/2.36/pangomm-2.36.0.tar.xz"
   sha256 "a8d96952c708d7726bed260d693cece554f8f00e48b97cccfbf4f5690b6821f0"
 
   bottle do

--- a/Library/Formula/pangox-compat.rb
+++ b/Library/Formula/pangox-compat.rb
@@ -1,16 +1,53 @@
-require 'formula'
-
 class PangoxCompat < Formula
   desc "Library for laying out and rendering of text"
-  homepage 'http://pango.org'
-  url 'http://ftp.gnome.org/pub/gnome/sources/pangox-compat/0.0/pangox-compat-0.0.2.tar.xz'
-  sha256 '552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046'
+  homepage "http://pango.org"
+  url "https://download.gnome.org/sources/pangox-compat/0.0/pangox-compat-0.0.2.tar.xz"
+  sha256 "552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'pango'
+  depends_on "pkg-config" => :build
+  depends_on "pango"
+  depends_on :x11
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <pango/pangox.h>
+      #include <string.h>
+
+      int main(int argc, char *argv[]) {
+        return strcmp(PANGO_RENDER_TYPE_X, "PangoRenderX");
+      }
+    EOS
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    pango = Formula["pango"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/pango-1.0
+      -I#{pango.opt_include}/pango-1.0
+      -I#{MacOS::X11.include}
+      -D_REENTRANT
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -L#{MacOS::X11.lib}
+      -lX11
+      -lglib-2.0
+      -lgobject-2.0
+      -lintl
+      -lpango-1.0
+      -lpangox-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -3,6 +3,7 @@ class Pidgin < Formula
   homepage "https://pidgin.im/"
   url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.10.11/pidgin-2.10.11.tar.bz2"
   sha256 "f2ae211341fc77efb9945d40e9932aa535cdf3a6c8993fe7919fca8cc1c04007"
+  revision 1
 
   bottle do
     revision 3
@@ -25,7 +26,6 @@ class Pidgin < Formula
   depends_on "libgcrypt"
 
   if build.with? "gui"
-    depends_on :x11 => :optional
     depends_on "gtk+"
     depends_on "cairo"
     depends_on "pango"
@@ -68,7 +68,7 @@ class Pidgin < Formula
       args << "--without-x"
       args << "--disable-gtkui"
     else
-      args << "--with-x"
+      args << "--without-x"
       args << "--disable-idn"
     end
 

--- a/Library/Formula/pygtk.rb
+++ b/Library/Formula/pygtk.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Pygtk < Formula
   desc "GTK+ bindings for Python"
   homepage 'http://www.pygtk.org/'
   url 'http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2'
-  sha1 '344e6a32a5e8c7e0aaeb807e0636a163095231c2'
+  sha256 "cd1c1ea265bd63ff669e92a2d3c2a88eb26bcd9e5363e0f82c896e649f206912"
+  revision 1
 
   bottle do
     sha1 "be4727a98966bb3c60d5f28b727dcab578361c1c" => :yosemite
@@ -12,28 +11,26 @@ class Pygtk < Formula
     sha1 "c715bf7639a0c547441da94e5e9052fc5e756ef9" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on :x11
-  depends_on 'glib'
-  depends_on 'gtk+'
-  depends_on 'atk'
-  depends_on 'pygobject'
-  depends_on 'py2cairo'
-  depends_on 'libglade' => :optional
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "gtk+"
+  depends_on "atk"
+  depends_on "pygobject"
+  depends_on "py2cairo"
 
   option :universal
 
   def install
-    ENV.append 'CFLAGS', '-ObjC'
+    ENV.append "CFLAGS", "-ObjC"
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
 
     # Fixing the pkgconfig file to find codegen, because it was moved from
     # pygtk to pygobject. But our pkgfiles point into the cellar and in the
     # pygtk-cellar there is no pygobject.
-    inreplace lib/'pkgconfig/pygtk-2.0.pc', 'codegendir=${datadir}/pygobject/2.0/codegen', "codegendir=#{HOMEBREW_PREFIX}/share/pygobject/2.0/codegen"
+    inreplace lib/"pkgconfig/pygtk-2.0.pc", "codegendir=${datadir}/pygobject/2.0/codegen", "codegendir=#{HOMEBREW_PREFIX}/share/pygobject/2.0/codegen"
     inreplace bin/"pygtk-codegen-2.0", "exec_prefix=${prefix}", "exec_prefix=#{Formula["pygobject"].opt_prefix}"
   end
 

--- a/Library/Formula/pygtk.rb
+++ b/Library/Formula/pygtk.rb
@@ -1,7 +1,7 @@
 class Pygtk < Formula
   desc "GTK+ bindings for Python"
   homepage 'http://www.pygtk.org/'
-  url 'http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2'
+  url 'https://download.gnome.org/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2'
   sha256 "cd1c1ea265bd63ff669e92a2d3c2a88eb26bcd9e5363e0f82c896e649f206912"
   revision 1
 

--- a/Library/Formula/pygtk.rb
+++ b/Library/Formula/pygtk.rb
@@ -17,6 +17,7 @@ class Pygtk < Formula
   depends_on "atk"
   depends_on "pygobject"
   depends_on "py2cairo"
+  depends_on "libglade" => :optional
 
   option :universal
 

--- a/Library/Formula/pygtkglext.rb
+++ b/Library/Formula/pygtkglext.rb
@@ -1,18 +1,17 @@
-require 'formula'
-
 class Pygtkglext < Formula
   desc "Python bindings to OpenGL GTK+ extension"
-  homepage 'http://projects.gnome.org/gtkglext/download.html#pygtkglext'
-  url 'https://downloads.sourceforge.net/gtkglext/pygtkglext-1.1.0.tar.gz'
-  sha1 '2ae3e87e8cdfc3318d8ff0e33b344377cb3df7cb'
+  homepage "http://projects.gnome.org/gtkglext/download.html#pygtkglext"
+  url "https://download.gnome.org/sources/pygtkglext/1.1/pygtkglext-1.1.0.tar.gz"
+  sha256 "9712c04c60bf6ee7d05e0c6a6672040095c2ea803a1546af6dfde562dc0178a3"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'pygtk'
-  depends_on 'gtkglext'
-  depends_on 'pygobject'
+  depends_on "pkg-config" => :build
+  depends_on "pygtk"
+  depends_on "gtkglext"
+  depends_on "pygobject"
 
   def install
-    ENV['PYGTK_CODEGEN'] = "#{Formula["pygobject"].opt_bin}/pygobject-codegen-2.0"
+    ENV["PYGTK_CODEGEN"] = "#{Formula["pygobject"].opt_bin}/pygobject-codegen-2.0"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make install"

--- a/Library/Formula/pygtkglext.rb
+++ b/Library/Formula/pygtkglext.rb
@@ -1,6 +1,6 @@
 class Pygtkglext < Formula
   desc "Python bindings to OpenGL GTK+ extension"
-  homepage "http://projects.gnome.org/gtkglext/download.html#pygtkglext"
+  homepage "https://projects.gnome.org/gtkglext/download.html#pygtkglext"
   url "https://download.gnome.org/sources/pygtkglext/1.1/pygtkglext-1.1.0.tar.gz"
   sha256 "9712c04c60bf6ee7d05e0c6a6672040095c2ea803a1546af6dfde562dc0178a3"
   revision 1

--- a/Library/Formula/pygtkglext.rb
+++ b/Library/Formula/pygtkglext.rb
@@ -14,7 +14,7 @@ class Pygtkglext < Formula
     ENV["PYGTK_CODEGEN"] = "#{Formula["pygobject"].opt_bin}/pygobject-codegen-2.0"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 
   test do

--- a/Library/Formula/pygtksourceview.rb
+++ b/Library/Formula/pygtksourceview.rb
@@ -1,20 +1,19 @@
-require 'formula'
-
 class Pygtksourceview < Formula
   desc "Python wrapper for the GtkSourceView widget library"
-  homepage 'http://projects.gnome.org/gtksourceview/pygtksourceview.html'
-  url 'http://ftp.gnome.org/pub/gnome/sources/pygtksourceview/2.10/pygtksourceview-2.10.0.tar.bz2'
-  sha256 'bfdde2ce4f61d461fb34dece9433cf81a73a9c9de6b62d4eb06177b8c9cec9c7'
+  homepage "https://projects.gnome.org/gtksourceview/pygtksourceview.html"
+  url "https://download.gnome.org/sources/pygtksourceview/2.10/pygtksourceview-2.10.1.tar.bz2"
+  sha256 "b4b47c5aeb67a26141cb03663091dfdf5c15c8a8aae4d69c46a6a943ca4c5974"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtksourceview'
-  depends_on 'pygtk'
+  depends_on "pkg-config" => :build
+  depends_on "gtksourceview"
+  depends_on "pygtk"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-docs"  # attempts to download chunk.xsl on demand (and sometimes fails)
-    system "make install"
+    system "make", "install"
   end
 
   test do

--- a/Library/Formula/pygtksourceview.rb
+++ b/Library/Formula/pygtksourceview.rb
@@ -7,6 +7,7 @@ class Pygtksourceview < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gtksourceview"
+  depends_on "gtk+"
   depends_on "pygtk"
 
   def install

--- a/Library/Formula/synfig.rb
+++ b/Library/Formula/synfig.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Synfig < Formula
   desc "Command-line renderer"
   homepage "http://synfig.org"
-  url "https://downloads.sourceforge.net/project/synfig/releases/0.64.3/source/synfig-0.64.3.tar.gz"
-  sha1 "868e55dcac9ecda93c6f4aa2d842713f5b77df8d"
+  url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/synfig-1.0.tar.gz"
+  sha256 "1f2f9b209d49dff838049e9817b0458ac6987e912a56c061aa2f9c2faeb40720"
 
   head "git://synfig.git.sourceforge.net/gitroot/synfig/synfig"
 
@@ -26,6 +24,7 @@ class Synfig < Formula
   depends_on "pango"
   depends_on "boost"
   depends_on "openexr"
+  depends_on "mlt"
   depends_on "libtool" => :run
 
   def install
@@ -34,6 +33,84 @@ class Synfig < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-boost=#{boost.opt_prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <synfig/version.h>
+      int main(int argc, char *argv[])
+      {
+        const char *version = synfig::get_version();
+        return 0;
+      }
+    EOS
+    ENV.libxml2
+    cairo = Formula["cairo"]
+    etl = Formula["etl"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    libpng = Formula["libpng"]
+    libsigcxx = Formula["libsigc++"]
+    libxmlxx = Formula["libxml++"]
+    mlt = Formula["mlt"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{cairo.opt_include}/cairo
+      -I#{etl.opt_include}
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/giomm-2.4
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/giomm-2.4/include
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{include}/synfig-1.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{libxmlxx.opt_include}/libxml++-2.6
+      -I#{libxmlxx.opt_lib}/libxml++-2.6/include
+      -I#{mlt.opt_include}
+      -I#{mlt.opt_include}/mlt
+      -I#{mlt.opt_include}/mlt++
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{cairo.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{libxmlxx.opt_lib}
+      -L#{lib}
+      -L#{mlt.opt_lib}
+      -L#{pango.opt_lib}
+      -lcairo
+      -lgio-2.0
+      -lgiomm-2.4
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lintl
+      -lmlt
+      -lmlt++
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lpthread
+      -lsigc-2.0
+      -lsynfig
+      -lxml++-2.6
+      -lxml2
+    ]
+    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/synfigstudio.rb
+++ b/Library/Formula/synfigstudio.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Synfigstudio < Formula
   desc "Vector-based 2D animation package"
   homepage "http://synfig.org"
-  url "https://downloads.sourceforge.net/project/synfig/releases/0.64.3/source/synfigstudio-0.64.3.tar.gz"
-  sha1 "63655509a6a5920eb067021730abbb52164436f5"
+  url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/synfigstudio-1.0.tar.gz"
+  sha256 "2b23916ca0be4073edad9b0cb92fd30311dd3b8f73372c836ba735100251ee28"
 
   bottle do
     sha1 "c8eb2ea83ffc2ca9959c20588ee7c18fdcf706b4" => :yosemite
@@ -16,7 +14,7 @@ class Synfigstudio < Formula
   depends_on "intltool" => :build
   depends_on "gettext"
   depends_on "libsigc++"
-  depends_on "gtkmm"
+  depends_on "gtkmm3"
   depends_on "etl"
   depends_on "synfig"
 
@@ -24,6 +22,11 @@ class Synfigstudio < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    # executable doesnt take options that will stop the gui from spawning
+    assert (share/"appdata/synfigstudio.appdata.xml").exist?
   end
 end

--- a/Library/Formula/vte.rb
+++ b/Library/Formula/vte.rb
@@ -1,18 +1,16 @@
-require 'formula'
-
 class Vte < Formula
   desc "Terminal emulator widget used by GNOME terminal"
-  homepage 'http://developer.gnome.org/vte/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/vte/0.28/vte-0.28.0.tar.bz2'
-  sha1 '49b66a0346da09c72f59e5c544cc5b50e7de9bc1'
+  homepage "https://developer.gnome.org/vte/"
+  url "https://download.gnome.org/sources/vte/0.28/vte-0.28.2.tar.xz"
+  sha256 "86cf0b81aa023fa93ed415653d51c96767f20b2d7334c893caba71e42654b0ae"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'intltool' => :build
-  depends_on 'gettext'
-  depends_on 'glib'
-  depends_on 'gtk+'
-  depends_on 'pygobject'
-  depends_on 'pygtk'
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gtk+"
+  depends_on "pygobject"
+  depends_on "pygtk"
   depends_on :python
 
   def install
@@ -20,16 +18,77 @@ class Vte < Formula
       "--disable-dependency-tracking",
       "--prefix=#{prefix}",
       "--disable-Bsymbolic",
+      "--enable-python"
     ]
 
-    if build.with? "python"
-      # pygtk-codegen-2.0 has been deprecated and replaced by
-      # pygobject-codegen-2.0, but the vte Makefile does not detect this.
-      ENV["PYGTK_CODEGEN"] = Formula["pygobject"].bin/'pygobject-codegen-2.0'
-      args << "--enable-python"
-    end
+    # pygtk-codegen-2.0 has been deprecated and replaced by
+    # pygobject-codegen-2.0, but the vte Makefile does not detect this.
+    ENV["PYGTK_CODEGEN"] = Formula["pygobject"].bin/"pygobject-codegen-2.0"
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <vte/vte.h>
+
+      int main(int argc, char *argv[]) {
+        char *rv = vte_get_user_shell();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gtkx = Formula["gtk+"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/gio-unix-2.0/
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gtkx.opt_include}/gtk-2.0
+      -I#{gtkx.opt_lib}/gtk-2.0/include
+      -I#{include}/vte-0.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gtkx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lgdk-quartz-2.0
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lgtk-quartz-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lvte
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -1,19 +1,15 @@
-require "formula"
-
 class Vte3 < Formula
   desc "Terminal emulator widget used by GNOME terminal"
-  homepage "http://developer.gnome.org/vte/"
-  url "http://ftp.gnome.org/pub/gnome/sources/vte/0.36/vte-0.36.3.tar.xz"
-  sha1 "a7acc1594eb6fa249edccb059c21132b3aa2657b"
+  homepage "https://developer.gnome.org/vte/"
+  url "https://download.gnome.org/sources/vte/0.40/vte-0.40.2.tar.xz"
+  sha256 "9b68fbc16b27f2d79e6271f2b0708808594ac5acf979d0fccea118608199fd2d"
 
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext"
-  depends_on "glib"
   depends_on "gtk+3"
-  depends_on "pygtk"
-  depends_on "gobject-introspection"
-  depends_on :python
+  depends_on "gnutls"
+  depends_on "vala"
 
   def install
     args = [
@@ -23,14 +19,81 @@ class Vte3 < Formula
       "--enable-introspection=yes",
     ]
 
-    if build.with? "python"
-      # pygtk-codegen-2.0 has been deprecated and replaced by
-      # pygobject-codegen-2.0, but the vte Makefile does not detect this.
-      ENV["PYGTK_CODEGEN"] = Formula["pygobject"].bin/"pygobject-codegen-2.0"
-      args << "--enable-python"
-    end
-
     system "./configure", *args
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <vte/vte.h>
+
+      int main(int argc, char *argv[]) {
+        guint v = vte_get_major_version();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gnutls = Formula["gnutls"]
+    gtkx3 = Formula["gtk+3"]
+    libepoxy = Formula["libepoxy"]
+    libpng = Formula["libpng"]
+    libtasn1 = Formula["libtasn1"]
+    nettle = Formula["nettle"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/gio-unix-2.0/
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gnutls.opt_include}
+      -I#{gtkx3.opt_include}/gtk-3.0
+      -I#{include}/vte-2.91
+      -I#{libepoxy.opt_include}
+      -I#{libpng.opt_include}/libpng16
+      -I#{libtasn1.opt_include}
+      -I#{nettle.opt_include}
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gnutls.opt_lib}
+      -L#{gtkx3.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lcairo-gobject
+      -lgdk-3
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgnutls
+      -lgobject-2.0
+      -lgtk-3
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lvte-2.91
+      -lz
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/xplanetfx.rb
+++ b/Library/Formula/xplanetfx.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Xplanetfx < Formula
   desc "Configure, run or daemonize xplanet for HQ Earth wallpapers"
   homepage "http://mein-neues-blog.de/xplanetFX/"
@@ -41,7 +39,7 @@ class Xplanetfx < Formula
       ENV.prepend_create_path "PYTHONPATH", "#{HOMEBREW_PREFIX}/lib/python2.7/site-packages/gtk-2.0"
       ENV.prepend_create_path "GDK_PIXBUF_MODULEDIR", "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
     end
-    bin.env_script_all_files(libexec+'bin', :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"])
+    bin.env_script_all_files(libexec+"bin", :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"])
   end
 
   def post_install
@@ -50,5 +48,9 @@ class Xplanetfx < Formula
       ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
       system "#{HOMEBREW_PREFIX}/bin/gdk-pixbuf-query-loaders", "--update-cache"
     end
+  end
+
+  test do
+    system "#{bin}/xplanetFX", "--help"
   end
 end

--- a/Library/Formula/xsane.rb
+++ b/Library/Formula/xsane.rb
@@ -1,23 +1,26 @@
-require 'formula'
-
 class Xsane < Formula
   desc "Graphical scanning frontend"
-  homepage 'http://www.xsane.org'
-  url 'http://www.xsane.org/download/xsane-0.999.tar.gz'
-  sha1 '633150e4e690c1e8c18d6b82886c2fb4daba4bc9'
+  homepage "http://www.xsane.org"
+  url "http://www.xsane.org/download/xsane-0.999.tar.gz"
+  sha256 "5782d23e67dc961c81eef13a87b17eb0144cae3d1ffc5cf7e0322da751482b4b"
+  revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'gtk+'
-  depends_on 'sane-backends'
+  depends_on "pkg-config" => :build
+  depends_on "gtk+"
+  depends_on "sane-backends"
 
   # Needed to compile against libpng 1.5
   patch :p0 do
     url "https://trac.macports.org/export/113352/trunk/dports/graphics/xsane/files/patch-src__xsane-save.c-libpng15-compat.diff"
-    sha1 "c303b09c3007a12557095cf2e2a2d3328dd4cf07"
+    sha256 "404b963b30081bfc64020179be7b1a85668f6f16e608c741369e39114af46e27"
   end
 
   def install
-     system "./configure", "--prefix=#{prefix}"
-     system "make", "install"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/xsane", "--version"
   end
 end

--- a/Library/Formula/xsane.rb
+++ b/Library/Formula/xsane.rb
@@ -10,6 +10,7 @@ class Xsane < Formula
   depends_on "sane-backends"
 
   # Needed to compile against libpng 1.5
+  # Project appears to be dead
   patch :p0 do
     url "https://trac.macports.org/export/113352/trunk/dports/graphics/xsane/files/patch-src__xsane-save.c-libpng15-compat.diff"
     sha256 "404b963b30081bfc64020179be7b1a85668f6f16e608c741369e39114af46e27"


### PR DESCRIPTION
@mikemcquaid 

This branch represents an effort to remove the X11 dependency completely from gtk+ and its dependencies cairo and pango.

The rationale behind this move is:

1. It is a major pain for homebrew to support simultaneously the X11 and quartz backends of gtk+. Some formulas require the quartz backend explicitly (like gtk-mac-integration, which for this reason is still not included in homebrew). See also e.g. #38969 for a discussion about this (there are a lot more PRs and issues where this problem was brought up!)
2. In gtk+3, the X11 backend is not even supported anymore
3. X11 is very un-Mac OS X anyway and delivers an inferior user experience (IMHO)
4. ~~Are there any packages that really need the gtk+ X11 backend to work properly anyway?~~ Apparently `gtkglarea` does, it will be moved to the boneyard...

My plan is basically to:

1. Remove X11 from the dependency list of cairo, pango and gtk+. Modify the configure argument list to ensure that no X11 bindings will get built. Explicitly enable quartz support. Update the revision number of these formulas
2. Update the revision number of all formulas in Homebrew/homebrew that depend on gtk+. This will be the most work since many of these formulas will not be audit --strict compliant (missing tests).
3. Update the revision number of all formulas in all other Homebrew taps that depend on gtk+. Will create separate pull request for each tap which should be pulled in when this PR is merged in.
  1. science: Homebrew/homebrew-science#2311
  2. x11: Homebrew/homebrew-x11#83
  3. games: Homebrew/homebrew-games#268

It is possible that some formulas that depend only on cairo and/or pango will also need a revision bump if they depend explicitly on the cairo/pango dylibs that are linked to X11. Not sure how to identify these though.

TO DO list (will get longer...):

- [x] cairo
- [x] pango
- [x] gtk+
- [x] cairomm
- [x] pangomm
- [x] gtkmm
- [x] bokken: 1.7 currently does not build on Yosemite (#36052 and #32016). Since it uses pygtk, and not gtk+ directly there is no need to rebuild the package anyway. It should work as soon as the build problem is fixed.
- [x] diffuse
- [x] gabedit
- [x] gbdfed
- [x] gdmap
- [x] gnome-icon-theme: lost its gtk+ dependency by updating librsvg
- [x] goffice: lost its gtk+ dependency by updating librsvg
- [x] gqview
- [x] grsync
- [x] gst-python
- [x] gtk-engines
- [x] gtk-gnutella
- [x] gtk-murrine-engine
- [x] gtkdatabox
- [x] gtkextra
- [x] gtkglarea: needs gtk+ with x11 backend, won't work with quartz. Used by one formula: `fsv`. Will be moved to the boneyard
- [x] gtkglext
- [x] gtksourceview: gtk-mac-integration is required first + patches
- [x] gwyddion
- [x] homebank
- [x] jigdo
- [x] lablgtk
- [x] libglade
- [x] libglademm
- [x] libgnomecanvas
- [x] libgnomecanvasmm
- [x] libinfinity
- [x] librsvg: removed incorrect gtk+ dependency
- [x] mdk: had incorrect gtk+3 dependency, should have been gtk+
- [x] minbif
- [x] open-scene-graph
- [x] pidgin
- [x] pygtk
- [x] pygtkglext
- [x] pygtksourceview
- [x] qiv: going to the boneyard. Needs gtk+ with X11 and uses X11 directly too...
- [x] synfigstudio
- [x] vte
- [x] vte3
- [x] xplanetfx
- [x] xsane
- [x] cogl
- [x] fontforge: formula updated but there's one `audit --strict` problem I cannot seem to fix
- [x] gtk-mac-integration 2.0.8: new formula added!