### PR TITLE
Fix for #33731

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -23,7 +23,8 @@ module Superenv
   end
 
   def self.bin
-    (HOMEBREW_REPOSITORY/"Library/ENV").subdirs.reject { |d| d.basename.to_s > MacOS::Xcode.version }.max
+    bin = (HOMEBREW_REPOSITORY/"Library/ENV").subdirs.reject { |d| d.basename.to_s > MacOS::Xcode.version }.max
+    bin.realpath unless bin.nil?
   end
 
   def reset


### PR DESCRIPTION
The xcrun script should be skipping the ENV directory when it scans
$PATH looking for tools to run. Unfortunately, the script compares the
paths found to the real path of the ENV directory (following symlinks),
but superenv was adding the nominal path to $PATH, not following
symlinks. As a consequence, platforms with Xcode <4.3 would get into
infinite loops when trying to call non-system versions of gcc, as xcrun
calls the ENV version of gcc-X.X which calls xcrun and so on forever.

This commit changes superenv to follow symlinks when determining the bin
path to use.