### PR TITLE
Fix UTF-8 character detection for SBCL build.

### DIFF
--- a/Library/Formula/sbcl.rb
+++ b/Library/Formula/sbcl.rb
@@ -77,7 +77,7 @@ class Sbcl < Formula
     # Remove non-ASCII values from environment as they cause build failures
     # More information: http://bugs.gentoo.org/show_bug.cgi?id=174702
     ENV.delete_if do |_, value|
-      value =~ /[\x80-\xff]/n
+      value.dup.force_encoding(Encoding::ASCII_8BIT) =~ /[\x80-\xff]/n
     end
 
     bootstrap = (build.build_32_bit? || !MacOS.prefer_64_bit?) ? "bootstrap32" : "bootstrap64"


### PR DESCRIPTION
If an ENV var has UTF-8 characters in it, the following error appears:

```
Error: incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
Please report this bug:
    https://git.io/brew-troubleshooting
/Users/austin/.brew/Library/Formula/sbcl.rb:81:in `block in install'
/Users/austin/.brew/Library/Formula/sbcl.rb:79:in `delete_if'
/Users/austin/.brew/Library/Formula/sbcl.rb:79:in `install'
/Users/austin/.brew/Library/Homebrew/build.rb:129:in `block in install'
/Users/austin/.brew/Library/Homebrew/formula.rb:540:in `block in brew'
/Users/austin/.brew/Library/Homebrew/formula.rb:935:in `block in stage'
/Users/austin/.brew/Library/Homebrew/resource.rb:91:in `block in unpack'
```

It is not possible to construct an invalid UTF-8 regexp, so it is necessary to
force the environment string to be parsed as ASCII_8BIT.