### PR TITLE
irssi: fix HEAD build

### DIFF
--- a/Library/Formula/irssi.rb
+++ b/Library/Formula/irssi.rb
@@ -29,11 +29,14 @@ class Irssi < Formula
   depends_on "dante" => :optional
 
   def install
-    # Make paths in man page Homebrew-specific
-    # https://github.com/irssi/irssi/issues/251
-    inreplace "docs/irssi.1" do |s|
-      s.gsub! "/usr/share", "#{HOMEBREW_PREFIX}/share"
-      s.gsub! "/etc/irssi.conf", "#{HOMEBREW_PREFIX}/etc/irssi.conf"
+    if build.stable?
+      # Make paths in man page Homebrew-specific
+      # (https://github.com/irssi/irssi/issues/251); can be removed in
+      # next stable release
+      inreplace "docs/irssi.1" do |s|
+        s.gsub! "/usr/share", "#{HOMEBREW_PREFIX}/share"
+        s.gsub! "/etc/irssi.conf", "#{HOMEBREW_PREFIX}/etc/irssi.conf"
+      end
     end
 
     args = %W[


### PR DESCRIPTION
The manpage has been updated (https://github.com/irssi/irssi/commit/e2eb2483b7d642e8dee31735f70cfb963d16323c), so the `inreplace` fails.