### PR TITLE
Update Typesafe-Activator to 1.3.3

### DIFF
--- a/Library/Formula/typesafe-activator.rb
+++ b/Library/Formula/typesafe-activator.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class TypesafeActivator < Formula
   homepage 'https://typesafe.com/activator'
-  url 'https://downloads.typesafe.com/typesafe-activator/1.3.2/typesafe-activator-1.3.2.zip'
-  sha1 'b222c96b082fe6e74e03e455fe3103817391f003'
+  url 'https://downloads.typesafe.com/typesafe-activator/1.3.3/typesafe-activator-1.3.3-minimal.zip'
+  sha1 '4930cd73b2d5b7e263287419c75df5be293b210a'
 
   def install
     rm Dir["*.bat"] # Remove Windows .bat files

--- a/Library/Formula/typesafe-activator.rb
+++ b/Library/Formula/typesafe-activator.rb
@@ -2,6 +2,7 @@ require 'formula'
 
 class TypesafeActivator < Formula
   homepage 'https://typesafe.com/activator'
+  version '1.3.3'
   url 'https://downloads.typesafe.com/typesafe-activator/1.3.3/typesafe-activator-1.3.3-minimal.zip'
   sha1 '4930cd73b2d5b7e263287419c75df5be293b210a'
 


### PR DESCRIPTION
Also changed to minimal distribution, which will make original download much faster, and leave the rest to activator to setup, which is recommended.

The full install (1.3.3 not minimal) URL and sha1 are:

    https://downloads.typesafe.com/typesafe-activator/1.3.3/typesafe-activator-1.3.3-minimal.zip
    ac8cc706a9b266f82a7d372f37e32f2a2ac34a30