### PR TITLE
sonar: add sonarqube alias

### DIFF
--- a/Library/Aliases/sonarqube
+++ b/Library/Aliases/sonarqube
@@ -1,0 +1,1 @@
+../Formula/sonar.rb


### PR DESCRIPTION
From the homepage:

> SonarQube™ software (previously known as “Sonar”) is an open source
> project hosted at Codehaus.

@mikemcquaid Do we handle software renaming? e.g. moving `sonar` to `sonarqube` or `sonar-qube` and adding an alias from the old name to the new name.

Also, should I use `sonarqube` or `sonaqube` (or both)?