### PR TITLE
Create & Use npm path nudge

### DIFF
--- a/Library/Formula/skinny.rb
+++ b/Library/Formula/skinny.rb
@@ -1,40 +1,31 @@
-require "formula"
-
-class UniversalNpm < Requirement
-  fatal true
-  satisfy { which("npm") }
-  def message
-    "npm is required. If you have installed node with `--without-npm` option, reinstall with `--with-npm`."
-  end
-end
-
 class Skinny < Formula
   desc "Full-stack web app framework built on Scalatra"
   homepage "http://skinny-framework.org/"
   url "https://github.com/skinny-framework/skinny-framework/releases/download/1.3.18/skinny-1.3.18.tar.gz"
-  sha1 "150fe1a5f010d0bba07491ed008d0797f8bd1f19"
-
-  depends_on "node"
-  depends_on UniversalNpm
+  sha256 "03551f3d87d85bbd0ab5ec1279c8ef62db3588921fe6ffca88892a4c896715d1"
 
   option "without-npm-generator", "Yeoman generator will not be installed"
 
+  depends_on "node"
+
   def install
-    libexec.install Dir["*"]
+    ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"
+    ENV["HOME"] = buildpath/".brew_home"
+
+    if build.with? "npm-generator"
+      system "npm", "install", "yo"
+      system "npm", "install", "generator-skinny"
+      libexec.install Dir["*"]
+      bin.install_symlink libexec/"node_modules/yo/lib/cli.js" => "yo"
+    else
+      libexec.install Dir["*"]
+    end
+
     (bin/"skinny").write <<-EOS.undent
       #!/bin/bash
       export PATH=#{bin}:$PATH
       PREFIX="#{libexec}" exec "#{libexec}/skinny" "$@"
     EOS
-  end
-
-  def post_install
-    return if build.without? "npm-generator"
-
-    cd libexec
-    system "npm", "install", "yo"
-    ln_s libexec/"node_modules/yo/cli.js", bin/"yo"
-    system "npm", "install", "generator-skinny"
   end
 
   test do

--- a/Library/Formula/tegh.rb
+++ b/Library/Formula/tegh.rb
@@ -1,18 +1,22 @@
-require 'formula'
-
 class Tegh < Formula
   desc "Command-line client for Prontserve"
-  homepage 'https://github.com/D1plo1d/tegh'
-  head 'https://github.com/D1plo1d/tegh.git', :branch => 'develop'
-  url 'https://s3.amazonaws.com/tegh_binaries/0.3.1/tegh-0.3.1-brew.tar.gz'
-  sha1 '7061165db148a27d229563e340d6c691b4fd92a8'
+  homepage "https://github.com/D1plo1d/tegh"
+  url "https://s3.amazonaws.com/tegh_binaries/0.3.1/tegh-0.3.1-brew.tar.gz"
+  sha256 "1aa9bdcc9579e8d56ab6a7b50704a1f32a6e5b8950ee2042f463b0a3b31daf4e"
 
-  depends_on 'node'
+  head "https://github.com/D1plo1d/tegh.git", :branch => "develop"
+
+  depends_on "node"
 
   def install
+    if build.head?
+      ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"
+      ENV["HOME"] = buildpath/".brew_home"
+      system "npm", "install"
+    end
+
     rm "bin/tegh.bat"
-    system "npm", "install" if build.head?
-    libexec.install Dir['*']
+    libexec.install Dir["*"]
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 end

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -489,6 +489,17 @@ class FormulaAuditor
     if text =~ /Formula\.factory\(/
       problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
     end
+
+    if text =~ /system "npm", "install"/ && text !~ %r[opt_libexec}/npm/bin]
+      need_npm = "\#{Formula[\"node\"].opt_libexec\}/npm/bin"
+      problem <<-EOS.undent
+       Please add ENV.prepend_path \"PATH\", \"#{need_npm}"\ to def install
+      EOS
+    end
+
+    if text =~ /system "npm", "install"/ && text !~ /"HOME"/
+      problem "Please add ENV[\"HOME\"] = buildpath/\".brew_home\" to def install"
+    end
   end
 
   def audit_line(line, lineno)


### PR DESCRIPTION
Various things:

* Stops `npm`-using formulae just breaking completely when `HOMEBREW_SANDBOX` is set, and spamming up the `$HOME` cache/config when it isn't.
* Stops `npm`-using formulae being reliant on `post_install` which currently means we can't bottle the most significant part of each of these compiles.
* Sets a standard format for how to get `npm` back in the `$PATH`, since `superenv` removes it and the answer so far has been to re-add `HOMEBREW_PREFIX/"bin"` manually which risks picking up unexpected deps, or using `post_install` which isn't great UX.