### PR TITLE
update sha256 hash for ghostscript libpng patch

### DIFF
--- a/Library/Formula/jbig2dec.rb
+++ b/Library/Formula/jbig2dec.rb
@@ -20,8 +20,8 @@ class Jbig2dec < Formula
   # http://bugs.ghostscript.com/show_bug.cgi?id=695890
   # Remove on next release.
   patch do
-    url "http://git.ghostscript.com/?p=jbig2dec.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc"
-    sha256 "c82f964fb47bb6e97f0686fc3af57ad819e7dbefd7e74ea078c9ba3f4f6c7b06"
+    url "http://git.ghostscript.com/?p=jbig2dec.git;a=commitdiff_plain;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc"
+    sha256 "5239e4eb991f198d2ba30d08011c2887599b5cead9db8b1d3eacec4b8912c2d0"
   end
 
   def install

--- a/Library/Formula/jbig2dec.rb
+++ b/Library/Formula/jbig2dec.rb
@@ -21,7 +21,7 @@ class Jbig2dec < Formula
   # Remove on next release.
   patch do
     url "http://git.ghostscript.com/?p=jbig2dec.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc"
-    sha256 "81ae6367ab74a18d88473a81dd2f36d8c892370a63fcf518d6f2a5af346ab867"
+    sha256 "c82f964fb47bb6e97f0686fc3af57ad819e7dbefd7e74ea078c9ba3f4f6c7b06"
   end
 
   def install


### PR DESCRIPTION
It appears that the libpng patch added in 0cd4c7fb65d7a84abd3d39a700299c9250c4c021 has the wrong sha512 hash, at least as of today. I'm unable to verify if it actually changed since it was added, but building `jbig2dec` for `ghostscript` from source currently breaks because of a hash mismatch. :cry: 

@DomT4 @xu-cheng 

```bash
$ curl -s 'http://git.ghostscript.com/?p=jbig2dec.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc' | sha256sum
c82f964fb47bb6e97f0686fc3af57ad819e7dbefd7e74ea078c9ba3f4f6c7b06  -
```

```bash
# homebrew@131fe3f7da34180114eec7e873e994cdc3297215
$ brew install jbig2dec --build-from-source --verbose
==> Downloading http://downloads.ghostscript.com/public/jbig2dec/jbig2dec-0.12.tar.gz
Already downloaded: /opt/boxen/cache/homebrew/jbig2dec-0.12.tar.gz
==> Verifying jbig2dec-0.12.tar.gz checksum
tar xf /opt/boxen/cache/homebrew/jbig2dec-0.12.tar.gz
==> Downloading http://git.ghostscript.com/?p=jbig2dec.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc
/usr/bin/curl -fLA Homebrew 0.9.5 (Ruby 2.0.0-481; Mac OS X 10.10.3) http://git.ghostscript.com/?p=jbig2dec.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc -C 0 -o /opt/boxen/cache/homebrew/jbig2dec--patch-81ae6367ab74a18d88473a81dd2f36d8c892370a63fcf518d6f2a5af346ab867.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4915    0  4915    0     0  18786      0 --:--:-- --:--:-- --:--:-- 18831
==> Verifying jbig2dec--patch-81ae6367ab74a18d88473a81dd2f36d8c892370a63fcf518d6f2a5af346ab867.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc checksum
Error: SHA256 mismatch
Expected: 81ae6367ab74a18d88473a81dd2f36d8c892370a63fcf518d6f2a5af346ab867
Actual: c82f964fb47bb6e97f0686fc3af57ad819e7dbefd7e74ea078c9ba3f4f6c7b06
Archive: /opt/boxen/cache/homebrew/jbig2dec--patch-81ae6367ab74a18d88473a81dd2f36d8c892370a63fcf518d6f2a5af346ab867.git;a=patch;h=70c7f1967f43a94f9f0d6808d6ab5700a120d2fc
To retry an incomplete download, remove the file above.
...

```