### PR TITLE
giter8 0.6.8

### DIFF
--- a/Library/Formula/giter8.rb
+++ b/Library/Formula/giter8.rb
@@ -3,8 +3,13 @@ require "formula"
 class Giter8 < Formula
   homepage "https://github.com/n8han/giter8"
   url "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.7/sbt-launch.jar"
-  sha1 "b407b2a76ad72165f806ac7e7ea09132b951ef53"
-  version "0.6.6"
+  sha256 "9673ca4611e6367955ae068d5888f7ae665ab013c3e8435ffe2ca94318c6d607"
+  # note: because sbt-launch dynamically downloads giter8 from the maven repos
+  #   at first run (using the launchconfig mechanism), and not when the formula
+  #   is installed, the above url and sha256 are related to sbt-launch.jar.
+  #   The version below is that of giter8, and when upgrading this formula,
+  #   one must check the giter8 version is available in maven repositories.
+  version "0.6.8"
 
   def exec_script; <<-EOS.undent
     #!/bin/sh


### PR DESCRIPTION
Hi,

upstream was updated to 0.6.8 several months ago, and the jar is available at maven repositories. The formula works well as is.

PS: upstream was later updated to 0.6.9, but the jar does not seem to be available yet.