### PR TITLE
pla 1.2

### DIFF
--- a/Library/Formula/pla.rb
+++ b/Library/Formula/pla.rb
@@ -1,8 +1,8 @@
 class Pla < Formula
   desc "A tool for building gantt charts in format PNG, EPS, PDF or SVG."
   homepage "http://www.arpalert.org/pla.html"
-  url "http://www.arpalert.org/src/pla-1.1.tar.gz"
-  sha256 "a213c5e1060c97618d0eb0462cfdf738532591b30f18b36a37c1a4398346ac37"
+  url "http://www.arpalert.org/src/pla-1.2.tar.gz"
+  sha256 "c2f1ce50b04032abf7f88ac07648ea40bed2443e86e9f28f104d341965f52b9c"
 
   bottle do
     cellar :any
@@ -12,10 +12,10 @@ class Pla < Formula
   end
 
   depends_on "cairo"
+  depends_on "pkg-config" => :build
 
   def install
-    ENV.prepend "CFLAGS", "-I#{Formula["cairo"].opt_include}/cairo"
-    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
+    system "make"
     bin.install "pla"
   end
 


### PR DESCRIPTION
I refer to #40159.

The package's author writes:
```
I produce a new version that can use pkg-config if it is avalaible. I
fix also some compilation warnings.

   http://www.arpalert.org/src/pla-1.2.tar.gz
```

I presume superenv should work now, as I understand it correctly?
However, make still fails:

```
bash-4.2$ brew install -v pla
==> Downloading http://www.arpalert.org/src/pla-1.2.tar.gz
Already downloaded: /Library/Caches/Homebrew/pla-1.2.tar.gz
==> Verifying pla-1.2.tar.gz checksum
tar xf /Library/Caches/Homebrew/pla-1.2.tar.gz
==> make
clang -Wall -g -O2 -I/usr/include/cairo   -c -o render.o render.c
clang -Wall -g -O2 -I/usr/include/cairo   -c -o render_txt.o render_txt.c
clang -Wall -g -O2 -I/usr/include/cairo   -c -o pla.o pla.c
clang -Wall -g -O2 -I/usr/include/cairo   -c -o utils.o utils.c
In file included from pla.c:16:
./utils.h:14:10: fatal error: 'cairo.h' file not found
#include <cairo.h>
         ^
render.c:16:10: fatal error: 'cairo.h' file not found
#include <cairo.h>
         ^
In file included from render_txt.c:16:
utils.c./utils.h:14:10::16 :fatal error10: fatal error: 'cairo.h' file not found
#include <cairo.h>
         ^
: 'cairo.h' file not found
#include <cairo.h>
         ^
1 error generated.
1 error generated.
make: *** [utils.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** [render_txt.o] Error 1
1 error generated.
1 error generated.
make: *** [pla.o] Error 1
make: *** [render.o] Error 1
==> Formula
Path: /usr/local/Library/Formula/pla.rb
==> Configuration
HOMEBREW_VERSION: 0.9.5
ORIGIN: https://github.com/Homebrew/homebrew.git
HEAD: b6af29782c69eb580974d7ec41177048326ecca3
Last commit: 3 days ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CELLAR: /usr/local/Cellar
CPU: quad-core 64-bit sandybridge
OS X: 10.9.5-x86_64
Xcode: N/A
CLT: 6.2.0.0.1.1424975374
Clang: 6.0 build 600
X11: 2.7.7 => /opt/X11
System Ruby: 2.0.0-p481
Perl: /usr/bin/perl
Python: /usr/local/bin/python => /usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/bin/python2.7
Ruby: /usr/bin/ruby
Java: 1.6.0_65
==> ENV
HOMEBREW_CC: clang
HOMEBREW_CXX: clang++
MAKEFLAGS: -j4
CMAKE_PREFIX_PATH: /usr/local/opt/gettext:/usr/local/opt/libffi:/usr/local
CMAKE_INCLUDE_PATH: /usr/include/libxml2:/opt/X11/include:/opt/X11/include/freetype2:/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers
CMAKE_LIBRARY_PATH: /opt/X11/lib:/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries
PKG_CONFIG_PATH: /usr/local/opt/libpng/lib/pkgconfig:/usr/local/opt/freetype/lib/pkgconfig:/usr/local/opt/fontconfig/lib/pkgconfig:/usr/local/opt/pixman/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/glib/lib/pkgconfig:/usr/local/opt/cairo/lib/pkgconfig
PKG_CONFIG_LIBDIR: /usr/lib/pkgconfig:/usr/local/Library/ENV/pkgconfig/10.9:/opt/X11/lib/pkgconfig:/opt/X11/share/pkgconfig
ACLOCAL_PATH: /usr/local/opt/gettext/share/aclocal:/usr/local/share/aclocal:/opt/X11/share/aclocal
PATH: /usr/local/Library/ENV/4.3:/usr/local/opt/libpng/bin:/usr/local/opt/freetype/bin:/usr/local/opt/fontconfig/bin:/usr/local/opt/gettext/bin:/usr/local/opt/glib/bin:/usr/local/opt/cairo/bin:/opt/X11/bin:/usr/bin:/bin:/usr/sbin:/sbin

Error: pla 1.2 did not build
Logs:
     /Users/USER/Library/Logs/Homebrew/pla/01.make
     /Users/USER/Library/Logs/Homebrew/pla/01.make.cc
```

What's wrong?
Kindly let me know if you need more information to troubleshoot.