### PR TITLE
Initial version for scw (1.2.1)

### DIFF
--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -1,0 +1,54 @@
+require "language/go"
+
+class Scw < Formula
+  desc "Manage BareMetal Servers from Command Line (as easily as with Docker)"
+  homepage "https://github.com/scaleway/scaleway-cli"
+  url "https://github.com/scaleway/scaleway-cli/archive/v1.2.1.tar.gz"
+  sha256 "e3ae09558a5f451935831381177f1ee3ce50aec438a1e11269dfc380e0e196c9"
+
+  head "https://github.com/scaleway/scaleway-cli.git"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/tools/godep" do
+    url "https://github.com/tools/godep.git", :revision => "58d90f262c13357d3203e67a33c6f7a9382f9223"
+  end
+
+  go_resource "github.com/kr/fs" do
+    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+  end
+
+  go_resource "golang.org/x/tools" do
+    url "https://github.com/golang/tools.git", :revision => "473fd854f8276c0b22f17fb458aa8f1a0e2cf5f5"
+  end
+
+  go_resource "golang.org/x/crypto" do
+    url "https://github.com/golang/crypto.git", :revision => "8b27f58b78dbd60e9a26b60b0d908ea642974b6d"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["CGO_ENABLED"] = "0"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    mkdir_p buildpath/"src/github.com/scaleway"
+    ln_s buildpath, buildpath/"src/github.com/scaleway/scaleway-cli"
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd "src/github.com/tools/godep" do
+      system "go", "install"
+    end
+
+    system "./bin/godep", "go", "build", "-o", "scw"
+    bin.install "scw"
+
+    bash_completion.install "contrib/completion/bash/scw"
+    zsh_completion.install "contrib/completion/zsh/_scw"
+  end
+
+  test do
+    output = shell_output(bin/"scw version")
+    assert output.include? "Client version: v1.2.1"
+    assert output.include? "Git commit (client): 3eb2cfb2478410b61992396fad5081ee80a140e9"
+  end
+end

--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -48,7 +48,6 @@ class Scw < Formula
 
   test do
     output = shell_output(bin/"scw version")
-    assert output.include? "Client version: v1.2.1"
-    assert output.include? "Git commit (client): 3eb2cfb2478410b61992396fad5081ee80a140e9"
+    assert output.include? "OS/Arch (client): darwin/amd64"
   end
 end


### PR DESCRIPTION
This formula download sources using Github tag release and build using Golang environment.
The sources contain all requirements (Godeps).

As soon as this is merged, I will add a link to official homebrew formula in our source formula (https://github.com/scaleway/scaleway-cli/tree/master/contrib/builder/homebrew), and update README.md+releases with brew instructions.

Related to #40917