### PR TITLE
Convert incoming unsigned gid/uid to signed, as expected by File.chown()

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -107,8 +107,19 @@ class Pathname
         old_stat = default_stat
       end
 
-      uid = Process.uid
-      gid = Process.groups.delete(old_stat.gid) { Process.gid }
+      # Process.uid/Process.gid return an unsigned int for nobody/nogroup
+      # (-2/-1) but tf.chown() below expects a signed Fixnum value (which
+      # is internally converted back to its two's complement representation)
+      def to_signed32bit(i)
+        if i >= 2**31
+          return i - 2**32
+        else
+          return i
+        end
+      end
+
+      uid = to_signed32bit(Process.uid)
+      gid = to_signed32bit(Process.groups.delete(old_stat.gid) { Process.gid })
 
       begin
         tf.chown(uid, gid)


### PR DESCRIPTION
Process.uid/Process.gid return an unsigned int for nobody/nogroup (-2/-1) but File.chown() expects a signed Fixnum value (which is internally converted back to its two's complement representation)

This should also fix issue #34619