### PR TITLE
pv: Remove gettext dependency

### DIFF
--- a/Library/Formula/pv.rb
+++ b/Library/Formula/pv.rb
@@ -12,7 +12,7 @@ class Pv < Formula
 
   option "with-nls", "Build with Native Language Support"
 
-  depends_on "gettext" => :optional
+  depends_on "gettext" if build.with? "nls"
 
   fails_with :llvm do
     build 2334

--- a/Library/Formula/pv.rb
+++ b/Library/Formula/pv.rb
@@ -10,15 +10,24 @@ class Pv < Formula
     sha256 "f343368e557cb1c86173bd0c62143b34834e2b825b1a188ac2a37c23d0c685dd" => :mountain_lion
   end
 
+  option "with-nls", "Build with Native Language Support"
+
+  depends_on "gettext" => :optional
+
   fails_with :llvm do
     build 2334
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--disable-nls"
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --mandir=#{man}
+    ]
+
+    args << "--disable-nls" if build.without? "nls"
+
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Library/Formula/pv.rb
+++ b/Library/Formula/pv.rb
@@ -10,8 +10,6 @@ class Pv < Formula
     sha256 "f343368e557cb1c86173bd0c62143b34834e2b825b1a188ac2a37c23d0c685dd" => :mountain_lion
   end
 
-  depends_on "gettext"
-
   fails_with :llvm do
     build 2334
   end
@@ -19,7 +17,8 @@ class Pv < Formula
   def install
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+                          "--mandir=#{man}",
+                          "--disable-nls"
     system "make", "install"
   end
 

--- a/Library/Formula/pv.rb
+++ b/Library/Formula/pv.rb
@@ -10,9 +10,9 @@ class Pv < Formula
     sha256 "f343368e557cb1c86173bd0c62143b34834e2b825b1a188ac2a37c23d0c685dd" => :mountain_lion
   end
 
-  option "with-nls", "Build with Native Language Support"
+  option "with-gettext", "Build with Native Language Support"
 
-  depends_on "gettext" if build.with? "nls"
+  depends_on "gettext" => :optional
 
   fails_with :llvm do
     build 2334
@@ -25,7 +25,7 @@ class Pv < Formula
       --mandir=#{man}
     ]
 
-    args << "--disable-nls" if build.without? "nls"
+    args << "--disable-nls" if build.without? "gettext"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Remove the gettext dependency from `pv`, since it's not mandatory.