### PR TITLE
modgit 1.0.1 (new formula)

### DIFF
--- a/Library/Formula/modgit.rb
+++ b/Library/Formula/modgit.rb
@@ -1,0 +1,14 @@
+class Modgit < Formula
+  desc "Tool for git repo deploy with filters. Used for magento development."
+  homepage "https://github.com/jreinke/modgit"
+  url "https://github.com/jreinke/modgit/archive/v1.0.1.tar.gz"
+  sha256 "3df1ccddaacf386a32be0fe5b6333438f17876bc6a4851d9bc22a68a73ae314d"
+
+  def install
+    bin.install "modgit"
+  end
+
+  test do
+    system "#{bin}/modgit"
+  end
+end


### PR DESCRIPTION
Adding new formula: modgit is a shell script for deploying multiple Git repositories in root folder of any project, which is not possible with default git submodule command. A common use case would be the easy installation of Magento modules that need to be deployed in root folder.