### PR TITLE
mcrypt: modernize formula, add test

### DIFF
--- a/Library/Formula/mcrypt.rb
+++ b/Library/Formula/mcrypt.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Mcrypt < Formula
   desc "Replacement for the old crypt package and crypt(1) command"
   homepage "http://mcrypt.sourceforge.net"
   url "https://downloads.sourceforge.net/project/mcrypt/MCrypt/2.6.8/mcrypt-2.6.8.tar.gz"
-  sha1 "8ae0e866714fbbb96a0a6fa9f099089dc93f1d86"
+  sha256 "5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098"
 
   bottle do
     sha1 "9afdc1c3fdbf8f9801301fb959c0192b99072fc7" => :mavericks
@@ -12,14 +10,14 @@ class Mcrypt < Formula
     sha1 "ac147e3524ce21a9d57c0fa84e3c8e2db26321e1" => :lion
   end
 
+  option :universal
+
   depends_on "mhash"
 
   resource "libmcrypt" do
     url "https://downloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.gz"
-    sha1 "9a426532e9087dd7737aabccff8b91abf9151a7a"
+    sha256 "e4eb6c074bbab168ac47b947c195ff8cef9d51a211cdd18ca9c9ef34d27a373e"
   end
-
-  option :universal
 
   # Patch to correct inclusion of malloc function on OSX.
   # Upstream: https://sourceforge.net/p/mcrypt/patches/14/
@@ -31,19 +29,28 @@ class Mcrypt < Formula
     resource("libmcrypt").stage do
       system "./configure", "--prefix=#{prefix}",
                             "--mandir=#{man}"
-      system "make install"
+      system "make", "install"
     end
 
     system "./configure", "--prefix=#{prefix}",
                           "--with-libmcrypt-prefix=#{prefix}",
                           "--mandir=#{man}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.txt").write <<-EOS.undent
+      Hello, world!
+    EOS
+    system bin/"mcrypt", "--key", "TestPassword", "--force", "test.txt"
+    rm "test.txt"
+    system bin/"mcrypt", "--key", "TestPassword", "--decrypt", "test.txt.nc"
   end
 end
 
 __END__
 diff --git a/src/rfc2440.c b/src/rfc2440.c
-index 5a1f296..fe15198 100644
+index 5a1f296..aeb501c 100644
 --- a/src/rfc2440.c
 +++ b/src/rfc2440.c
 @@ -23,7 +23,12 @@
@@ -56,6 +63,6 @@ index 5a1f296..fe15198 100644
 +#else
  #include <malloc.h>
 +#endif
-
+ 
  #include "xmalloc.h"
  #include "keys.h"


### PR DESCRIPTION
Main intent here is to get a binary bottle built for Yosemite. Please let me know if the diff in the `bottle` block is sufficient to get this accomplished as the upstream has not had a code-change in a very long time.