### PR TITLE
add missing luarock dependency for SILE

### DIFF
--- a/Library/Formula/sile.rb
+++ b/Library/Formula/sile.rb
@@ -33,6 +33,7 @@ class Sile < Formula
   def install
     system "luarocks-5.2", "install", "lpeg"
     system "luarocks-5.2", "install", "luaexpat"
+    system "luarocks-5.2", "install", "luafilesystem"
     system "./bootstrap.sh" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Library/Formula/sile.rb
+++ b/Library/Formula/sile.rb
@@ -4,13 +4,6 @@ class Sile < Formula
   url "https://github.com/simoncozens/sile/releases/download/v0.9.2/sile-0.9.2.tar.bz2"
   sha256 "2223582818df06daa4609cee40a81e8787085ad1795d4b2ce5edbe0663b74e18"
 
-  bottle do
-    cellar :any
-    sha256 "aacf9f59beae5b6de301b7e865d8aef602d47d6aa99ac8a87615c267a90a8646" => :yosemite
-    sha256 "04bb77b8e45794a08c31ad9efea24d722d704b31180ff89d4da80d5696150b73" => :mavericks
-    sha256 "3e634157cf79e6be843c73034cd4f4d7099c760a3ed2b2d2905e42512dac7c2c" => :mountain_lion
-  end
-
   head do
     url "https://github.com/simoncozens/sile.git"
     depends_on "automake" => :build
@@ -25,15 +18,16 @@ class Sile < Formula
   depends_on "freetype"
   depends_on "lua"
 
+  depends_on "lpeg" => :lua
+  depends_on "luaexpat" => :lua
+  depends_on "luafilesystem" => :lua
+
   resource("simple.sil") do
     url "https://raw.githubusercontent.com/simoncozens/sile/v0.9.2/examples/simple.sil"
     sha256 "f788723cd984d98343c8f8dc1b93b8f769cea6894a28f9ba6e0bec6aebf78f92"
   end
 
   def install
-    system "luarocks-5.2", "install", "lpeg"
-    system "luarocks-5.2", "install", "luaexpat"
-    system "luarocks-5.2", "install", "luafilesystem"
     system "./bootstrap.sh" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
The SILE typesetter actually has a dependency on the `luafilesystem` library that needs to be installed as a Lua rock. This is per [upstream issue 119](https://github.com/simoncozens/sile/pull/119), and the documentation has been updated upstream to reflect this. The library is only used for certain operations so it wasn't immediately apparent that it was failing.

Now that the upstream makefile demands it this formula will error on installing from HEAD, but ever though the current 0.9.2 release didn't call for it explicitly it needs this too.