### PR TITLE
Fix for #40124

### DIFF
--- a/Library/Homebrew/cmd/switch.rb
+++ b/Library/Homebrew/cmd/switch.rb
@@ -40,7 +40,7 @@ module Homebrew
     keg = Keg.new(rack+version)
 
     # Link new version, if not keg-only
-    if keg_only?(canonical_name)
+    if keg_only?(rack)
       keg.optlink
       puts "Opt link created for #{keg}"
     else


### PR DESCRIPTION
Switch command was not updated to match changes to cmd/link.rb `keg_only?`