### PR TITLE
Add description field to Formulae

### DIFF
--- a/Library/Contributions/example-formula.rb
+++ b/Library/Contributions/example-formula.rb
@@ -9,6 +9,7 @@
 # Homebrew does enforce that the name of the file and the class correspond.
 # Check with `brew search` that the name is free.
 class ExampleFormula < Formula
+  desc "An example formula" # shows up in `brew info`, and can be searched with `brew search --desc`.
   homepage "https://www.example.com" # used by `brew home example-formula`.
   revision 1 # This is used when there's no new version but it needs recompiling for another reason.
              # 0 is default & unwritten.

--- a/Library/Formula/ack.rb
+++ b/Library/Formula/ack.rb
@@ -1,4 +1,5 @@
 class Ack < Formula
+  desc "A search tool like grep, but optimized for programmers"
   homepage "http://beyondgrep.com/"
   url "http://beyondgrep.com/ack-2.14-single-file"
   sha256 "1d203cfbc52ce8f49e3992be1cd3e4d7d5dfb7daa3739e8628aa9858ccc5b9df"

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -244,6 +244,32 @@ class FormulaAuditor
     end
   end
 
+  def audit_desc
+    # For now, only check the description when using `--strict`
+    return unless @strict
+
+    desc = formula.desc
+
+    unless desc and desc.length > 0
+      problem "Formula should have a desc (Description)."
+      return
+    end
+
+    # Make sure the formula name plus description is no longer than 80 characters
+    linelength = formula.name.length + ": ".length + desc.length
+    if linelength > 80
+      problem "Description is too long. \"name: desc\" should be less than 80 characters (currently #{linelength})."
+    end
+
+    if desc =~ %r[[Cc]ommandline]
+      problem "It should be \"command-line\", not \"commandline\"."
+    end
+
+    if desc =~ %r[[Cc]ommand line]
+      problem "It should be \"command-line\", not \"command line\"."
+    end
+  end
+
   def audit_homepage
     homepage = formula.homepage
 
@@ -706,6 +732,7 @@ class FormulaAuditor
     audit_file
     audit_class
     audit_specs
+    audit_desc
     audit_homepage
     audit_deps
     audit_conflicts

--- a/Library/Homebrew/cmd/create.rb
+++ b/Library/Homebrew/cmd/create.rb
@@ -124,6 +124,7 @@ class FormulaCreator
     # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 
     class #{Formulary.class_s(name)} < Formula
+      desc ""
       homepage ""
       url "#{url}"
     <% unless version.nil? or version.detected_from_url? %>

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -94,6 +94,8 @@ module Homebrew
 
     puts "#{f.name}: #{specs*', '}#{' (pinned)' if f.pinned?}"
 
+    puts f.desc if f.desc
+
     puts f.homepage
 
     if f.keg_only?

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -20,6 +20,13 @@ module Homebrew
       exec_browser "https://admin.fedoraproject.org/pkgdb/packages/%2A#{ARGV.next}%2A/"
     elsif ARGV.include? '--ubuntu'
       exec_browser "http://packages.ubuntu.com/search?keywords=#{ARGV.next}&searchon=names&suite=all&section=all"
+    elsif ARGV.include? '--desc'
+      query = ARGV.next
+      Formula.each do |formula|
+        if formula.desc =~ query_regexp(query)
+          puts "#{formula.name}: #{formula.desc}"
+        end
+      end
     elsif ARGV.empty?
       puts_columns Formula.names
     elsif ARGV.first =~ HOMEBREW_TAP_FORMULA_REGEX

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -163,6 +163,12 @@ class Formula
     Bottle.new(self, bottle_specification) if bottled?
   end
 
+  # The description of the software.
+  # @see .desc
+  def desc
+    self.class.desc
+  end
+
   # The homepage for the software.
   # @see .homepage
   def homepage
@@ -685,6 +691,7 @@ class Formula
   def to_hash
     hsh = {
       "name" => name,
+      "desc" => desc,
       "homepage" => homepage,
       "versions" => {
         "stable" => (stable.version.to_s if stable),
@@ -920,6 +927,12 @@ class Formula
     # {::HOMEBREW_PREFIX}.
     # @private
     attr_reader :keg_only_reason
+
+    # @!attribute [w]
+    # A one-line description of the software. Used by users to get an overview
+    # of the software and Homebrew maintainers.
+    # Shows when running `brew info`.
+    attr_rw :desc
 
     # @!attribute [w]
     # The homepage for the software. Used by users to get more information


### PR DESCRIPTION
• Add a desc field to the Formula class
• Fill out the desc field for each formula in Homebrew/homebrew
• `brew audit` checks for desc
• `brew info` shows the desc
• `brew search --desc` searches on desc (preliminary)