### PR TITLE
headphones: fix plist DOCTYPE

### DIFF
--- a/Library/Formula/headphones.rb
+++ b/Library/Formula/headphones.rb
@@ -41,7 +41,7 @@ class Headphones < Formula
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/$
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
     <dict>
       <key>Label</key>


### PR DESCRIPTION
When I try to "launchctl load" the provided plist file for the headphones formula, I get an error:

```
[jon@home ~]$ launchctl load ~/Library/LaunchAgents/homebrew.mxcl.headphones.plist
/usr/local/Cellar/headphones/0.5.2/homebrew.mxcl.headphones.plist: Invalid property list
```

It must be that the DOCTYPE line is malformed, because the attached patch fixes it. launchctl now exits silently and with a 0 exit status. Copied the line verbatim from the sickbeard formula.

```
[jon@home ~]$ grep DOCTYPE ~/Library/LaunchAgents/homebrew.mxcl.headphones.plist
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/$
[jon@home ~]$ grep DOCTYPE ~/Library/LaunchAgents/homebrew.mxcl.sickbeard.plist
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
```