### PR TITLE
subversion: add non-homebrew universal python fail

### DIFF
--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -52,6 +52,7 @@ class Subversion < Formula
 
   # Fix #23993 by stripping flags swig can't handle from SWIG_CPPFLAGS
   # Prevent "-arch ppc" from being pulled in from Perl's $Config{ccflags}
+  # Prevent linking into a Python Framework
   patch :DATA
 
   if build.with?("perl") || build.with?("ruby")
@@ -70,6 +71,19 @@ class Subversion < Formula
   end
 
   def install
+    # OS X's Python is built universally and can't link with Homebrew's deps
+    # unless Homebrew's deps are universal as well.
+    # https://github.com/Homebrew/homebrew-versions/issues/777
+    # https://github.com/Homebrew/homebrew/issues/34119
+    if build.with?("python") && (which "python").universal?
+      unless build.universal?
+        raise <<-EOS.undent
+          You must build subversion --universal unless Homebrew's
+          Python is installed, otherwise the build will fail.
+        EOS
+      end
+    end
+
     serf_prefix = libexec+"serf"
 
     resource("serf").stage do
@@ -95,7 +109,7 @@ class Subversion < Formula
     end
 
     if build.include? "unicode-path"
-      fail <<-EOS.undent
+      raise <<-EOS.undent
         The --unicode-path patch is not supported on Subversion 1.8.
 
         Upgrading from a 1.7 version built with this patch is not supported.
@@ -172,6 +186,7 @@ class Subversion < Formula
     if build.with? "python"
       system "make", "swig-py"
       system "make", "install-swig-py"
+      (lib/"python2.7/site-packages").install_symlink Dir["#{lib}/svn-python/*"]
     end
 
     if build.with? "perl"
@@ -289,3 +304,17 @@ index a60430b..bd9b017 100644
      INC  => join(' ', $includes, $cppflags,
                   " -I$swig_srcdir/perl/libsvn_swig_perl",
                   " -I$svnlib_srcdir/include",
+
+diff --git a/build/get-py-info.py b/build/get-py-info.py
+index 29a6c0a..dd1a5a8 100644
+--- a/build/get-py-info.py
++++ b/build/get-py-info.py
+@@ -83,7 +83,7 @@ def link_options():
+   options = sysconfig.get_config_var('LDSHARED').split()
+   fwdir = sysconfig.get_config_var('PYTHONFRAMEWORKDIR')
+ 
+-  if fwdir and fwdir != "no-framework":
++  if fwdir and fwdir != "no-framework" and sys.platform != 'darwin':
+ 
+     # Setup the framework prefix
+     fwprefix = sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX')


### PR DESCRIPTION
Borrows my change from https://github.com/Homebrew/homebrew-versions/pull/779

Closes #34119