### PR TITLE
libepoxy: build requires Python 2.7

### DIFF
--- a/Library/Formula/libepoxy.rb
+++ b/Library/Formula/libepoxy.rb
@@ -14,6 +14,7 @@ class Libepoxy < Formula
   depends_on "automake" => :build
   depends_on "autoconf" => :build
   depends_on "libtool" => :build
+  depends_on :python => :build if MacOS.version <= :snow_leopard
 
   resource "xorg-macros" do
     url "http://xorg.freedesktop.org/releases/individual/util/util-macros-1.19.0.tar.bz2"


### PR DESCRIPTION
Which ships with Lion, but Snow Leopard is still on 2.6.