### PR TITLE
fpp 0.6.0

### DIFF
--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,7 +1,7 @@
 class Fpp < Formula
   homepage "https://facebook.github.io/PathPicker/"
-  url "https://github.com/facebook/PathPicker/releases/download/0.5.7/fpp.0.5.7.tar.gz"
-  sha256 "1293e9510b2d7c1f83320d11cd2f3034545f92daffb6d8de3ee3c8a563972783"
+  url "https://github.com/facebook/PathPicker/releases/download/0.6.0/fpp.0.6.0.tar.gz"
+  sha256 "5e3f9e8ffa5e5d0f4608af521458a93010f2f504ce936ac33cf376505099dc65"
   head "https://github.com/facebook/pathpicker.git"
 
   bottle do


### PR DESCRIPTION
PathPicker 0.6.0 release! Notes here:
https://github.com/facebook/PathPicker/releases/tag/0.6.0

```
[pcottle:~/Dropbox (Facebook)/wip/homebrew:pathPicker0.6.0]$ brew audit --strict ./Library/Formula/fpp.rb
==> brew style fpp

1 file inspected, no offenses detected
```