### PR TITLE
Do not fail when xcode-select is missing

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -37,7 +37,8 @@ module OS
     end
 
     def active_developer_dir
-      @active_developer_dir ||= Utils.popen_read("/usr/bin/xcode-select", "-print-path").strip
+      @active_developer_dir ||= which("xcode-select") ?
+        Utils.popen_read("/usr/bin/xcode-select", "-print-path").strip : ""
     end
 
     def sdk_path(v = version)


### PR DESCRIPTION
When xcode-select is missing, Homebrew fails even though a compiler is installed.