### PR TITLE
libmicrohttpd: update to 0.9.42

### DIFF
--- a/Library/Formula/libmicrohttpd.rb
+++ b/Library/Formula/libmicrohttpd.rb
@@ -1,18 +1,9 @@
-require "formula"
-
 class Libmicrohttpd < Formula
   desc "Light HTTP/1.1 server library"
-  homepage "http://www.gnu.org/software/libmicrohttpd/"
-  url "http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.38.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.38.tar.gz"
-  sha1 "1d0a6685b984b022a6be565f7b179c449944b3f1"
-
-  option "with-ssl", "Enable SSL support"
-
-  if build.with? "ssl"
-    depends_on "libgcrypt"
-    depends_on "gnutls"
-  end
+  homepage "https://www.gnu.org/software/libmicrohttpd/"
+  url "http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.42.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.42.tar.gz"
+  sha256 "00352073367003da40607319e4090a6a8308748b59246ae80e9871f34dad7d5b"
 
   bottle do
     cellar :any
@@ -21,7 +12,13 @@ class Libmicrohttpd < Formula
     sha1 "99df120ff4063f1026fc8ebcaecd3d6d96a778f9" => :mountain_lion
   end
 
+  option "with-ssl", "Enable SSL support"
   option :universal
+
+  if build.with? "ssl"
+    depends_on "libgcrypt"
+    depends_on "gnutls"
+  end
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
Also updated the Formula to pass `brew audit --strict`, with the exception of adding a `test ... do` block.

The example program for the `test ... do` block that I tried to put in is a simple HTTP server (the example from the project homepage), which is interactive and must be killed to stop, thus leaving a non-zero exit code and failing the test. Any ideas on how to implement a working test?