### PR TITLE
flatbuffers 1.1.0

### DIFF
--- a/Library/Formula/flatbuffers.rb
+++ b/Library/Formula/flatbuffers.rb
@@ -1,8 +1,8 @@
 class Flatbuffers < Formula
   desc "Serialization library for C++, supporting Java, C#, and Go"
   homepage "https://google.github.io/flatbuffers"
-  url "https://github.com/google/flatbuffers/archive/v1.0.3.tar.gz"
-  sha1 "8daba5be5436b7cb99f1883e3eb7f1c5da52d6b9"
+  url "https://github.com/google/flatbuffers/archive/v1.1.0.tar.gz"
+  sha1 "c9324d5e3e27e97d2e8883dccd02e18ca4057890"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Updating to latest. Release notes copied from https://github.com/google/flatbuffers/releases/tag/v1.1.0

> A summary of what is in this release since 1.0.0:

> An extensive overhaul to the Java API.
Out-of-the-box support for C# and Go.
An optional verifier to make FlatBuffers practical in untrusted scenarios.
.proto parsing for easier migration from Protocol Buffers.
Optional manual assignment of field IDs.
Dictionary functionality through binary search on a key field.
Bug fixes and other improvements thanks to 200+ commits from 28 contributors.

