### PR TITLE
tmux: moved to github

### DIFF
--- a/Library/Formula/tmux.rb
+++ b/Library/Formula/tmux.rb
@@ -1,9 +1,7 @@
-require 'formula'
-
 class Tmux < Formula
-  homepage 'http://tmux.sourceforge.net'
-  url 'https://downloads.sourceforge.net/project/tmux/tmux/tmux-2.0/tmux-2.0.tar.gz'
-  sha1 '977871e7433fe054928d86477382bd5f6794dc3d'
+  homepage "https://tmux.github.io/"
+  url "https://github.com/tmux/tmux/releases/download/2.0/tmux-2.0.tar.gz"
+  sha256 "795f4b4446b0ea968b9201c25e8c1ef8a6ade710ebca4657dd879c35916ad362"
 
   bottle do
     cellar :any
@@ -13,27 +11,28 @@ class Tmux < Formula
   end
 
   head do
-    url 'git://git.code.sf.net/p/tmux/tmux-code'
+    url "https://github.com/tmux/tmux.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'libevent'
+  depends_on "pkg-config" => :build
+  depends_on "libevent"
 
   def install
     system "sh", "autogen.sh" if build.head?
 
-    ENV.append "LDFLAGS", '-lresolv'
+    ENV.append "LDFLAGS", "-lresolv"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}"
-    system "make install"
 
-    bash_completion.install "examples/bash_completion_tmux.sh" => 'tmux'
-    (share/'tmux').install "examples"
+    system "make", "install"
+
+    bash_completion.install "examples/bash_completion_tmux.sh" => "tmux"
+    (share/"tmux").install "examples"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
tmux has officially moved to Github.com (from SourceForge.net).

Also, this commit modernizes the tmux formula, including:
- adding a `desc` field
- switching to sha256 checksums

NOTE: although the tmux/tmux repo includes release tarballs, they appear
to be "bad" in that they are missing a proper `configure` script. Hence
the usage of the tmux/releases repo as the tarball source.