### PR TITLE
pwsafe: fix download URL and more

### DIFF
--- a/Library/Formula/pwsafe.rb
+++ b/Library/Formula/pwsafe.rb
@@ -1,17 +1,38 @@
-require 'formula'
-
 class Pwsafe < Formula
   desc "Generate passwords and manage encrypted password databases"
-  homepage 'http://nsd.dyndns.org/pwsafe/'
-  url 'https://downloads.sourceforge.net/project/pwsafe/pwsafe/0.2.0/pwsafe-0.2.0.tar.gz'
-  sha1 '026643a391796a527a48ffccf93d542113ca79d4'
+  homepage "http://nsd.dyndns.org/pwsafe/"
+  url "http://nsd.dyndns.org/pwsafe/releases/pwsafe-0.2.0.tar.gz"
+  sha256 "61e91dc5114fe014a49afabd574eda5ff49b36c81a6d492c03fcb10ba6af47b7"
+  revision 1
 
-  depends_on 'readline'
+  depends_on "openssl"
+  depends_on "readline"
+
+  # A password database for testing is provided upstream. How nice!
+  resource "test-pwsafe-db" do
+    url "http://nsd.dyndns.org/pwsafe/test.dat"
+    sha256 "7ecff955871e6e58e55e0794d21dfdea44a962ff5925c2cd0683875667fbcc79"
+  end
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    test_db_passphrase = "abc"
+    test_account_name = "testing"
+    test_account_pass = "sg1rIWHL?WTOV=d#q~DmxiQq%_j-$f__U7EU"
+
+    resource("test-pwsafe-db").stage do
+      Utils.popen(
+        "#{bin}/pwsafe -f test.dat -p #{test_account_name}", "r+"
+      ) do |pipe|
+        pipe.puts test_db_passphrase
+        assert_match(/^#{Regexp.escape(test_account_pass)}$/, pipe.read)
+      end
+    end
   end
 end


### PR DESCRIPTION
* Replace broken download URL with current URL from homepage
* Add openssl dependency
* Add test using upstream's test db
* Other edits for `brew audit --strict`