### PR TITLE
imagemagick: Change libtiff to recommended

### DIFF
--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -31,11 +31,11 @@ class Imagemagick < Formula
 
   depends_on "jpeg" => :recommended
   depends_on "libpng" => :recommended
+  depends_on "libtiff" => :recommended
   depends_on "freetype" => :recommended
 
   depends_on :x11 => :optional
   depends_on "fontconfig" => :optional
-  depends_on "libtiff" => :optional
   depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
   depends_on "libwmf" => :optional


### PR DESCRIPTION
TIFF is a pretty common file format, particularly in printing, and would be useful to include by default. `libtiff` is not a particularly large or onerous dependency.