### PR TITLE
superenv cc: accept single-digit g++ version

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -44,13 +44,13 @@ class Cmd
     @tool ||= case @arg0
     when 'ld' then 'ld'
     when 'cpp' then 'cpp'
-    when /\w\+\+(-\d\.\d)?$/
+    when /\w\+\+(-\d(\.\d)?)?$/
       case ENV['HOMEBREW_CC']
       when /clang/
         'clang++'
       when /llvm-gcc/
         'llvm-g++-4.2'
-      when /gcc(-\d\.\d)?$/
+      when /gcc(-\d(\.\d)?)?$/
         'g++' + $1.to_s
       end
     else


### PR DESCRIPTION
As you might imagine, not having this causes all kinds of problems when compiling formulae that use C++ with gcc-5.