### PR TITLE
protobuf 3.0.0-alpha-3

### DIFF
--- a/Library/Formula/protobuf.rb
+++ b/Library/Formula/protobuf.rb
@@ -4,9 +4,9 @@ class Protobuf < Formula
   sha1 '6421ee86d8fb4e39f21f56991daa892a3e8d314b'
 
   devel do
-    url "https://github.com/google/protobuf/archive/v3.0.0-alpha-2.tar.gz"
-    sha256 "46df8649e2a0ce736e37f8f347f92b32a9b8b54d672bf60bd8f6f4d24d283390"
-    version "3.0.0-alpha-2"
+    url "https://github.com/google/protobuf/archive/v3.0.0-alpha-3.tar.gz"
+    sha256 "bf90fb01b054d364d05d362d63e09d3466311e24bd6db1127dfcd88af443bf05"
+    version "3.0.0-alpha-3"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -107,7 +107,7 @@ class Protobuf < Formula
         syntax = "proto3";
         package test;
         message TestCase {
-          optional string name = 4;
+          string name = 4;
         }
         message Test {
           repeated TestCase case = 1;


### PR DESCRIPTION
This updates the protobuf --devel formula for the new alpha released
yesterday at https://github.com/google/protobuf/releases/tag/v3.0.0-alpha-3
and fixes the proto3 test which was broken:

```
test.proto:4:12: Explicit 'optional' labels are disallowed in the Proto3
syntax. To define 'optional' fields in Proto3, simply remove the
'optional' label, as fields are 'optional' by default.
```

Optional fields should not be specified in proto3.

Signed-off-by: Peter Edge <peter.edge@gmail.com>