### PR TITLE
mongo-c 1.1.6

### DIFF
--- a/Library/Formula/mongo-c.rb
+++ b/Library/Formula/mongo-c.rb
@@ -1,7 +1,7 @@
 class MongoC < Formula
   homepage "https://docs.mongodb.org/ecosystem/drivers/c/"
-  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.1.5/mongo-c-driver-1.1.5.tar.gz"
-  sha256 "ebad1af02c50b6db20bb9ca988d1050b97c13bed65e9de8b5ac93eee71115c29"
+  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.1.6/mongo-c-driver-1.1.6.tar.gz"
+  sha256 "231d0d038c848e8871fa03b70f74284dd8481734eac2bf05fb240e94c9279130"
 
   bottle do
     cellar :any


### PR DESCRIPTION
I'm no expert on Homebrew, is there a reason my predecessors used a sha1 for libbson and sha256 for mongo-c?