### PR TITLE
uberftp 2.8

### DIFF
--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -9,6 +9,7 @@ class Uberftp < Formula
   def install
     globus = Formula["globus-toolkit"].opt_prefix
 
+    #patches needed since location changed with globus-toolkit versions >= 6.0, patch to upstream not yet merged https://github.com/JasonAlt/UberFTP/pull/8
     inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
     inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"
 

--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -1,23 +1,18 @@
 class Uberftp < Formula
   desc "Interactive GridFTP client"
-  homepage "http://dims.ncsa.illinois.edu/set/uberftp/"
-  url "https://github.com/JasonAlt/UberFTP/archive/Version_2_7.tar.gz"
-  sha256 "29a111a86fa70dbbc529a5d3e5a6befc1681e64e32dc019a1a6a98cd43ffb204"
+  homepage 'http://dims.ncsa.illinois.edu/set/uberftp/'
+  url 'https://github.com/JasonAlt/UberFTP/archive/Version_2_8.tar.gz'
+  sha256 '8a397d6ef02bb714bb0cbdb259819fc2311f5d36231783cd520d606c97759c2a'
 
   depends_on "globus-toolkit"
 
   def install
-    # get the flavor
     globus = Formula["globus-toolkit"].opt_prefix
 
-    core = `"#{globus}/sbin/gpt-query" globus_core`
-    flavor = case core
-    when /gcc64dbg/ then "gcc64dbg"
-    when /gcc32dbg/ then "gcc32dbg"
-    end
+    inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
+    inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"
 
     system "./configure", "--prefix=#{prefix}",
-                          "--with-globus-flavor=#{flavor}",
                           "--with-globus=#{globus}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
Hi,

version has bumped to 2.8. In addition, I fixed a problem that uberftp do not compile with globus-toolkit versions >= 6.0. Could you review and merge, please.

Thanks,
Manuel