### PR TITLE
add env var to config bottle source

### DIFF
--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -27,7 +27,8 @@ module Homebrew
       HOMEBREW_SVN HOMEBREW_GIT
       HOMEBREW_SDKROOT HOMEBREW_BUILD_FROM_SOURCE
       MAKE GIT CPP
-      ACLOCAL_PATH PATH CPATH].select { |key| env.key?(key) }
+      ACLOCAL_PATH PATH CPATH
+      HOMEBREW_BOTTLE_DOMAIN HOMEBREW_BOTTLE_ROOT_URL].select { |key| env.key?(key) }
   end
 
   def dump_build_env env, f=$stdout

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -258,8 +258,8 @@ end
 class BottleSpecification
   DEFAULT_PREFIX = "/usr/local".freeze
   DEFAULT_CELLAR = "/usr/local/Cellar".freeze
-  DEFAULT_DOMAIN = "https://homebrew.bintray.com".freeze
-  DEFAULT_ROOT_URL = "#{DEFAULT_DOMAIN}/bottles".freeze
+  DEFAULT_DOMAIN = (ENV["HOMEBREW_BOTTLE_DOMAIN"] || "https://homebrew.bintray.com").freeze
+  DEFAULT_ROOT_URL = (ENV["HOMEBREW_BOTTLE_ROOT_URL"] || "#{DEFAULT_DOMAIN}/bottles").freeze
 
   attr_rw :root_url, :prefix, :cellar, :revision
   attr_reader :checksum, :collector


### PR DESCRIPTION
The previous patch #41327 has an empty file `source.rb`, so I make a new one.


