### PR TITLE
[GSoC] Allow Prioritization of Taps

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -11,9 +11,9 @@ module Homebrew
     problem_count = 0
 
     strict = ARGV.include? "--strict"
-    if strict && ARGV.formulae.any? && MacOS.version >= :mavericks
+    if strict && ARGV.formulae(false, true).any? && MacOS.version >= :mavericks
       require "cmd/style"
-      ohai "brew style #{ARGV.formulae.join " "}"
+      ohai "brew style #{ARGV.formulae(false, true).join " "}"
       style
     end
 
@@ -43,7 +43,7 @@ module Homebrew
     ff = if ARGV.named.empty?
       Formula
     else
-      ARGV.formulae
+      ARGV.formulae(false, true)
     end
 
     output_header = !strict

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -11,9 +11,9 @@ module Homebrew
     problem_count = 0
 
     strict = ARGV.include? "--strict"
-    if strict && ARGV.formulae(false, true).any? && MacOS.version >= :mavericks
+    if strict && ARGV.formulae(FactoryBehavior::ENFORCE_UNIQUE).any? && MacOS.version >= :mavericks
       require "cmd/style"
-      ohai "brew style #{ARGV.formulae(false, true).join " "}"
+      ohai "brew style #{ARGV.formulae(FactoryBehavior::ENFORCE_UNIQUE).join " "}"
       style
     end
 
@@ -43,7 +43,7 @@ module Homebrew
     ff = if ARGV.named.empty?
       Formula
     else
-      ARGV.formulae(false, true)
+      ARGV.formulae(FactoryBehavior::ENFORCE_UNIQUE)
     end
 
     output_header = !strict

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -29,7 +29,7 @@ module Homebrew
       ARGV.named.each_with_index do |f,i|
         puts unless i == 0
         begin
-          info_formula Formulary.factory(f, nil ,false, true)
+          info_formula Formulary.factory(f, nil, FactoryBehavior::ENFORCE_UNIQUE)
         rescue FormulaUnavailableError
           # No formula with this name, try a blacklist lookup
           if (blacklist = blacklisted?(f))

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -29,7 +29,7 @@ module Homebrew
       ARGV.named.each_with_index do |f,i|
         puts unless i == 0
         begin
-          info_formula Formulary.factory(f)
+          info_formula Formulary.factory(f, nil ,false, true)
         rescue FormulaUnavailableError
           # No formula with this name, try a blacklist lookup
           if (blacklist = blacklisted?(f))

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -38,7 +38,7 @@ module Homebrew
         end
       end
 
-      ARGV.formulae.each do |f|
+      ARGV.formulae(true).each do |f|
         # head-only without --HEAD is an error
         if not ARGV.build_head? and f.stable.nil? and f.devel.nil?
           raise <<-EOS.undent

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -38,7 +38,7 @@ module Homebrew
         end
       end
 
-      ARGV.formulae(true).each do |f|
+      ARGV.formulae(FactoryBehavior::INSTALL_LIKE).each do |f|
         # head-only without --HEAD is an error
         if not ARGV.build_head? and f.stable.nil? and f.devel.nil?
           raise <<-EOS.undent

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -37,7 +37,7 @@ module Homebrew
     else
       taps.each_with_index do |tap, i|
         puts unless i == 0
-        info = "[#{tap.get_priority.to_s.rjust(2, '0')}] #{tap}: "
+        info = "[#{tap.padded_priority}] #{tap}: "
         if tap.installed?
           formula_count = tap.formula_files.size
           info += "#{formula_count} formula#{plural(formula_count, "e")} " if formula_count > 0

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -37,7 +37,7 @@ module Homebrew
     else
       taps.each_with_index do |tap, i|
         puts unless i == 0
-        info = "#{tap}: "
+        info = "[#{tap.get_priority.to_s.rjust(2, '0')}] #{tap}: "
         if tap.installed?
           formula_count = tap.formula_files.size
           info += "#{formula_count} formula#{plural(formula_count, "e")} " if formula_count > 0

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -23,8 +23,10 @@ module Homebrew
         opoo "Priority not specified, terminating."
       else
         priority = priority.to_i
