### PR TITLE
Multirust: don't always rely on GPG when pouring bottle

### DIFF
--- a/Library/Formula/multirust.rb
+++ b/Library/Formula/multirust.rb
@@ -13,7 +13,7 @@ class Multirust < Formula
     sha256 "fda4e8a56c51643e5b3edea4e714c311287e53038dfe7acf955776e6c881bf94" => :mountain_lion
   end
 
-  depends_on :gpg => :recommended
+  depends_on :gpg => [:recommended, :run]
 
   def install
     system "./build.sh"

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -239,6 +239,7 @@ class FormulaInstaller
   def install_requirement_default_formula?(req, dependent, build)
     return false unless req.default_formula?
     return true unless req.satisfied?
+    return false if req.tags.include?(:run)
     install_bottle_for?(dependent, build) || build_bottle?
   end
 


### PR DESCRIPTION
As this is a runtime dependency mark it as such and ensure the (hideous) dependency code handles this particular case.