### PR TITLE
pdf2svg: migrate back to core (from homebrew-x11)

### DIFF
--- a/Library/Formula/pdf2svg.rb
+++ b/Library/Formula/pdf2svg.rb
@@ -1,0 +1,29 @@
+class Pdf2svg < Formula
+  desc "PDF converter to SVG"
+  homepage "http://www.cityinthesky.co.uk/opensource/pdf2svg"
+  url "https://github.com/db9052/pdf2svg/archive/v0.2.3.tar.gz"
+  sha256 "4fb186070b3e7d33a51821e3307dce57300a062570d028feccd4e628d50dea8a"
+
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles-x11"
+    cellar :any
+    sha256 "852f856ee819872e3369a9c9aac6f8596b2efa2a5b0489fdf75fa7b83d0f8249" => :yosemite
+    sha256 "048368bd4847a9ae310efcb699b0a22f6e2ef7072127187e5ba2b43430cd2566" => :mavericks
+    sha256 "d02bbc276dab02d3c6290f981ce7b91b9f3c271171d9fedfc0bff87e630c8fd5" => :mountain_lion
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "poppler"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    curl "-O", "http://partners.adobe.com/public/developer/en/xml/AdobeXMLFormsSamples.pdf"
+    system "#{bin}/pdf2svg", "AdobeXMLFormsSamples.pdf", "test.svg"
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -155,7 +155,6 @@ TAP_MIGRATIONS = {
   "pcb" => "homebrew/x11",
   "pdfjam" => "homebrew/tex",
   "pdf2image" => "homebrew/x11",
-  "pdf2svg" => "homebrew/x11",
   "pdftoipe" => "homebrew/head-only",
   "pebble-sdk" => "pebble/pebble-sdk",
   "pgplot" => "homebrew/x11",


### PR DESCRIPTION
Turns out `pdf2svg` no longer depends on GTK+ or X11 (and previously did this only by mistake).

See also the related PR Homebrew/homebrew-x11#97.