### PR TITLE
zeromq multicast support, pgm and norm

### DIFF
--- a/Library/Formula/norm.rb
+++ b/Library/Formula/norm.rb
@@ -1,0 +1,30 @@
+class Norm < Formula
+  desc "NACK-Oriented Reliable Multicast"
+  homepage "https://www.nrl.navy.mil/itd/ncs/products/norm"
+  url "https://downloads.pf.itd.nrl.navy.mil/norm/archive/src-norm-1.5b3.tgz"
+  sha256 "ec2014f57be12ea3ade0685faa1e6e161f168311c8975093bce33a6e1dc5e77c"
+
+  def install
+    system "./waf", "configure", "--prefix=#{prefix}"
+    system "./waf", "install"
+    include.install "include/normApi.h"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <assert.h>
+      #include <normApi.h>
+
+      int main()
+      {
+        NormInstanceHandle i;
+        i = NormCreateInstance(false);
+        assert(i != NORM_INSTANCE_INVALID);
+        NormDestroyInstance(i);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lnorm", "-o", "test"
+    system "./test"
+  end
+end

--- a/Library/Formula/zeromq.rb
+++ b/Library/Formula/zeromq.rb
@@ -24,12 +24,14 @@ class Zeromq < Formula
 
   option :universal
   option "with-libpgm", "Build with PGM extension"
+  option "with-norm", "Build with NORM extension"
 
   deprecated_option "with-pgm" => "with-libpgm"
 
   depends_on "pkg-config" => :build
   depends_on "libpgm" => :optional
   depends_on "libsodium" => :optional
+  depends_on "norm" => :optional
 
   def install
     ENV.universal_binary if build.universal?
@@ -37,9 +39,9 @@ class Zeromq < Formula
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
     if build.with? "libpgm"
       # Use HB libpgm-5.2 because their internal 5.1 is b0rked.
-      ENV['OpenPGM_CFLAGS'] = %x[pkg-config --cflags openpgm-5.2].chomp
-      ENV['OpenPGM_LIBS'] = %x[pkg-config --libs openpgm-5.2].chomp
-      args << "--with-system-pgm"
+      ENV['pgm_CFLAGS'] = %x[pkg-config --cflags openpgm-5.2].chomp
+      ENV['pgm_LIBS'] = %x[pkg-config --libs openpgm-5.2].chomp
+      args << "--with-pgm"
     end
 
     if build.with? "libsodium"
@@ -47,6 +49,8 @@ class Zeromq < Formula
     else
       args << "--without-libsodium"
     end
+
+    args << "--with-norm" if build.with? "norm"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
Currently the zeromq formular in homebrew does not have working multicast support. There was a PGM option, but it broke (```configure: WARNING: unrecognized options: --with-system-pgm```) at some point, most likely with zeromq 4.1.
This pull request fixes that, but also adds optional support for the [new norm transport](http://zeromq.org/topics:norm-protocol-transport), included with zeromq 4.1. [Norm](http://www.nrl.navy.mil/itd/ncs/products/norm) seems like a little known, but widely supported and without deps, solution to reliable multicast communication. 
Zeromq already gave the perfect [rationale](http://zeromq.org/topics:norm-protocol-transport), but from my POV it's also easier to use than PGM, especially when running multiple zeromq instances, such as on a development laptop. In fact, based on my testing, it might be the only way to do it on OS X without doing virtual network interfaces.