### PR TITLE
nghttp2 1.0.0

### DIFF
--- a/Library/Formula/nghttp2.rb
+++ b/Library/Formula/nghttp2.rb
@@ -1,7 +1,7 @@
 class Nghttp2 < Formula
   homepage "https://nghttp2.org"
-  url "https://github.com/tatsuhiro-t/nghttp2/releases/download/v0.7.13/nghttp2-0.7.13.tar.xz"
-  sha256 "91f2bfcad1e27472d8c96de71d9bcb37d93b131ee60c775c95b46be82a24e1db"
+  url "https://github.com/tatsuhiro-t/nghttp2/releases/download/v1.0.0/nghttp2-1.0.0.tar.xz"
+  sha256 "b4c3b9176f5fc70c52878a09a71c877f6d54efd25867093c4bf04852bfe24282"
 
   bottle do
     sha256 "d8503c739001158d086269440377054db0fa3dd82fe160b049c39b98bb59051d" => :yosemite


### PR DESCRIPTION
Words of caution:
https://nghttp2.org/blog/2015/05/16/nghttp2-v1-0-0/
https://www.youtube.com/watch?v=VN4rVnf2cR8

The API changed in incompatible ways with the 0.7.16 to 1.0.0 bump. Its only dependency inside Homebrew, `curl` will break with its current release when built against optional `nghttp2`. It will be made compatible with its next scheduled release 7.43.0, when it will require 1.0.0.