### PR TITLE
mpssh: patch URL fixed

### DIFF
--- a/Library/Formula/mpssh.rb
+++ b/Library/Formula/mpssh.rb
@@ -1,7 +1,7 @@
 class Mpssh < Formula
   homepage "https://github.com/ndenev/mpssh"
   url "https://github.com/ndenev/mpssh/archive/1.3.3.tar.gz"
-  sha1 "ba11dfe7607cac3d47f1c86db236a2e440700ce7"
+  sha256 "510e11c3e177a31c1052c8b4ec06357c147648c86411ac3ed4ac814d0d927f2f"
   head "https://github.com/ndenev/mpssh.git"
 
   bottle do
@@ -13,9 +13,9 @@ class Mpssh < Formula
 
   stable do
     patch do
-      # don't install binaries as root (upstream PR merged in HEAD)
-      url "https://github.com/bfontaine/mpssh/commit/3cbb868b6fdf8dff9ab86868510c0455ad1ec1b3.diff"
-      sha1 "745b6d07bc479a2d4d64d71904342d76c52fa8ab"
+      # don't install binaries as root (upstream commit)
+      url "https://github.com/ndenev/mpssh/commit/3cbb868b6fdf8dff9ab86868510c0455ad1ec1b3.diff"
+      sha256 "f5df424a91df1f427f96cd482d0bc22cfd90ac25c9e6beb8ca029f3a1038c3de"
     end
   end
 


### PR DESCRIPTION
This is my fault: back in January I made a PR to upstream to fix a build issue and linked my fork in the formula instead of the upstream PR. I then deleted my fork, rendering this patch URL unusable.