-        if priority < 0 or priority > 99
-          opoo "Priority not allowed, terminating."
+        if priority < 0 || priority > 99
+          opoo "Priority must be between 0 and 99, terminating."
+        elsif priority == tap.get_priority
+          opoo "Priority not changed, terminating."
         else
           tap.set_priority priority
         end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -3,7 +3,7 @@ require "tap"
 module Homebrew
   def tap
     if ARGV.empty?
-      puts Tap.names
+      Tap.each {|tap| puts " * [#{tap.get_priority.to_s.rjust(2, '0')}] #{tap.name}"}
     elsif ARGV.first == "--repair"
       migrate_taps :force => true
     else

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -3,7 +3,7 @@ require "tap"
 module Homebrew
   def tap
     if ARGV.empty?
-      Tap.each {|tap| puts " * [#{tap.get_priority.to_s.rjust(2, '0')}] #{tap.name}"}
+      Tap.each {|tap| puts " * [#{tap.padded_priority}] #{tap.name}"}
     elsif ARGV.first == "--repair"
       migrate_taps :force => true
     else

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -13,6 +13,9 @@ module Homebrew
       formula_count = tap.formula_files.size
       tap.path.rmtree
       tap.path.dirname.rmdir_if_possible
+
+      tap.json_path.delete
+
       puts "Untapped #{formula_count} formula#{plural(formula_count, 'e')}"
     end
   end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -73,7 +73,7 @@ class TapFormulaAmbiguityError < RuntimeError
     @paths = paths
     @formulae = paths.map do |path|
       match = path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-      match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}" : "Core"  # TODO: is this useful?
+      match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}" : "core/#{name}"  # TODO: is this useful?
     end
 
     super <<-EOS.undent

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -72,8 +72,7 @@ class TapFormulaAmbiguityError < RuntimeError
     @name = name
     @paths = paths
     @formulae = paths.map do |path|
-      match = path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-      match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}" : "core/#{name}"  # TODO: is this useful?
+      path.fully_qualified_name
     end
 
     super <<-EOS.undent

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -72,8 +72,8 @@ class TapFormulaAmbiguityError < RuntimeError
     @name = name
     @paths = paths
     @formulae = paths.map do |path|
-      path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-      "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}"
+      match = path.to_s =~ HOMEBREW_TAP_PATH_REGEX
+      match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}" : "Core"  # TODO: is this useful?
     end
 
     super <<-EOS.undent

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -70,15 +70,12 @@ class TapFormulaAmbiguityError < RuntimeError
 
   def initialize name, paths
     @name = name
-    @paths = paths
-    @formulae = paths.map do |path|
-      path.fully_qualified_name
-    end
+    @paths = paths.sort! {|a, b| a.tap_priority <=> b.tap_priority}
 
     super <<-EOS.undent
-      Formulae found in multiple taps: #{formulae.map { |f| "\n       * #{f}" }.join}
+      Formulae found in multiple taps: #{@paths.map { |p| "\n       * [#{p.tap_priority.to_s.rjust(2, '0')}] #{p.fully_qualified_name}" }.join}
 
-      Please use the fully-qualified name e.g. #{formulae.first} to refer the formula.
+      Please use the fully-qualified name e.g. #{@paths.first.fully_qualified_name} to refer the formula.
     EOS
   end
 end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -11,9 +11,9 @@ module HomebrewArgvExtension
     select { |arg| arg.start_with?("--") }
   end
 
-  def formulae(is_installing = false, warn_all_ambiguity = false)
+  def formulae(behavior = FactoryBehavior::KEG_FIRST)
     require "formula"
