### PR TITLE
mpd + libnfs

### DIFF
--- a/Library/Formula/libnfs.rb
+++ b/Library/Formula/libnfs.rb
@@ -1,0 +1,40 @@
+class Libnfs < Formula
+  homepage "https://github.com/sahlberg/libnfs"
+  url "https://github.com/sahlberg/libnfs/archive/libnfs-1.9.7.tar.gz"
+  sha256 "7c2e088f5fd85b791ab644a5221b717894208bc5fb8b8a5a49633802ecaa0990"
+
+  depends_on "libtool" => :build
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+
+  def install
+    system "./bootstrap"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <nfsc/libnfs.h>
+
+      int main(void)
+      {
+        int result = 1;
+        struct nfs_context *nfs = NULL;
+        nfs = nfs_init_context();
+
+        if (nfs != NULL) {
+            result = 0;
+            nfs_destroy_context(nfs);
+        }
+
+        return result;
+      }
+    EOS
+    system ENV.cc, "test.c", "-lnfs", "-o", "test"
+    system "./test"
+  end
+end

--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -59,6 +59,7 @@ class Mpd < Formula
   depends_on "yajl" => :optional        # JSON library for SoundCloud
   depends_on "opus" => :optional        # Opus support
   depends_on "libvorbis" => :optional
+  depends_on "libnfs" => :optional
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -88,6 +89,7 @@ class Mpd < Formula
     args << "--disable-lame-encoder" if build.without? "lame"
     args << "--disable-soundcloud" if build.without? "yajl"
     args << "--enable-vorbis-encoder" if build.with? "libvorbis"
+    args << "--enable-nfs" if build.with? "libnfs"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
At the risk of revisting #3337...

Adds libnfs as a new formula and updates mpd to allow it as an optional dependency.