### PR TITLE
 czmq: avoid unicode char to fix `brew update` error

### DIFF
--- a/Library/Formula/czmq.rb
+++ b/Library/Formula/czmq.rb
@@ -1,5 +1,5 @@
 class Czmq < Formula
-  desc "High-level C binding for ØMQ"
+  desc "High-level C binding for ZeroMQ"
   homepage "http://czmq.zeromq.org/"
   url "http://download.zeromq.org/czmq-2.2.0.tar.gz"
   sha1 "2f4fd8de4cf04a68a8f6e88ea7657d8068f472d2"


### PR DESCRIPTION
```
$ brew update
Error: /usr/local/Library/Formula/czmq.rb:2: invalid multibyte char (US-ASCII)
/usr/local/Library/Formula/czmq.rb:2: invalid multibyte char (US-ASCII)
/usr/local/Library/Formula/czmq.rb:2: syntax error, unexpected end-of-input, expecting keyword_end
  desc "High-level C binding for ØMQ"
                                   ^
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/formulary.rb:20:in `module_eval'
/usr/local/Library/Homebrew/formulary.rb:20:in `load_formula'
/usr/local/Library/Homebrew/formulary.rb:67:in `load_file'
/usr/local/Library/Homebrew/formulary.rb:58:in `klass'
/usr/local/Library/Homebrew/formulary.rb:54:in `get_formula'
/usr/local/Library/Homebrew/formulary.rb:166:in `factory'
/usr/local/Library/Homebrew/cmd/update.rb:173:in `block in report'
/usr/local/Library/Homebrew/cmd/update.rb:159:in `each_line'
/usr/local/Library/Homebrew/cmd/update.rb:159:in `report'
/usr/local/Library/Homebrew/cmd/update.rb:24:in `update'
/usr/local/Library/brew.rb:140:in `<main>'
```