### PR TITLE
chadwick 0.6.4 (new formula)

### DIFF
--- a/Library/Formula/chadwick.rb
+++ b/Library/Formula/chadwick.rb
@@ -1,0 +1,24 @@
+class Chadwick < Formula
+  desc "Chadwick tools for parsing Retrosheet MLB play-by-play files."
+  homepage "http://chadwick.sourceforge.net/doc/index.html"
+  url "https://downloads.sourceforge.net/project/chadwick/chadwick-0.6/chadwick-0.6.4/chadwick-0.6.4.tar.gz"
+  sha256 "2fcc44b4110c3aebf8b9f3daaccf22ccaba3760d3d878e65d38b86127b913559"
+
+  resource "event_files" do
+    url "http://www.retrosheet.org/events/2014eve.zip"
+    sha256 "f2bdcf2c587ea8b67d5c5485edad67c688a8e02325c2b787362ab360b79abdbd"
+  end
+
+  def install
+    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    resource("event_files").stage testpath
+    output = shell_output("#{bin}/cwbox -i ATL201404080 -y 2014 2014ATL.EVN")
+    assert output.include?("Game of 4/8/2014 -- New York at Atlanta")
+    assert_equal 0, $?.exitstatus
+  end
+end


### PR DESCRIPTION
These tools allow one to parse Retrosheet.org .EVA and .EVN files
which contain play-by-play data from Major League Baseball games.

Retrosheet data allows baseball enthusiasts to perform traditional
baseball analysis and modern sabermetric analysis.

There was a pull request for chadwick 0.5.3 in 2011, but it was rejected for being too niche. That might still apply, but four years is a long time. With the increase in popular interest about sabermetric analysis (i.e. the success of Fangraphs.com), I thought it would be a good idea to see if the maintainers would reconsider.

These tools are really the only way a fan can access play by play data, and it is a solid gateway into computer programming in general. The only way I figured out I actually wanted to learn about programming was because of my interest in baseball statistics.