### PR TITLE
Disable MMX. Clang in 10.11 doesn't support the inline assembly. 

### DIFF
--- a/Library/Formula/pixman.rb
+++ b/Library/Formula/pixman.rb
@@ -31,18 +31,15 @@ class Pixman < Formula
 
   def install
     ENV.universal_binary if build.universal?
-    if MacOS.version >= "10.11" then
-      system "./configure", "--disable-dependency-tracking",
-                            "--disable-silent-rules",
-                            "--prefix=#{prefix}",
-                            "--disable-gtk",
-                            "--disable-mmx"
-    else
-      system "./configure", "--disable-dependency-tracking",
-                            "--disable-silent-rules",
-                            "--prefix=#{prefix}",
-                            "--disable-gtk"
-    end
+
+    args = %W[--disable-dependency-tracking
+              --disable-gtk
+              --disable-silent-rules
+              --prefix=#{prefix}]
+
+    args << "--disable-mmx" if MacOS.version >= :el_capitan
+
+    system "./configure", *args
     system "make", "install"
   end
 end

--- a/Library/Formula/pixman.rb
+++ b/Library/Formula/pixman.rb
@@ -31,12 +31,18 @@ class Pixman < Formula
 
   def install
     ENV.universal_binary if build.universal?
-
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--disable-gtk",
-                          "--disable-mmx"
+    if MacOS.version >= "10.11" then
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{prefix}",
+                            "--disable-gtk",
+                            "--disable-mmx"
+    else
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{prefix}",
+                            "--disable-gtk"
+    end
     system "make", "install"
   end
 end

--- a/Library/Formula/pixman.rb
+++ b/Library/Formula/pixman.rb
@@ -35,7 +35,8 @@ class Pixman < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--disable-gtk"
+                          "--disable-gtk",
+                          "--disable-mmx"
     system "make", "install"
   end
 end


### PR DESCRIPTION
Upstream has been notified.