### PR TITLE
style: bump rubocop to 0.32.1

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -6,7 +6,7 @@ module Homebrew
       ARGV.formulae.map(&:path)
     end
 
-    Homebrew.install_gem_setup_path! "rubocop", "0.32.0"
+    Homebrew.install_gem_setup_path! "rubocop", "0.32.1"
 
     args = [
       "--format", "simple", "--config",


### PR DESCRIPTION
Just a bug fix release mostly. Doesn't seem to break anything.