### PR TITLE
finatra 1.5.3

### DIFF
--- a/Library/Formula/finatra.rb
+++ b/Library/Formula/finatra.rb
@@ -3,7 +3,7 @@ require "formula"
 class Finatra < Formula
   homepage "http://finatra.info/"
   url "https://github.com/twitter/finatra/archive/1.5.3.tar.gz"
-  sha1 "bb9fe6a7175c1bff404f515731f071e9f8cca586"
+  sha1 "7f2fcf458badf42c5401587b7be19a4f5c5b439c"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
Due to (inadvertent) Finatra history changes the SHA1 of the Finatra 1.5.3 release archive has changed. This change is to update to the new correct SHA1 for the binary.