### PR TITLE
ack: fix devel version

### DIFF
--- a/Library/Formula/ack.rb
+++ b/Library/Formula/ack.rb
@@ -10,6 +10,7 @@ class Ack < Formula
   devel do
     url "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/ack-2.15_01.tar.gz"
     sha256 "dfd1df3def5d3b16af8a7c585fc8954362d4f2b097891919490c89fdb484fd83"
+    version "2.15-01"
   end
 
   resource "File::Next" do


### PR DESCRIPTION
Was scanned as 15.01.  I figure this is better than `2.15_01` since underscores are usually reserved for formula revisions, right?