### PR TITLE
asciidoc new home page and head site

### DIFF
--- a/Library/Formula/asciidoc.rb
+++ b/Library/Formula/asciidoc.rb
@@ -1,5 +1,5 @@
 class Asciidoc < Formula
-  homepage "http://www.methods.co.nz/asciidoc"
+  homepage "http://asciidoc.org/"
   url "https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
   sha1 "82e574dd061640561fa0560644bc74df71fb7305"
 
@@ -12,7 +12,7 @@ class Asciidoc < Formula
   end
 
   head do
-    url "https://code.google.com/p/asciidoc/", :using => :hg
+    url "https://github.com/asciidoc/asciidoc.git"
     depends_on "autoconf" => :build
   end
 


### PR DESCRIPTION
AsciiDoc has a new "official" website, asciidoc.org, along with a change in development
organization.  They have also recently migrated from Google Code to
GitHub. This change points the `asciidoc` formula's `home` and `head` at the new locations.

Reference: https://groups.google.com/forum/#!topic/asciidoc/6p7KcFRabp4

Caveat: [Moot now; see UPDATE] When you merge this PR, `brew install asciidoc --HEAD` will start failing with the error `install: filters/latex/latex2png.py: No such file or directory`. This is not an issue with the brew formula; it's because the asciidoc build on `master` is currently broken, due to outstanding issue asciidoc/asciidoc#67. The formula was working for `--HEAD` previously because it's pulling stale code from Google Code.

UPDATE 2015-05-25: AsciiDoc fixed the build on `master`, so the "Caveat" is no longer relevant. `--HEAD` works with this PR now.