### PR TITLE
uni2ascii: use debian url/mirror

### DIFF
--- a/Library/Formula/uni2ascii.rb
+++ b/Library/Formula/uni2ascii.rb
@@ -1,8 +1,11 @@
 # encoding: UTF-8
 class Uni2ascii < Formula
   desc "Bi-directional conversion between UTF-8 and various ASCII flavors"
+  # homepage/url: "the website you are looking for is suspended"
+  # Switched to Debian mirrors June 2015.
   homepage "http://billposer.org/Software/uni2ascii.html"
-  url "http://billposer.org/Software/Downloads/uni2ascii-4.18.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
   sha256 "9e24bb6eb2ced0a2945e2dabed5e20c419229a8bf9281c3127fa5993bfa5930e"
 
   bottle do


### PR DESCRIPTION
The homepage and normal URL are both dead with "This Website Is No Longer Available" and "Sorry, but the website you are looking for is suspended."

I've left the homepage here, but replaced the url and added a mirror.

This problem is currently what's causing the failure in #40449 - The current download appears to be following through to the suspended page and downloading http://billposer.org/cgi-sys/suspendedpage.cgi as uni2ascii-4.18.tar.gz, which obviously then fails the checksum assertion.