### PR TITLE
Update colordiff to 1.0.15

### DIFF
--- a/Library/Formula/colordiff.rb
+++ b/Library/Formula/colordiff.rb
@@ -1,8 +1,8 @@
 class Colordiff < Formula
   desc "Color-highlighted diff(1) output"
   homepage "http://www.colordiff.org/"
-  url "http://www.colordiff.org/colordiff-1.0.13.tar.gz"
-  sha1 "64e369aed2230f3aa5f1510b231fcac270793c09"
+  url "http://www.colordiff.org/colordiff-1.0.15.tar.gz"
+  sha1 "77c518233f81c8ef2542cbd32e6597ee3e5ef432"
 
   bottle do
     cellar :any
@@ -34,14 +34,6 @@ diff --git a/Makefile b/Makefile
 index 6ccbfc7..e5d64e7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -8,6 +8,7 @@ DIST_FILES=COPYING INSTALL Makefile README \
- TMPDIR=colordiff-${VERSION}
- TARBALL=${TMPDIR}.tar.gz
-
-+.PHONY: install
-
- doc: colordiff.xml cdiff.xml
- 	xmlto -vv man colordiff.xml
 @@ -28,8 +29,8 @@ install:
  	if [ ! -f ${DESTDIR}${INSTALL_DIR}/cdiff ] ; then \
  	  install cdiff.sh ${DESTDIR}${INSTALL_DIR}/cdiff; \


### PR DESCRIPTION
The 1.0.13 tar.gz is no longer available on their website. The newest version is 1.0.15.

Since they have updated their Makefile, I've removed part of the patch that is now useless.