### PR TITLE
curl: use https url

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -1,8 +1,8 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "http://curl.haxx.se/"
-  url "http://curl.haxx.se/download/curl-7.43.0.tar.bz2"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/cURL/curl-7.43.0.tar.bz2"
+  url "https://github.com/bagder/curl/releases/download/curl-7_43_0/curl-7.43.0.tar.bz2"
+  mirror "http://curl.haxx.se/download/curl-7.43.0.tar.bz2"
   sha256 "baa654a1122530483ccc1c58cc112fec3724a82c11c6a389f1e6a37dc8858df9"
 
   bottle do
@@ -98,7 +98,7 @@ class Curl < Formula
     # Fetch the curl tarball and see that the checksum matches.
     # This requires a network connection, but so does Homebrew in general.
     filename = (testpath/"test.tar.gz")
-    system "#{bin}/curl", stable.url, "-o", filename
+    system "#{bin}/curl", "-L", stable.url, "-o", filename
     filename.verify_checksum stable.checksum
   end
 end


### PR DESCRIPTION
The new URL points to GitHub, therefore I deleted the 
previous GitHub mirror kindly maintained by @DomT4.

Announcement: http://curl.haxx.se/news.html [June 29 2015]
Download page: http://curl.haxx.se/download.html