### PR TITLE
remove openssl as an osquery dependency

### DIFF
--- a/Library/Formula/osquery.rb
+++ b/Library/Formula/osquery.rb
@@ -22,7 +22,6 @@ class Osquery < Formula
   depends_on "rocksdb" => :build
   depends_on "thrift" => :build
   depends_on "yara" => :build
-  depends_on "openssl"
 
   resource "markupsafe" do
     url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"


### PR DESCRIPTION
osquery no longer depends on the homebrew openssl library