### PR TITLE
boost: use c++11 compilers in c++11 mode

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -36,6 +36,8 @@ class Boost < Formula
     cause "Dropped arguments to functions when linking with boost"
   end
 
+  needs :cxx11 if build.cxx11?
+
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
     if build.with?("mpi") && build.with?("single")


### PR DESCRIPTION
This feels like something that Formula or SoftwareSpec should "know" but I'm not sure about the right place to encode that knowledge.

Fixes #40319.