### PR TITLE
dnsmasq: add -C option to sample plist to use config file from correct homebrew prefix

### DIFF
--- a/Library/Formula/dnsmasq.rb
+++ b/Library/Formula/dnsmasq.rb
@@ -68,6 +68,8 @@ class Dnsmasq < Formula
         <array>
           <string>#{opt_sbin}/dnsmasq</string>
           <string>--keep-in-foreground</string>
+          <string>-C</string>
+          <string>#{etc}/dnsmasq.conf</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
Since dnsmasq is installed from keg the default config location is not the same as the homebrew prefix if you use a custom one. The patch adds the -C option to the plist to point to the correct location of the config file.