### PR TITLE
ctorrent: add explicit openssl dependency and test

### DIFF
--- a/Library/Formula/ctorrent.rb
+++ b/Library/Formula/ctorrent.rb
@@ -1,14 +1,34 @@
-require 'formula'
-
 class Ctorrent < Formula
   desc "BitTorrent command-line client"
-  homepage 'http://www.rahul.net/dholmes/ctorrent/'
-  url 'https://downloads.sourceforge.net/project/dtorrent/dtorrent/3.3.2/ctorrent-dnh3.3.2.tar.gz'
-  sha1 'd4e221f0292268f80e2430ce9d451dd64cf1ffaa'
+  homepage "http://www.rahul.net/dholmes/ctorrent/"
+  url "https://downloads.sourceforge.net/project/dtorrent/dtorrent/3.3.2/ctorrent-dnh3.3.2.tar.gz"
+  sha256 "c87366c91475931f75b924119580abd06a7b3cb3f00fef47346552cab1e24863"
+  revision 1
+
+  depends_on "openssl"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    agent_string = "Enhanced-CTorrent/dnh#{version}"
+    test_url     = "http://example.com/test"
+
+    # Arbitrary content
+    (testpath/"test").write "Test\n"
+
+    system "#{bin}/ctorrent", "-tpu", test_url, "-s", "test.meta", "test"
+    expected = Regexp.escape(
+      "d8:announce" \
+      "#{test_url.length}:#{test_url}" \
+      "10:created by" \
+      "#{agent_string.length}:#{agent_string}" \
+      "13:creation date"
+    ) + "i\\d+e"
+    actual = File.open(testpath/"test.meta", "rb").read
+    assert_match(/^#{expected}/, actual)
   end
 end


### PR DESCRIPTION
This also does some cleanup for `brew audit --strict`.