### PR TITLE
wavpack 4.75.0

### DIFF
--- a/Library/Formula/wavpack.rb
+++ b/Library/Formula/wavpack.rb
@@ -1,14 +1,41 @@
-require 'formula'
-
 class Wavpack < Formula
   desc "Hybrid lossless audio compression"
-  homepage 'http://www.wavpack.com/'
-  url 'http://www.wavpack.com/wavpack-4.70.0.tar.bz2'
-  sha1 '7bf2022c988c19067196ee1fdadc919baacf46d1'
+  homepage "http://www.wavpack.com/"
+
+  stable do
+    url "http://www.wavpack.com/wavpack-4.75.0.tar.bz2"
+    sha256 "c63e5c2106749dc6b2fb4302f2260f4803a93dd6cadf337764920dc836e3af2e"
+
+    patch do
+      url "https://github.com/dbry/WavPack/commit/12867b33e2de3e95b88d7cb6f449ce0c5c87cdd5.diff"
+      sha256 "a6e010e3a50697811db42860ee4af1190ef4c098f65738d21890c2fb2d57f282"
+    end
+  end
+
+  head do
+    url "https://github.com/dbry/WavPack.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make install"
+    args = [
+      "--prefix=#{prefix}",
+      "--disable-dependency-tracking",
+      # https://github.com/dbry/WavPack/issues/3
+      "--disable-asm"
+    ]
+    if build.head?
+      system "./autogen.sh", *args
+    else
+      system "./configure", *args
+    end
+    system "make", "install"
+  end
+
+  test do
+    system bin/"wavpack", test_fixtures("test.wav"), "-o", testpath/"test.wv"
+    File.exist? "test.wv"
   end
 end


### PR DESCRIPTION
Without `--disable-asm` and `--disable-shared` there are "suspicious" build failures:

- without `--disable-asm`: https://gist.github.com/dunn/de2dd3666c9a35bd54e9
- without `--disable-shared`: https://gist.github.com/dunn/e2335420bb6622796da2

Is there maybe a better way to get it to build without just disabling things?