### PR TITLE
clutter 1.22.2

### DIFF
--- a/Library/Formula/clutter.rb
+++ b/Library/Formula/clutter.rb
@@ -1,18 +1,14 @@
-require "formula"
-
 class Clutter < Formula
   desc "Generic high-level canvas library"
   homepage "https://wiki.gnome.org/Projects/Clutter"
-  url "http://ftp.gnome.org/pub/gnome/sources/clutter/1.20/clutter-1.20.0.tar.xz"
-  sha256 "cc940809e6e1469ce349c4bddb0cbcc2c13c087d4fc15cda9278d855ee2d1293"
+  url "https://download.gnome.org/sources/clutter/1.22/clutter-1.22.2.tar.xz"
+  sha256 "8e69d21d9f7e8e89eafc072e2615c289903260c470af39bcb578b081139c11ac"
 
   bottle do
     sha1 "f9ef97d254247e2e0ab98fbaf3723d577c115ab4" => :mavericks
     sha1 "063234b823140c65483e9ac0dbbf4af63764431b" => :mountain_lion
     sha1 "7565ae43a559f988271cfdf8a745cc7919659efe" => :lion
   end
-
-  deprecated_option "without-x" => "without-x11"
 
   depends_on "pkg-config" => :build
   depends_on "glib"
@@ -22,7 +18,6 @@ class Clutter < Formula
   depends_on "atk"
   depends_on "pango"
   depends_on "json-glib"
-  depends_on :x11 => ["2.5.1", :recommended]
   depends_on "gobject-introspection"
 
   def install
@@ -33,26 +28,78 @@ class Clutter < Formula
       --enable-introspection=yes
       --disable-silent-rules
       --disable-Bsymbolic
-      --disable-tests
       --disable-examples
       --disable-gtk-doc-html
+      --enable-gdk-pixbuf=yes
+      --without-x --enable-x11-backend=no
+      --enable-quartz-backend=yes
     ]
 
-    if build.with? "x11"
-      args.concat %w{
-        --with-x --enable-x11-backend=yes
-        --enable-gdk-pixbuf=yes
-        --enable-quartz-backend=no
-      }
-    else
-      args.concat %w{
-        --without-x --enable-x11-backend=no
-        --enable-gdk-pixbuf=no
-        --enable-quartz-backend=yes
-      }
-    end
-
     system "./configure", *args
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <clutter/clutter.h>
+
+      int main(int argc, char *argv[]) {
+        GOptionGroup *group = clutter_get_option_group_without_init();
+        return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    cairo = Formula["cairo"]
+    cogl = Formula["cogl"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    json_glib = Formula["json-glib"]
+    libpng = Formula["libpng"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{cairo.opt_include}/cairo
+      -I#{cogl.opt_include}/cogl
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/clutter-1.0
+      -I#{json_glib.opt_include}/json-glib-1.0
+      -I#{libpng.opt_include}/libpng16
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -D_REENTRANT
+      -L#{atk.opt_lib}
+      -L#{cairo.opt_lib}
+      -L#{cogl.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{json_glib.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -latk-1.0
+      -lcairo
+      -lcairo-gobject
+      -lclutter-1.0
+      -lcogl
+      -lcogl-pango
+      -lcogl-path
+      -lgio-2.0
+      -lglib-2.0
+      -lgmodule-2.0
+      -lgobject-2.0
+      -lintl
+      -ljson-glib-1.0
+      -lpango-1.0
+      -lpangocairo-1.0
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
   end
 end


### PR DESCRIPTION
version bump
audit --strict compliance
X11 support removed since it didnt work anymore after cairo and pango
transitioned to quartz