### PR TITLE
libxc: bump revision for gcc 5

### DIFF
--- a/Library/Formula/libxc.rb
+++ b/Library/Formula/libxc.rb
@@ -2,6 +2,7 @@ class Libxc < Formula
   homepage "http://www.tddft.org/programs/octopus/wiki/index.php/Libxc"
   url "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-2.2.2.tar.gz"
   sha256 "6ca1d0bb5fdc341d59960707bc67f23ad54de8a6018e19e02eee2b16ea7cc642"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,5 +22,30 @@ class Libxc < Formula
     system "make"
     system "make", "check"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+      #include <xc.h>
+      int main()
+      {
+        int i, vmajor, vminor, func_id = 1;
+        xc_version(&vmajor, &vminor);
+        printf(\"%d.%d\", vmajor, vminor);
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lxc", "-I#{include}", "-o", "ctest"
+    system "./ctest"
+
+    (testpath/"test.f90").write <<-EOS.undent
+      program lxctest
+        use xc_f90_types_m
+        use xc_f90_lib_m
+      end program lxctest
+    EOS
+    ENV.fortran
+    system ENV.fc, "test.f90", "-L#{lib}", "-lxc", "-I#{include}", "-o", "ftest"
+    system "./ftest"
   end
 end


### PR DESCRIPTION
Causing `atomic-pseudopotential-engine` build failure in https://github.com/Homebrew/homebrew-science/pull/2303.
```
otool -L /usr/local/opt/libxc/lib/libxcf90.dylib
/usr/local/opt/libxc/lib/libxcf90.dylib:
	/usr/local/lib/libxcf90.3.dylib (compatibility version 4.0.0, current version 4.2.0)
	/usr/local/Cellar/libxc/2.2.2/lib/libxc.3.dylib (compatibility version 4.0.0, current version 4.2.0)
	/usr/local/lib/gcc/4.9/libgfortran.3.dylib (compatibility version 4.0.0, current version 4.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/local/lib/gcc/4.9/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/lib/gcc/4.9/libquadmath.0.dylib (compatibility version 1.0.0, current version 1.0.0)