### PR TITLE
added trace2html

### DIFF
--- a/Library/Formula/trace2html.rb
+++ b/Library/Formula/trace2html.rb
@@ -1,19 +1,19 @@
 class Trace2html < Formula
   desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
   homepage "https://github.com/google/trace-viewer"
-  url "https://github.com/google/trace-viewer/archive/a4c4894801935627ff412c3cc6c3ddae96019cc5.zip"
-  sha256 "b9fc71e6f1a36f91ca09c1ea26ae2c38e42d3183b6470e603d1db8b1ee6e8316"
+  url "https://github.com/google/trace-viewer/archive/a4c4894801935627ff412c3cc6c3ddae96019cc5.tar.gz"
+  sha256 "40bf1613e23c0f483536667d3ab584889c50219768414f0086150b3c364269c3"
 
-  depends_on "Python"
+  depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    cp_r(buildpath, libexec)
+    libexec.install Dir["*"]
     bin.install_symlink libexec/"trace2html"
   end
 
   test do
     touch "test.json"
-    system "#{bin}/trace2html test.json"
+    system "#{bin}/trace2html", "test.json"
     assert File.exist?("test.html")
   end
 end

--- a/Library/Formula/trace2html.rb
+++ b/Library/Formula/trace2html.rb
@@ -1,0 +1,19 @@
+class Trace2html < Formula
+  desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
+  homepage "https://github.com/google/trace-viewer"
+  url "https://github.com/google/trace-viewer/archive/a4c4894801935627ff412c3cc6c3ddae96019cc5.zip"
+  sha256 "b9fc71e6f1a36f91ca09c1ea26ae2c38e42d3183b6470e603d1db8b1ee6e8316"
+
+  depends_on "Python"
+
+  def install
+    cp_r(buildpath, libexec)
+    bin.install_symlink libexec/"trace2html"
+  end
+
+  test do
+    touch "test.json"
+    system "#{bin}/trace2html test.json"
+    assert File.exist?("test.html")
+  end
+end

--- a/Library/Formula/trace2html.rb
+++ b/Library/Formula/trace2html.rb
@@ -1,8 +1,8 @@
 class Trace2html < Formula
   desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
   homepage "https://github.com/google/trace-viewer"
-  url "https://github.com/google/trace-viewer/archive/a4c4894801935627ff412c3cc6c3ddae96019cc5.tar.gz"
-  sha256 "40bf1613e23c0f483536667d3ab584889c50219768414f0086150b3c364269c3"
+  url "https://github.com/google/trace-viewer/archive/2015-06-23.tar.gz"
+  sha256 "97ad0ca9c07a50c53a3d881b69b6b6f7424d6b0f4d9e9fb531c2d9273e413f19"
 
   depends_on :python if MacOS.version <= :snow_leopard
 


### PR DESCRIPTION
On [React Native](https://github.com/facebook/react-native) we will be using `trace2html` to visualize the results from our profiler - it would be great to be able to just have users install via Homebrew, even though it's fairly simple.