### PR TITLE
avoid unicode in desc to fix `brew update` failures

### DIFF
--- a/Library/Formula/czmq.rb
+++ b/Library/Formula/czmq.rb
@@ -1,5 +1,5 @@
 class Czmq < Formula
-  desc "High-level C binding for ØMQ"
+  desc "High-level C binding for ZeroMQ"
   homepage "http://czmq.zeromq.org/"
   url "http://download.zeromq.org/czmq-2.2.0.tar.gz"
   sha1 "2f4fd8de4cf04a68a8f6e88ea7657d8068f472d2"

--- a/Library/Formula/euca2ools.rb
+++ b/Library/Formula/euca2ools.rb
@@ -1,5 +1,5 @@
 class Euca2ools < Formula
-  desc "Eucalyptus client API tools—works with Amazon EC2 and IAM"
+  desc "Eucalyptus client API tools-works with Amazon EC2 and IAM"
   homepage "https://github.com/eucalyptus/euca2ools"
   url "https://github.com/eucalyptus/euca2ools/archive/v3.2.0.tar.gz"
   sha256 "4cfbae3b978312fa23e6a0329ec346568823afbbae0bc01075c8cff6707e7cb8"

--- a/Library/Formula/ltl2ba.rb
+++ b/Library/Formula/ltl2ba.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Ltl2ba < Formula
-  desc "Translate LTL formulae to Büchi automata"
+  desc "Translate LTL formulae to Buchi automata"
   homepage "http://www.lsv.ens-cachan.fr/~gastin/ltl2ba/"
   url "http://www.lsv.ens-cachan.fr/~gastin/ltl2ba/ltl2ba-1.2b1.tar.gz"
   sha1 "74cff4914203753544bf300e041f433dbaeb3289"

--- a/Library/Formula/radamsa.rb
+++ b/Library/Formula/radamsa.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Radamsa < Formula
-  desc "Test case generator for robustness testing (a.k.a. a “fuzzer”)"
+  desc "Test case generator for robustness testing (a.k.a. a \"fuzzer"\)"
   homepage 'https://code.google.com/p/ouspg/wiki/Radamsa'
   url 'https://ouspg.googlecode.com/files/radamsa-0.3.tar.gz'
   sha1 '94664298b9c5c1563fe4aa7b8fc8530bb6628a51'

--- a/Library/Formula/shocco.rb
+++ b/Library/Formula/shocco.rb
@@ -7,7 +7,7 @@ class MarkdownProvider < Requirement
 end
 
 class Shocco < Formula
-  desc "Literate documentation tool for shell scripts (à la Docco)"
+  desc "Literate documentation tool for shell scripts (a la Docco)"
   homepage "http://rtomayko.github.io/shocco/"
   url "https://github.com/rtomayko/shocco/archive/1.0.tar.gz"
   sha1 "e29d58fb8109040b4fb4a816f330bb1c67064f6d"

--- a/Library/Formula/termrec.rb
+++ b/Library/Formula/termrec.rb
@@ -1,7 +1,7 @@
 require "formula"
 
 class Termrec < Formula
-  desc "Record “videos” of terminal output"
+  desc "Record \"videos\" of terminal output"
   homepage "http://angband.pl/termrec.html"
   head "http://angband.pl/git/termrec/", :using => :git
   url "https://github.com/kilobyte/termrec/archive/0.17.tar.gz"


### PR DESCRIPTION
Fixes: https://github.com/Homebrew/homebrew/issues/40416

```
==> brew readall --syntax						 FAILED
Error: problem in /usr/local/Library/Formula/czmq.rb
Error: problem in /usr/local/Library/Formula/ltl2ba.rb
Error: problem in /usr/local/Library/Formula/radamsa.rb
Error: problem in /usr/local/Library/Formula/shocco.rb
Error: problem in /usr/local/Library/Formula/termrec.rb
```

```
$ brew update
Error: /usr/local/Library/Formula/czmq.rb:2: invalid multibyte char (US-ASCII)
/usr/local/Library/Formula/czmq.rb:2: invalid multibyte char (US-ASCII)
/usr/local/Library/Formula/czmq.rb:2: syntax error, unexpected end-of-input, expecting keyword_end
  desc "High-level C binding for ØMQ"
                                   ^
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/formulary.rb:20:in `module_eval'
/usr/local/Library/Homebrew/formulary.rb:20:in `load_formula'
/usr/local/Library/Homebrew/formulary.rb:67:in `load_file'
/usr/local/Library/Homebrew/formulary.rb:58:in `klass'
/usr/local/Library/Homebrew/formulary.rb:54:in `get_formula'
/usr/local/Library/Homebrew/formulary.rb:166:in `factory'
/usr/local/Library/Homebrew/cmd/update.rb:173:in `block in report'
/usr/local/Library/Homebrew/cmd/update.rb:159:in `each_line'
/usr/local/Library/Homebrew/cmd/update.rb:159:in `report'
/usr/local/Library/Homebrew/cmd/update.rb:24:in `update'
/usr/local/Library/brew.rb:140:in `<main>'
```