### PR TITLE
open-mesh: make qt optional

### DIFF
--- a/Library/Formula/open-mesh.rb
+++ b/Library/Formula/open-mesh.rb
@@ -1,8 +1,8 @@
 class OpenMesh < Formula
   desc "Generic data structure to represent and manipulate polygonal meshes"
   homepage "http://openmesh.org"
-  url "http://www.openmesh.org/media/Releases/3.3/OpenMesh-3.3.tar.gz"
-  sha256 "1fbc458e6f7d43d24a0e13005c094d15f08cc2f734a943d6c5417f0e6d9ad70e"
+  url "http://www.openmesh.org/media/Releases/4.0/OpenMesh-4.0.tar.gz"
+  sha256 "93cdd9a7d41842fba39a6b53ec494d99127302d43e60812697a1397deeeff344"
 
   bottle do
     cellar :any
@@ -14,16 +14,76 @@ class OpenMesh < Formula
   head "http://openmesh.org/svnrepo/OpenMesh/trunk/", :using => :svn
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt" => :optional
+
+  # For 4.0 version, when BUILD_APPS=OFF, the fixbundle.cmake will not be
+  # generated for a lacking cmake command `configure_file`.
+  # the oirinal patch for version 3.3 is submitted to openmesh-bounces@lists.rwth-aachen.de on July 8, 2015.
+  # And the bug has been confirmed from upstream by moebius@cs.rwth-aachen.de on July 24.
+  # The cmakelists.txt is patched a little by adding the missing line to
+  # generate the fixbundle file even when build app. option is off. Another way
+  # (cleaner way) is to disable customized target option.
+  patch do
+    url "https://gist.githubusercontent.com/autosquid/d41d6348bbf028c4d6f8/raw/1f9296b81b998e73f9980f7504460fc3bc00b030/CMakeLists.patch"
+    sha256 "19a795c9e0760085944470f5c3baf846edb251be20ff5cc7c24d0e2b47244c36"
+  end
+
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
+      args = std_cmake_args
+      if build.with? "qt"
+        args << "-DBUILD_APPS=ON"
+      else
+        args << "-DBUILD_APPS=OFF"
+      end
+      system "cmake", "..", *args
+      system "make install"
     end
   end
 
   test do
-    system "#{bin}/mconvert", "-help"
+    (testpath/"test.cpp").write <<-EOS.undent
+    #include <iostream>
+    #include <OpenMesh/Core/IO/MeshIO.hh>
+    #include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
+    typedef OpenMesh::PolyMesh_ArrayKernelT<>  MyMesh;
+    int main()
+    {
+        MyMesh mesh;
+        MyMesh::VertexHandle vhandle[4];
+        vhandle[0] = mesh.add_vertex(MyMesh::Point(-1, -1,  1));
+        vhandle[1] = mesh.add_vertex(MyMesh::Point( 1, -1,  1));
+        vhandle[2] = mesh.add_vertex(MyMesh::Point( 1,  1,  1));
+        vhandle[3] = mesh.add_vertex(MyMesh::Point(-1,  1,  1));
+        std::vector<MyMesh::VertexHandle>  face_vhandles;
+        face_vhandles.clear();
+        face_vhandles.push_back(vhandle[0]);
+        face_vhandles.push_back(vhandle[1]);
+        face_vhandles.push_back(vhandle[2]);
+        face_vhandles.push_back(vhandle[3]);
+        mesh.add_face(face_vhandles);
+        try
+        {
+        if ( !OpenMesh::IO::write_mesh(mesh, "triangle.off") )
+        {
+            std::cerr << "Cannot write mesh to file 'triangle.off'" << std::endl;
+            return 1;
+        }
+        }
+        catch( std::exception& x )
+        {
+        std::cerr << x.what() << std::endl;
+        return 1;
+        }
+        return 0;
+    }
+
+    EOS
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[ -I#{include} -L#{lib} -lOpenMeshCore -lOpenMeshTools]
+    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system "./test"
+
   end
 end


### PR DESCRIPTION
qt dependency is only optional according to build instructions from official doc.