### PR TITLE
botan: Fix documentation directory

### DIFF
--- a/Library/Formula/botan.rb
+++ b/Library/Formula/botan.rb
@@ -22,7 +22,7 @@ class Botan < Formula
   def install
     args = %W[
       --prefix=#{prefix}
-      --docdir=#{share}/doc
+      --docdir=share/doc
       --cpu=#{MacOS.preferred_arch}
       --cc=#{ENV.compiler}
       --os=darwin


### PR DESCRIPTION
The `configure.py` script of the `botan` package interprets `--docdir=` relative to `--prefix=`, resulting in the documentation directory `#{prefix}#{prefix}/share/doc` (e.g. `/usr/local/Cellar/botan/1.10.9/usr/local/Cellar/botan/1.10.9/share/doc`) instead of `#{prefix}/share/doc` (e.g. `/usr/local/Cellar/botan/1.10.9/share/doc`). This pull request addresses this.