### PR TITLE
sudo_check: don't use a set

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -98,7 +98,7 @@ begin
 
   cmd = aliases[cmd] if aliases[cmd]
 
-  sudo_check = Set.new %w[ install link pin unpin upgrade ]
+  sudo_check = %w[ install link pin unpin upgrade ]
 
   if sudo_check.include? cmd
     if Process.uid.zero? and not File.stat(HOMEBREW_BREW_FILE).uid.zero?


### PR DESCRIPTION
This is unnecessary here because we use it only once. The difference won't be noticeable but the check is 4 times faster now.

```ruby
require "benchmark"

def b(&bk); Benchmark.realtime { (1..10000).each(&bk) }; end

b { Set.new(%w[ install link pin unpin upgrade ]).include? "install" }
# => 0.055957

b { %w[ install link pin unpin upgrade ].include? "install" }
# => 0.01427

b { s=Set.new %w[ install link pin unpin upgrade ]; s.include? "upgrade" }
# => 0.056501

b { s= %w[ install link pin unpin upgrade ]; s.include? "upgrade" }
# => 0.017182

b { s=Set.new %w[ install link pin unpin upgrade ]; s.include? "upgrad" }
# => 0.057888

b { s=%w[ install link pin unpin upgrade ]; s.include? "upgrad" }
# => 0.015577
```