### PR TITLE
ola 0.9.6

### DIFF
--- a/Library/Formula/ola.rb
+++ b/Library/Formula/ola.rb
@@ -3,8 +3,8 @@ require "formula"
 class Ola < Formula
   desc "Open Lighting Architecture for lighting control information"
   homepage "http://www.openlighting.org/ola/"
-  url "https://github.com/OpenLightingProject/ola/releases/download/0.9.5/ola-0.9.5.tar.gz"
-  sha256 "7c24ac98e865b4c354a04563b88012e782205ffd932a05cf944273f6f5ea82ca"
+  url "https://github.com/OpenLightingProject/ola/releases/download/0.9.6/ola-0.9.6.tar.gz"
+  sha256 "e1bbc7ed833d64107f13d64274ff92b0a0dfc6c1e2f6def18c6ad4b6fa2be744"
 
   bottle do
     sha256 "d2a19c0604c17fe15625ffff673a059f61fb3357888df98cac4086dff864ba72" => :yosemite


### PR DESCRIPTION
Version 0.9.6 of the Open Lighting Architecture has been released.