### PR TITLE
pango HEAD install fails due to Gnome.org URL

### DIFF
--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -6,7 +6,7 @@ class Pango < Formula
   revision 1
 
   head do
-    url "https://git.gnome.org/browse/pango"
+    url "https://git.gnome.org/browse/pango.git"
 
     depends_on "automake" => :build
     depends_on "autoconf" => :build


### PR DESCRIPTION
Adding ".git" to URL fixes the problem.

To reproduce the error:

    brew install pango --HEAD

Brew error *without* --interactive:

    Pango install fail on 10.11 (https://github.com/Homebrew/homebrew/issues/41086)
    pango-1.36.8 failed to build on 10.10.3 (14D136) (https://github.com/Homebrew/homebrew/issues/40853)

Brew error *with* --interactive:

    $ ./autogen.sh
    bash: ./autogen.sh: No such file or directory

running ls -la inside --interactive shell:

    drwx------   3 webavant  wheel    102 Jun 30 13:40 .
    drwxrwxrwt  45 webavant  wheel   1530 Jun 30 13:40 ..
    -rw-r--r--   1 webavant  wheel  19648 Jun 30 13:40 pango

Contents of the 'pango' file is the downloaded webpage from the HEAD url, which is https://git.gnome.org/browse/pango. Simply appending '.git' to that url fixes the problem.