### PR TITLE
formula_assertions: unused condition removed

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -15,8 +15,6 @@ module Homebrew
 
     if defined?(MiniTest::Assertion)
       FailedAssertion = MiniTest::Assertion
-    elsif defined?(Minitest::Assertion)
-      FailedAssertion = Minitest::Assertion
     else
       FailedAssertion = Test::Unit::AssertionFailedError
     end


### PR DESCRIPTION
This condition repeats the first one.