### PR TITLE
download_strategy: remove exclamation point

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -129,7 +129,7 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
       unless current_revision == @revision
         raise <<-EOS.undent
           #{@ref} tag should be #{@revision}
-          but is actually #{current_revision}!
+          but is actually #{current_revision}
         EOS
       end
     end


### PR DESCRIPTION
Not a big deal, but it can be mistaken for a number and caught up in a copy-paste.