### PR TITLE
Build gflags as a shared library by default.

### DIFF
--- a/Library/Formula/gflags.rb
+++ b/Library/Formula/gflags.rb
@@ -13,7 +13,7 @@ class Gflags < Formula
   end
 
   option "with-debug", "Build debug version"
-  option "with-static", "Build gflags as a static library."
+  option "with-static", "Build gflags as a static (instead of shared) library."
 
   depends_on "cmake" => :build
 

--- a/Library/Formula/gflags.rb
+++ b/Library/Formula/gflags.rb
@@ -13,13 +13,20 @@ class Gflags < Formula
   end
 
   option "with-debug", "Build debug version"
+  option "with-static", "Build gflags as a static library."
 
   depends_on "cmake" => :build
 
   def install
     ENV.append_to_cflags "-DNDEBUG" if build.without? "debug"
+    args = std_cmake_args
+    if build.with? "static"
+      args << "-DBUILD_SHARED_LIBS=OFF"
+    else
+      args << "-DBUILD_SHARED_LIBS=ON"
+    end
     mkdir "buildroot" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
- By default, newer versions of gflags that use CMake, build a static
  library, whereas previously (e.g. v2.0) it was built as a shared
  library.
- Building gflags statically causes issues when glog is built as a
  shared library (its default option).  Specifically, the gflags defined
  by glog will not be visible unless glog appears explicitly prior to
  gflags in the link step for an application (i.e. there are undefined
  symbols from gflags that need to be resolved).
- In fact, on Linux the linker will refuse to build glog (0.3.4) as a
  shared library if gflags (2.1.2) is built as a static library due to
  gflags not being position independent.