### PR TITLE
Create scaleway-cli formula

### DIFF
--- a/Library/Formula/scaleway-cli.rb
+++ b/Library/Formula/scaleway-cli.rb
@@ -1,14 +1,13 @@
-require "formula"
-
 class ScalewayCli < Formula
-  desc "Interact with Scaleway API from the command line"
+  desc "Interact with Scaleway API from the command-line"
   homepage "https://github.com/scaleway/scaleway-cli/"
   url "https://github.com/scaleway/scaleway-cli/releases/download/v1.1.0/scw-Darwin-x86_64"
-  sha1 "8860b5daf4af43684c523aab62c48ee7e99517d4"
+  version "1.1.0"
+  sha256 "78ac104bf11f856ea50e7c75442264e5601214b5d33118648866250fcc0bff80"
 
   def install
-    mv 'scw-Darwin-x86_64', 'scw'
-    bin.install 'scw'
+    mv "scw-Darwin-x86_64", "scw"
+    bin.install "scw"
   end
 
   test do

--- a/Library/Formula/scaleway-cli.rb
+++ b/Library/Formula/scaleway-cli.rb
@@ -6,8 +6,7 @@ class ScalewayCli < Formula
   sha256 "78ac104bf11f856ea50e7c75442264e5601214b5d33118648866250fcc0bff80"
 
   def install
-    mv "scw-Darwin-x86_64", "scw"
-    bin.install "scw"
+    bin.install "scw-Darwin-x86_64" => "scw"
   end
 
   test do

--- a/Library/Formula/scaleway-cli.rb
+++ b/Library/Formula/scaleway-cli.rb
@@ -1,0 +1,17 @@
+require "formula"
+
+class ScalewayCli < Formula
+  desc "Interact with Scaleway API from the command line"
+  homepage "https://github.com/scaleway/scaleway-cli/"
+  url "https://github.com/scaleway/scaleway-cli/releases/download/v1.1.0/scw-Darwin-x86_64"
+  sha1 "8860b5daf4af43684c523aab62c48ee7e99517d4"
+
+  def install
+    mv 'scw-Darwin-x86_64', 'scw'
+    bin.install 'scw'
+  end
+
+  test do
+    system "#{bin}/scw", "version"
+  end
+end


### PR DESCRIPTION
I create a new formula to add the [scaleway-cli](https://github.com/scaleway/scaleway-cli).

It exists a binary for 32-bits OSs but I don't know how I have to precise it. Maybe it could be added.
And also I'm not sure if I have to precise bottle and how.