### PR TITLE
formula: always override user home

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -929,8 +929,17 @@ class Formula
   def stage
     active_spec.stage do
       @buildpath = Pathname.pwd
-      yield
-      @buildpath = nil
+      env_home = buildpath/".brew_home"
+      mkdir_p env_home
+
+      old_home, ENV["HOME"] = ENV["HOME"], env_home
+
+      begin
+        yield
+      ensure
+        @buildpath = nil
+        ENV["HOME"] = old_home
+      end
     end
   end
 


### PR DESCRIPTION
This is a rough draft of the initial idea that we always override the user's home directory. It borrows a chunk of code from further up a bit.

It meshes particularly well with the `HOMEBREW_SANDBOX` variable, reducing the number of failures associated with sandboxed formulae trying to write to `$HOME`, but it also means we no longer write files into the home `.cache`, `.config`, `.local`, `.npm`, etc folders which is consistently stuff that should be thrown away once we're done with it (Cached downloads, etc).

Tested against Node and #39771 with success.

Still need to check it doesn't conflict with [this chunk of optional test-bot code](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/cmd/test-bot.rb#L690-L694), although it shouldn't, theoretically.