### PR TITLE
orbit: modernise

### DIFF
--- a/Library/Formula/orbit.rb
+++ b/Library/Formula/orbit.rb
@@ -1,29 +1,31 @@
-require 'formula'
-
 class Orbit < Formula
   desc "CORBA 2.4-compliant object request broker (ORB)"
-  homepage 'http://projects.gnome.org/ORBit2/'
-  url 'http://ftp.gnome.org/pub/gnome/sources/ORBit2/2.14/ORBit2-2.14.19.tar.bz2'
-  sha256 '55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550'
+  homepage "https://projects.gnome.org/ORBit2"
+  url "https://download.gnome.org/sources/ORBit2/2.14/ORBit2-2.14.19.tar.bz2"
+  sha256 "55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550"
 
-  depends_on 'pkg-config' => :build
-  depends_on 'glib'
-  depends_on 'libidl'
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libidl"
 
   # per MacPorts, re-enable use of deprecated glib functions
   patch :p0 do
     url "https://trac.macports.org/export/105275/trunk/dports/devel/orbit2/files/patch-linc2-src-Makefile.in.diff"
-    sha1 "8941a2bec91403e49de600a74af307a95c0ce2b1"
+    sha256 "572771ea59f841d74ac361d51f487cc3bcb2d75dacc9c20a8bd6cbbaeae8f856"
   end
 
   patch :p0 do
     url "https://trac.macports.org/export/105275/trunk/dports/devel/orbit2/files/patch-configure.diff"
-    sha1 "2ef976d53af55d88237e6c72ade1154c7a655556"
+    sha256 "34d068df8fc9482cf70b291032de911f0e75a30994562d4cf56b0cc2a8e28e42"
   end
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    assert_match /#{version}/, shell_output("#{bin}/orbit2-config --prefix --version")
   end
 end


### PR DESCRIPTION
This threw up what looked like a race condition earlier. It needed updating/bottling regardless, so I thought I'd leave off the `ENV.deparallelize` during the first run and see if the race actually reproduces.