### PR TITLE
serveit (new formula) - migrated from headonly

### DIFF
--- a/Library/Formula/serveit.rb
+++ b/Library/Formula/serveit.rb
@@ -1,6 +1,8 @@
 class Serveit < Formula
   desc "synchronous server and rebuilder of static content"
   homepage "https://github.com/garybernhardt/serveit"
+  url "https://github.com/garybernhardt/serveit/archive/v0.0.1.tar.gz"
+  sha256 "8cf25c80ea9b9fe0383545d083e305f7723b6dec7e70d29a4e15016264861f49"
   head "https://github.com/garybernhardt/serveit.git"
 
   depends_on :ruby => "1.9"

--- a/Library/Formula/serveit.rb
+++ b/Library/Formula/serveit.rb
@@ -1,0 +1,22 @@
+class Serveit < Formula
+  desc "synchronous server and rebuilder of static content"
+  homepage "https://github.com/garybernhardt/serveit"
+  head "https://github.com/garybernhardt/serveit.git"
+
+  depends_on :ruby => "1.9"
+
+  def install
+    bin.install "serveit"
+  end
+
+  test do
+    begin
+      pid = fork { exec bin/"serveit" }
+      sleep 2
+      assert_match /Listing for/, shell_output("curl localhost:8000")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
The serveit formula was *just* merged into the headonly tap. And coinciding with that momentous occasion, serveit now has tagged releases, so needn't be in the headonly tap.

https://github.com/Homebrew/homebrew-head-only/pull/96 merged at https://github.com/Homebrew/homebrew-head-only/commit/6bd6c4f49d3fa73cc7c9fe83747d9b9cd2d64bac

PR to remove serveit from headonly tap: https://github.com/Homebrew/homebrew-head-only/pull/144