### PR TITLE
mosh: update formula for now-generated scripts/mosh

### DIFF
--- a/Library/Formula/mobile-shell.rb
+++ b/Library/Formula/mobile-shell.rb
@@ -24,8 +24,13 @@ class MobileShell < Formula
 
     # teach mosh to locate mosh-client without referring
     # PATH to support launching outside shell e.g. via launcher
-    inreplace "scripts/mosh", "'mosh-client", "\'#{bin}/mosh-client"
-
+    #
+    # In HEAD, mosh is generated from mosh.pl, This will be in 1.2.5, coming soon.
+    if build.head?
+      inreplace "scripts/mosh.pl", "'mosh-client", "\'#{bin}/mosh-client"
+    else
+      inreplace "scripts/mosh", "'mosh-client", "\'#{bin}/mosh-client"
+    end
     # Upstream prefers O2:
     # https://github.com/keithw/mosh/blob/master/README.md
     ENV.O2


### PR DESCRIPTION
Mosh used to have its startup script at scripts/mosh.  We now edit in
build information, so it's been moved to scripts/mosh.pl and the
Makefile generates scripts/mosh with the appropriate edits.  Homebrew
does its own edits before the build, so tell it about this.  Once
1.2.5 is released, the formula can lose the conditionals again.

Closes #40338.