### PR TITLE
odt2txt: fix missing prefix

### DIFF
--- a/Library/Formula/odt2txt.rb
+++ b/Library/Formula/odt2txt.rb
@@ -1,9 +1,12 @@
-require "formula"
-
 class Odt2txt < Formula
   homepage "https://github.com/dstosberg/odt2txt/"
   url "https://github.com/dstosberg/odt2txt/archive/v0.5.tar.gz"
-  sha1 "deac1995f02d3b907843dd99a975b201a5f55177"
+  sha256 "23a889109ca9087a719c638758f14cc3b867a5dcf30a6c90bf6a0985073556dd"
+
+  resource "sample" do
+    url "https://github.com/Turbo87/odt2txt/raw/samples/samples/sample-1.odt"
+    sha256 "78a5b17613376e50a66501ec92260d03d9d8106a9d98128f1efb5c07c8bfa0b2"
+  end
 
   bottle do
     cellar :any
@@ -13,12 +16,7 @@ class Odt2txt < Formula
   end
 
   def install
-    system "make", "install"
-  end
-
-  resource "sample" do
-    url "https://github.com/Turbo87/odt2txt/raw/samples/samples/sample-1.odt"
-    sha1 "0f29df4fd772c407d7d7b105281cd926f0204b17"
+    system "make", "install", "DESTDIR=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
The bottle is empty and the from-source installs directly into `/usr/local/bin`. This fixes that.

Closes #39871