### PR TITLE
ffmpeg 2.7.1

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -1,9 +1,8 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-2.6.3.tar.bz2"
-  sha256 "59eb98c1b5896ac29abc0385f7c875d1b4942d695818818d418ee71eea1e0cfb"
-
+  url "http://ffmpeg.org/releases/ffmpeg-2.7.1.tar.bz2"
+  sha256 "7e07b97d2415feeae9c9b5595e35e7b7aab33207e81bf9f8c0d1eece43f7f720"
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
@@ -116,7 +115,7 @@ class Ffmpeg < Formula
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"
       args << "--disable-decoder=jpeg2000"
-      args << "--extra-cflags=" + %x(pkg-config --cflags libopenjpeg).chomp
+      args << "--extra-cflags=" + `pkg-config --cflags libopenjpeg`.chomp
     end
 
     # These librares are GPL-incompatible, and require ffmpeg be built with


### PR DESCRIPTION
###### From [changelog](http://git.videolan.org/?p=ffmpeg.git;a=blob;f=RELEASE_NOTES;hb=release/2.7), [added](http://git.videolan.org/?p=ffmpeg.git;a=blob;f=Changelog;hb=release/2.7) in ffmpeg 2.7, we can distinguish:
- Accelerate decoding of H. 264 using [MMAL](http://www.jvcref.com/files/PI/documentation/html/) (Multi-Media Abstraction Layer)
- Acceleration encode H. 264 streams means Intel QSV (Intel Quick Sync Video)
- Dropped support for version nvenc API, younger than 5.0
- For WebP images available WebPAnimEncoder API
- Improved compatibility with Quickdraw
- In bitstream filter for MPEG-4 now unpack B-frames, packaged in the style of DivX
- New decoders: TDSC, extensions with DTS lossless compression (XLL), DTS (via libdcadec), Canopus HQ/HQA
- New filters: FFT (Fast Fourier transform for video), showwavespic (showwaves filter option), detelecine and chorus
- Packer of mediacontainer (muxer) for live WebM streams
- Support accelerated decoding means Direct3D11
- Support decoding of VP9 with great depth of color and extended color spaces
- Support for Transport Layer Security (TLS)
- Supports auto rotation video on the basis specified in the metadata file
- The encoder and packer mediacontainer to APNG format associated with the file `apng`
- The nvenc encoder for HEVC/H. 265 using hardware accelerated encoder available in NVIDIA GPU
- Unpacking mediacontainer (demuxer) for Multipart JPEG
