### PR TITLE
[WIP] Improve version match

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -349,11 +349,11 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. https://www.openssl.org/source/openssl-0.9.8s.tar.gz
-    m = /-v?([^-]+)/.match(stem)
+    m = /-v?((?:\d+\.)*\d+[^-]*)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. astyle_1.23_macosx.tar.gz
-    m = /_([^_]+)/.match(stem)
+    m = /_((?:\d+\.)*\d+[^_]*)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. http://mirrors.jenkins-ci.org/war/1.486/jenkins.war


### PR DESCRIPTION
* [x] Prevent `foo-bar-1.0-foo.bar` being parsed as `bar` rather than `1.0`.
* [ ] Support `foo/v1.0/bar` and `foo/1.0/bar`.
* [ ] Create testcase.
* [ ] Cleanup redundant explicit version assign?
