### PR TITLE
Upgrade to Liquibase version 3.3.5.

### DIFF
--- a/Library/Formula/liquibase.rb
+++ b/Library/Formula/liquibase.rb
@@ -1,8 +1,8 @@
 class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "http://liquibase.org"
-  url "https://downloads.sourceforge.net/project/liquibase/Liquibase%20Core/liquibase-3.3.2-bin.tar.gz"
-  sha1 "89ddda7d5ca8d38947bfee0d4aa58534d943b990"
+  url "https://github.com/liquibase/liquibase/releases/download/liquibase-parent-3.3.5/liquibase-3.3.5-bin.tar.gz"
+  sha1 "94ae9bf3de3dcfa41c2951d2b7d21495af740f3c"
 
   def install
     rm_f Dir["*.bat"]


### PR DESCRIPTION
Upgraded Liquibase formula to latest version 3.3.5.

Also fixed broken download link as Liquibase switched binary hosting from Sourceforge to Github due to security concerns:

http://blog.liquibase.org/2015/06/liquibase-downloads-moved-off-sourceforge.html