### PR TITLE
tab: tweak options info output

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -207,7 +207,7 @@ class Tab < OpenStruct
     unless used_options.empty?
       s << "Installed" if s.empty?
       s << "with:"
-      s << used_options.to_a.join(", ")
+      s << used_options.to_a.join(" ")
     end
     s.join(" ")
   end


### PR DESCRIPTION
Essentially turns:

```
brew info git

/usr/local/Cellar/git/2.4.5 (1388 files, 41M) *
  Built from source with: --with-brewed-curl, --with-brewed-openssl, --with-brewed-svn, --with-gettext, --with-pcre, --with-persistent-https
```

Into:
```
brew info git

/usr/local/Cellar/git/2.4.5 (1388 files, 41M) *
  Built from source with: --with-brewed-curl --with-brewed-openssl --with-brewed-svn --with-gettext --with-pcre --with-persistent-https
```

My primary use of viewing the options I build with in `brew info` is to remove the formula and copy the options over to a new install, i.e. when doing a manual bump of a `devel` installation, and manually removing the commas is :octopus:.

The commas also aren't technically correct, because you wouldn't pass them to `brew` as arguments because `brew` ignores any argument placed before a comma, such as:

```
brew install -v shmcat --with-nls, --with-ftok

==> ./configure --disable-dependency-tracking --prefix=/usr/local/Cellar/shmcat/1.7 --disable-nls
```

And it doesn't look less clean without the comma.

This doesn't seem to horribly break anything. Ran it through several installs, several brew commands and `brew tests`. Filed it as a PR in case anyone really loves the current usage.