### PR TITLE
brew-deps: improved --tree formatting

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'formula'
 require 'ostruct'
 
@@ -63,18 +64,25 @@ module Homebrew
   def puts_deps_tree(formulae)
     formulae.each do |f|
       puts f.full_name
-      recursive_deps_tree(f, 1)
+      recursive_deps_tree(f, "")
       puts
     end
   end
 
-  def recursive_deps_tree f, level
-    f.requirements.select(&:default_formula?).each do |req|
-      puts "|  "*(level-1) + "|- :#{req.to_dependency.name}"
+  def recursive_deps_tree f, prefix
+    reqs = f.requirements.select(&:default_formula?)
+    max = reqs.length - 1
+    reqs.each_with_index do |req, i|
+      chr = i == max ? "└──" : "├──"
+      puts prefix + "#{chr} :#{req.to_dependency.name}"
     end
-    f.deps.default.each do |dep|
-      puts "|  "*(level-1) + "|- #{dep.name}"
-      recursive_deps_tree(Formulary.factory(dep.name), level+1)
+    deps = f.deps.default
+    max = deps.length - 1
+    deps.each_with_index do |dep, i|
+      chr = i == max ? "└──" : "├──"
+      prefix_ext = i == max ? "    " : "|   "
+      puts prefix + "#{chr} #{dep.name}"
+      recursive_deps_tree(Formulary.factory(dep.name), prefix + prefix_ext)
     end
   end
 end


### PR DESCRIPTION
This improves the way the tree is formatted with `brew deps --tree`.

Before:
```
$ brew deps cairo --tree
cairo
|- xz
|- pkg-config
|- freetype
|  |- libpng
|  |  |- xz
|- fontconfig
|  |- pkg-config
|  |- freetype
|  |  |- libpng
|  |  |  |- xz
|- libpng
|  |- xz
|- pixman
|  |- pkg-config
|- glib
|  |- xz
|  |- pkg-config
|  |- gettext
|  |  |- xz
|  |- libffi
```

After:
```
$ brew deps cairo --tree
cairo
├── xz
├── pkg-config
├── freetype
|   └── libpng
|       └── xz
├── fontconfig
|   ├── pkg-config
|   └── freetype
|       └── libpng
|           └── xz
├── libpng
|   └── xz
├── pixman
|   └── pkg-config
└── glib
    ├── xz
    ├── pkg-config
    ├── gettext
    |   └── xz
    └── libffi
```

Update: I added the new output after @xu-cheng’s suggestion.