### PR TITLE
gcc: use patch for Xcode 7/El Capitan.

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -32,6 +32,15 @@ class Gcc < Formula
     sha256 "77bce635f78bc26bd01010b5ece480251af223bf2dba6d48c29af6b29b441296" => :mountain_lion
   end
 
+  if MacOS.version >= :el_capitan
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
   option "with-java", "Build the gcj compiler"
   option "with-all-languages", "Enable all compilers and languages, except Ada"
   option "with-nls", "Build with native language support (localization)"


### PR DESCRIPTION
I'm gonna kill this build immediately as it won't run on any of our machines but I think it'd be good to add this patch. CC @Homebrew/owners for any objections. If there are none I'll add it to all the `homebrew-versions` versions where it applies cleanly too.