### PR TITLE
aap 1.094

### DIFF
--- a/Library/Formula/aap.rb
+++ b/Library/Formula/aap.rb
@@ -1,25 +1,14 @@
 class Aap < Formula
   desc "Aap is a make-like tool to download, build, and install software"
   homepage "http://www.a-a-p.org"
-  url "https://downloads.sourceforge.net/project/a-a-p/Aap/1.093/aap-1.093.zip"
-  sha256 "7a6c6c4a819a8379e60c679fe0c3f93eb1b74204cd7cc1c158263f4b34943001"
-
-  bottle do
-    sha256 "2a0ac5d749435a00a40366cbbf0438e7cc29579d4ea73b4491743d34d53dafad" => :yosemite
-    sha256 "3044bc85097466a3b88dd7811602d8494f2afe6e1f6c98170056d2e52ca55094" => :mavericks
-    sha256 "250cbd3d70ba5d0972c625e5045a019b7ef53d07ecf5da9f9ead3e783b0bced0" => :mountain_lion
-  end
+  url "https://downloads.sourceforge.net/project/a-a-p/aap-1.094.zip"
+  sha256 "3f53b2fc277756042449416150acc477f29de93692944f8a77e8cef285a1efd8"
 
   depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    # Aap only installs "man" at top level. This moves it under share/,
-    # which OS X and Homebrew use by default.
-    # Upstream bug report: http://sourceforge.net/p/a-a-p/mailman/message/34146703/
-    inreplace "main.aap", "mandir = $PREFIX/man/man1", "mandir = $PREFIX/share/man/man1"
-
     # Aap is designed to install using itself
-    system "./aap", "install", "PREFIX=#{prefix}"
+    system "./aap", "install", "PREFIX=#{prefix}", "MANSUBDIR=share/man"
   end
 
   test do


### PR DESCRIPTION
Update aap from 1.093 to 1.094
This removes the need for a patch in the original formula (#40089) because Aap 1.094 adds a "MANSUBDIR" option.