### PR TITLE
yle-dl 2.7.1

### DIFF
--- a/Library/Formula/yle-dl.rb
+++ b/Library/Formula/yle-dl.rb
@@ -44,6 +44,6 @@ class YleDl < Formula
 
   test do
     assert_equal "3 minuuttia-2012-05-30T10:51:00\n",
-                 shell_output("#{bin}/yle-dl --showtitle http://areena.yle.fi/tv/1570236")
+                 shell_output("#{bin}/yle-dl --showtitle http://areena.yle.fi/1-1570236")
   end
 end

--- a/Library/Formula/yle-dl.rb
+++ b/Library/Formula/yle-dl.rb
@@ -1,7 +1,7 @@
 class YleDl < Formula
   homepage "https://aajanki.github.io/yle-dl/index-en.html"
-  url "https://github.com/aajanki/yle-dl/archive/2.5.0.tar.gz"
-  sha1 "6530a47b69a905f7ae92b97ded37c81437a8be72"
+  url "https://github.com/aajanki/yle-dl/archive/2.7.1.tar.gz"
+  sha1 "041f212d56a981e1c53f6bdf042a281db965d6ed"
 
   head "https://github.com/aajanki/yle-dl.git"
 

--- a/Library/Formula/yle-dl.rb
+++ b/Library/Formula/yle-dl.rb
@@ -43,7 +43,7 @@ class YleDl < Formula
   end
 
   test do
-    assert_equal "3 minuuttia-2012-05-30T10:51:00\n",
+    assert_equal "Yle - Sinun tarinasi: 3 minuuttia-2012-05-30T10:51:00+03:00\n",
                  shell_output("#{bin}/yle-dl --showtitle http://areena.yle.fi/1-1570236")
   end
 end


### PR DESCRIPTION
Yle Areena has changed its URL format rendering the previous version
unable to download videos.