### PR TITLE
GitHub Summer of Code: Formula renames

### DIFF
--- a/Library/Aliases/caf
+++ b/Library/Aliases/caf
@@ -1,1 +1,0 @@
-../Formula/libcppa.rb

--- a/Library/Formula/caf.rb
+++ b/Library/Formula/caf.rb
@@ -1,6 +1,5 @@
-class Libcppa < Formula
-  # TODO: since libcppa has been renamed to CAF, this formula should eventually
-  # be renamed to 'caf.rb'.
+class Caf < Formula
+  # Renamed from libccpa
   desc "Implementation of the Actor Model for C++"
   homepage "http://actor-framework.org/"
   url "https://github.com/actor-framework/actor-framework/archive/0.14.0.tar.gz"
@@ -15,12 +14,12 @@ class Libcppa < Formula
     sha256 "0ca6c6a6cae249472146a938458464b275b8d409a81ab9ffa36f22c7523d365a" => :mountain_lion
   end
 
-  depends_on "cmake" => :build
-
   needs :cxx11
 
   option "with-opencl", "build with support for OpenCL actors"
   option "without-check", "skip unit tests (not recommended)"
+
+  depends_on "cmake" => :build
 
   def install
     args = %W[./configure --prefix=#{prefix} --no-examples --build-static]

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -6,6 +6,7 @@ require "official_taps"
 require "tap_migrations"
 require "cmd/search"
 require "date"
+require "formula_renames"
 
 module Homebrew
   def audit
@@ -229,6 +230,11 @@ class FormulaAuditor
       return
     end
 
+    if FORMULA_RENAMES.key? name
+      problem "'#{name}' is reserved as the old name of #{FORMULA_RENAMES[name]}"
+      return
+    end
+
     if !formula.core_formula? && Formula.core_names.include?(name)
       problem "Formula name conflicts with existing core formula."
       return
@@ -268,6 +274,10 @@ class FormulaAuditor
         rescue TapFormulaAmbiguityError
           problem "Ambiguous dependency #{dep.name.inspect}."
           next
+        end
+
+        if FORMULA_RENAMES[dep.name] == dep_f.name
+          problem "Dependency '#{dep.name}' was renamed; use newname '#{dep_f.name}'."
         end
 
         if @@aliases.include?(dep.name)

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -1,0 +1,20 @@
+require "migrator"
+require "formula_renames"
+
+module Homebrew
+  def migrate
+    raise FormulaUnspecifiedError if ARGV.named.empty?
+
+    ARGV.resolved_formulae.each do |f|
+      if f.oldname
+        unless (rack = HOMEBREW_CELLAR/f.oldname).exist? && !rack.subdirs.empty?
+          raise NoSuchKegError, f.oldname
+        end
+        raise "#{rack} is a symlink" if rack.symlink?
+      end
+
+      migrator = Migrator.new(f)
+      migrator.migrate
+    end
+  end
+end

--- a/Library/Homebrew/cmd/switch.rb
+++ b/Library/Homebrew/cmd/switch.rb
@@ -12,8 +12,7 @@ module Homebrew
     name = ARGV.shift
     version = ARGV.shift
 
-    canonical_name = Formulary.canonical_name(name)
-    rack = HOMEBREW_CELLAR.join(canonical_name)
+    rack = Formulary.to_rack(name)
 
     unless rack.directory?
       onoe "#{name} not found in the Cellar."

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -1,30 +1,66 @@
 require "keg"
 require "formula"
+require "migrator"
 
 module Homebrew
   def uninstall
     raise KegUnspecifiedError if ARGV.named.empty?
 
+    # Find symlinks that can point to keg.rack
+    links = HOMEBREW_CELLAR.subdirs.select(&:symlink?)
+
     if !ARGV.force?
       ARGV.kegs.each do |keg|
         keg.lock do
           puts "Uninstalling #{keg}... (#{keg.abv})"
+
+          old_cellars = []
+          # Remove every symlink that links to keg, because it can
+          # be left by migrator
+          links.each do |link|
+            old_opt = HOMEBREW_PREFIX/"opt/#{link.basename}"
+            if link.exist? && link.realpath == keg.rack.realpath
+              old_cellars << link
+            end
+
+            if old_opt.symlink? && old_opt.realpath.to_s == keg.to_s
+              old_opt.unlink
+              old_opt.parent.rmdir_if_possible
+            end
+          end
+
           keg.unlink
           keg.uninstall
           rack = keg.rack
           rm_pin rack
+
           if rack.directory?
             versions = rack.subdirs.map(&:basename)
             verb = versions.length == 1 ? "is" : "are"
             puts "#{keg.name} #{versions.join(", ")} #{verb} still installed."
             puts "Remove them all with `brew uninstall --force #{keg.name}`."
+          else
+            # If we delete Cellar/newname, then Cellar/oldname symlink
+            # can become broken and we have to remove it.
+            old_cellars.each(&:unlink)
           end
         end
       end
     else
       ARGV.named.each do |name|
-        name = Formulary.canonical_name(name)
-        rack = HOMEBREW_CELLAR/name
+        rack = Formulary.to_rack(name)
+        name = rack.basename
+
+        links.each do |link|
+          old_opt = HOMEBREW_PREFIX/"opt/#{link.basename}"
+          if old_opt.symlink? && old_opt.exist? \
+              && old_opt.realpath.parent == rack.realpath
+            old_opt.unlink
+            old_opt.parent.rmdir_if_possible
+          end
+
+          lnk.unlink if lnk.exist? && lnk.realpath == rack.realpath
+        end
 
         if rack.directory?
           puts "Uninstalling #{name}... (#{rack.abv})"

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -86,6 +86,26 @@ class TapFormulaAmbiguityError < RuntimeError
   end
 end
 
+class TapFormulaWithOldnameAmbiguityError < RuntimeError
+  attr_reader :name, :possible_tap_newname_formulae, :taps
+
+  def initialize(name, possible_tap_newname_formulae)
+    @name = name
+    @possible_tap_newname_formulae = possible_tap_newname_formulae
+
+    @taps = possible_tap_newname_formulae.map do |newname|
+      newname =~ HOMEBREW_TAP_FORMULA_REGEX
+      "#{$1}/#{$2}"
+    end
+
+    super <<-EOS.undent
+      Formulae with '#{name}' old name found in multiple taps: #{taps.map { |t|  "\n       * #{t}" }.join}
+
+      Please use the fully-qualified name e.g. #{taps.first}/#{name} to refer the formula or use its new name.
+    EOS
+  end
+end
+
 class TapUnavailableError < RuntimeError
   attr_reader :name
 

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -47,14 +47,14 @@ module HomebrewArgvExtension
     require "keg"
     require "formula"
     @kegs ||= downcased_unique_named.collect do |name|
-      canonical_name = Formulary.canonical_name(name)
-      rack = HOMEBREW_CELLAR/canonical_name
+      rack = Formulary.to_rack(name)
+
       dirs = rack.directory? ? rack.subdirs : []
 
-      raise NoSuchKegError.new(canonical_name) if dirs.empty?
+      raise NoSuchKegError.new(rack.basename) if dirs.empty?
 
-      linked_keg_ref = HOMEBREW_LIBRARY.join("LinkedKegs", canonical_name)
-      opt_prefix = HOMEBREW_PREFIX.join("opt", canonical_name)
+      linked_keg_ref = HOMEBREW_LIBRARY.join("LinkedKegs", rack.basename)
+      opt_prefix = HOMEBREW_PREFIX.join("opt", rack.basename)
 
       begin
         if opt_prefix.symlink? && opt_prefix.directory?
@@ -66,7 +66,7 @@ module HomebrewArgvExtension
         elsif (prefix = (name.include?("/") ? Formulary.factory(name) : Formulary.from_rack(rack)).prefix).directory?
           Keg.new(prefix)
         else
-          raise MultipleVersionsInstalledError.new(canonical_name)
+          raise MultipleVersionsInstalledError.new(rack.basename)
         end
       rescue FormulaUnavailableError
         raise <<-EOS.undent

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -10,6 +10,7 @@ require "software_spec"
 require "install_renamed"
 require "pkg_version"
 require "tap"
+require "formula_renames"
 
 # A formula provides instructions and metadata for Homebrew to install a piece
 # of software. Every Homebrew formula is a {Formula}.
@@ -221,6 +222,21 @@ class Formula
   # A named Resource for the currently active {SoftwareSpec}.
   def resource(name)
     active_spec.resource(name)
+  end
+
+  # An old name for the formula
+  def oldname
+    @oldname ||= if core_formula?
+      if FORMULA_RENAMES && FORMULA_RENAMES.value?(name)
+        FORMULA_RENAMES.to_a.rassoc(name).first
+      end
+    elsif tap?
+      user, repo = tap.split("/")
+      formula_renames = Tap.new(user, repo.sub("homebrew-", "")).formula_renames
+      if formula_renames.value?(name)
+        formula_renames.to_a.rassoc(name).first
+      end
+    end
   end
 
   # The {Resource}s for the currently active {SoftwareSpec}.
@@ -864,6 +880,7 @@ class Formula
       "full_name" => full_name,
       "desc" => desc,
       "homepage" => homepage,
+      "oldname" => oldname,
       "versions" => {
         "stable" => (stable.version.to_s if stable),
         "bottle" => bottle ? true : false,

--- a/Library/Homebrew/formula_renames.rb
+++ b/Library/Homebrew/formula_renames.rb
@@ -1,2 +1,3 @@
 FORMULA_RENAMES = {
+  "libcppa" => "caf"
 }

--- a/Library/Homebrew/formula_renames.rb
+++ b/Library/Homebrew/formula_renames.rb
@@ -1,0 +1,2 @@
+FORMULA_RENAMES = {
+}

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -195,6 +195,24 @@ class Formulary
     end
   end
 
+  def self.to_rack(ref)
+    name = canonical_name(ref)
+    rack = HOMEBREW_CELLAR/name
+
+    # Handle the case when ref is an old name and the installation
+    # hasn't been migrated or when it's a package installed from
+    # path but same name formula was renamed.
+    unless rack.directory?
+      if ref =~ HOMEBREW_TAP_FORMULA_REGEX
+        rack = HOMEBREW_CELLAR/$3
+      elsif !ref.include?("/")
+        rack = HOMEBREW_CELLAR/ref
+      end
+    end
+
+    rack
+  end
+
   def self.canonical_name(ref)
     loader_for(ref).name
   rescue TapFormulaAmbiguityError

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -298,6 +298,13 @@ Note that these flags should only appear after a command.
 
     If no <formulae> are given, check all installed brews.
 
+  * `migrate [--force]` <formulae>:
+    Migrate renamed packages to new name, where <formulae> are old names of
+    packages.
+
+    If `--force` is passed and installed <formulae> have nil tap, then treat
+    them like packages installed from core.
+
   * `options [--compact] [--all] [--installed]` <formula>:
     Display install options specific to <formula>.
 

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -1,0 +1,303 @@
+require "formula"
+require "keg"
+require "tab"
+require "tap_migrations"
+
+class Migrator
+  class MigratorNoOldnameError < RuntimeError
+    def initialize(formula)
+      super "#{formula.name} doesn't replace any formula."
+    end
+  end
+
+  class MigratorNoOldpathError < RuntimeError
+    def initialize(formula)
+      super "#{HOMEBREW_CELLAR/formula.oldname} doesn't exist."
+    end
+  end
+
+  class MigratorDifferentTapsError < RuntimeError
+    def initialize(formula, tap)
+      if tap.nil?
+        super <<-EOS.undent
+        #{formula.name} from #{formula.tap} is given, but old name #{formula.oldname} wasn't installed from taps or core formulae
+
+        You can try `brew migrate --force #{formula.oldname}`.
+        EOS
+      else
+        user, repo = tap.split("/")
+        repo.sub!("homebrew-", "")
+        name = "fully-qualified #{user}/#{repo}/#{formula.oldname}"
+        name = formula.oldname if tap == "Homebrew/homebrew"
+        super <<-EOS.undent
+        #{formula.name} from #{formula.tap} is given, but old name #{formula.oldname} was installed from #{tap}
+
+        Please try to use #{name} to refer the formula
+        EOS
+      end
+    end
+  end
+
+  attr_reader :formula
+  attr_reader :oldname, :oldpath, :old_pin_record, :old_opt_record
+  attr_reader :old_linked_keg_record, :oldkeg, :old_tabs, :old_tap
+  attr_reader :newname, :newpath, :new_pin_record
+  attr_reader :old_pin_link_record
+
+  def initialize(formula)
+    @oldname = formula.oldname
+    @newname = formula.name
+    raise MigratorNoOldnameError.new(formula) unless oldname
+
+    @formula = formula
+    @oldpath = HOMEBREW_CELLAR/formula.oldname
+    raise MigratorNoOldpathError.new(formula) unless oldpath.exist?
+
+    @old_tabs = oldpath.subdirs.each.map { |d| Tab.for_keg(Keg.new(d)) }
+    @old_tap = old_tabs.first.tap
+    raise MigratorDifferentTapsError.new(formula, old_tap) unless from_same_taps?
+
+    @newpath = HOMEBREW_CELLAR/formula.name
+
+    if @oldkeg = get_linked_oldkeg
+      @old_linked_keg_record = oldkeg.linked_keg_record if oldkeg.linked?
+      @old_opt_record = oldkeg.opt_record if oldkeg.optlinked?
+    end
+
+    @old_pin_record = HOMEBREW_LIBRARY/"PinnedKegs"/oldname
+    @new_pin_record = HOMEBREW_LIBRARY/"PinnedKegs"/newname
+    @pinned = old_pin_record.symlink?
+    @old_pin_link_record = old_pin_record.readlink if @pinned
+  end
+
+  # Fix INSTALL_RECEIPTS for tap-migrated formula.
+  def fix_tabs
+    old_tabs.each do |tab|
+      tab.source["tap"] = formula.tap
+      tab.write
+    end
+  end
+
+  def from_same_taps?
+    if old_tap == nil && formula.core_formula? && ARGV.force?
+      true
+    elsif formula.tap == old_tap
+      true
+    # Homebrew didn't use to update tabs while performing tap-migrations,
+    # so there can be INSTALL_RECEIPT's containing wrong information about
+    # tap (tap is Homebrew/homebrew if installed formula migrates to a tap), so
+    # we check if there is an entry about oldname migrated to tap and if
+    # newname's tap is the same as tap to which oldname migrated, then we
+    # can perform migrations and the taps for oldname and newname are the same.
+    elsif TAP_MIGRATIONS && (rec = TAP_MIGRATIONS[formula.oldname]) \
+          && rec == formula.tap.sub("homebrew-", "")
+      fix_tabs
+      true
+    elsif formula.tap
+      false
+    end
+  end
+
+  def get_linked_oldkeg
+    kegs = oldpath.subdirs.map { |d| Keg.new(d) }
+    kegs.detect(&:linked?) || kegs.detect(&:optlinked?)
+  end
+
+  def pinned?
+    @pinned
+  end
+
+  def oldkeg_linked?
+    !!oldkeg
+  end
+
+  def migrate
+    if newpath.exist?
+      onoe "#{newpath} already exists; remove it manually and run brew migrate #{oldname}."
+      return
+    end
+
+    begin
+      oh1 "Migrating #{Tty.green}#{oldname}#{Tty.white} to #{Tty.green}#{newname}#{Tty.reset}"
+      unlink_oldname
+      move_to_new_directory
+      repin
+      link_newname
+      link_oldname_opt
+      link_oldname_cellar
+      update_tabs
+    rescue Interrupt
+      ignore_interrupts { backup_oldname }
+    rescue Exception => e
+      onoe "error occured while migrating."
+      puts e if ARGV.debug?
+      puts "Backuping..."
+      ignore_interrupts { backup_oldname }
+    end
+  end
+
+  # move everything from Cellar/oldname to Cellar/newname
+  def move_to_new_directory
+    puts "Moving to: #{newpath}"
+    FileUtils.mv(oldpath, newpath)
+  end
+
+  def repin
+    if pinned?
+      # old_pin_record is a relative symlink and when we try to to read it
+      # from <dir> we actually try to find file
+      # <dir>/../<...>/../Cellar/name/version.
+      # To repin formula we need to update the link thus that it points to
+      # the right directory.
+      # NOTE: old_pin_record.realpath.sub(oldname, newname) is unacceptable
+      # here, because it resolves every symlink for old_pin_record and then
+      # substitutes oldname with newname. It breaks things like
+      # Pathname#make_relative_symlink, where Pathname#relative_path_from
+      # is used to find relative path from source to destination parent and
+      # it assumes no symlinks.
+      src_oldname = old_pin_record.dirname.join(old_pin_link_record).expand_path
+      new_pin_record.make_relative_symlink(src_oldname.sub(oldname, newname))
+      old_pin_record.delete
+    end
+  end
+
+  def unlink_oldname
+    oh1 "Unlinking #{Tty.green}#{oldname}#{Tty.reset}"
+    oldpath.subdirs.each do |d|
+      keg = Keg.new(d)
+      keg.unlink
+    end
+  end
+
+  def link_newname
+    oh1 "Linking #{Tty.green}#{newname}#{Tty.reset}"
+    keg = Keg.new(formula.installed_prefix)
+
+    if formula.keg_only?
+      begin
+        keg.optlink
+      rescue Keg::LinkError => e
+        onoe "Failed to create #{formula.opt_prefix}"
+        puts e
+        raise
+      end
+      return
+    end
+
+    keg.remove_linked_keg_record if keg.linked?
+
+    begin
+      keg.link
+    rescue Keg::ConflictError => e
+      onoe "Error while executing `brew link` step on #{newname}"
+      puts e
+      puts
+      puts "Possible conflicting files are:"
+      mode = OpenStruct.new(:dry_run => true, :overwrite => true)
+      keg.link(mode)
+      raise
+    rescue Keg::LinkError => e
+      onoe "Error while linking"
+      puts e
+      puts
+      puts "You can try again using:"
+      puts "  brew link #{formula.name}"
+    rescue Exception => e
+      onoe "An unexpected error occurred during linking"
+      puts e
+      puts e.backtrace
+      ignore_interrupts { keg.unlink }
+      raise e
+    end
+  end
+
+  # Link keg to opt if it was linked before migrating.
+  def link_oldname_opt
+    if old_opt_record
+      old_opt_record.delete if old_opt_record.symlink? || old_opt_record.exist?
+      old_opt_record.make_relative_symlink(formula.installed_prefix)
+    end
+  end
+
+  # After migtaion every INSTALL_RECEIPT.json has wrong path to the formula
+  # so we must update INSTALL_RECEIPTs
+  def update_tabs
+    new_tabs = newpath.subdirs.map { |d| Tab.for_keg(Keg.new(d)) }
+    new_tabs.each do |tab|
+      tab.source["path"] = formula.path.to_s if tab.source["path"]
+      tab.write
+    end
+  end
+
+  # Remove opt/oldname link if it belongs to newname.
+  def unlink_oldname_opt
+    return unless old_opt_record
+    if old_opt_record.symlink? && formula.installed_prefix.exist? \
+              && formula.installed_prefix.realpath == old_opt_record.realpath
+      old_opt_record.unlink
+      old_opt_record.parent.rmdir_if_possible
+    end
+  end
+
+  # Remove oldpath if it exists
+  def link_oldname_cellar
+    oldpath.delete if oldpath.symlink? || oldpath.exist?
+    oldpath.make_relative_symlink(formula.rack)
+  end
+
+  # Remove Cellar/oldname link if it belongs to newname.
+  def unlink_oldname_cellar
+    if (oldpath.symlink? && !oldpath.exist?) || (oldpath.symlink? \
+          && formula.rack.exist? && formula.rack.realpath == oldpath.realpath)
+      oldpath.unlink
+    end
+  end
+
+  # Backup everything if errors occured while migrating.
+  def backup_oldname
+    unlink_oldname_opt
+    unlink_oldname_cellar
+    backup_oldname_cellar
+    backup_old_tabs
+
+    if pinned? && !old_pin_record.symlink?
+      src_oldname = old_pin_record.dirname.join(old_pin_link_record).expand_path
+      old_pin_record.make_relative_symlink(src_oldname)
+      new_pin_record.delete
+    end
+
+    if newpath.exist?
+      newpath.subdirs.each do |d|
+        newname_keg = Keg.new(d)
+        newname_keg.unlink
+        newname_keg.uninstall
+      end
+    end
+
+    if oldkeg_linked?
+      begin
+        # The keg used to be linked  and when we backup everything we restore
+        # Cellar/oldname, the target also gets restored, so we are able to
+        # create a keg using its old path
+        keg = Keg.new(Pathname.new(oldkeg.to_s))
+        keg.link
+      rescue Keg::LinkError
+        keg.unlink
+        raise
+      rescue Keg::AlreadyLinkedError
+        keg.unlink
+        retry
+      end
+    end
+  end
+
+  def backup_oldname_cellar
+    unless oldpath.exist?
+      FileUtils.mv(newpath, oldpath)
+    end
+  end
+
+  def backup_old_tabs
+    old_tabs.each(&:write)
+  end
+end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1,3 +1,5 @@
+require "utils/json"
+
 # a {Tap} is used to extend the formulae provided by Homebrew core.
 # Usually, it's synced with a remote git repository. And it's likely
 # a Github repository with the name of `user/homebrew-repo`. In such
@@ -135,6 +137,15 @@ class Tap
       "command_files" => command_files.map(&:to_s),
       "pinned" => pinned?
     }
+  end
+
+  # Hash with tap formula renames
+  def formula_renames
+    @formula_renames ||= if (rename_file = path/"formula_renames.json").file?
+      Utils::JSON.load(rename_file.read)
+    else
+      {}
+    end
   end
 
   def self.each

--- a/Library/Homebrew/test/test_migrator.rb
+++ b/Library/Homebrew/test/test_migrator.rb
@@ -1,0 +1,268 @@
+require "testing_env"
+require "migrator"
+require "testball"
+require "tab"
+require "keg"
+
+class Formula
+  def set_oldname oldname
+    @oldname = oldname
+  end
+end
+
+class MigratorErrorsTests < Homebrew::TestCase
+  def setup
+    @new_f = Testball.new("newname")
+    @new_f.set_oldname "oldname"
+    @old_f = Testball.new("oldname")
+  end
+
+  def test_no_oldname
+    assert_raises(Migrator::MigratorNoOldnameError) { Migrator.new(@old_f) }
+  end
+
+  def test_no_oldpath
+    assert_raises(Migrator::MigratorNoOldpathError) { Migrator.new(@new_f) }
+  end
+
+  def test_different_taps
+    keg = HOMEBREW_CELLAR/"oldname/0.1"
+    keg.mkpath
+    tab = Tab.empty
+    tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
+    tab.source["tap"] = "Homebrew/homebrew"
+    tab.write
+    assert_raises(Migrator::MigratorDifferentTapsError) { Migrator.new(@new_f) }
+  ensure
+    keg.parent.rmtree
+  end
+end
+
+class MigratorTests < Homebrew::TestCase
+  include FileUtils
+
+  def setup
+    @new_f = Testball.new("newname")
+    @new_f.set_oldname "oldname"
+
+    @old_f = Testball.new("oldname")
+
+    @old_keg_record = HOMEBREW_CELLAR/"oldname/0.1"
+    @old_keg_record.join("bin").mkpath
+    @new_keg_record = HOMEBREW_CELLAR/"newname/0.1"
+
+    %w[inside bindir].each { |file| touch @old_keg_record.join("bin", file) }
+
+    @old_tab = Tab.empty
+    @old_tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
+    @old_tab.source["path"] = "/oldname"
+    @old_tab.write
+
+    @keg = Keg.new(@old_keg_record)
+    @keg.link
+    @keg.optlink
+
+    @old_pin = HOMEBREW_LIBRARY/"PinnedKegs/oldname"
+    @old_pin.make_relative_symlink @old_keg_record
+
+    @migrator = Migrator.new(@new_f)
+
+    mkpath HOMEBREW_PREFIX/"bin"
+  end
+
+  def teardown
+    @old_pin.unlink if @old_pin.symlink?
+
+    if @old_keg_record.parent.symlink?
+      @old_keg_record.parent.unlink
+    elsif @old_keg_record.directory?
+      @keg.unlink
+      @keg.uninstall
+    end
+
+    if @new_keg_record.directory?
+      new_keg = Keg.new(@new_keg_record)
+      new_keg.unlink
+      new_keg.uninstall
+    end
+
+    @old_keg_record.parent.rmtree if @old_keg_record.parent.directory?
+    @new_keg_record.parent.rmtree if @new_keg_record.parent.directory?
+
+    rmtree HOMEBREW_PREFIX/"bin"
+    rmtree HOMEBREW_PREFIX/"opt" if (HOMEBREW_PREFIX/"opt").directory?
+    # What to do with pin?
+    @new_f.unpin
+  end
+
+  def test_move_cellar
+    @keg.unlink
+    shutup { @migrator.move_to_new_directory }
+    assert_predicate @new_keg_record, :directory?
+    assert_predicate @new_keg_record/"bin", :directory?
+    assert_predicate @new_keg_record/"bin/inside", :file?
+    assert_predicate @new_keg_record/"bin/bindir", :file?
+    refute_predicate @old_keg_record, :directory?
+  end
+
+  def test_backup_cellar
+    @old_keg_record.parent.rmtree
+    @new_keg_record.join("bin").mkpath
+
+    @migrator.backup_oldname_cellar
+
+    assert_predicate @old_keg_record, :directory?
+    assert_predicate @old_keg_record/"bin", :directory?
+  end
+
+  def test_oldkeg_linked
+    assert_predicate @migrator, :oldkeg_linked?
+  end
+
+  def test_repin
+    @new_keg_record.join("bin").mkpath
+    expected_relative = @new_keg_record.relative_path_from HOMEBREW_LIBRARY/"PinnedKegs"
+
+    @migrator.repin
+
+    assert_predicate @migrator.new_pin_record, :symlink?
+    assert_equal expected_relative, @migrator.new_pin_record.readlink
+    refute_predicate @migrator.old_pin_record, :exist?
+  end
+
+  def test_unlink_oldname
+    assert_equal 1, HOMEBREW_LIBRARY.join("LinkedKegs").children.size
+    assert_equal 1, HOMEBREW_PREFIX.join("opt").children.size
+
+    shutup { @migrator.unlink_oldname }
+
+    refute_predicate HOMEBREW_LIBRARY/"LinkedKegs", :exist?
+    refute_predicate HOMEBREW_LIBRARY.join("bin"), :exist?
+  end
+
+  def test_link_newname
+    @keg.unlink
+    @keg.uninstall
+    @new_keg_record.join("bin").mkpath
+    %w[inside bindir].each { |file| touch @new_keg_record.join("bin", file) }
+
+    shutup { @migrator.link_newname }
+
+    assert_equal 1, HOMEBREW_LIBRARY.join("LinkedKegs").children.size
+    assert_equal 1, HOMEBREW_PREFIX.join("opt").children.size
+  end
+
+  def test_link_oldname_opt
+    @new_keg_record.mkpath
+    @migrator.link_oldname_opt
+    assert_equal @new_keg_record.realpath, (HOMEBREW_PREFIX/"opt/oldname").realpath
+  end
+
+  def test_link_oldname_cellar
+    @new_keg_record.join("bin").mkpath
+    @keg.unlink
+    @keg.uninstall
+    @migrator.link_oldname_cellar
+    assert_equal @new_keg_record.parent.realpath, (HOMEBREW_CELLAR/"oldname").realpath
+  end
+
+  def test_update_tabs
+    @new_keg_record.join("bin").mkpath
+    tab = Tab.empty
+    tab.tabfile = HOMEBREW_CELLAR/"newname/0.1/INSTALL_RECEIPT.json"
+    tab.source["path"] = "/path/that/must/be/changed/by/update_tabs"
+    tab.write
+    @migrator.update_tabs
+    assert_equal @new_f.path.to_s, Tab.for_keg(@new_keg_record).source["path"]
+  end
+
+  def test_migrate
+    tab = Tab.empty
+    tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
+    tab.source["path"] = @old_f.path.to_s
+    tab.write
+
+    shutup { @migrator.migrate }
+
+    assert_predicate @new_keg_record, :exist?
+    assert_predicate @old_keg_record.parent, :symlink?
+    refute_predicate (HOMEBREW_LIBRARY/"LinkedKegs/oldname"), :exist?
+    assert_equal @new_keg_record.realpath, (HOMEBREW_LIBRARY/"LinkedKegs/newname").realpath
+    assert_equal @new_keg_record.realpath, @old_keg_record.realpath
+    assert_equal @new_keg_record.realpath, (HOMEBREW_PREFIX/"opt/oldname").realpath
+    assert_equal @new_keg_record.parent.realpath, (HOMEBREW_CELLAR/"oldname").realpath
+    assert_equal @new_keg_record.realpath, (HOMEBREW_LIBRARY/"PinnedKegs/newname").realpath
+    assert_equal @new_f.path.to_s, Tab.for_keg(@new_keg_record).source["path"]
+  end
+
+  def test_unlinik_oldname_opt
+    @new_keg_record.mkpath
+    old_opt_record = HOMEBREW_PREFIX/"opt/oldname"
+    old_opt_record.unlink if old_opt_record.symlink?
+    old_opt_record.make_relative_symlink(@new_keg_record)
+    @migrator.unlink_oldname_opt
+    refute_predicate old_opt_record, :symlink?
+  end
+
+  def test_unlink_oldname_cellar
+    @new_keg_record.mkpath
+    @keg.unlink
+    @keg.uninstall
+    @old_keg_record.parent.make_relative_symlink(@new_keg_record.parent)
+    @migrator.unlink_oldname_cellar
+    refute_predicate @old_keg_record.parent, :symlink?
+  end
+
+  def test_backup_oldname_cellar
+    @new_keg_record.join("bin").mkpath
+    @keg.unlink
+    @keg.uninstall
+    @migrator.backup_oldname_cellar
+    refute_predicate @old_keg_record.subdirs, :empty?
+  end
+
+  def test_backup_old_tabs
+    tab = Tab.empty
+    tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
+    tab.source["path"] = "/should/be/the/same"
+    tab.write
+    migrator = Migrator.new(@new_f)
+    tab.tabfile.delete
+    migrator.backup_old_tabs
+    assert_equal "/should/be/the/same", Tab.for_keg(@old_keg_record).source["path"]
+  end
+
+  # Backup tests are divided into three groups: when oldname Cellar is deleted
+  # and when it still exists and when it's a symlink
+
+  def check_after_backup
+    assert_predicate @old_keg_record.parent, :directory?
+    refute_predicate @old_keg_record.parent.subdirs, :empty?
+    assert_predicate HOMEBREW_LIBRARY/"LinkedKegs/oldname", :exist?
+    assert_predicate HOMEBREW_PREFIX/"opt/oldname", :exist?
+    assert_predicate HOMEBREW_LIBRARY/"PinnedKegs/oldname", :symlink?
+    assert_predicate @keg, :linked?
+  end
+
+  def test_backup_cellar_exist
+    @migrator.backup_oldname
+    check_after_backup
+  end
+
+  def test_backup_cellar_removed
+    @new_keg_record.join("bin").mkpath
+    @keg.unlink
+    @keg.uninstall
+    @migrator.backup_oldname
+    check_after_backup
+  end
+
+  def test_backup_cellar_linked
+    @new_keg_record.join("bin").mkpath
+    @keg.unlink
+    @keg.uninstall
+    @old_keg_record.parent.make_relative_symlink(@new_keg_record.parent)
+    @migrator.backup_oldname
+    check_after_backup
+  end
+end

--- a/share/doc/homebrew/Rename-A-Formula.md
+++ b/share/doc/homebrew/Rename-A-Formula.md
@@ -1,0 +1,26 @@
+# Renaming a Formula
+
+Sometimes software and formulae need to be renamed. To rename core formula
+you need:
+
+1. Rename formula file and its class to new formula. New name must meet all the rules of naming. Fix any test failures that may occur due to the stricter requirements for new formula than existing formula (e.g. brew audit --strict must pass for that formula).
+
+2. Create a pull request to the main repository deleting the formula file, adding new formula file and also add it to `Library/Homebrew/formula_renames.rb` with a commit message like `rename: ack -> newack`
+
+To rename tap formula you need to follow the same steps, but add formula to `formula_renames.json` in the root of your tap. You don't need to change `Library/Homebrew/formula_renames.rb`, because that file is for core formulae only. Use canonical name (e.g. `ack` instead of `user/repo/ack`).
+
+`Library/Homebrew/formula_renames.rb` example for core formula renames:
+
+```ruby
+FORMULA_RENAMES = {
+  "ack" => "newack"
+}
+```
+
+`formula_renames.json` example for tap:
+
+```json
+{
+  "ack": "newack"
+}
+```

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -290,6 +290,12 @@ If \fB\-\-pinned\fR is passed, show the versions of pinned formulae, or only the
 If no \fIformulae\fR are given, check all installed brews\.
 .
 .IP "\(bu" 4
+\fBmigrate [\-\-force]\fR \fIformulae\fR: Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
+.
+.IP
+If \fB\-\-force\fR is passed and installed \fIformulae\fR have nil tap, then treat them like packages installed from core\.
+.
+.IP "\(bu" 4
 \fBoptions [\-\-compact] [\-\-all] [\-\-installed]\fR \fIformula\fR: Display install options specific to \fIformula\fR\.
 .
 .IP


### PR DESCRIPTION
Hi! I'm a summer of code student working on "Handling formula renames" project https://github.com/Homebrew/homebrew/issues/14374. My mentor is @mikemcquaid. 

The problem with formula renames is that if we just rename the formula and its class, user who has this formula installed will never be able to upgrade it. The second problem are dependencies, if we rename formula we won't be able to install any formula that depends on old name.

The solution is to inform user about renames and perform some migrations that won't break anything. After that user can use his software, but the software will move to new directory and the formula for the software will be changed to new name.

Let's define `oldname` as an old name of the package and the formula and `newname` for new ones.

Approach
=======
The approach is to have `FORMULA_RENAMES` hash, that stores old names as keys and new names as values. The migrations are performed during the `update`, when we have information about added and deleted formulae from diff.

The approach doesn't allow us to create `oldname` formula after it gets renamed to `newname`.

Pros of this:

* No mess in versions
* Simple structure of metadata
* Issues like https://github.com/Homebrew/homebrew/issues/15776 can still be fixed.

Update
======
* Get the `formula_renames.rb` containing `FORMULA_RENAMES` from the last revision and load it.
* If we find from the `report` that the core formula was deleted and we have it in the Cellar, we try to find it in `FORMULA_RENAMES` and perform migrations using `Migrator` class, described below.

Migrator
=======
`Migrator` is a class for performing migrations for the formulae, that have `oldname`s. If the formula doesn't have `oldname`, then the exception is raised.
`Migrator#migrate` performs following steps:

1. Unlink oldname keg
2. Move `Cellar/oldname` to `Cellar/newname` if `Cellar/newname` doesn't exist already.
3. Pin `newname` keg if `oldname` was pinned.
4. Link newname keg.
6. Create `Cellar/oldname` symlink with `Cellar/newname` target.
7. Create opt link if `oldname` had it.

If one of these steps goes wrong, everything rolls back to initial state, which brings us to `migrate` command.

Migrate
======
If automatic migration fails, the user have to manually migrate his package.
 `brew migrate oldname` is used for that purpose.

Uninstalling
=========
If we uninstall `newname` after migration, we also remove `oldname` links to `newname`.

Taps
====
Taps can also be renamed.
The structure is almost the same as for core formulae.

Each tap that has renamed formulae must be provided with `formula_renames.json` file with, that stores information about renames in the following format:
```json
{
  "oldname": "newname"
}
```

TODOs
======

- [x] Establish behaviour for changed `ARGV.kegs` and rewrite it if needed.
- [x] Rename formulae from taps.
     - [x] uninstalling
     - [x] dependencies
     - [x] updating
- [x] `brew upgrade newname` now won't relink `oldname`. It's OK.
- [x] unit tests (in progress)
    - [x] tests for migrator exceptions
    - [x] tests for migrator

`brew migrate` manual tests
=====================
- [x] Migrate core formula
- [x] Migrate tap formula (canonical/fully-qualified) 
- [x] Migrate core formula when the same tap formula exists
- [x] Migrate tap formula when the same core one exists
- [x] Migrate tap formula using canonical name
- [x] Migrate tap formula using canonical name, when multiple taps have this formula
- [x] Install formula from path and try to migrate it (MigratorDifferentTapsError is raised)
- [x] Migrate formula, that depends on another
- [x] Migrate library some formula depends on (tested on zint and libpng, itstool and libxml2)
- [x] The same for library formulae 
- [x] Dependency on tap oldname :+1: both canonical and fully-qualified names work.
- [x] Dependency on core formula oldname (reinstall zint after renaming libpng)
- [x] Uninstall using oldname (canonical/fully-qualified) `Error: /usr/local/Cellar/ack is a symlink` :+1: 
- [x] Uninstall using newname (canonical/fully-qualified) OK :+1: 
- [x] Migrating keg_only works.

*NOTE*
What if there are two taps with `newack` formula? (`user/repo/newack` and `user1/repo1/newack`) and we want to `migrate` ack?
Both repositories have `"ack" => "newack"` in `TAP_FORMULA_RENAMES` hash.
`brew migrate ack` shows error (`TapFormulaWithOldnameAmbiguityError`) and says that you have to use fully-qualified name. However, if only one tap has "ack" renamed, everything is OK.

Changes
=======
* add `migrate` command.
* add `Migrator` class for handling migrations.
* `uninstall oldname` uninstalls `newname` with `oldname` symlinks.
* `uninstall newname` uninstalls package with its oldname symlinks.
* `update` perform formula renames(migrations) and tap formula renames(migrations) for renamed formulae.
* `update` changes `Tab` if formula migrates to a tap.
* `Formula#oldname` returns oldname for formula.
* `Formulary#loader_for(ref)` tries to load formula from oldname and from tap oldname.
*`TapLoader` tries to load tap formula from oldname.
* Add `Formulary.to_rack`
*  `Tap#formula_rename` loads `formula_renames.json` and stores Hash with renames.
* `brew migrate oldname` migrates `oldname` to `newname`.
* `brew audit` warns about dependencies on `oldname`.
* Add `TapFormulaWithOldnameAmbiguityError` exception that is raised when there are multiple tap formulae with given `oldname`.
* Add `test_migrator.rb` tests.
* Add tests for errors in `Migrator`.

Any feedback/suggestions on the approach and anything else are appreciated.
Thanks!