### PR TITLE
Make HOMEBREW_GITHUB_API_TOKEN copy/paste friendly

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -329,7 +329,7 @@ module GitHub extend self
         GitHub #{error}
         Try again in #{pretty_ratelimit_reset(reset)}, or create an personal access token:
           https://github.com/settings/tokens
-        and then set it as HOMEBREW_GITHUB_API_TOKEN.
+        and then set the token as: HOMEBREW_GITHUB_API_TOKEN
         EOS
     end
 


### PR DESCRIPTION
A simple change that allows for easy copy/pasting. Right now if you were to double click on the text it will also inadvertently copy the trailing period. This change will alleviate the unnecessary gymnastics of not capturing the trailing period.

/most_pedantic_pull_request_ever