### PR TITLE
Make go-app-engine formulae use SHA-256

### DIFF
--- a/Library/Formula/go-app-engine-32.rb
+++ b/Library/Formula/go-app-engine-32.rb
@@ -4,7 +4,7 @@ class GoAppEngine32 < Formula
   desc "Google App Engine SDK for Go!"
   homepage "https://cloud.google.com/appengine/docs/go/"
   url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.23.zip"
-  sha1 "43532c19ea8a0c282ddb93cdf8af079a280c2240"
+  sha256 "01271376dd0f04e1ff3bc52d71f2a933b4add478a6c9e8ca3b2de3468327b561"
 
   def install
     cd ".."

--- a/Library/Formula/go-app-engine-64.rb
+++ b/Library/Formula/go-app-engine-64.rb
@@ -4,7 +4,7 @@ class GoAppEngine64 < Formula
   desc "Google App Engine SDK for Go!"
   homepage "https://cloud.google.com/appengine/docs/go/"
   url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.23.zip"
-  sha1 "2a0e4d73fb47db730316d6ee804cf14d8c9f79c1"
+  sha256 "4eb357055f5c4d2ddc95253b6613ddeb5459dfa17c247ad0ba44f930d47096db"
 
   def install
     cd ".."


### PR DESCRIPTION
As requested by @DomT4 in #41161 