### PR TITLE
formula_installer: set tap source for bottles.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -631,6 +631,7 @@ class FormulaInstaller
     )
 
     tab = Tab.for_keg(formula.prefix)
+    tab.tap = formula.tap
     tab.poured_from_bottle = true
     tab.write
   end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -170,6 +170,10 @@ class Tab < OpenStruct
     source["tap"]
   end
 
+  def tap=(tap)
+    source["tap"] = tap
+  end
+
   def to_json
     attributes = {
       "used_options" => used_options.as_flags,


### PR DESCRIPTION
This defaults to the value that's in the bottle but that isn't necessarily correct. For example, some Boxen modules will reuse our old bottles and so if they are installed from there we should be sure
to set the tab's tap to the tap we've installed from rather than the one set inside the bottle's tarball.