### PR TITLE
Pass formula objects, not strings, into the build environment

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -79,8 +79,8 @@ class Build
     ENV.activate_extensions!
 
     if superenv?
-      ENV.keg_only_deps = keg_only_deps.map(&:name)
-      ENV.deps = deps.map { |d| d.to_formula.name }
+      ENV.keg_only_deps = keg_only_deps
+      ENV.deps = deps.map(&:to_formula)
       ENV.x11 = reqs.any? { |rq| rq.kind_of?(X11Requirement) }
       ENV.setup_build_environment(formula)
       post_superenv_hacks

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -3,7 +3,7 @@ require "extend/ENV"
 module Homebrew
   def __env
     ENV.activate_extensions!
-    ENV.deps = ARGV.formulae.map(&:name) if superenv?
+    ENV.deps = ARGV.formulae if superenv?
     ENV.setup_build_environment
     ENV.universal_binary if ARGV.build_universal?
 

--- a/Library/Homebrew/cmd/sh.rb
+++ b/Library/Homebrew/cmd/sh.rb
@@ -7,7 +7,7 @@ module Homebrew
 
     if superenv?
       ENV.x11 = MacOS::X11.installed?
-      ENV.deps = Formula.installed.select{|f| f.keg_only? and f.opt_prefix.directory? }.map(&:name)
+      ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
     end
     ENV.setup_build_environment
     if superenv?

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -56,7 +56,7 @@ module Superenv
     self['CMAKE_INCLUDE_PATH'] = determine_cmake_include_path
     self['CMAKE_LIBRARY_PATH'] = determine_cmake_library_path
     self['ACLOCAL_PATH'] = determine_aclocal_path
-    self['M4'] = MacOS.locate("m4") if deps.include? "autoconf"
+    self['M4'] = MacOS.locate("m4") if deps.any? { |d| d.name == "autoconf" }
     self["HOMEBREW_ISYSTEM_PATHS"] = determine_isystem_paths
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
@@ -103,7 +103,7 @@ module Superenv
     paths = [Superenv.bin]
 
     # Formula dependencies can override standard tools.
-    paths += deps.map { |dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/bin" }
+    paths += deps.map { |d| d.opt_bin.to_s }
 
     # On 10.9, there are shims for all tools in /usr/bin.
     # On 10.7 and 10.8 we need to add these directories ourselves.
@@ -133,8 +133,8 @@ module Superenv
   end
 
   def determine_pkg_config_path
-    paths  = deps.map{|dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/lib/pkgconfig" }
-    paths += deps.map{|dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/share/pkgconfig" }
+    paths  = deps.map { |d| "#{d.opt_lib}/pkgconfig" }
+    paths += deps.map { |d| "#{d.opt_share}/pkgconfig" }
     paths.to_path_s
   end
 
@@ -145,7 +145,7 @@ module Superenv
   end
 
   def determine_aclocal_path
-    paths = keg_only_deps.map{|dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/share/aclocal" }
+    paths = keg_only_deps.map { |d| "#{d.opt_share}/aclocal" }
     paths << "#{HOMEBREW_PREFIX}/share/aclocal"
     paths << "#{MacOS::X11.share}/aclocal" if x11?
     paths.to_path_s
@@ -154,7 +154,7 @@ module Superenv
   def determine_isystem_paths
     paths = []
     paths << "#{HOMEBREW_PREFIX}/include"
-    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.include? "libxml2"
+    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
     paths << "#{effective_sysroot}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"
@@ -162,7 +162,7 @@ module Superenv
   end
 
   def determine_include_paths
-    paths = keg_only_deps.map { |dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/include" }
+    paths = keg_only_deps.map { |d| d.opt_include.to_s }
 
     # https://github.com/Homebrew/homebrew/issues/38514
     if MacOS::CLT.installed? && MacOS.active_developer_dir.include?("CommandLineTools") &&
@@ -174,7 +174,7 @@ module Superenv
   end
 
   def determine_library_paths
-    paths = keg_only_deps.map { |dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/lib" }
+    paths = keg_only_deps.map { |d| d.opt_lib.to_s }
     paths << "#{HOMEBREW_PREFIX}/lib"
     paths << MacOS::X11.lib.to_s if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries"
@@ -182,14 +182,14 @@ module Superenv
   end
 
   def determine_cmake_prefix_path
-    paths = keg_only_deps.map { |dep| "#{HOMEBREW_PREFIX}/opt/#{dep}" }
+    paths = keg_only_deps.map { |d| d.opt_prefix.to_s }
     paths << HOMEBREW_PREFIX.to_s
     paths.to_path_s
   end
 
   def determine_cmake_include_path
     paths = []
-    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.include? "libxml2"
+    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
     paths << "#{effective_sysroot}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"
@@ -204,7 +204,7 @@ module Superenv
   end
 
   def determine_cmake_frameworks_path
-    paths = deps.map { |dep| "#{HOMEBREW_PREFIX}/opt/#{dep}/Frameworks" }
+    paths = deps.map { |d| d.opt_frameworks.to_s }
     paths << "#{effective_sysroot}/System/Library/Frameworks" if MacOS::Xcode.without_clt?
     paths.to_path_s
   end


### PR DESCRIPTION
This is cleanup that emerged from a larger refactoring of the build environment code.