### PR TITLE
Updating hardcoded .Net v4.0 to v4.5

### DIFF
--- a/Library/Formula/fsharp.rb
+++ b/Library/Formula/fsharp.rb
@@ -29,7 +29,7 @@ class Fsharp < Formula
       %w|Microsoft.Portable.FSharp.Targets
          Microsoft.FSharp.Targets|.each do |fsharp_targ|
 
-        tree_dir   = "lib/mono/Microsoft\ SDKs/F\#/#{fsharp_ver}/Framework/v4.0"
+        tree_dir   = "lib/mono/Microsoft\ SDKs/F\#/#{fsharp_ver}/Framework/v4.5"
         source_dir = File.expand_path "#{prefix}/../../mono/#{mono_ver}/#{tree_dir}"
 
         # variables:


### PR DESCRIPTION
`fsharp` no longer has `/usr/local/Cellar/fsharp/3.1.1.32/lib/mono/Microsoft SDKs/F#/3.0/Framework/v4.0/Microsoft.FSharp.Targets`. So updated it to `4.5`.