### PR TITLE
pipebench: use debian as url

### DIFF
--- a/Library/Formula/pipebench.rb
+++ b/Library/Formula/pipebench.rb
@@ -1,15 +1,16 @@
-require 'formula'
-
 class Pipebench < Formula
   desc "Measure the speed of STDIN/STDOUT communication"
-  homepage 'http://www.habets.pp.se/synscan/programs.php?prog=pipebench'
-  url 'http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz'
-  sha1 '5ac405b9f1f25b39b3760fd9684533ccb778b26c'
+  homepage "http://www.habets.pp.se/synscan/programs.php?prog=pipebench"
+  # Upstream server behaves oddly: https://github.com/Homebrew/homebrew/issues/40897
+  # url "http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
+  sha256 "ca764003446222ad9dbd33bbc7d94cdb96fa72608705299b6cc8734cd3562211"
 
   def install
     system "make"
-    bin.install 'pipebench'
-    man1.install 'pipebench.1'
+    bin.install "pipebench"
+    man1.install "pipebench.1"
   end
 
   test do


### PR DESCRIPTION
The upstream server for this formula behaves in a number of strange ways detailed in https://github.com/Homebrew/homebrew/issues/40897.

The inconsistency of handing off different files to browsers and cURL in particular, and the checksum changes that can come with that make it hard to verify which package is intended to be the "proper" one from the server.