### PR TITLE
add `brew command`

### DIFF
--- a/Library/Homebrew/cmd/command.rb
+++ b/Library/Homebrew/cmd/command.rb
@@ -1,0 +1,14 @@
+module Homebrew
+  def command
+    cmd = ARGV.first
+    cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
+
+    if (path = HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.rb"; path.file?)
+      puts path
+    elsif (path = which("brew-#{cmd}") || which("brew-#{cmd}.rb"))
+      puts path
+    else
+      odie "Unknown command: #{cmd}"
+    end
+  end
+end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -54,3 +54,20 @@ HOMEBREW_PULL_OR_COMMIT_URL_REGEX = %r[https://github\.com/([\w-]+)/homebrew(-[\
 require 'compat' unless ARGV.include? "--no-compat" or ENV['HOMEBREW_NO_COMPAT']
 
 ORIGINAL_PATHS = ENV['PATH'].split(File::PATH_SEPARATOR).map{ |p| Pathname.new(p).expand_path rescue nil }.compact.freeze
+
+HOMEBREW_INTERNAL_COMMAND_ALIASES = {
+  'ls' => 'list',
+  'homepage' => 'home',
+  '-S' => 'search',
+  'up' => 'update',
+  'ln' => 'link',
+  'instal' => 'install', # gem does the same
+  'rm' => 'uninstall',
+  'remove' => 'uninstall',
+  'configure' => 'diy',
+  'abv' => 'info',
+  'dr' => 'doctor',
+  '--repo' => '--repository',
+  'environment' => '--env',
+  '--config' => 'config',
+}

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -69,6 +69,9 @@ Note that these flags should only appear after a command.
     versions of formula. Note downloads for any installed formula will still not be
     deleted. If you want to delete those too: `rm -rf $(brew --cache)`
 
+  * `command` <cmd>:
+    Display the path to the file which is used when invoking `brew <cmd>`.
+
   * `commands`:
     Show a list of built-in and external commands.
 

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -65,22 +65,6 @@ end
 begin
   trap("INT", std_trap) # restore default CTRL-C handler
 
-  aliases = {'ls' => 'list',
-             'homepage' => 'home',
-             '-S' => 'search',
-             'up' => 'update',
-             'ln' => 'link',
-             'instal' => 'install', # gem does the same
-             'rm' => 'uninstall',
-             'remove' => 'uninstall',
-             'configure' => 'diy',
-             'abv' => 'info',
-             'dr' => 'doctor',
-             '--repo' => '--repository',
-             'environment' => '--env',
-             '--config' => 'config',
-             }
-
   empty_argv = ARGV.empty?
   help_regex = /(-h$|--help$|--usage$|-\?$|^help$)/
   help_flag = false
@@ -96,7 +80,7 @@ begin
     end
   end
 
-  cmd = aliases[cmd] if aliases[cmd]
+  cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
 
   sudo_check = %w[ install link pin unpin upgrade ]
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -74,6 +74,9 @@ If \fB\-n\fR is passed, show what would be removed, but do not actually remove a
 If \fB\-s\fR is passed, scrubs the cache, removing downloads for even the latest versions of formula\. Note downloads for any installed formula will still not be deleted\. If you want to delete those too: \fBrm \-rf $(brew \-\-cache)\fR
 .
 .IP "\(bu" 4
+\fBcommand\fR \fIcmd\fR: Display the path to the file which is used when invoking \fBbrew <cmd>\fR\.
+.
+.IP "\(bu" 4
 \fBcommands\fR: Show a list of built\-in and external commands\.
 .
 .IP "\(bu" 4


### PR DESCRIPTION
It can be helpful to check whether an external command is installed. Therefore, I can do something like this in my shell configuration:
```bash
if brew command command-not-found-init > /dev/null; then eval "$(brew command-not-found-init)"; fi
```

cc @Homebrew/owners 
