### PR TITLE
bgpq3 0.1.30

### DIFF
--- a/Library/Formula/bgpq3.rb
+++ b/Library/Formula/bgpq3.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bgpq3 < Formula
   desc "bgp filtering automation for Cisco and Juniper routers"
   homepage 'http://snar.spb.ru/prog/bgpq3/'
-  url 'https://github.com/snar/bgpq3/archive/v0.1.27.tar.gz'
-  sha1 'fae5f735033202ab288aef3ad7a83a0b323ae8d7'
+  url 'https://github.com/snar/bgpq3/archive/v0.1.30.tar.gz'
+  sha1 'ba74b304eb7b3b7f5c0305d75222411baee9816f'
   head "https://github.com/snar/bgpq3.git"
 
   bottle do


### PR DESCRIPTION
Mostly bug fixes, compared to 0.1.27:

    - bugfix: private asns with number > 2^31 were printed as negative integers.
    - do not use ASNs reserved for documentation purposes and private use
    - allow as-path generation with BIRD output.
    - merge README.md changes
    - bugfix: incorrect asdot representation (as101. without symbols after dot) is not allowed anymore.
    - do not include routes registered for AS23456 (transition-as) by default.Use new option -2 to restore old behaviour.
    - minor changes: .spec update, non-silent failure on wrong af, more room for masklen