### PR TITLE
tomcat-native: depend on Java 1.7 and up, use sha256, add mirror

### DIFF
--- a/Library/Formula/tomcat-native.rb
+++ b/Library/Formula/tomcat-native.rb
@@ -1,9 +1,8 @@
-require 'formula'
-
 class TomcatNative < Formula
-  homepage 'https://tomcat.apache.org/native-doc/'
-  url 'https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz'
-  sha1 'c7626c8e5144ee8e958175c4cd034cef90eab1ed'
+  homepage "https://tomcat.apache.org/native-doc/"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz"
+  mirror "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz"
+  sha256 "523dde7393c57307eedf4972ebbe19a9e9af6f7699e3b1ef6dabd7a11677866e"
 
   bottle do
     cellar :any
@@ -14,20 +13,20 @@ class TomcatNative < Formula
 
   depends_on "libtool" => :build
   depends_on "tomcat" => :recommended
-  depends_on :java => "1.7"
+  depends_on :java => "1.7+"
   depends_on "openssl"
   depends_on "apr" => :optional
 
   def install
     cd "jni/native" do
-      if build.with? 'apr'
-        apr_path = Formula['apr'].opt_prefix
+      if build.with? "apr"
+        apr_path = Formula["apr"].opt_prefix
       else
         apr_path = "#{MacOS.sdk_path}/usr"
       end
       system "./configure", "--prefix=#{prefix}",
                             "--with-apr=#{apr_path}",
-                            "--with-java-home=#{`/usr/libexec/java_home`.chomp}",
+                            "--with-java-home=#{ENV["JAVA_HOME"]}",
                             "--with-ssl=#{Formula["openssl"].opt_prefix}"
 
       # fixes occasional compiling issue: glibtool: compile: specify a tag with `--tag'
@@ -36,7 +35,7 @@ class TomcatNative < Formula
       # usr/local/opt/libtool/bin/glibtool: line 1125: /Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.8.xctoolchain/usr/bin/cc: No such file or directory
       args << "CC=#{ENV.cc}" if MacOS.version >= :mountain_lion
       system "make", *args
-      system "make install"
+      system "make", "install"
     end
   end
 


### PR DESCRIPTION
This should also fix #40023.

Java 1.7 is not strictly required as per [webpage](http://tomcat.apache.org/native-doc/):
> Any JDK should work but it is advisable to use the same JVM version the JVM you use with Tomcat.