### PR TITLE
Added support for removing given formula versions

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -9,7 +9,9 @@ module Homebrew
       ARGV.kegs.each do |keg|
         keg.lock do
           puts "Uninstalling #{keg}... (#{keg.abv})"
-          keg.unlink
+          if keg.linked?
+            keg.unlink
+          end
           keg.uninstall
           rack = keg.rack
           rm_pin rack

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -35,6 +35,15 @@ module HomebrewArgvExtension
     require 'keg'
     require 'formula'
     @kegs ||= downcased_unique_named.collect do |name|
+      name_parts = name.split('/')
+      if name_parts.length == 1
+        name = name_parts[0]
+      elsif name_parts.length == 2
+        name = name_parts[0]
+        version = name_parts[1]
+      else
+        raise "invalid name spec"
+      end
       canonical_name = Formulary.canonical_name(name)
       rack = HOMEBREW_CELLAR/canonical_name
       dirs = rack.directory? ? rack.subdirs : []
@@ -45,7 +54,9 @@ module HomebrewArgvExtension
       opt_prefix = HOMEBREW_PREFIX.join("opt", canonical_name)
 
       begin
-        if opt_prefix.symlink? && opt_prefix.directory?
+        if version
+          Keg.new(rack.join(version))
+        elsif opt_prefix.symlink? && opt_prefix.directory?
           Keg.new(opt_prefix.resolved_path)
         elsif linked_keg_ref.symlink? && linked_keg_ref.directory?
           Keg.new(linked_keg_ref.resolved_path)


### PR DESCRIPTION
Doing `uninstall formula/version` uninstalls just the keg for version 'version' of formula 'formula.
Doing `uninstall formula` behaves as before.