### PR TITLE
Formula-Cookbook: update download strategy example

### DIFF
--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -619,11 +619,11 @@ end
 To use one of Homebrew’s built-in download strategies, specify the `:using =>` flag on a `url` or `head`.  For example:
 
 ```ruby
-class Sip < Formula
-  url "http://www.riverbankcomputing.co.uk/hg/sip/archive/4.11"
-  md5 "dbafd7101a4e7caee6f529912a1356e5"
-  head "http://www.riverbankcomputing.co.uk/hg/sip", :using => :hg
-  homepage "http://www.riverbankcomputing.co.uk/software/sip"
+class Python3 < Formula
+  homepage "https://www.python.org/"
+  url "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz"
+  sha256 "b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8"
+  head "https://hg.python.org/cpython", :using => :hg
 ```
 
 The downloaders offered by Homebrew are:


### PR DESCRIPTION
The new one uses sha256 instead of md5 and 
the URLs still work and are all https, too.