-    @formulae ||= (downcased_unique_named - casks).map { |name| Formulary.factory(name, spec, is_installing, warn_all_ambiguity) }
+    @formulae ||= (downcased_unique_named - casks).map { |name| Formulary.factory(name, spec, behavior) }
   end
 
   def resolved_formulae

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -11,9 +11,9 @@ module HomebrewArgvExtension
     select { |arg| arg.start_with?("--") }
   end
 
-  def formulae
+  def formulae(is_installing = false, warn_all_ambiguity = false)
     require "formula"
-    @formulae ||= (downcased_unique_named - casks).map { |name| Formulary.factory(name, spec) }
+    @formulae ||= (downcased_unique_named - casks).map { |name| Formulary.factory(name, spec, is_installing, warn_all_ambiguity) }
   end
 
   def resolved_formulae

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -20,7 +20,7 @@ module HomebrewArgvExtension
     require "formula"
     @resolved_formulae ||= (downcased_unique_named - casks).map do |name|
       if name.include?("/")
-        Formulary.factory(name, spec)
+        Formulary.factory(name, spec, FactoryBehavior::ENFORCE_UNIQUE)
       else
         Formulary.from_rack(HOMEBREW_CELLAR/name, spec)
       end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -397,6 +397,11 @@ class Pathname
     out
   end
 
+  def fully_qualified_name
+    match = self.to_s =~ HOMEBREW_TAP_PATH_REGEX
+    match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{self.basename(".rb")}" : "core/#{self.basename(".rb")}"
+  end
+
   # We redefine these private methods in order to add the /o modifier to
   # the Regexp literals, which forces string interpolation to happen only
   # once instead of each time the method is called. This is fixed in 1.9+.

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -398,8 +398,17 @@ class Pathname
   end
 
   def fully_qualified_name
+    "#{self.tap_name}/#{self.basename(".rb")}"
+  end
+
+  def tap_name
     match = self.to_s =~ HOMEBREW_TAP_PATH_REGEX
-    match ? "#{$1}/#{$2.sub("homebrew-", "")}/#{self.basename(".rb")}" : "core/#{self.basename(".rb")}"
+    match ? "#{$1}/#{$2.sub("homebrew-", "")}" : "core"
+  end
+
+  def tap_priority
+    match = self.to_s =~ HOMEBREW_TAP_PATH_REGEX
+    match ? Tap.new($1, $2.sub("homebrew-", "")).get_priority : Tap.core_priority
   end
 
   # We redefine these private methods in order to add the /o modifier to

--- a/Library/Homebrew/factory_behavior.rb
+++ b/Library/Homebrew/factory_behavior.rb
@@ -1,0 +1,20 @@
+module FactoryBehavior
+
+  # Install-like behavior where we search all taps following the priority.
+  # If multiple formulae are found in the highest priority level, users will be asked to make a selection on the spot.
+  INSTALL_LIKE = 0
+
+  # Enforce the uniqueness of the formula.
+  # If multiple formulae (with any priority) are found, throw TapFormulaAmbiguityError.
+  ENFORCE_UNIQUE = 1
+
+  # Choose any formula from highest priority level.
+  # This should only be used when the command does not really care about what formula it is referring to.
+  CHOOSE_ANY = 2
+
+  # Try to look for the already installed formula.
+  # If not found follow the behavior of ENFORCE_UNIQUE
+  # TODO: not implemented!
+  KEG_FIRST = 3
+
+end

--- a/Library/Homebrew/factory_behavior.rb
+++ b/Library/Homebrew/factory_behavior.rb
@@ -17,4 +17,6 @@ module FactoryBehavior
   # TODO: not implemented!
   KEG_FIRST = 3
 
+  # Return only core formula.
+  CORE_ONLY = 4
 end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -249,8 +249,8 @@ class Formulary
     available_formulas = tap_paths(ref)
     core_formula = core_path(ref)
     if core_formula.file?
