### PR TITLE
teem: fix build

### DIFF
--- a/Library/Formula/teem.rb
+++ b/Library/Formula/teem.rb
@@ -1,33 +1,34 @@
-require 'formula'
-
 class Teem < Formula
   desc "Libraries for scientific raster data"
-  homepage 'http://teem.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz'
-  sha1 'faafa0362abad37591bc1d01441730af462212f9'
+  homepage "http://teem.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
+  sha256 "a01386021dfa802b3e7b4defced2f3c8235860d500c1fa2f347483775d4c8def"
+  head "https://teem.svn.sourceforge.net/svnroot/teem/teem/trunk"
 
-  head 'https://teem.svn.sourceforge.net/svnroot/teem/teem/trunk'
+  option "with-experimental-apps", "Build experimental apps"
+  option "with-experimental-libs", "Build experimental libs"
 
-  depends_on 'cmake' => :build
+  deprecated_option "experimental-apps" => "with-experimental-apps"
+  deprecated_option "experimental-libs" => "with-experimental-libs"
 
-  option 'experimental-apps', "Build experimental apps"
-  option 'experimental-libs', "Build experimental libs"
+  depends_on "cmake" => :build
+  depends_on "libpng"
 
   def install
-    cmake_args = std_cmake_args
-    cmake_args << "-DBUILD_SHARED_LIBS:BOOL=ON"
+    args = std_cmake_args
+    args << "-DBUILD_SHARED_LIBS:BOOL=ON"
+    args << "-DBUILD_EXPERIMENTAL_APPS:BOOL=ON" if build.with? "experimental-apps"
+    args << "-DBUILD_EXPERIMENTAL_LIBS:BOOL=ON" if build.with? "experimental-libs"
 
-    if build.include? 'experimental-apps'
-      cmake_args << "-DBUILD_EXPERIMENTAL_APPS:BOOL=ON"
-    end
-    if build.include? 'experimental-libs'
-      cmake_args << "-DBUILD_EXPERIMENTAL_LIBS:BOOL=ON"
-    end
+    # Installs CMake archive files directly into lib, which we discourage.
+    # Workaround by adding version to libdir & then symlink into expected structure.
+    args << "-DTeem_USE_LIB_INSTALL_SUBDIR:BOOL=ON"
 
-    cmake_args << "."
+    system "cmake", *args
+    system "make", "install"
 
-    system "cmake", *cmake_args
-    system "make install"
+    lib.install_symlink Dir.glob(lib/"Teem-#{version}/*.dylib")
+    (lib/"cmake/teem").install_symlink Dir.glob(lib/"Teem-#{version}/*.cmake")
   end
 
   test do


### PR DESCRIPTION
There's an expectation to find libpng during compile that isn't being satisfied by the current dependencies.

The formula insists on installing `.cmake` files directly into `lib` which grates against our stated desire and install warnings not to install non-libs in lib. Consequently I've added a fairly dancy workaround to stop this happening and preserve the expected sort of directory structure.

Various audit fixes as well.

Closes #41164.