### PR TITLE
Update yubico-piv-tool to version 1.0.0

### DIFF
--- a/Library/Formula/yubico-piv-tool.rb
+++ b/Library/Formula/yubico-piv-tool.rb
@@ -1,8 +1,8 @@
 class YubicoPivTool < Formula
   desc "Command-line tool for the YubiKey NEO PIV applet"
   homepage "https://developers.yubico.com/yubico-piv-tool/"
-  url "https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-0.1.6.tar.gz"
-  sha256 "eff765169153fdf75ba4ff48eb2e4748f62623760bb5c15e4cce89b7263f59bb"
+  url "https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-1.0.0.tar.gz"
+  sha256 "303f576eb17af65234f8a3feddcab6add13c6c2dc82de875e165b6bfc2b9bab7"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Version 1.0.0 (released 2015-06-23)

* Add a test-decipher action.
* Check that e is 0x10001 on importing rsa keys
* Use PCSC transactions when sending and receiving data