### PR TITLE
dos2unix: Remove gettext dependency

### DIFF
--- a/Library/Formula/dos2unix.rb
+++ b/Library/Formula/dos2unix.rb
@@ -16,9 +16,9 @@ class Dos2unix < Formula
     sha256 "59cea39b181913532bf9e9c234a142c15e330d5eee145cd6b90f54becd6ec27b"
   end
 
-  option "with-nls", "Build with Native Language Support"
+  option "with-gettext", "Build with Native Language Support"
 
-  depends_on "gettext" if build.with? "nls"
+  depends_on "gettext" => :optional
 
   def install
     args = %W[
@@ -29,7 +29,7 @@ class Dos2unix < Formula
       install
     ]
 
-    if build.without? "nls"
+    if build.without? "gettext"
       args << "ENABLE_NLS="
     else
       gettext = Formula["gettext"]

--- a/Library/Formula/dos2unix.rb
+++ b/Library/Formula/dos2unix.rb
@@ -16,17 +16,13 @@ class Dos2unix < Formula
     sha256 "59cea39b181913532bf9e9c234a142c15e330d5eee145cd6b90f54becd6ec27b"
   end
 
-  depends_on "gettext"
-
   def install
-    gettext = Formula["gettext"]
     system "make", "prefix=#{prefix}",
                    "CC=#{ENV.cc}",
                    "CPP=#{ENV.cc}",
                    "CFLAGS=#{ENV.cflags}",
-                   "CFLAGS_OS=-I#{gettext.include}",
-                   "LDFLAGS_EXTRA=-L#{gettext.lib} -lintl",
-                   "install"
+                   "install",
+                   "ENABLE_NLS="
   end
 
   test do

--- a/Library/Formula/dos2unix.rb
+++ b/Library/Formula/dos2unix.rb
@@ -16,13 +16,28 @@ class Dos2unix < Formula
     sha256 "59cea39b181913532bf9e9c234a142c15e330d5eee145cd6b90f54becd6ec27b"
   end
 
+  option "with-nls", "Build with Native Language Support"
+
+  depends_on "gettext" if build.with? "nls"
+
   def install
-    system "make", "prefix=#{prefix}",
-                   "CC=#{ENV.cc}",
-                   "CPP=#{ENV.cc}",
-                   "CFLAGS=#{ENV.cflags}",
-                   "install",
-                   "ENABLE_NLS="
+    args = %W[
+      prefix=#{prefix}
+      CC=#{ENV.cc}
+      CPP=#{ENV.cc}
+      CFLAGS=#{ENV.cflags}
+      install
+    ]
+
+    if build.without? "nls"
+      args << "ENABLE_NLS="
+    else
+      gettext = Formula["gettext"]
+      args << "CFLAGS_OS=-I#{gettext.include}"
+      args << "LDFLAGS_EXTRA=-L#{gettext.lib} -lintl"
+    end
+
+    system "make", *args
   end
 
   test do


### PR DESCRIPTION
Remove the gettext dependency, which is not mandatory but only goes along with NLS support.