### PR TITLE
Run .DS_Store cleanup as background process?

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -108,10 +108,7 @@ module Homebrew
   end
 
   def rm_DS_Store
-    paths = %w[Cellar Frameworks Library bin etc include lib opt sbin share var].
-      map { |p| HOMEBREW_PREFIX/p }.select(&:exist?)
-    args = paths.map(&:to_s) + %w[-name .DS_Store -delete]
-    quiet_system "find", *args
+    quiet_system "find", HOMEBREW_PREFIX, "-name", ".DS_Store", "-delete", "&"
   end
 
   def eligible_for_cleanup?(formula)


### PR DESCRIPTION
I have a lot of packages installed usually, and `brew cleanup` is really annoyingly slow for me, due to the .DS_Store cleanup. May I suggest that task be backgrounded? Even if someone runs `brew cleanup` and then exits the shell before that last task is completed, its not exactly the end of the world, IHMO?

Before:
```sh
> bash -c 'time brew cleanup' 2>&1 | tee cleanup.log
/Users/Shared/Developer/homebrew/Library/brew.rb (Formulary::FormulaLoader): loading /Users/Shared/Developer/homebrew/Library/Formula/aalib.rb

...snip...

/Users/Shared/Developer/homebrew/Library/brew.rb (Formulary::FormulaLoader): 
loading /Users/Shared/Developer/homebrew/Library/Formula/zsh-lovers.rb
find /Users/Shared/Developer/homebrew/Cellar /Users/Shared/Developer/homebrew/Frameworks /Users/Shared/Developer/homebrew/Library /Users/Shared/Developer/homebrew/bin /Users/Shared/Developer/homebrew/etc /Users/Shared/Developer/homebrew/include /Users/Shared/Developer/homebrew/lib /Users/Shared/Developer/homebrew/opt /Users/Shared/Developer/homebrew/sbin /Users/Shared/Developer/homebrew/share /Users/Shared/Developer/homebrew/var -name .DS_Store -delete

real	0m25.925s
user	0m4.192s
sys	0m17.014s
```

After:
```sh
> bash -c 'time brew cleanup' 2>&1 | tee cleanup.log
/Users/Shared/Developer/homebrew/Library/brew.rb (Formulary::FormulaLoader): loading /Users/Shared/Developer/homebrew/Library/Formula/aalib.rb

...snip...

/Users/Shared/Developer/homebrew/Library/brew.rb (Formulary::FormulaLoader): 
loading /Users/Shared/Developer/homebrew/Library/Formula/zsh-lovers.rb
find /Users/Shared/Developer/homebrew -name .DS_Store -delete &

real	0m5.035s
user	0m3.506s
sys	0m0.644s
```
