### PR TITLE
manpage: irb command take `--examples` options

### DIFF
--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -224,10 +224,10 @@ To install a newer version of HEAD use \fBbrew rm <foo> && brew install \-\-HEAD
 If \fB\-\-git\fR is passed, Homebrew will create a Git repository, useful for creating patches to the software\.
 .
 .IP "\(bu" 4
-\fBirb [\-\-example]\fR: Enter the interactive Homebrew Ruby shell\.
+\fBirb [\-\-examples]\fR: Enter the interactive Homebrew Ruby shell\.
 .
 .IP
-If \fB\-\-example\fR is passed, several examples will be shown\.
+If \fB\-\-examples\fR is passed, several examples will be shown\.
 .
 .IP "\(bu" 4
 \fBleaves\fR: Show installed formulae that are not dependencies of another installed formula\.


### PR DESCRIPTION
The manpage for `irb` command has a typo in the option name.

```
kalbasit@cratos ~/code/src/gopkg.in/acd.v0 [master] ± % brew irb --example
==> Interactive Homebrew Shell
Example commands available with: brew irb --examples
Error: Unrecognized switch: --example
Please report this bug:
    https://git.io/brew-troubleshooting
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/irb/init.rb:216:in `parse_opts'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/irb/init.rb:18:in `setup'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/irb.rb:380:in `start'
/usr/local/Library/Homebrew/cmd/irb.rb:26:in `irb'
/usr/local/Library/brew.rb:140:in `<main>'
kalbasit@cratos ~/code/src/gopkg.in/acd.v0 [master] ± % brew irb --examples
'v8'.f # => instance of the v8 formula
:hub.f.installed?
:lua.f.methods - 1.methods
:mpd.f.recursive_dependencies.reject(&:installed?)
```