### PR TITLE
audit: formula version string should have digit

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -340,6 +340,14 @@ class FormulaAuditor
       spec.patches.select(&:external?).each { |p| audit_patch(p) }
     end
 
+    %w[Stable Devel].each do |name|
+      next unless spec = formula.send(name.downcase)
+      version = spec.version
+      if version.to_s !~ /\d/
+        problem "#{name}: version (#{version}) is set to a string without a digit"
+      end
+    end
+
     if formula.stable && formula.devel
       if formula.devel.version < formula.stable.version
         problem "devel version #{formula.devel.version} is older than stable version #{formula.stable.version}"


### PR DESCRIPTION
Inspired by #40022. And I catched two formulae with such problem.

```
$ brew audit | grep -B 1 "without a digit"
denominator:
 * Stable: version (cli) is set to a string without a digit
--
moco:
 * Stable: version (runner) is set to a string without a digit
Error: 349 problems in 258 formulae
```
