### PR TITLE
pinentry: Patch to fix backspacing issues

### DIFF
--- a/Library/Formula/pinentry.rb
+++ b/Library/Formula/pinentry.rb
@@ -14,6 +14,8 @@ class Pinentry < Formula
 
   depends_on "pkg-config" => :build
 
+  patch :DATA
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -27,3 +29,22 @@ class Pinentry < Formula
     system "#{bin}/pinentry", "--version"
   end
 end
+
+__END__
+diff --git a/pinentry/pinentry-curses.c b/pinentry/pinentry-curses.c
+index 235435a..784c770 100644
+--- a/pinentry/pinentry-curses.c
++++ b/pinentry/pinentry-curses.c
+@@ -705,7 +705,11 @@ dialog_input (dialog_t diag, int alt, int chr)
+   switch (chr)
+     {
+     case KEY_BACKSPACE:
+-    case 'h' - 'a' + 1: /* control-h.  */
++      /* control-h.  */
++    case 'h' - 'a' + 1:
++      /* ASCII DEL.  What Mac OS X apparently emits when the "delete"
++	 (backspace) key is pressed.  */
++    case 127:
+       if (diag->pin_len > 0)
+ 	{
+ 	  diag->pin_len--;

--- a/Library/Formula/pinentry.rb
+++ b/Library/Formula/pinentry.rb
@@ -14,6 +14,8 @@ class Pinentry < Formula
 
   depends_on "pkg-config" => :build
 
+  # Fix backspacing in pinentry-curses.  Remove at next release.
+  # https://bugs.gnupg.org/gnupg/issue2020
   patch :DATA
 
   def install


### PR DESCRIPTION
Remove this patch at their next release.

Fixes #40335.