### PR TITLE
node: fix sometimes-broken manpage linkage

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -31,8 +31,8 @@ class Node < Formula
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.7.6.tgz"
-    sha256 "a9445167f68a42ffcdaa36f9f5c14a954237fce6898555c362e8785261fd72a1"
+    url "https://registry.npmjs.org/npm/-/npm-2.10.0.tgz"
+    sha256 "c85b990fd63c4c60a5fcf54deff500438e2918f0b2b010d1ca62d94f29af0d3a"
   end
 
   def install
@@ -94,7 +94,7 @@ class Node < Formula
       # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
       mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      ln_sf Dir[libexec/"npm/share/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 
     npm_root = node_modules/"npm"


### PR DESCRIPTION
This issue is fun. Firstly, it does impact the upstream build. I reproduced our Homebrew build outside of Homebrew, and the symlinking the symlinks breaks there.

The way npm's `make install` works is to install everything into the prefix specified, in this case `libexec/npm`, and then it creates symlinks from `libexec/npm/lib/node_modules/npm/man/man*/npm*` to `libexec/npm/share/man*/npm*`.

For some reason, those symlinks break, both inside and outside of Homebrew, albeit slightly differently. Outside of Homebrew they break in the symlinking the symlinks stage. Inside of Homebrew they break in `make install`. Who even knows why.

This issue also doesn't reproduce constantly. Sometimes it ["just works"](https://farm3.staticflickr.com/2066/5807458526_dc54025065_z.jpg). Exactly what variables cause it to work and what causes it to break, who knows. I looked into different shells, different versions of npm, different OS X versions - None of it seemed to matter.

The workaround is just to symlink the solid, tangible manpages that exist in `libexec/npm/lib/node_modules/npm/man/man*` rather than symlinking the symlinks that exist in `libexec/npm/share/man/*`.

As reported in https://github.com/Homebrew/homebrew/issues/39823#issue-77146790 in some cases the `make install` stage of `npm` seems to symlink inside the buildpath, even though we're setting the prefix to `libexec/npm` and have encountered no other issues with retention of build paths.

The problem *seems* to be that `ln_sf` itself is storing the paths. If I do it outside of Homebrew, I get this:

```
ln -sf share/man/man1/* /Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1
ls -l /Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1/npm-config.1

/Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1/npm-config.1 -> share/man/man1/npm-config.1
```

Which obviously creates dead symlinks in `/Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1/*`.

If I switch over to using GNU's `ln` instead of OS X's default, and use this command instead:
`gln -sfr share/man/man1/* /Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1` I get:

```
/Users/Dominyk/Downloads/package/TEST1/hmm/share/man/man1/npm-config.1 -> ../../../../../man/man1/npm-config.1
```

And it seems to work. To my knowledge, BSD `ln` doesn't contain the relative option.

Closes #39823