### PR TITLE
test-bot: simplify the upload logic

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -789,6 +789,14 @@ module Homebrew
         version = formula.pkg_version
         bintray_package = Bintray.package formula_name
 
+        if system "curl", "-I", "--silent", "--fail", "--output", "/dev/null",
+                  "#{BottleSpecification::DEFAULT_DOMAIN}/#{bintray_repo}/#{filename}"
+          raise <<-EOS.undent
+            #{filename} is already published. Please remove it manually from
+            https://bintray.com/homebrew/#{bintray_repo}/#{bintray_package}/view#files
+          EOS
+        end
+
         unless formula_packaged[formula_name]
           package_url = "#{bintray_repo_url}/#{bintray_package}"
           unless system "curl", "--silent", "--fail", "--output", "/dev/null", package_url
@@ -802,10 +810,7 @@ module Homebrew
 
         content_url = "https://api.bintray.com/content/homebrew"
         content_url += "/#{bintray_repo}/#{bintray_package}/#{version}/#{filename}"
-        unless system "curl", "-I", "--fail", "--output", "/dev/null",
-                      "https://homebrew.bintray.com/#{bintray_repo}/#{filename}"
-          content_url += "?override=1"
-        end
+        content_url += "?override=1"
         curl "--silent", "--fail", "-u#{bintray_user}:#{bintray_key}",
              "-T", filename, content_url
         puts


### PR DESCRIPTION
If the bottle is already published, let's fail directly.
Also silent the curl output.