### PR TITLE
dovecot 2.2.18: add pam build option, logging in plist

### DIFF
--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -1,9 +1,9 @@
 class Dovecot < Formula
   desc "IMAP/POP3 server"
   homepage "http://dovecot.org/"
-  url "http://dovecot.org/releases/2.2/dovecot-2.2.16.tar.gz"
-  mirror "https://fossies.org/linux/misc/dovecot-2.2.16.tar.gz"
-  sha256 "56ce1287a17fa88a2083116db00200deff1a5390af5eac1c8ae3f59a2079cff0"
+  url "http://dovecot.org/releases/2.2/dovecot-2.2.18.tar.gz"
+  mirror "https://fossies.org/linux/misc/dovecot-2.2.18.tar.gz"
+  sha256 "b6d8468cea47f1227f47b80618f7fb872e2b2e9d3302adc107a005dd083865bb"
 
   bottle do
     sha256 "c7e6a66e2c2feeaee294ce730d839476ea2ee8f6bd6e0be15d3de7f51d0c7c91" => :yosemite
@@ -13,6 +13,8 @@ class Dovecot < Formula
 
   depends_on "openssl"
   depends_on "clucene" => :optional
+
+  option "with-pam", "Build with PAM support"
 
   def install
     args = %W[
@@ -28,6 +30,7 @@ class Dovecot < Formula
     ]
 
     args << "--with-lucene" if build.with? "clucene"
+    args << "--with-pam" if build.with? "pam"
 
     system "./configure",  *args
     system "make", "install"
@@ -53,6 +56,10 @@ class Dovecot < Formula
         </array>
         <key>ServiceDescription</key>
         <string>Dovecot mail server</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/dovecot/dovecot.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/dovecot/dovecot.log</string>
       </dict>
     </plist>
     EOS


### PR DESCRIPTION
Updated to version 2.2.18, added support for a PAM build option, and added logging to the plist; it doesn't log anything otherwise.