### PR TITLE
dynamips: Upgrade to 0.2.15

### DIFF
--- a/Library/Formula/dynamips.rb
+++ b/Library/Formula/dynamips.rb
@@ -1,8 +1,8 @@
 class Dynamips < Formula
   desc "Cisco 7200/3600/3725/3745/2600/1700 Router Emulator"
   homepage "http://www.gns3.net/dynamips/"
-  url "https://github.com/GNS3/dynamips/archive/v0.2.14.tar.gz"
-  sha1 "1f0b62d19586365246a957b4eb4dab0cdbd657ad"
+  url "https://github.com/GNS3/dynamips/archive/v0.2.15.tar.gz"
+  sha1 "890c9357c668c91b7fd39a96f017b4e5e6ca580e"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Upgrade to new release from upstream which fixes starting Cisco IOS images on OS X.