### PR TITLE
yafc 1.3.6

### DIFF
--- a/Library/Formula/yafc.rb
+++ b/Library/Formula/yafc.rb
@@ -1,14 +1,17 @@
-require 'formula'
-
 class Yafc < Formula
-  homepage 'http://www.yafc-ftp.com/'
-  url 'http://www.yafc-ftp.com/upload/yafc-1.3.2.tar.xz'
-  sha1 'a4cd5518b84cd40c4503f2e022ba946a8bd5484a'
+  homepage "http://www.yafc-ftp.com/"
+  url "http://www.yafc-ftp.com/upload/yafc-1.3.6.tar.xz"
+  sha256 "63a32556ed16a589634a5aca3f03134b8d488e06ecb36f9df6ef450aa3a47973"
 
-  depends_on 'readline'
-  depends_on 'libssh' => :recommended
+  depends_on "readline"
+  depends_on "libssh" => :recommended
+  depends_on "pkg-config" => :build
 
-  patch :DATA
+  # Upstream commit to fix the sed flags for OSX in the bash-completion script
+  patch do
+    url "https://github.com/sebastinas/yafc/commit/e8e31e4191f252ab1b58a486e85aabfa28c8da65.diff"
+    sha256 "55b361e7ff87f85776a0cd4560b3c39a7f7db132a232c71265e567d734f11f25"
+  end
 
   def install
     readline = Formula["readline"].opt_prefix
@@ -25,20 +28,3 @@ class Yafc < Formula
     system "#{bin}/yafc", "-V"
   end
 end
-
-__END__
-# The bash-completion script assumes GNU sed and its 'r' option for
-# extended regular expressions. OSX's sed calls this 'E' (they're not
-# entirely compatible, but enough for this use case).
-diff --git a/completion/yafc b/completion/yafc
-index 03c452a..87f02e2 100644
---- a/completion/yafc
-+++ b/completion/yafc
-@@ -8,7 +8,7 @@ _yafc()
-     cur=`_get_cword`
-
-     if [ $COMP_CWORD -eq 1 ] && [ -f ~/.yafc/bookmarks ]; then
--        COMPREPLY=( $( compgen -W '$( sed -nre "/machine/ s/.* alias '\''([^'\'']*)'\''/\1/ p" \
-+        COMPREPLY=( $( compgen -W '$( sed -nEe "/machine/ s/.* alias '\''([^'\'']*)'\''/\1/ p" \
-             ~/.yafc/bookmarks )' -- "$cur" ) )
-     fi


### PR DESCRIPTION
@mikemcquaid Is it ok if I replace the patch with an `inreplace` call given that it’s OSX-specific and upstream only targets Linux (see their homepage)?