### PR TITLE
vim --with-client-server build fix

### DIFF
--- a/Library/Formula/vim.rb
+++ b/Library/Formula/vim.rb
@@ -62,12 +62,12 @@ class Vim < Formula
     end
 
     opts << "--disable-nls" if build.include? "disable-nls"
+    opts << "--without-x"
 
     if build.with? "client-server"
       opts << "--enable-gui=gtk2"
     else
       opts << "--enable-gui=no"
-      opts << "--without-x"
     end
 
     if build.with? "luajit"


### PR DESCRIPTION
failed as a consequence of the gtk-quartz migration
Closes #40832.