### PR TITLE
Ability to compile cryptopp and log4cxx packages in C++11 mode

### DIFF
--- a/Library/Formula/cryptopp.rb
+++ b/Library/Formula/cryptopp.rb
@@ -13,7 +13,17 @@ class Cryptopp < Formula
     sha256 "30508cb32dc476ff24e405c64d3b535a6e6a61dabb93810860c58344759c7de5" => :mountain_lion
   end
 
+  option :cxx11
+
+  # Incorporated upstream, remove on next version update
+  # https://groups.google.com/forum/#!topic/cryptopp-users/1wdyb2FSwc4
+  patch :p1 do
+    url "https://github.com/weidai11/cryptopp/commit/44015c26ba215f955b1e653f9c8f3c894a532707.patch"
+    sha256 "2ca6c2f9dda56fa29df952d0ee829c9501a2cbc43a68bdc786d8241aefaddea6"
+  end
+
   def install
+    ENV.cxx11 if build.cxx11?
     system "make", "CXX=#{ENV.cxx}"
     system "make", "install", "PREFIX=#{prefix}"
   end
@@ -33,6 +43,7 @@ class Cryptopp < Formula
         return 0;
       }
     EOS
+    ENV.cxx11 if build.cxx11?
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lcryptopp", "-o", "test"
     system "./test"
   end

--- a/Library/Formula/log4cxx.rb
+++ b/Library/Formula/log4cxx.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Log4cxx < Formula
   desc "Library of C++ classes for flexible logging"
-  homepage 'http://logging.apache.org/log4cxx/index.html'
-  url 'http://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz'
+  homepage 'https://logging.apache.org/log4cxx/index.html'
+  url 'https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz'
   sha1 'd79c053e8ac90f66c5e873b712bb359fd42b648d'
 
   depends_on "autoconf" => :build
@@ -11,6 +11,7 @@ class Log4cxx < Formula
   depends_on "libtool" => :build
 
   option :universal
+  option :cxx11
 
   fails_with :llvm do
     build 2334
@@ -18,13 +19,29 @@ class Log4cxx < Formula
   end
 
   # Incorporated upstream, remove on next version update
-  # https://issues.apache.org/jira/browse/LOGCXX-404
-  # https://issues.apache.org/jira/browse/LOGCXX-417
-  patch :DATA
+  # https://issues.apache.org/jira/browse/LOGCXX-400 (r1414037)
+  # https://issues.apache.org/jira/browse/LOGCXX-404 (r1414037)
+  patch :p0 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/be8b4e610a1e21b34aaaf8fb4151362dcfb782ff/LOGCXX-400,LOGCXX-404---r1414037.patch"
+    sha256 "822c24f4eebd970aa284672eec2f71c6f8e192a85d78edb15a232c15011a52d4"
+  end
+
+  # https://issues.apache.org/jira/browse/LOGCXX-417 (r1556413)
+  patch :p0 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/4188731bd771a961a91fcfbe561f3999b555b9c3/LOG4CXX-417---r1556413.patch"
+    sha256 "eca194ec349b4925d0ad53d2b67c18b6a1aa7a979e7bd8729cfd1ed1ef4994c7"
+  end
+
+  # https://issues.apache.org/jira/browse/LOGCXX-400 (reported)
+  patch :p1 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/f33998566cccf91fb84133e101f5a92a14b31aed/LOGCXX-404---domtestcase.cpp.patch"
+    sha256 "3eaf321e1df8e8e4a0a507a96646727180e7e721b2c42af22a5d40962d3dbecc"
+  end
 
   def install
     ENV.universal_binary if build.universal?
     ENV.O2 # Using -Os causes build failures on Snow Leopard.
+    ENV.cxx11 if build.cxx11?
 
     # Fixes build error with clang, old libtool scripts. cf. #12127
     # Reported upstream here: https://issues.apache.org/jira/browse/LOGCXX-396
@@ -37,26 +54,3 @@ class Log4cxx < Formula
     system "make install"
   end
 end
-__END__
---- a/src/main/include/log4cxx/helpers/simpledateformat.h
-+++ b/src/main/include/log4cxx/helpers/simpledateformat.h
-@@ -27,10 +27,9 @@
-
- #include <log4cxx/helpers/dateformat.h>
- #include <vector>
-+#include <locale>
- #include <time.h>
-
--namespace std { class locale; }
--
- namespace log4cxx
- {
-         namespace helpers
---- a/src/main/cpp/stringhelper.cpp
-+++ b/src/main/cpp/stringhelper.cpp
-@@ -28,6 +28,7 @@
- #endif
- #include <log4cxx/private/log4cxx_private.h>
- #include <cctype>
-+#include <cstdlib>
- #include <apr.h>


### PR DESCRIPTION
I have a project that is compiled in c++11 mode and depends on these libraries.  WIthout c++11 mode, compilation fails on OSX <= 10.8, because of incompatible STL libraries.
