### PR TITLE
rocksdb: Add --with-lite option

### DIFF
--- a/Library/Formula/rocksdb.rb
+++ b/Library/Formula/rocksdb.rb
@@ -14,6 +14,8 @@ class Rocksdb < Formula
     sha256 "ada906d1b4fa26f73ce3aa4b393c6c9d7ec76bf50663e2ff748d143f6c3518bc" => :mountain_lion
   end
 
+  option "with-lite", "Build mobile/non-flash optimized lite version"
+
   needs :cxx11
   depends_on "snappy"
   depends_on "lz4"
@@ -21,6 +23,7 @@ class Rocksdb < Formula
   def install
     ENV.cxx11
     ENV["PORTABLE"] = "1" if build.bottle?
+    ENV.append_to_cflags "-DROCKSDB_LITE=1" if build.with? "lite"
     system "make", "clean"
     system "make", "static_lib"
     system "make", "shared_lib"


### PR DESCRIPTION
This adds an optional `--with-lite` to the from-source build of RocksDB.

RocksDB (librocksdb) can be included as an embedded database for applications running on memory constrained platforms like iOS using the LITE version. This version is regression-tested to maintain size and in practice requires significantly less private memory. See [ROCKSDB_LITE](https://github.com/facebook/rocksdb/blob/master/ROCKSDB_LITE.md) for the complete guide/vision.

Example build:
```
brew install --build-bottle --build-from-source -v --with-lite ./Library/Formula/rocksdb.rb
```

And in the including/linking application: `CXX_FLAGS+=-DROCKSDB_LITE`.
