### PR TITLE
utils: prefer keg curl over system on 10.6

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -175,7 +175,12 @@ def quiet_system cmd, *args
 end
 
 def curl *args
-  curl = Pathname.new '/usr/bin/curl'
+  brewed_curl = HOMEBREW_PREFIX/"opt/curl/bin/curl"
+  curl = if MacOS.version <= "10.6" && brewed_curl.exist?
+    brewed_curl
+  else
+    Pathname.new '/usr/bin/curl'
+  end
   raise "#{curl} is not executable" unless curl.exist? and curl.executable?
 
   flags = HOMEBREW_CURL_ARGS


### PR DESCRIPTION
Adds support for using a different curl binary than /usr/bin/curl
via a HOMEBREW_CURL_PATH environment variable.

Pretty self-explanatory, I hope. Discovered I needed this when trying to brew install anything sourced from https://download.gnome.org/; the version of curl shipped with 10.6 (I know, I know) doesn't play well with servers running newer versions of OpenSSL (see http://sourceforge.net/p/curl/bugs/1037/).