### PR TITLE
lesspipe : changend to use all kind of decompressor.

### DIFF
--- a/Library/Formula/lesspipe.rb
+++ b/Library/Formula/lesspipe.rb
@@ -13,7 +13,7 @@ class Lesspipe < Formula
       inreplace 'configure', %q{$ifsyntax = "\L$ifsyntax";}, %q{$ifsyntax = "\Ly";}
     end
 
-    system "./configure", "--prefix=#{prefix}", "--default"
+    system "./configure", "--prefix=#{prefix}", "--yes"
     man1.mkpath
     system "make install"
   end


### PR DESCRIPTION
before the configure script will check the decompressor which is installed on the build
machine. but now skip the checker in configure script.