### PR TITLE
CurlGnomeSecureMirrorDownloadStrategy added

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -378,6 +378,20 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
   end
 end
 
+# Download from Gnome HTTPS mirrors if possible
+class CurlGnomeSecureMirrorDownloadStrategy < CurlDownloadStrategy
+  def actual_urls
+    return super unless ENV["HOMEBREW_NO_INSECURE_REDIRECT"]
+    url = actual_url
+    url ? [url] : super
+  end
+
+  def actual_url
+    Utils.popen_read("curl", "-I", @url) =~ %r[^Link: <(https://[^>]+)>; rel=duplicate;]
+    $1
+  end
+end
+
 # Download via an HTTP POST.
 # Query parameters on the URL are converted into POST parameters
 class CurlPostDownloadStrategy < CurlDownloadStrategy
@@ -834,6 +848,8 @@ class DownloadStrategyDetector
       GitDownloadStrategy
     when %r[^https?://www\.apache\.org/dyn/closer\.cgi]
       CurlApacheMirrorDownloadStrategy
+    when %r[^https://download.gnome.org/sources/]
+      CurlGnomeSecureMirrorDownloadStrategy
     when %r[^https?://(.+?\.)?googlecode\.com/svn], %r[^https?://svn\.], %r[^svn://], %r[^https?://(.+?\.)?sourceforge\.net/svnroot/]
       SubversionDownloadStrategy
     when %r[^cvs://]


### PR DESCRIPTION
This *sometimes* fixes #40915.

Here are the response headers when you query for an archive on `https://download.gnome.org/sources/`:

```
HTTP/1.1 302 Found
X-MirrorBrain-Mirror: fr2.rpmfind.net
X-MirrorBrain-Realm: country
Link: <http://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz.meta4>; rel=describedby; type="application/metalink4+xml"
Link: <http://fr2.rpmfind.net/linux/gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz>; rel=duplicate; pri=1; geo=fr
Link: <https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz>; rel=duplicate; pri=4; geo=gb
Link: <http://ftp2.nluug.nl/windowing/gnome/sources/pango/1.36/pango-1.36.8.tar.xz>; rel=duplicate; pri=5; geo=nl
Location: http://fr2.rpmfind.net/linux/gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz
```

(some of them are omitted for clarity)

It advertises *some* mirrors using the `Link` headers with `rel=duplicate`. Some mirrors support HTTPS while some others don’t. `CurlGnomeSecureMirrorDownloadStrategy` makes a first query to get this mirrors list and picks the first HTTPS link it finds and returns it. If it fails to find one it’ll fallback on the default behavior.

The problem is that this list is not always the same for two requests. This is why I emphasized “sometimes” above. You might get an HTTPS link in one request but not in the next one. It’s rare, but it happens:

```
$ HOMEBREW_NO_INSECURE_REDIRECT=1 brew install -s pango
==> Downloading https://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz
==> Downloading from: https://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz
^C
$ HOMEBREW_NO_INSECURE_REDIRECT=1 brew install -s pango
==> Downloading https://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz
==> Downloading from: http://fr2.rpmfind.net/linux/gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz
Error: HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set.
```

Note that this PR doesn’t change anything if `HOMEBREW_NO_INSECURE_REDIRECT` is not set.

cc @Homebrew/owners. Does someone knows of a way to get all mirrors for an archive instead of this solution?