### PR TITLE
docker-machine 0.3.0

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachine < Formula
   desc "Create Docker hosts locally and on cloud providers"
   homepage "https://docs.docker.com/machine"
-  url "https://github.com/docker/machine/archive/v0.2.0.tar.gz"
-  sha256 "ba4df6728280732e70dcabc2aeb903babac0bbefb3f1c11e7f131e3aad0f2131"
+  url "https://github.com/docker/machine/archive/v0.3.0.tar.gz"
+  sha256 "fa1cbb8d806ca422b2c80b66952171875a2b092c9661baea7be11d5c60e279ac"
   head "https://github.com/docker/machine.git"
 
   bottle do
@@ -32,8 +32,12 @@ class DockerMachine < Formula
     url "https://github.com/golang/crypto.git", :revision => "8b27f58b78dbd60e9a26b60b0d908ea642974b6d"
   end
 
+  go_resource "github.com/Sirupsen/logrus" do
+    url "https://github.com/Sirupsen/logrus.git", :revision => "21d4508646ae56d79244bd9046c1df63a5fa8c37"
+  end
+
   go_resource "github.com/docker/machine" do
-    url "https://github.com/docker/machine.git", :revision => "8b9eaf2b6fda23550e09bde1054eeab78e5493bd"
+    url "https://github.com/docker/machine.git", :revision => "0a251fe434d868165cca28200ffd71f16abb5c10" # the 0.3.0 tag
   end
 
   def install


### PR DESCRIPTION
A new docker-machine was recently released. This version adds a migration path from using the "boot2docker" package directly (with its CLI tools).