### PR TITLE
Make audit recognise hed-only and devel-only in all taps

### DIFF
--- a/Library/Formula/libuv.rb
+++ b/Library/Formula/libuv.rb
@@ -6,9 +6,9 @@ class Libuv < Formula
 
   bottle do
     cellar :any
-    sha256 "36280ae768a4bad91583ae76488d46c31a1e68f6f01b684a5e01f8a88cb1ec7a" => :yosemite
-    sha256 "2468bc83ef571b9631f1a26c5d017bdf8bf3daf23c965cb80b22cbe692713a48" => :mavericks
-    sha256 "c7ceebd9e3f941e2e9962580e2b18879952f1cd9aa111f70d26109e879a1e43c" => :mountain_lion
+    sha256 "b5f1923e12b4a6c9ea71f3285112b2d9b94bd4540e9bd205ead9a1a6de56b08d" => :yosemite
+    sha256 "7ead4ed4138cefd5cc5c00066dc7fd1b301dec4900166fc069a7b383349cf6c9" => :mavericks
+    sha256 "ff0d54bfc137c1c564ee8369cdd45e53eac86bf8dd0b7d8677af331c95fada47" => :mountain_lion
   end
 
   option "without-docs", "Don't build and install documentation"


### PR DESCRIPTION
- add wildcard into expressions to identify head-only and dev-only taps