### PR TITLE
Give `brew tap` a little `brew any-tap` magic!

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -1,11 +1,15 @@
 module Homebrew
   def tap
     if ARGV.empty?
-      show_taps
+      each_tap do |user, repo|
+        if (repo/".git").directory?
+          puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}"
+        end
+      end
     elsif ARGV.first == "--repair"
       migrate_taps :force => true
     else
-      opoo "Already tapped!" unless install_tap(*tap_args, ARGV.named[1])
+      opoo "Already tapped!" unless install_tap(*tap_args)
     end
   end
 
@@ -70,7 +74,7 @@ module Homebrew
   def tap_args(tap_name=ARGV.named.first)
     tap_name =~ HOMEBREW_TAP_ARGS_REGEX
     raise "Invalid tap name" unless $1 && $3
-    [$1, $3]
+    [$1, $3, ARGV.named[1]]
   end
 
   def private_tap?(user, repo)
@@ -79,13 +83,5 @@ module Homebrew
     true
   rescue GitHub::Error
     false
-  end
-
-  def show_taps
-    each_tap do |user, repo|
-      if (repo/".git").directory?
-        puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}"
-      end
-    end
   end
 end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -9,7 +9,9 @@ module Homebrew
     elsif ARGV.first == "--repair"
       migrate_taps :force => true
     else
-      opoo "Already tapped!" unless install_tap(*tap_args)
+      user, repo = tap_args
+      clone_target = ARGV.named[1]
+      opoo "Already tapped!" unless install_tap(user, repo, clone_target)
     end
   end
 
@@ -74,7 +76,7 @@ module Homebrew
   def tap_args(tap_name=ARGV.named.first)
     tap_name =~ HOMEBREW_TAP_ARGS_REGEX
     raise "Invalid tap name" unless $1 && $3
-    [$1, $3, ARGV.named[1]]
+    [$1, $3]
   end
 
   def private_tap?(user, repo)

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -9,7 +9,7 @@ module Homebrew
     end
   end
 
-  def install_tap user, repo, clone_target
+  def install_tap user, repo, clone_target=nil
     # we special case homebrew so users don't have to shift in a terminal
     repouser = if user == "homebrew" then "Homebrew" else user end
     user = "homebrew" if user == "Homebrew"

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -2,9 +2,7 @@ module Homebrew
   def tap
     if ARGV.empty?
       each_tap do |user, repo|
-        if (repo/".git").directory?
-          puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}"
-        end
+        puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}" if (repo/".git").directory?
       end
     elsif ARGV.first == "--repair"
       migrate_taps :force => true

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -1,17 +1,15 @@
 module Homebrew
   def tap
     if ARGV.empty?
-      each_tap do |user, repo|
-        puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}" if (repo/".git").directory?
-      end
+      show_taps
     elsif ARGV.first == "--repair"
       migrate_taps :force => true
     else
-      opoo "Already tapped!" unless install_tap(*tap_args)
+      opoo "Already tapped!" unless install_tap(*tap_args, ARGV.named[1])
     end
   end
 
-  def install_tap user, repo, clone_target=nil
+  def install_tap user, repo, clone_target
     # we special case homebrew so users don't have to shift in a terminal
     repouser = if user == "homebrew" then "Homebrew" else user end
     user = "homebrew" if user == "Homebrew"
@@ -69,11 +67,10 @@ module Homebrew
     end
   end
 
-  def tap_args()
-    tap_name, clone_target = ARGV.named[0..1]
+  def tap_args(tap_name=ARGV.named.first)
     tap_name =~ HOMEBREW_TAP_ARGS_REGEX
     raise "Invalid tap name" unless $1 && $3
-    [$1, $3, clone_target]
+    [$1, $3]
   end
 
   def private_tap?(user, repo)
@@ -82,5 +79,13 @@ module Homebrew
     true
   rescue GitHub::Error
     false
+  end
+
+  def show_taps
+    each_tap do |user, repo|
+      if (repo/".git").directory?
+        puts "#{user.basename}/#{repo.basename.sub("homebrew-", "")}"
+      end
+    end
   end
 end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -34,8 +34,8 @@ module Homebrew
     tapd.find_formula { |file| files << file }
     puts "Tapped #{files.length} formula#{plural(files.length, 'e')} (#{tapd.abv})"
 
-    unless clone_target
-      if private_tap?(repouser, repo) then puts <<-EOS.undent
+    if check_private?(clone_target, repouser, repo)
+      puts <<-EOS.undent
         It looks like you tapped a private repository. To avoid entering your
         credentials each time you update, you can use git HTTP credential
         caching or issue the following command:
@@ -43,7 +43,6 @@ module Homebrew
           cd #{tapd}
           git remote set-url origin git@github.com:#{repouser}/homebrew-#{repo}.git
         EOS
-      end
     end
 
     true
@@ -83,5 +82,9 @@ module Homebrew
     true
   rescue GitHub::Error
     false
