### PR TITLE
audit: don't complain ENV.fortran if `depends_on :fortran`

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -597,7 +597,7 @@ class FormulaAuditor
       problem "Define method #{$1.inspect} in the class body, not at the top-level"
     end
 
-    if line =~ /ENV.fortran/
+    if line =~ /ENV.fortran/ && !formula.requirements.map(&:class).include?(FortranDependency)
       problem "Use `depends_on :fortran` instead of `ENV.fortran`"
     end
 


### PR DESCRIPTION
Fix the audit problem in #40000.