### PR TITLE
apache-spark 1.4.0

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -4,10 +4,9 @@ class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
   head "https://github.com/apache/spark.git"
-  url "https://d3kbcqa49mib13.cloudfront.net/spark-1.3.1-bin-hadoop2.6.tgz"
-  version "1.3.1"
-  revision 1
-  sha1 "86911b6c8964230a93691bd45589f491c10d36c0"
+  url "https://www.apache.org/dyn/closer.cgi?path=spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.6.tgz"
+  version "1.4.0"
+  sha256 "19c7b4b58f3b84bed513d4d532344290d104dc394fb74c6b7bdbabab69e1f605"
 
   def install
     # Rename beeline to distinguish it from hive's beeline


### PR DESCRIPTION
Apache Spark has a new release, 1.4.0: [spark release blog post](https://spark.apache.org/news/spark-1-4-0-released.html)
