### PR TITLE
ssht 0.3 (new formula)

### DIFF
--- a/Library/Formula/ssht.rb
+++ b/Library/Formula/ssht.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class Ssht < Formula
+  homepage 'https://github.com/brejoc/ssht/'
+  url 'https://github.com/brejoc/ssht/archive/0.3.tar.gz'
+  sha1 'bcfde2a7c90fbe88e111cb45c18ebd800e60477f'
+
+  head 'https://github.com/brejoc/ssht.git', :revision => '4783d77f6db4035100f695f904e8ec0a20021a9c'
+
+  def install
+    bin.install "ssht"
+  end
+end


### PR DESCRIPTION
Added formula to ssht version 0.3 to the Homebrew repo. ssht is a
shortcut right into a tmux session on a remote computer.