### PR TITLE
cookbook: add an explicit version if necessary

### DIFF
--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -342,6 +342,8 @@ Add aliases by creating symlinks in `Library/Aliases`.
 
 You can run `brew audit` to test formulae for adherence to Homebrew house style. This includes warnings for trailing whitespace, preferred URLs for certain source hosts, and a lot of other style issues. Fixing these warnings before committing will make the process a lot smoother for us.
 
+Use `brew info` and check if the version guessed by Homebrew from the URL is
+correct. Add an explicit `version` if not.
 
 ## Commit
 


### PR DESCRIPTION
I’ve notice two cases in the past few days where someone bumped a version number and Homebrew’s guessing failed. See #40242 for example. I’m not sure this is the right place to put that, I’m open to suggestions.