### PR TITLE
calabash 1.1.4-96

### DIFF
--- a/Library/Formula/calabash.rb
+++ b/Library/Formula/calabash.rb
@@ -5,16 +5,9 @@ class Calabash < Formula
   sha256 "a68b729c1cf392433534c207e9fe1002deca42282ed409ed93fbeb0e13b7583c"
 
   depends_on "saxon"
-  
   def install
     libexec.install Dir["*"]
     bin.write_jar_script libexec/"xmlcalabash-#{version}.jar", "calabash", "-Xmx1024m"
-  end
-
-  def caveats; <<-EOS.undent
-    This formula requires Saxon version 9.6.
-    Run `brew upgrade saxon` if your version is older.
-    EOS
   end
 
   test do

--- a/Library/Formula/calabash.rb
+++ b/Library/Formula/calabash.rb
@@ -1,14 +1,20 @@
 class Calabash < Formula
   desc "An XProc (XML Pipeline Language) implementation"
   homepage "http://xmlcalabash.com"
-  url "https://github.com/ndw/xmlcalabash1/releases/download/1.1.0-95/xmlcalabash-1.1.0-95.zip"
-  sha256 "d75a8699ec496fb854761d8e375015732ac51047aad5d7bec57ea3a5349feae7"
+  url "https://github.com/ndw/xmlcalabash1/releases/download/1.1.4-96/xmlcalabash-1.1.4-96.zip"
+  sha256 "a68b729c1cf392433534c207e9fe1002deca42282ed409ed93fbeb0e13b7583c"
 
   depends_on "saxon"
-
+  
   def install
     libexec.install Dir["*"]
     bin.write_jar_script libexec/"xmlcalabash-#{version}.jar", "calabash", "-Xmx1024m"
+  end
+
+  def caveats; <<-EOS.undent
+    This formula requires Saxon version 9.6.
+    Run `brew upgrade saxon` if your version is older.
+    EOS
   end
 
   test do


### PR DESCRIPTION
This updates the `calabash` formula to the latest version.

Calabash has two releases: one for Saxon 9.5, and one for Saxon 9.6.  

After searching Homebrew’s Wiki and Issues, the best I can determine is that Homebrew does not (no longer?) allow version-specific dependencies.  In other words, all deps are assumed to be the latest version.  

This update therefore follows the policy, and I added a `caveats` section to notify users.