### PR TITLE
Install shell completion scripts for flow

### DIFF
--- a/Library/Formula/flow.rb
+++ b/Library/Formula/flow.rb
@@ -21,7 +21,7 @@ class Flow < Formula
     (share/"flow").install "bin/examples"
 
     bash_completion.install "resources/shell/bash-completion" => "flow-completion.bash"
-    zsh_completion.install_symlink (bash_completion/"flow-completion.bash") => "_flow"
+    zsh_completion.install_symlink bash_completion/"flow-completion.bash" => "_flow"
   end
 
   test do

--- a/Library/Formula/flow.rb
+++ b/Library/Formula/flow.rb
@@ -19,6 +19,9 @@ class Flow < Formula
     system "make"
     bin.install "bin/flow"
     (share/"flow").install "bin/examples"
+
+    bash_completion.install "resources/shell/bash-completion" => "flow-completion.bash"
+    zsh_completion.install_symlink (bash_completion/"flow-completion.bash") => "_flow"
   end
 
   test do


### PR DESCRIPTION
`resources/shell/bash-completion` also supports zsh, so I symlinked zsh to bash.