### PR TITLE
Tika: add US and EU mirrors

### DIFF
--- a/Library/Formula/tika.rb
+++ b/Library/Formula/tika.rb
@@ -3,6 +3,8 @@ require 'formula'
 class Tika < Formula
   homepage 'https://tika.apache.org/'
   url 'https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.8.jar'
+  mirror 'http://www.us.apache.org/dist/tika/tika-app-1.8.jar'
+  mirror 'http://www.eu.apache.org/dist/tika/tika-app-1.8.jar'
   sha256 '9346cf68c00a46b2e6189794d5fb2e127bf9b60ef6d216edf06e01917f7deaef'
 
   resource 'server' do


### PR DESCRIPTION
Tika currently cannot be installed due to the way the Apache mirrors work (see #39935) but this avoids the problem by specifying the official backup URLs as mirrors