### PR TITLE
cmd/install: check time of last update if FormulaUnavailableError

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -91,6 +91,16 @@ module Homebrew
         puts_columns(search_formulae(query))
         puts "Searching taps..."
         puts_columns(search_taps(query))
+
+        # If they haven't updated in 48 hours (172800 seconds), that
+        # might explain the error
+        master = HOMEBREW_REPOSITORY.join(".git", "refs", "heads", "master")
+        if master.exist? && (Time.now.to_i - File.mtime(master).to_i) > 172800
+          ohai "You haven't updated Homebrew in a while."
+          puts <<-EOS.undent
+            A formula for #{e.name} might have been added recently: run `brew update` to make sure everything's up-to-date!
+          EOS
+        end
       end
     end
   end


### PR DESCRIPTION
A second attempt at #39794, addressing the problems with that PR.

This was the least invasive place I could think to put the reminder while still having it be useful.