### PR TITLE
rabbitmq-c 0.7.0

### DIFF
--- a/Library/Formula/rabbitmq-c.rb
+++ b/Library/Formula/rabbitmq-c.rb
@@ -37,4 +37,8 @@ class RabbitmqC < Formula
     system "cmake", ".", *args
     system "make", "install"
   end
+
+  test do
+    system "amqp-get", "--help"
+  end
 end

--- a/Library/Formula/rabbitmq-c.rb
+++ b/Library/Formula/rabbitmq-c.rb
@@ -1,8 +1,8 @@
 class RabbitmqC < Formula
   desc "RabbitMQ C client"
   homepage "https://github.com/alanxz/rabbitmq-c"
-  url "https://github.com/alanxz/rabbitmq-c/archive/v0.5.2.tar.gz"
-  sha256 "418726e830567c296292fd37325d8eeea7b8973c143c4b50b8acf694244ff6a7"
+  url "https://github.com/alanxz/rabbitmq-c/archive/v0.7.0.tar.gz"
+  sha256 "b8b9a5cca871968de95538a87189f7321a3f86aca07ae8a81874e93d73cf9a4d"
 
   head "https://github.com/alanxz/rabbitmq-c.git"
 

--- a/Library/Formula/rabbitmq-c.rb
+++ b/Library/Formula/rabbitmq-c.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class RabbitmqC < Formula
   desc "RabbitMQ C client"
   homepage "https://github.com/alanxz/rabbitmq-c"
   url "https://github.com/alanxz/rabbitmq-c/archive/v0.5.2.tar.gz"
-  sha1 "6c442aefbc4477ac0598c05361c767a75d6e1541"
+  sha256 "418726e830567c296292fd37325d8eeea7b8973c143c4b50b8acf694244ff6a7"
 
   head "https://github.com/alanxz/rabbitmq-c.git"
 
@@ -20,8 +18,8 @@ class RabbitmqC < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
-  depends_on "rabbitmq" => :recommended
   depends_on "popt" if build.with? "tools"
+  depends_on "openssl"
 
   def install
     ENV.universal_binary if build.universal?
@@ -31,10 +29,10 @@ class RabbitmqC < Formula
     args << "-DBUILD_API_DOCS=OFF"
 
     args << if build.with? "tools"
-      "-DBUILD_TOOLS=ON"
-    else
-      "-DBUILD_TOOLS=OFF"
-    end
+              "-DBUILD_TOOLS=ON"
+            else
+              "-DBUILD_TOOLS=OFF"
+            end
 
     system "cmake", ".", *args
     system "make", "install"

--- a/Library/Formula/simple-amqp-client.rb
+++ b/Library/Formula/simple-amqp-client.rb
@@ -1,11 +1,10 @@
-require "formula"
-
 class SimpleAmqpClient < Formula
   desc "C++ interface to rabbitmq-c"
   homepage "https://github.com/alanxz/SimpleAmqpClient"
   url "https://github.com/alanxz/SimpleAmqpClient/archive/v2.4.0.tar.gz"
-  sha1 "5b24c79a34dc8c97ff5dd0c78d545b9f507478a5"
+  sha256 "5735ccccd638b2e2c275ca254f2f947bdfe34511247a32822985c3c25239e06e"
   head "https://github.com/alanxz/SimpleAmqpClient.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -25,19 +24,19 @@ class SimpleAmqpClient < Formula
   end
 
   test do
-     (testpath/"test.cpp").write <<-EOS.undent
-       #include <SimpleAmqpClient/SimpleAmqpClient.h>
-       #include <string>
-       int main() {
-         const std::string expected = "test body";
-         AmqpClient::BasicMessage::ptr_t msg = AmqpClient::BasicMessage::Create(expected);
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <SimpleAmqpClient/SimpleAmqpClient.h>
+      #include <string>
+      int main() {
+        const std::string expected = "test body";
+        AmqpClient::BasicMessage::ptr_t msg = AmqpClient::BasicMessage::Create(expected);
 
-         if(msg->Body() != expected) return 1;
+        if(msg->Body() != expected) return 1;
 
-         return 0;
-       }
-     EOS
-     system ENV.cxx, "test.cpp", "-lSimpleAmqpClient", "-o", "test"
-     system "./test"
-   end
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-lSimpleAmqpClient", "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
update `rabbitmq-c` depends
* `rabbitmq-c` does not depend on `rabbitmq` server.
* `rabbitmq-c` depends on `openssl`

update to version 0.7.0