### PR TITLE
Add new formula for SILE typesetting engine.

### DIFF
--- a/Library/Formula/sile.rb
+++ b/Library/Formula/sile.rb
@@ -1,0 +1,45 @@
+class Sile < Formula
+  desc "Modern typesetting system inspired by TeX"
+  homepage "http://www.sile-typesetter.org/"
+  url "https://github.com/simoncozens/sile/releases/download/v0.9.2/sile-0.9.2.tar.bz2"
+  sha256 "2223582818df06daa4609cee40a81e8787085ad1795d4b2ce5edbe0663b74e18"
+
+  head do
+    url "https://github.com/simoncozens/sile.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "harfbuzz"
+  depends_on "fontconfig"
+  depends_on "libpng"
+  depends_on "freetype"
+  depends_on "lua"
+
+  resource("simple.sil") do
+    url "https://raw.githubusercontent.com/simoncozens/sile/v0.9.2/examples/simple.sil"
+    sha256 "f788723cd984d98343c8f8dc1b93b8f769cea6894a28f9ba6e0bec6aebf78f92"
+  end
+
+  def install
+    system "luarocks-5.2", "install", "lpeg"
+    system "luarocks-5.2", "install", "luaexpat"
+    system "./bootstrap.sh" if build.head?
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--with-lua=#{prefix}",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    resource("simple.sil").stage do
+      system "sile", "simple.sil"
+      assert File.exist? "simple.pdf"
+    end
+  end
+end


### PR DESCRIPTION
This is a new formula with both stable and head rules for installing the [SILE typesetting engine](https://github.com/simoncozens/sile).

Note I had some difficulty with the luarocks dependencies. I couldn't find any documentation, the assorted comments in previous issues were all about the obsolete luarocks package but not how to add dependencies to new packages, and the [one example](https://github.com/Homebrew/homebrew/blob/master/Library/Contributions/example-formula.rb) I found made it sound like you could do this:

    depends_on "lpeg" => :lua
    depends_on "luaexpect" => :lua

…but that throws an error saying to install them by hand. So I added a `system` call to do just that.

If there is a better way to do that, could somebody point me to either the documentation or an another formula that does it right?