### PR TITLE
zeromq-4.1.2, czmq-3.0.1

### DIFF
--- a/Library/Formula/czmq.rb
+++ b/Library/Formula/czmq.rb
@@ -1,9 +1,8 @@
 class Czmq < Formula
   desc "High-level C binding for ZeroMQ"
   homepage "http://czmq.zeromq.org/"
-  url "http://download.zeromq.org/czmq-2.2.0.tar.gz"
-  sha1 "2f4fd8de4cf04a68a8f6e88ea7657d8068f472d2"
-  revision 1
+  url "http://download.zeromq.org/czmq-3.0.1.tar.gz"
+  sha1 "fc69f8175347c73a61d2004fc9699f10f8a73eb2"
 
   bottle do
     cellar :any
@@ -43,13 +42,9 @@ class Czmq < Formula
 
     system "./autogen.sh" if build.head?
     system "./configure", *args
+    system "make"
+    system "make", "check"
     system "make", "install"
     rm Dir["#{bin}/*.gsl"]
-  end
-
-  test do
-    bin.cd do
-      system "#{bin}/czmq_selftest"
-    end
   end
 end

--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -4,7 +4,7 @@ class Fontforge < Formula
   url "https://github.com/fontforge/fontforge/archive/20150430.tar.gz"
   sha256 "430c6d02611c7ca948df743e9241994efe37eda25f81a94aeadd9b6dd286ff37"
   head "https://github.com/fontforge/fontforge.git"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/mongrel2.rb
+++ b/Library/Formula/mongrel2.rb
@@ -5,6 +5,7 @@ class Mongrel2 < Formula
   homepage 'http://mongrel2.org/'
   url 'https://github.com/zedshaw/mongrel2/releases/download/1.9.2/mongrel2-v1.9.2.tar.bz2'
   sha1 '1b44d8028bba7f427cfda3fc7bf6c4350d810a75'
+  revision 1
 
   head 'https://github.com/zedshaw/mongrel2.git'
 

--- a/Library/Formula/pushpin.rb
+++ b/Library/Formula/pushpin.rb
@@ -3,6 +3,7 @@ class Pushpin < Formula
   homepage "http://pushpin.org"
   url "http://packages.fanout.io/source/pushpin-1.3.0.tar.bz2"
   sha256 "b3f45a6faca6873299eb68c876eab21f965cb961a3c91e8ed13cccb4018ff5e6"
+  revision 1
 
   head "https://github.com/fanout/pushpin.git"
 

--- a/Library/Formula/zeromq.rb
+++ b/Library/Formula/zeromq.rb
@@ -1,7 +1,6 @@
 class Zeromq < Formula
   desc "High-performance, asynchronous messaging library"
   homepage "http://www.zeromq.org/"
-  revision 2
 
   bottle do
     cellar :any
@@ -19,15 +18,8 @@ class Zeromq < Formula
   end
 
   stable do
-    url "http://download.zeromq.org/zeromq-4.0.5.tar.gz"
-    sha1 "a664ec63661a848ef46114029156a0a6006feecd"
-
-    patch do
-      # enable --without-libsodium on libzmq < 4.1
-      # zeromq/zeromq4-x#105
-      url "https://gist.githubusercontent.com/minrk/478aab66adf7016158ff/raw/b5ea2d61c3f66db6ff3e266b76d1bec4ad4a238b/without-libsodium.patch"
-      sha1 "68543ff1b0f64b22994cb13b4d24bce8f76cf431"
-    end
+    url "http://download.zeromq.org/zeromq-4.1.2.tar.gz"
+    sha1 "86c17096f7f4bf46cbcd2ad242cf8fec8a7cfb7b"
   end
 
   option :universal

--- a/Library/Formula/zurl.rb
+++ b/Library/Formula/zurl.rb
@@ -3,6 +3,7 @@ class Zurl < Formula
   homepage "https://github.com/fanout/zurl"
   url "http://packages.fanout.io/source/zurl-1.4.1.tar.bz2"
   sha256 "5e51f76463bd46a6e362e4043e4c1a7af50b48622f83b273edf89a5a4bd1b525"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
latest stable release.

Also remove now-obsolete patch for 4.0.x.