### PR TITLE
New formula: extract_url 1.5.8

### DIFF
--- a/Library/Formula/extract_url.rb
+++ b/Library/Formula/extract_url.rb
@@ -57,7 +57,7 @@ class ExtractUrl < Formula
     end
 
     resource("URI::Find").stage do
-      system "perl", "Build.PL", "--install_base", "#{libexec}"
+      system "perl", "Build.PL", "--install_base", libexec
       system "./Build"
       system "./Build", "install"
     end

--- a/Library/Formula/extract_url.rb
+++ b/Library/Formula/extract_url.rb
@@ -4,20 +4,74 @@ class ExtractUrl < Formula
   url "https://extracturl.googlecode.com/files/extract_url-1.5.8.tar.gz"
   sha256 "58eac907cb926deba74ab81e7503a1055fd3cbe20952f011d8e6b75da12d6bcc"
 
-  depends_on "MIME::Parser" => :perl
-  depends_on "HTML::Parser" => :perl
-  depends_on "Pod::Usage" => :perl
-  depends_on "Env" => :perl
-  depends_on "Getopt::Long" => :perl
+  resource "MIME::Parser" do
+    url "https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/MIME-tools-5.506.tar.gz"
+    sha256 "dbed9bf46830c4a1df9840a546824ee44d14902012870f0c34bc4f5cc86af812"
+  end
+
+  resource "HTML::Parser" do
+    url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTML-Parser-3.71.tar.gz"
+    sha256 "be918b3749d3ff93627f72ee4b825683332ecb4c81c67a3a8d72b0435ffbd802"
+  end
+
+  resource "Pod::Usage" do
+    url "https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Usage-1.67.tar.gz"
+    sha256 "c8be6d29b0dfe304c4ddfcc140f93d4c4de7a8362ea6e2651611c288b53cc68a"
+  end
+
+  resource "Env" do
+    url "https://cpan.metacpan.org/authors/id/F/FL/FLORA/Env-1.04.tar.gz"
+    sha256 "d94a3d412df246afdc31a2199cbd8ae915167a3f4684f7b7014ce1200251ebb0"
+  end
+
+  resource "Getopt::Long" do
+    url "https://cpan.metacpan.org/authors/id/J/JV/JV/Getopt-Long-2.47.tar.gz"
+    sha256 "f5e6633ccda3f56a2df7a29f4187f4c787be4b746d97e9eb4aabd3aec1d9ed7b"
+  end
+
+  resource "URI::Find" do
+    url "https://cpan.metacpan.org/authors/id/M/MS/MSCHWERN/URI-Find-20140709.tar.gz"
+    sha256 "c0c34c5f7eddacc1c6553099015fe776797f1ec5a70e11e6e8fa68810224ec33"
+  end
+
+  resource "Curses" do
+    url "https://cpan.metacpan.org/authors/id/G/GI/GIRAFFED/Curses-1.32.tgz"
+    sha256 "5dba44fd7964806d9765e6692bc7eb8eb30aeced2740f28b9a4070a5d14ba650"
+  end
+
+  resource "Curses::UI" do
+    url "https://cpan.metacpan.org/authors/id/M/MD/MDXI/Curses-UI-0.9609.tar.gz"
+    sha256 "0ab827a513b6e14403184fb065a8ea1d2ebda122d2178cbf45c781f311240eaf"
+  end
 
   def install
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+    ENV.prepend_path "PERL5LIB", libexec/"lib"
+
+    %w[MIME::Parser HTML::Parser Pod::Usage Env Getopt::Long Curses Curses::UI].each do |r|
+      resource(r).stage do
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+        system "make"
+        system "make", "install"
+      end
+    end
+
+    resource("URI::Find").stage do
+      system "perl", "Build.PL", "--install_base", "#{libexec}"
+      system "./Build"
+      system "./Build", "install"
+    end
+
     system "make", "man"
-    mv "extract_url.pl", "extract_url"
-    bin.install "extract_url"
+
+    libexec.install "extract_url.pl"
+    chmod 0755, libexec/"extract_url.pl"
+    (bin/"extract_url").write_env_script("#{libexec}/extract_url.pl", :PERL5LIB => ENV["PERL5LIB"])
     man1.install "extract_url.1"
   end
 
   test do
-    system "#{bin}/extract_url", "--help"
+    (testpath/"test.txt").write("Hello World!\nhttps://www.google.com\nFoo Bar")
+    assert_match "https://www.google.com", pipe_output("#{bin}/extract_url -l test.txt")
   end
 end

--- a/Library/Formula/extract_url.rb
+++ b/Library/Formula/extract_url.rb
@@ -8,8 +8,6 @@ class ExtractUrl < Formula
   depends_on "HTML::Parser" => :perl
   depends_on "Pod::Usage" => :perl
   depends_on "Env" => :perl
-  #depends_on "URI::Find" => :perl
-  #depends_on "Curses::UI" => :perl
   depends_on "Getopt::Long" => :perl
 
   def install
@@ -20,7 +18,6 @@ class ExtractUrl < Formula
   end
 
   test do
-    system "extract_url", "--help"
+    system "#{bin}/extract_url", "--help"
   end
-
 end

--- a/Library/Formula/extract_url.rb
+++ b/Library/Formula/extract_url.rb
@@ -1,0 +1,26 @@
+class ExtractUrl < Formula
+  desc "Perl script to extracts URLs from emails or plain text."
+  homepage "http://www.memoryhole.net/~kyle/extract_url/"
+  url "https://extracturl.googlecode.com/files/extract_url-1.5.8.tar.gz"
+  sha256 "58eac907cb926deba74ab81e7503a1055fd3cbe20952f011d8e6b75da12d6bcc"
+
+  depends_on "MIME::Parser" => :perl
+  depends_on "HTML::Parser" => :perl
+  depends_on "Pod::Usage" => :perl
+  depends_on "Env" => :perl
+  #depends_on "URI::Find" => :perl
+  #depends_on "Curses::UI" => :perl
+  depends_on "Getopt::Long" => :perl
+
+  def install
+    system "make", "man"
+    mv "extract_url.pl", "extract_url"
+    bin.install "extract_url"
+    man1.install "extract_url.1"
+  end
+
+  test do
+    system "extract_url", "--help"
+  end
+
+end


### PR DESCRIPTION
This is a Perl script that extracts URLs from correctly-encoded MIME
email messages or plain text.