### PR TITLE
poppler 0.33.0

### DIFF
--- a/Library/Formula/poppler.rb
+++ b/Library/Formula/poppler.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Poppler < Formula
   homepage 'http://poppler.freedesktop.org'
-  url 'http://poppler.freedesktop.org/poppler-0.29.0.tar.xz'
-  sha1 'ba3330ab884e6a139ca63dd84d0c1c676f545b5e'
+  url 'http://poppler.freedesktop.org/poppler-0.33.0.tar.xz'
+  sha1 '56c195f2c5e56fa017d32c0507a31b226f48bedb'
 
   bottle do
     sha1 "b83e3b7fe032d69343367ceb481a0387e447e565" => :yosemite


### PR DESCRIPTION
Hi,

It's been a while since we've pushed an updated recipe for poppler so I'm unsure what the current status of things are. Every update since 0.29 has added core fixes for better handling of malformed documents and memory leaks so these would be nice to have.

I've tested by building these from source:

`brew install --build-from-source pdf2svg pdfgrep pdftoipe diff-pdf mat xournal`

All build successfully except:

1. `mat` still reports "MAT was built without PDF support nor GUI." and there's still no flag to enable this.
2. `frescobaldi` complains that `fontforge` "was built with a different C++ standard
library (libstdc++ from clang)." Building `fontforge` (and `gettext`) from source doesn't resolve this though.

I've recently updated to the latest Xcode and command-line tools. Could this be causing this?