### PR TITLE
nginx fix missed problems

### DIFF
--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -35,7 +35,7 @@ class Nginx < Formula
   def install
     # Changes default port to 8080
     inreplace "conf/nginx.conf", "listen       80;", "listen       8080;"
-    open("conf/nginx.conf", "a") { |f| f.puts "include servers/*;" }
+    inreplace "conf/nginx.conf", "    #}\n\n}", "    #}\n    include servers/*;\n}"
 
     pcre = Formula["pcre"]
     openssl = Formula["openssl"]
@@ -86,9 +86,12 @@ class Nginx < Formula
       system "./configure", *args
     end
 
-    system "make"
     system "make", "install"
-    man8.install "objs/nginx.8"
+    if build.head?
+      man8.install "docs/man/nginx.8"
+    else
+      man8.install "man/nginx.8"
+    end
 
     (etc/"nginx/servers").mkpath
     (var/"run/nginx").mkpath
@@ -121,7 +124,6 @@ class Nginx < Formula
   end
 
   def passenger_caveats; <<-EOS.undent
-
     To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the 'http' context:
       passenger_root #{Formula["passenger"].opt_libexec}/lib/phusion_passenger/locations.ini;
       passenger_ruby /usr/bin/ruby;
@@ -137,7 +139,7 @@ class Nginx < Formula
 
     nginx will load all files in #{etc}/nginx/servers/.
     EOS
-    s << passenger_caveats if build.with? "passenger"
+    s << "\n" << passenger_caveats if build.with? "passenger"
     s
   end
 


### PR DESCRIPTION
- Homebrew/homebrew-nginx#92
- Homebrew/homebrew-nginx#96

```
nginx: [emerg] "server" directive is not allowed here in /usr/local/etc/nginx/servers/myserver:1

== Library/Formula/nginx.rb ==
C:128:  1: Extra empty line detected at method body beginning.

nginx:
 * `bottle block`(line 14) should be put before `devel block`(line 9)
 * `caveats method`(line 135) should be put before `test block`(line 123)
```