### PR TITLE
imagemagick 6.9.1-5

### DIFF
--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -1,9 +1,8 @@
 class Imagemagick < Formula
   desc "Tools and libraries to manipulate images in many formats"
   homepage "http://www.imagemagick.org"
-  url "http://www.imagemagick.org/download/releases/ImageMagick-6.9.1-4.tar.xz"
-  mirror "https://downloads.sourceforge.net/project/imagemagick/6.9.1-sources/ImageMagick-6.9.1-4.tar.xz"
-  sha256 "74973478058069ce44040ff76b61df713d70adcadfd207836cc0622cadf1e4bf"
+  url "http://www.imagemagick.org/download/releases/ImageMagick-6.9.1-5.tar.xz"
+  sha256 "34d59b83a2c3e526a7fad1fed30a950ea7b4ba2e936017a4c71581250c86352d"
 
   head "https://subversion.imagemagick.org/subversion/ImageMagick/trunk",
        :using => :svn


### PR DESCRIPTION
```
2015-06-13  6.9.1-6 Glenn Randers-Pehrson <glennrp@image...>
  * Reverted change to 6.9.1-3 that skipped palette-building.

2015-06-03  6.9.1-5 Cristy  <quetzlzacatenango@image...>
  * Use correct scale when interpretting alpha (e.g. rgba(0,0,0,1)).
  * DrawGetVectorGraphics() now returns proper XML (reference
    http://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=27751).
  * Support writing EXR files with different color types (reference
    http://www.imagemagick.org/discourse-server/viewtopic.php?f=2&t=27759).
  * Prefer PKG_CHECK_MODULES() when searching for delegate libraries.
  * Throw exception if frame option bevel exceeds to the image width / height.
  * Resolve undefined behaviors (reference
    http://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=27811).
```