### PR TITLE
search --desc: cache the query regexp

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -23,8 +23,9 @@ module Homebrew
       exec_browser "http://packages.ubuntu.com/search?keywords=#{ARGV.next}&searchon=names&suite=all&section=all"
     elsif ARGV.include? '--desc'
       query = ARGV.next
+      rx = query_regexp(query)
       Formula.each do |formula|
-        if formula.desc =~ query_regexp(query)
+        if formula.desc =~ rx
           puts "#{formula.full_name}: #{formula.desc}"
         end
       end


### PR DESCRIPTION
I haven’t noticed any real performance improvement for the average case, but it’s still better to avoid one function call at each iteration.