### PR TITLE
Add fsmonitor.py to files installed with unison

### DIFF
--- a/Library/Formula/unison.rb
+++ b/Library/Formula/unison.rb
@@ -22,5 +22,6 @@ class Unison < Formula
     system "make ./mkProjectInfo"
     system "make UISTYLE=text"
     bin.install 'unison'
+    bin.install 'fsmonitor.py'
   end
 end


### PR DESCRIPTION
This makes `unison -repeat watch` work instead of failing with `Fatal error: No file monitoring helper program found`.