### PR TITLE
Update mongo fomula to always gen conf from homebrew config

### DIFF
--- a/Library/Formula/mongodb.rb
+++ b/Library/Formula/mongodb.rb
@@ -90,9 +90,12 @@ class Mongodb < Formula
     end
 
     scons "install", *args
+  end
 
-    (buildpath+"mongod.conf").write mongodb_conf
-    etc.install "mongod.conf"
+  def post_install
+    conf = etc + "mongod.conf"
+    conf.unlink
+    conf.write mongodb_conf
 
     (var+"mongodb").mkpath
     (var+"log/mongodb").mkpath


### PR DESCRIPTION
We noticed that our per-user install didn't work without --build-from-source now that a keg is available. This is because the install function wasn't being called and the prebuilt mongo.conf was being installed. By moving the conf generation code into post_install, it's executed on both keg installs and clean builds. The unlink is necessary because keg installs will cp their default mongo.conf