### PR TITLE
Add the graphite2 smart font rendering engine.

### DIFF
--- a/Library/Formula/graphite2.rb
+++ b/Library/Formula/graphite2.rb
@@ -19,7 +19,7 @@ class Graphite2 < Formula
 
   test do
     resource("testfont").stage do
-      shape = `gr2fonttest Simple-Graphite-Font.ttf "abcde"`
+      shape = `#{bin}/gr2fonttest Simple-Graphite-Font.ttf "abcde"`
       assert_match /67.*36.*37.*38.*71/m, shape
     end
   end

--- a/Library/Formula/graphite2.rb
+++ b/Library/Formula/graphite2.rb
@@ -1,0 +1,26 @@
+class Graphite2 < Formula
+  desc "Smart font renderer for non-Roman scripts"
+  homepage "http://scripts.sil.org/cms/scripts/page.php?site_id=projects&item_id=graphite_home"
+  url "https://downloads.sourceforge.net/project/silgraphite/graphite2/graphite2-1.2.4.tgz"
+  sha256 "4bc3d5168029bcc0aa00eb2c973269d29407be2796ff56f9c80e10736bd8b003"
+
+  depends_on "cmake" => :build
+
+  resource "testfont" do
+    url "http://scripts.sil.org/pub/woff/fonts/Simple-Graphite-Font.ttf"
+    sha256 "7e573896bbb40088b3a8490f83d6828fb0fd0920ac4ccdfdd7edb804e852186a"
+  end
+
+  def install
+    args = std_cmake_args
+    system "cmake", ".", *args
+    system "make", "install"
+  end
+
+  test do
+    resource("testfont").stage do
+        shape = `gr2fonttest Simple-Graphite-Font.ttf "abcde"`
+        assert_match /67.*36.*37.*38.*71/m , shape
+    end
+  end
+end

--- a/Library/Formula/graphite2.rb
+++ b/Library/Formula/graphite2.rb
@@ -19,8 +19,8 @@ class Graphite2 < Formula
 
   test do
     resource("testfont").stage do
-        shape = `gr2fonttest Simple-Graphite-Font.ttf "abcde"`
-        assert_match /67.*36.*37.*38.*71/m , shape
+      shape = `gr2fonttest Simple-Graphite-Font.ttf "abcde"`
+      assert_match /67.*36.*37.*38.*71/m, shape
     end
   end
 end


### PR DESCRIPTION
[Graphite](http://scripts.sil.org/cms/scripts/page.php?site_id=projects&item_id=graphite_home) is a library for rendering complex non-Roman fonts. It's already part of Libreoffice, Firefox, Thunderbird, XeTeX and so on, etc.

Harfbuzz (which is [in Homebrew](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/harfbuzz.rb)) has Graphite2 as an optional dependency; it likes to have Graphite2 as an additional shaper to call out to in order to render more complex scripts. 

Currently there's no way to build the Harfbuzz package in Homebrew with Graphite2 support; even if Graphite2 is installed manually it's ignored. If the graphite2 formula is accepted, then I'll also send a patch adding a `--with-graphite=auto` configuration directive to Harfbuzz, so that it can pick up on the Graphite2 library if it's installed.