### PR TITLE
look in HOMEBREW_PREFIX for config

### DIFF
--- a/Library/Formula/multitail.rb
+++ b/Library/Formula/multitail.rb
@@ -19,7 +19,7 @@ class Multitail < Formula
   end
 
   def install
-    system "make", "-f", "makefile.macosx", "multitail"
+    system "make", "-f", "makefile.macosx", "multitail", "DESTDIR=#{HOMEBREW_PREFIX}"
 
     bin.install "multitail"
     man1.install gzip("multitail.1")


### PR DESCRIPTION
The global config is installed by etc.install, but the makefile isn't being told the DESTDIR, so it's hardcoding the default config path of /etc/multitail.conf. This is also a bug in the bottled formula, so brewed multitail has no chance of finding its global config.