### PR TITLE
Clang format: optionally install integration scripts

### DIFF
--- a/Library/Formula/clang-format.rb
+++ b/Library/Formula/clang-format.rb
@@ -53,6 +53,7 @@ class ClangFormat < Formula
       bin.install "bin/clang-format"
     end
     bin.install "tools/clang/tools/clang-format/git-clang-format"
+    (share/"clang").install Dir["tools/clang/tools/clang-format/clang-format*"]
   end
 
   test do


### PR DESCRIPTION
This patch adds the options --with-vim, --with-emacs, --with-sublime, --with-bbedit, and --with-diff which cause their respective integration scripts to be installed into share/clang/. 