### PR TITLE
Weechat options + SHA-1 to SHA-256 change

### DIFF
--- a/Library/Formula/weechat.rb
+++ b/Library/Formula/weechat.rb
@@ -30,12 +30,13 @@ class Weechat < Formula
 
     args = std_cmake_args
 
-    args << "-DENABLE_LUA=OFF"    if build.without? "lua"
-    args << "-DENABLE_PERL=OFF"   if build.without? "perl"
-    args << "-DENABLE_RUBY=OFF"   if build.without? "ruby"
+    args << "-DENABLE_LUA=OFF" if build.without? "lua"
+    args << "-DENABLE_PERL=OFF" if build.without? "perl"
+    args << "-DENABLE_RUBY=OFF" if build.without? "ruby"
     args << "-DENABLE_ASPELL=OFF" if build.without? "aspell"
-    args << "-DENABLE_GUILE=OFF"  if build.without? "guile"
+    args << "-DENABLE_GUILE=OFF" if build.without? "guile"
     args << "-DENABLE_PYTHON=OFF" if build.without? "python"
+    args << "-DENABLE_JAVASCRIPT=OFF"
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Library/Formula/weechat.rb
+++ b/Library/Formula/weechat.rb
@@ -2,7 +2,7 @@ class Weechat < Formula
   desc "Extensible IRC client"
   homepage "https://www.weechat.org"
   url "https://weechat.org/files/src/weechat-1.2.tar.gz"
-  sha1 "84b93c3a52f8762940380edd9a4eaa3432066351"
+  sha256 "0f9b00e3fe4d0a4e864111d4231e1756f7be5c1b2b6d17da43bd785ab9f035d8"
 
   head "https://github.com/weechat/weechat.git"
 


### PR DESCRIPTION
Change SHA-1 to SHA-256.
Added options to formula for most of supported languages for scripts (problems for v8/Javascript for now).

I would mention that on Linux the package is by default with all those languages for scripts supported by default. It could be nice to have the same with Homebrew, but it would require to have some dependencies not optional anymore: guile, lua, python, maybe curl.

I don't know enough how bottle building works to know if bottle's binary could have this by default.