### PR TITLE
ccd2iso: added test; `brew audit --strict`

### DIFF
--- a/Library/Formula/ccd2iso.rb
+++ b/Library/Formula/ccd2iso.rb
@@ -1,14 +1,18 @@
-require 'formula'
-
 class Ccd2iso < Formula
   desc "Convert CloneCD images to ISO images"
-  homepage 'http://ccd2iso.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/ccd2iso/ccd2iso/ccd2iso-0.3/ccd2iso-0.3.tar.gz'
-  sha1 'cbefdc086adf45138d921a4a7c0ff012dd7c9ca7'
+  homepage "http://ccd2iso.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/ccd2iso/ccd2iso/ccd2iso-0.3/ccd2iso-0.3.tar.gz"
+  sha256 "f874b8fe26112db2cdb016d54a9f69cf286387fbd0c8a55882225f78e20700fc"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    assert_match(
+      /^#{Regexp.escape(version)}$/, shell_output("#{bin}/ccd2iso --version")
+    )
   end
 end


### PR DESCRIPTION
I know you all prefer tests that go deeper than a basic installation qualification, but that would require obtaining an image file in CloneCD format. Since [CloneCD](http://slysoft.com/en/clonecd.html) is a commercial product, I don't really want to spend the money just to make a test image. So I hope this will suffice in this case.