### PR TITLE
Support override openssl

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -105,6 +105,7 @@ class DependencyCollector
     when :x11        then X11Dependency.new(spec.to_s, tags)
     when :xcode      then XcodeDependency.new(tags)
     when :macos      then MinimumMacOSRequirement.new(tags)
+    when :libssl     then LibsslDependency.new(tags)
     when :mysql      then MysqlDependency.new(tags)
     when :postgresql then PostgresqlDependency.new(tags)
     when :gpg        then GPGDependency.new(tags)

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -52,6 +52,13 @@ class XcodeDependency < Requirement
   end
 end
 
+class LibsslDependency < Requirement
+  fatal true
+  default_formula 'openssl'
+
+  satisfy { which 'openssl' }
+end
+
 class MysqlDependency < Requirement
   fatal true
   default_formula 'mysql'


### PR DESCRIPTION
If we clearly do not want to use, we can try to use universal `:libssl`, provides the ability to override libressl instead of installing openssl `depends_on :libssl`.
- Homebrew/homebrew#35758

We can also do `unlink libressl` `link openssl` when it is clearly needed.
