### PR TITLE
singular/plural phrasing in audit report

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -46,7 +46,9 @@ module Homebrew
     end
 
     unless problem_count.zero?
-      ofail "#{problem_count} problems in #{formula_count} formulae"
+      problems = "problem" + plural(problem_count)
+      formulae = "formula" + plural(formula_count, "e")
+      ofail "#{problem_count} #{problems} in #{formula_count} #{formulae}"
     end
   end
 end


### PR DESCRIPTION
Without this I get weird reports like “2 problems in 1 formulae”.