### PR TITLE
Change formula to use sshuttle/sshuttle fork

### DIFF
--- a/Library/Formula/sshuttle.rb
+++ b/Library/Formula/sshuttle.rb
@@ -1,17 +1,29 @@
 require 'formula'
 
 class Sshuttle < Formula
-  homepage 'https://github.com/apenwarr/sshuttle'
-  url 'https://github.com/apenwarr/sshuttle/archive/sshuttle-0.61.tar.gz'
-  sha1 '05551cdc78e866d983470ba4084beb206bacebd8'
+  homepage 'https://github.com/sshuttle/sshuttle'
+  url 'https://github.com/sshuttle/sshuttle/archive/sshuttle-0.71.tar.gz'
+  sha256 '62f0f8be5497c2d0098238c54e881ac001cd84fce442c2506ab6d37aa2f698f0'
 
-  head 'https://github.com/apenwarr/sshuttle.git'
+  # Restrict to 10.9 and above until proven otherwise
+  depends_on :macos => :mavericks
+
+  head 'https://github.com/sshuttle/sshuttle.git'
 
   def install
     # Building the docs requires installing
     # markdown & BeautifulSoup Python modules
     # so we don't.
-    libexec.install Dir['*']
+    libexec.install Dir['src/*']
     bin.write_exec_script libexec/'sshuttle'
+  end
+  test do
+    require "open3"
+    cmd = '#{bin}/sshuttle --server'
+    Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+      sleep 1
+      exit_status = wait_thr.value
+      return false unless exit_status.success?
+    end
   end
 end


### PR DESCRIPTION
This is a simple change to use the fork at https://github.com/sshuttle/sshuttle that includes fixes for sshuttle to work in recent releases of OS X. See the discussion at https://github.com/Homebrew/homebrew/issues/37907