### PR TITLE
brew deps --installed support for formulae

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -14,16 +14,17 @@ module Homebrew
 
     if mode.installed? && mode.tree?
       puts_deps_tree Formula.installed
-    elsif mode.installed?
-      puts_deps Formula.installed
     elsif mode.all?
       puts_deps Formula
     elsif mode.tree?
       raise FormulaUnspecifiedError if ARGV.named.empty?
       puts_deps_tree ARGV.formulae
+    elsif ARGV.named.empty?
+      raise FormulaUnspecifiedError unless mode.installed?
+      puts_deps Formula.installed
     else
-      raise FormulaUnspecifiedError if ARGV.named.empty?
       all_deps = deps_for_formulae(ARGV.formulae, !ARGV.one?, &(mode.union? ? :| : :&))
+      all_deps.keep_if(&:installed?) if mode.installed?
       all_deps = all_deps.sort_by(&:name) unless mode.topo_order?
       puts all_deps
     end


### PR DESCRIPTION
Current situation:

```
# shows all foo's dependencies (both installed and not)
$ brew deps foo

# shows all installed formulae and their dependencies
$ brew deps --installed

# shows all installed formulae and their dependencies (again)
$ brew deps --installed foo
```

This PR fixes the last case by making `brew deps --installed foo` show only the installed dependencies for `foo`. It allows people to remove all the dependencies for a formula using `brew rm $(brew deps --installed <formula>)`.

See #39903.