### PR TITLE
style: bump rubocop to 0.32.0

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -6,7 +6,7 @@ module Homebrew
       ARGV.formulae.map(&:path)
     end
 
-    Homebrew.install_gem_setup_path! "rubocop", "0.31.0"
+    Homebrew.install_gem_setup_path! "rubocop", "0.32.0"
 
     args = [
       "--format", "simple", "--config",


### PR DESCRIPTION
A fairly minor [release](https://github.com/bbatsov/rubocop/releases/tag/v0.32.0) this time, with no breaking changes to our Rubocop. Should be fine to just pull without change to our Rubocop handling consequently.