-      available_formulas[50] = [] if available_formulas[50].nil?
-      available_formulas[50] << core_formula
+      available_formulas[Tap.core_priority] = [] if available_formulas[50].nil?
+      available_formulas[Tap.core_priority] << core_formula
     end
 
     unless available_formulas.empty?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -249,7 +249,7 @@ class Formulary
     available_formulas = tap_paths(ref)
     core_formula = core_path(ref)
     if core_formula.file?
-      available_formulas[Tap.core_priority] = [] if available_formulas[50].nil?
+      available_formulas[Tap.core_priority] = [] if available_formulas[Tap.core_priority].nil?
       available_formulas[Tap.core_priority] << core_formula
     end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -265,9 +265,12 @@ class Formulary
         available_formulas.keys.sort.each do |this_priority|
           if available_formulas[this_priority].length > 1
             if is_installing
-              ohai "Multiple available. Please choose one: Sorry not supported yet, we temporarily choose first one for you lah."
-              puts available_formulas[this_priority].to_s
-              selected_index = 0
+              ohai "Multiple formulae with same name and priority available."
+              formulae_list = available_formulas[this_priority]
+              puts_columns (0..formulae_list.length-1).map { |i| "#{i+1}. #{formulae_list[i].fully_qualified_name}"}
+              print "Please choose one by inputing the number before it: "
+              selected_index = $stdin.readline.to_i - 1
+              ohai "Installing #{available_formulas[this_priority][selected_index].fully_qualified_name}"
             else
               raise TapFormulaAmbiguityError.new(ref, available_formulas[this_priority])
             end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -181,9 +181,9 @@ class Formulary
     tap = Tab.for_keg(keg).tap
 
     if tap.nil? || tap == "Homebrew/homebrew" || tap == "mxcl/master"
-      factory(rack.basename.to_s, spec)
+      factory(rack.basename.to_s, spec, FactoryBehavior::CORE_ONLY)
     else
-      factory("#{tap.sub("homebrew-", "")}/#{rack.basename}", spec)
+      factory("#{tap.sub("homebrew-", "")}/#{rack.basename}", spec, FactoryBehavior::ENFORCE_UNIQUE)
     end
   end
 
@@ -211,14 +211,13 @@ class Formulary
       return TapLoader.new(ref)
     end
 
+    if behavior == FactoryBehavior::CORE_ONLY
+      return FormulaLoader.new(ref, core_path(ref))
+    end
+
     if File.extname(ref) == ".rb"
       return FromPathLoader.new(ref)
     end
-
-    # formula_with_that_name = core_path(ref)
-    # if formula_with_that_name.file?
-    #   return FormulaLoader.new(ref, formula_with_that_name)
-    # end
 
     formula_with_that_name = find_with_priority(ref, behavior)
     if formula_with_that_name

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -260,7 +260,7 @@ class Formulary
           raise TapFormulaAmbiguityError.new(ref, flat_formulas)
         end
       else
-        if available_formulas.length > 1
+        if available_formulas.length > 1 && behavior != FactoryBehavior::CHOOSE_ANY
           opoo "Some formulae are excluded due to priority settings. Run brew info #{ref} to see them."
         end
         available_formulas.keys.sort.each do |this_priority|

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -188,7 +188,7 @@ class Formulary
   end
 
   def self.canonical_name(ref)
-    loader_for(ref).name
+    loader_for(ref, FactoryBehavior::CHOOSE_ANY).name
   rescue TapFormulaAmbiguityError
     # If there are multiple tap formulae with the name of ref,
     # then ref is the canonical name

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -195,8 +195,8 @@ class Formulary
     ref.downcase
   end
 
-  def self.path(ref)
-    loader_for(ref).path
+  def self.path(ref, behavior = FactoryBehavior::KEG_FIRST)
+    loader_for(ref, behavior).path
   end
 
   def self.loader_for(ref, behavior = FactoryBehavior::KEG_FIRST)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -176,7 +176,7 @@ class Formulary
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
 
     keg = kegs.detect(&:linked?) || kegs.detect(&:optlinked?) || kegs.max_by(&:version)
