### PR TITLE
libtorrent: switch homepage/url

### DIFF
--- a/Library/Formula/libtorrent.rb
+++ b/Library/Formula/libtorrent.rb
@@ -1,10 +1,16 @@
-require "formula"
-
 class Libtorrent < Formula
   desc "BitTorrent library"
-  homepage "http://libtorrent.rakshasa.no/"
-  url "http://libtorrent.rakshasa.no/downloads/libtorrent-0.13.4.tar.gz"
-  sha1 "3a3ca87054d020bc376abe2c1ea15bbbaef31131"
+  homepage "https://github.com/rakshasa/libtorrent"
+  # Both homepage and primary url have been down since at least ~April 2015
+  # https://github.com/rakshasa/rtorrent/issues/295
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libt/libtorrent/libtorrent_0.13.4.orig.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/libt/libtorrent/libtorrent_0.13.4.orig.tar.gz"
+  sha256 "74a193d0e91a26f9471c12424596e03b82413d0dd0e1c8d4d7dad25a01cc60e5"
+
+  def pour_bottle?
+    # https://github.com/Homebrew/homebrew/commit/5eb5e4499c9
+    false
+  end
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
@@ -16,7 +22,7 @@ class Libtorrent < Formula
 
   def install
     # Currently can't build against libc++; see:
-    # https://github.com/mxcl/homebrew/issues/23483
+    # https://github.com/homebrew/homebrew/issues/23483
     # https://github.com/rakshasa/libtorrent/issues/47
     ENV.libstdcxx if ENV.compiler == :clang
 
@@ -26,6 +32,6 @@ class Libtorrent < Formula
                           "--with-kqueue",
                           "--enable-ipv6"
     system "make"
-    system "make install"
+    system "make", "install"
   end
 end


### PR DESCRIPTION
The upstream url/homepage has been taken over apparently, and is down regardless.

Switched to the Github homepage and Debian mirrors - The current Github tarball for the existing libtorrent release doesn't compile against the newest libtool/autotools combination.

Re #40392