### PR TITLE
nghttp2: optionally enable python3 bindings

### DIFF
--- a/Library/Formula/nghttp2.rb
+++ b/Library/Formula/nghttp2.rb
@@ -22,7 +22,7 @@ class Nghttp2 < Formula
   option "without-docs", "Don't build man pages"
   option "with-python3", "This is required for enabling the python bindings"
 
-  depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs") && build.without?("python3")
+  depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
   depends_on :python3 => :optional
   depends_on "libxml2" if MacOS.version <= :lion
   depends_on "pkg-config" => :build
@@ -92,46 +92,31 @@ class Nghttp2 < Formula
   resource "Cython" do
     url "https://pypi.python.org/packages/source/C/Cython/cython-0.22.tar.gz"
     sha256 "14307e7a69af9a0d0e0024d446af7e51cc0e3e4d0dfb10d36ba837e5e5844015"
-  end if build.with?("python3")
+  end
 
   # https://github.com/tatsuhiro-t/nghttp2/issues/125
   # Upstream requested the issue closed and for users to use gcc instead.
   # Given this will actually build with Clang with cxx11, just use that.
   needs :cxx11
 
-  def python_version
-   @python_version ||= begin
-     build.with?('python3') ? [3, 4] : [2, 7]
-   end
-  end
-
-  def python
-   @python ||= begin
-     "python#{python_version.join('.')}"
-   end
-  end
-
-  patch :p1, :DATA
-
   def install
     ENV.cxx11
 
     if build.with? "docs"
-      ENV.prepend_create_path "PYTHONPATH", buildpath+"sphinx/lib/#{python}/site-packages"
+      ENV.prepend_create_path "PYTHONPATH", buildpath+"sphinx/lib/python2.7/site-packages"
       resources.each do |r|
         r.stage do
-          system python, *Language::Python.setup_install_args(buildpath/'sphinx')
-        end unless r.name == 'Cython'
+          system "python", *Language::Python.setup_install_args(buildpath/"sphinx")
+        end unless r.name == "Cython"
       end
       ENV.prepend_path "PATH", (buildpath/"sphinx/bin")
     end
 
-    if build.with?('python3')
-       ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/#{python}/site-packages"
-       resource('Cython').stage do
-         system python, *(Language::Python.setup_install_args(libexec/"vendor") << "--install-scripts=#{libexec}/vendor/bin")
+    if build.with? "python3"
+       ENV.prepend_create_path "PYTHONPATH", buildpath/"cython/lib/python#{Language::Python.major_minor_version "python3"}/site-packages"
+       resource("Cython").stage do
+         system "python3", *(Language::Python.setup_install_args(buildpath/"cython") << "--install-scripts=#{buildpath}/cython/bin")
        end
-       bin.env_script_all_files(libexec/"vendor/bin", :PYTHONPATH => ENV["PYTHONPATH"])
     end
 
     args = %W[
@@ -144,8 +129,8 @@ class Nghttp2 < Formula
 
     args << "--enable-examples" if build.with? "examples"
     args << "--with-spdylay" if build.with? "spdylay"
-    if build.with?('python3')
-      args << "--enable-python-bindings" << "PYTHON=#{Formula['python3'].bin}/#{python}" << "CYTHON=#{libexec}/vendor/bin/cython"
+    if build.with? "python3"
+      args << "--enable-python-bindings" << "PYTHON=python3" << "CYTHON=#{buildpath}/cython/bin/cython" << "PYTHON_EXTRA_LDFLAGS=-undefined dynamic_lookup"
     else
       args << "--disable-python-bindings"
     end
@@ -169,30 +154,3 @@ class Nghttp2 < Formula
     system bin/"nghttp", "-nv", "https://nghttp2.org"
   end
 end
-__END__
-diff --git a/configure b/configure
-index 2d46036..2142ed3 100755
---- a/configure
-+++ b/configure
-@@ -17559,9 +17559,7 @@ $as_echo "$PYTHON_SITE_PKG" >&6; }
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra libraries" >&5
- $as_echo_n "checking python extra libraries... " >&6; }
- 	if test -z "$PYTHON_EXTRA_LIBS"; then
--	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
--                conf = distutils.sysconfig.get_config_var; \
--                print (conf('LIBS'))"`
-+	   PYTHON_EXTRA_LIBS=`$PYTHON-config --libs`
- 	fi
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
- $as_echo "$PYTHON_EXTRA_LIBS" >&6; }
-@@ -17573,9 +17571,7 @@ $as_echo "$PYTHON_EXTRA_LIBS" >&6; }
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra linking flags" >&5
- $as_echo_n "checking python extra linking flags... " >&6; }
- 	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
--		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
--			conf = distutils.sysconfig.get_config_var; \
--			print (conf('LINKFORSHARED'))"`
-+		PYTHON_EXTRA_LDFLAGS=`$PYTHON-config --ldflags`
- 	fi
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
- $as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }


### PR DESCRIPTION
This optionally enables the python 3 bindings of the nghttp2 library.
It should still work with python2, when with-docs are requested. 

The patch is required to detect the linker flags properly under Mac OS X and python 3.4.
I'll try to upstream it, as soon as I find out, where in the automake chain that actually gets generated.