-    return factory(rack.basename.to_s, spec) unless keg
+    return factory(rack.basename.to_s, spec, FactoryBehavior::ENFORCE_UNIQUE) unless keg
 
     tap = Tab.for_keg(keg).tap
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -262,6 +262,9 @@ class Formulary
           raise TapFormulaAmbiguityError.new(ref, flat_formulas)
         end
       else
+        if available_formulas.length > 1
+          opoo "Some formulae are excluded due to priority settings. Run brew info #{ref} to see them."
+        end
         available_formulas.keys.sort.each do |this_priority|
           if available_formulas[this_priority].length > 1
             if is_installing

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -40,6 +40,7 @@ HOMEBREW_USER_AGENT = "Homebrew #{HOMEBREW_VERSION} (Ruby #{RUBY_VERSION}-#{RUBY
 HOMEBREW_CURL_ARGS = '-f#LA'
 
 require 'tap_constants'
+require 'factory_behavior'
 
 module Homebrew
   include FileUtils

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -120,6 +120,10 @@ class Tap
     end
   end
 
+  def padded_priority
+    self.get_priority.to_s.rjust(2, '0')
+  end
+
   def to_hash
     {
       "name" => @name,

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -102,7 +102,7 @@ class Tap
   end
 
   def get_priority
-    @json_path.exist?? Utils::JSON.load(File.read(@json_path))["priority"] : 99
+    @json_path.exist?? Utils::JSON.load(File.read(@json_path))["priority"] : Tap.default_priority
   end
 
   def set_priority priority
@@ -110,7 +110,7 @@ class Tap
         "priority" => priority
     }
     @json_path.atomic_write(Utils::JSON.dump(attributes))
-    if priority == 50
+    if priority == Tap.core_priority
       opoo "Core formulae has a priority of 50, we don't recommand do this!"
     end
     Tap.each do |other_tap|
@@ -156,5 +156,9 @@ class Tap
 
   def self.core_priority
     50
+  end
+
+  def self.default_priority
+    99
   end
 end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -153,4 +153,8 @@ class Tap
   def self.names
     map(&:name)
   end
+
+  def self.core_priority
+    50
+  end
 end

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -8,3 +8,5 @@ HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
 # match the default brew-cask tap e.g. Caskroom/cask
 HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^(Caskroom)/(cask)/([\w+-.]+)$}
+# match fully qualified core formula, e.g. core/someformula
+HOMEBREW_CORE_FORMULA_REGEX = %r{core/([\w+-.]+)$}


### PR DESCRIPTION
This is a Google Summer of Code project on prioritization of taps.

The most important changes are:

* Taps now have a priority index between 00 and 99, while core formulae has the index of 50.
* Use command like `brew tap homebrew/versions --priority=10` to set the priority index.
* `brew install` will then follow the priority index to find the formula to install.
* To refer to a formula in a specific formula, fully qualified names should be used. Since core formulae are not always prioritized, they now have fully qualified names in the format of `core/xyz`.

A full progress report is available at: https://github.com/CNA-Bld/homebrew/wiki/Progress


However, there is another improvement current in progress, in which more precise control of `formulary.factory`'s behavior will be implemented. After this, commands can call `formulary.factory` with a choice of 4 different behaviors:

1. Like installing, follow the priority and let the user choose in case multiple formulae available
2. Follow the priority and choose whatever one if multiple are available (this is used when the command only needs methods like `formula.alias` and does not really care about other infomation)
3. Throw TapFormulaAmbiguityError when multiple formulae available (this is used for commands like `brew audit`, when we would prefer usage of fully qualified names because we don't want to mess things up)
4. Try to find the already installed formula and follow one of the above behavior if not found (for commands like `brew test` where it only makes sense to refer to the installed one)

This new behavior will be hopefully finished within a couple of days.


I am a new contributor to Homebrew and just started learning Ruby a few weeks ago. So please do not hesitate to share your suggestions and point out problems or drawbacks here. Hope this new feature can be a part of Homebrew by the end of this summer. Thank you very much :)