### PR TITLE
download_strategy: remove extra colon

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -273,7 +273,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     unless cached_location.exist?
       urls = actual_urls
       unless urls.empty?
-        ohai "Downloading from: #{urls.last}"
+        ohai "Downloading from #{urls.last}"
         if !ENV["HOMEBREW_NO_INSECURE_REDIRECT"].nil? && @url.start_with?("https://") &&
           urls.any? { |u| !u.start_with? "https://" }
           raise "HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set."


### PR DESCRIPTION
It's kinda wierd for me to have a colon on `Download from` but without one for `Download`.
This change makes two messages have the unified form.