### PR TITLE
xcode: update clang version

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -119,7 +119,8 @@ module OS
           when 51      then "5.1"
           when 60      then "6.0"
           when 61      then "6.1"
-          else "6.1"
+          when 70      then "7.0"
+          else "7.0"
           end
         end
       end
@@ -162,7 +163,7 @@ module OS
 
       def latest_version
         case MacOS.version
-        when "10.11" then "700.0.53"
+        when "10.11" then "700.0.53.3"
         when "10.10" then "602.0.53"
         when "10.9"  then "600.0.57"
         when "10.8"  then "503.0.40"


### PR DESCRIPTION
Confirmed in a VM:

```
~> clang --version
Apple LLVM version 7.0.0 (clang-700.0.53.3)
Target: x86_64-apple-darwin15.0.0
Thread model: posix
```

I presume we carry the very minor `.3` on the end given that's what Clang says it is?