### PR TITLE
app-engine-java-sdk 1.9.21

### DIFF
--- a/Library/Formula/app-engine-java-sdk.rb
+++ b/Library/Formula/app-engine-java-sdk.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class AppEngineJavaSdk < Formula
   homepage "https://developers.google.com/appengine/docs/java/gettingstarted/introduction"
-  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.19.zip"
-  sha256 "22a761ea50af1d1a0e1f698cc3fa91765391902a633ca886ea1a6426c3ae1ccb"
+  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.21.zip"
+  sha1 "a405c32aa72d90c404fff0cab59624bf44d9c43d"
 
   def install
     rm Dir["bin/*.cmd"]

--- a/Library/Formula/app-engine-java-sdk.rb
+++ b/Library/Formula/app-engine-java-sdk.rb
@@ -3,7 +3,7 @@ require "formula"
 class AppEngineJavaSdk < Formula
   homepage "https://developers.google.com/appengine/docs/java/gettingstarted/introduction"
   url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.21.zip"
-  sha1 "a405c32aa72d90c404fff0cab59624bf44d9c43d"
+  sha256 "1c1a107330ab45945b4ca3e787dd83be23d0aaf1d177ca30857208d5aec8ac96"
 
   def install
     rm Dir["bin/*.cmd"]


### PR DESCRIPTION
Bumping GAE Java SDK, using SHA from https://cloud.google.com/appengine/downloads#Google_App_Engine_SDK_for_Java