### PR TITLE
audit: enforce gnome urls

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -892,6 +892,8 @@ class ResourceAuditor
         problem "Please use https:// for #{p}"
       when %r[^http://search\.mcpan\.org/CPAN/(.*)]i
         problem "#{p} should be `https://cpan.metacpan.org/#{$1}`"
+      when %r[^(http|ftp)://ftp\.gnome\.org/pub/gnome/(.*)]i
+        problem "#{p} should be `https://download.gnome.org/#{$2}`"
       end
     end
 


### PR DESCRIPTION
`gnome.org` maintainers had tweaked the mirroring logic to have actual `https` mirrors and those even have priority over plaintext ones:
https://bugzilla.gnome.org/show_bug.cgi?id=749481#c3