### PR TITLE
trafficserver 5.3.0

### DIFF
--- a/Library/Formula/trafficserver.rb
+++ b/Library/Formula/trafficserver.rb
@@ -1,15 +1,18 @@
 class Trafficserver < Formula
   homepage "https://trafficserver.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-5.2.1.tar.bz2"
-  mirror "https://archive.apache.org/dist/trafficserver/trafficserver-5.2.1.tar.bz2"
-  sha256 "7980be2c1b95d9b1c6b91d6a8ab88e24a8c31b36acd2d02c4df8c47dc18e6b1d"
+  url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-5.3.0.tar.bz2"
+  mirror "https://archive.apache.org/dist/trafficserver/trafficserver-5.3.0.tar.bz2"
+  sha256 "d14184546769bac7134804c15c2fea32232c28c920717167e633d29e6eb0822b"
 
   head do
     url "https://github.com/apache/trafficserver.git"
-
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool"  => :build
+
+    fails_with :gcc do
+      cause "symbol(s) not found for architecture x86_64: https://issues.apache.org/jira/browse/TS-3630"
+    end
   end
 
   bottle do
@@ -28,13 +31,10 @@ class Trafficserver < Formula
     depends_on "pkg-config" => :build
   end
 
-  # Patch 1: OpenSSL 1.0.2+ tls1.h detection, remove on 5.3.0 (upstream bug TS-3443)
-  # Patch 2: Xcode 6.3 compile fix, remove on 5.3.0 (upstream bug TS-3302)
-  stable do
-    patch :DATA
-  end
+  needs :cxx11
 
   def install
+    ENV.cxx11
     # Needed for correct ./configure detections.
     ENV.enable_warnings
     # Needed for OpenSSL headers on Lion.
@@ -51,9 +51,10 @@ class Trafficserver < Formula
     args << "--enable-experimental-plugins" if build.with? "experimental-plugins"
     system "./configure", *args
     # Fix wrong username in the generated startup script for bottles.
-    inreplace "rc/trafficserver.in", "@pkgsysuser@", '$USER'
+    inreplace "rc/trafficserver.in", "@pkgsysuser@", "$USER"
     if build.with? "experimental-plugins"
-      # Disable mysql_remap plugin due to missing symbol compile error (upstream bug TS-3490)
+      # Disable mysql_remap plugin due to missing symbol compile error:
+      # https://issues.apache.org/jira/browse/TS-3490
       inreplace "plugins/experimental/Makefile", " mysql_remap", ""
     end
     system "make" if build.head?
@@ -61,61 +62,6 @@ class Trafficserver < Formula
   end
 
   test do
-    system "#{bin}/trafficserver", "status"
+    assert_match "Apache Traffic Server is not running.", shell_output("#{bin}/trafficserver status").chomp
   end
 end
-
-__END__
---- a/configure	2015-03-15 05:01:02.000000000 +0100
-+++ b/configure	2015-03-15 05:08:09.000000000 +0100
-@@ -22608,7 +22608,7 @@
-     done
-   fi
-
--  for ac_header in openssl/tls1.h openssl/ssl.h openssl/ts.h
-+  for ac_header in openssl/ssl.h openssl/ts.h
- do :
-   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
- ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
-@@ -22621,6 +22621,22 @@
-
- done
-
-+  for ac_header in openssl/tls1.h
-+do :
-+  ac_fn_c_check_header_compile "$LINENO" "openssl/tls1.h" "ac_cv_header_openssl_tls1_h" " #if HAVE_OPENSSL_SSL_H
-+#include <openssl/ssl.h>
-+#include <openssl/tls1.h>
-+#endif
-+"
-+if test "x$ac_cv_header_openssl_tls1_h" = xyes; then :
-+  cat >>confdefs.h <<_ACEOF
-+#define HAVE_OPENSSL_TLS1_H 1
-+_ACEOF
-+
-+fi
-+
-+done
-+
-   # We are looking for SSL_CTX_set_tlsext_servername_callback, but it's a
-   # macro, so AC_CHECK_FUNCS is not going to do the business.
-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSL_CTX_set_tlsext_servername_callback" >&5
-diff --git a/lib/ts/IntrusiveDList.h b/lib/ts/IntrusiveDList.h
-index 81a5192..b79ab10 100644
---- a/lib/ts/IntrusiveDList.h
-+++ b/lib/ts/IntrusiveDList.h
-@@ -42,13 +42,8 @@
-
-  */
-
--# if USE_STL
--#   include <iterator>
--# else
--namespace std {
--  struct bidirectional_iterator_tag;
--}
--# endif
-+/// FreeBSD doesn't like just declaring the tag struct we need so we have to include the file.
-+# include <iterator>
-
- /** Intrusive doubly linked list container.


### PR DESCRIPTION
`needs :cxx11`/`ENV.cxx11` was only _required_ for the HEAD build, but trafficserver does use c++11 stuff so I figured it should be unconditional.