+  end
+
+  def check_private?(clone_target, user, repo)
+    not clone_target && private_tap?(user, repo)
   end
 end

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -1,31 +1,29 @@
-require 'cmd/tap' # for tap_args and show_taps
+require 'cmd/tap' # for tap_args
 
 module Homebrew
   def untap
-    if ARGV.empty?
-      show_taps
-    else
-      ARGV.each do |tapname|
-        user, repo = tap_args(tapname)
+    raise "Usage is `brew untap <tap-name>`" if ARGV.empty?
 
-        # we consistently downcase in tap to ensure we are not bitten by
-        # case-insensive filesystem issues. Which is the default on mac. The
-        # problem being the filesystem cares, but our regexps don't. So unless
-        # we resolve *every* path we will get bitten.
-        user.downcase!
-        repo.downcase!
+    ARGV.each do |tapname|
+      user, repo = tap_args(tapname)
 
-        tapd = HOMEBREW_LIBRARY/"Taps/#{user}/homebrew-#{repo}"
+      # We consistently downcase in tap to ensure we are not bitten by
+      # case-insensitive filesystem issues, which is the default on mac. The
+      # problem being the filesystem cares, but our regexps don't. So unless we
+      # resolve *every* path we will get bitten.
+      user.downcase!
+      repo.downcase!
 
-        raise "No such tap!" unless tapd.directory?
-        puts "Untapping #{tapname}... (#{tapd.abv})"
+      tapd = HOMEBREW_LIBRARY/"Taps/#{user}/homebrew-#{repo}"
 
-        files = []
-        tapd.find_formula { |file| files << file }
-        tapd.rmtree
-        tapd.dirname.rmdir_if_possible
-        puts "Untapped #{files.length} formula#{plural(files.length, 'e')}"
-      end
+      raise "No such tap!" unless tapd.directory?
+      puts "Untapping #{tapname}... (#{tapd.abv})"
+
+      files = []
+      tapd.find_formula { |file| files << file }
+      tapd.rmtree
+      tapd.dirname.rmdir_if_possible
+      puts "Untapped #{files.length} formula#{plural(files.length, 'e')}"
     end
   end
 end

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -5,7 +5,7 @@ module Homebrew
     raise "Usage is `brew untap <tap-name>`" if ARGV.empty?
 
     ARGV.each do |tapname|
-      user, repo = tap_args(tapname)
+      user, repo = tap_args()
 
       # we consistently downcase in tap to ensure we are not bitten by case-insensive
       # filesystem issues. Which is the default on mac. The problem being the

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -1,29 +1,31 @@
-require 'cmd/tap' # for tap_args
+require 'cmd/tap' # for tap_args and show_taps
 
 module Homebrew
   def untap
-    raise "Usage is `brew untap <tap-name>`" if ARGV.empty?
+    if ARGV.empty?
+      show_taps
+    else
+      ARGV.each do |tapname|
+        user, repo = tap_args(tapname)
 
-    ARGV.each do |tapname|
-      user, repo = tap_args()
+        # we consistently downcase in tap to ensure we are not bitten by
+        # case-insensive filesystem issues. Which is the default on mac. The
+        # problem being the filesystem cares, but our regexps don't. So unless
+        # we resolve *every* path we will get bitten.
+        user.downcase!
+        repo.downcase!
 
-      # we consistently downcase in tap to ensure we are not bitten by case-insensive
-      # filesystem issues. Which is the default on mac. The problem being the
-      # filesystem cares, but our regexps don't. So unless we resolve *every* path
-      # we will get bitten.
-      user.downcase!
-      repo.downcase!
+        tapd = HOMEBREW_LIBRARY/"Taps/#{user}/homebrew-#{repo}"
 
-      tapd = HOMEBREW_LIBRARY/"Taps/#{user}/homebrew-#{repo}"
+        raise "No such tap!" unless tapd.directory?
+        puts "Untapping #{tapname}... (#{tapd.abv})"
 
-      raise "No such tap!" unless tapd.directory?
-      puts "Untapping #{tapname}... (#{tapd.abv})"
-
-      files = []
-      tapd.find_formula { |file| files << file }
-      tapd.rmtree
-      tapd.dirname.rmdir_if_possible
-      puts "Untapped #{files.length} formula#{plural(files.length, 'e')}"
+        files = []
+        tapd.find_formula { |file| files << file }
+        tapd.rmtree
+        tapd.dirname.rmdir_if_possible
+        puts "Untapped #{files.length} formula#{plural(files.length, 'e')}"
+      end
     end
   end
 end


### PR DESCRIPTION
`brew tap` restricts users to GitHub and checks for private repos. I created
`brew any-tap` to support a wider variety of taps.

With very small changes (and no extra flags!), this PR brings `any-tap` to `brew`.

Users can use `brew tap` with GitHub as they always have or add one extra 
argument and tap any repository of any type from anywhere.

tl;dr

    brew tap user/name              # Same as it ever was
    brew tap user/name URL          # Tap URL, whatever it happens to be

ping @mikemcquaid @mistydemeo @jacknagel 