### PR TITLE
Lua tweaks

### DIFF
--- a/Library/Formula/libquvi.rb
+++ b/Library/Formula/libquvi.rb
@@ -1,10 +1,8 @@
-require 'formula'
-
 class Libquvi < Formula
   desc "C library to parse flash media stream properties"
-  homepage 'http://quvi.sourceforge.net/'
-  url 'https://downloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2'
-  sha1 'b7ac371185c35a1a9a2135ef4ee61c86c48f78f4'
+  homepage "http://quvi.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2"
+  sha256 "f5a2fb0571634483e8a957910f44e739f5a72eb9a1900bd10b453c49b8d5f49d"
   revision 1
 
   bottle do
@@ -14,27 +12,23 @@ class Libquvi < Formula
     sha1 "6a963aa4d1ce0eb5768a529f07227621b320bab0" => :mountain_lion
   end
 
-  depends_on 'pkg-config' => :build
-  depends_on 'lua'
+  depends_on "pkg-config" => :build
+  depends_on "lua"
 
-  resource 'scripts' do
-    url 'https://downloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz'
-    sha1 'fe721c8d882c5c4a826f1339c79179c56bb0fe41'
+  resource "scripts" do
+    url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz"
+    sha256 "b8d17d53895685031cd271cf23e33b545ad38cad1c3bddcf7784571382674c65"
   end
 
   def install
-    scripts = prefix/'libquvi-scripts'
-    resource('scripts').stage do
+    scripts = prefix/"libquvi-scripts"
+    resource("scripts").stage do
       system "./configure", "--prefix=#{scripts}", "--with-nsfw"
-      system "make install"
+      system "make", "install"
     end
-    ENV.append_path 'PKG_CONFIG_PATH', "#{scripts}/lib/pkgconfig"
-
-    # Lua 5.2 does not have a proper lua.pc
-    ENV['liblua_CFLAGS'] = ' '
-    ENV['liblua_LIBS'] = '-llua'
+    ENV.append_path "PKG_CONFIG_PATH", "#{scripts}/lib/pkgconfig"
 
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 end

--- a/Library/Formula/lua.rb
+++ b/Library/Formula/lua.rb
@@ -1,10 +1,8 @@
 class Lua < Formula
   desc "Powerful, lightweight programming language"
   homepage "http://www.lua.org/"
-  url "http://www.lua.org/ftp/lua-5.2.3.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/l/lua5.2/lua5.2_5.2.3.orig.tar.gz"
-  sha256 "13c2fb97961381f7d06d5b5cea55b743c163800896fd5c5e2356201d3619002d"
-  revision 2
+  url "http://www.lua.org/ftp/lua-5.2.4.tar.gz"
+  sha256 "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
 
   bottle do
     revision 1
@@ -84,7 +82,7 @@ class Lua < Formula
 
         system "./configure", "--prefix=#{libexec}", "--rocks-tree=#{HOMEBREW_PREFIX}",
                               "--sysconfdir=#{etc}/luarocks52", "--with-lua=#{prefix}",
-                              "--lua-version=5.2", "--versioned-rocks-dir", "--force-config=#{etc}/luarocks52"
+                              "--lua-version=5.2", "--versioned-rocks-dir"
         system "make", "build"
         system "make", "install"
 
@@ -107,7 +105,7 @@ class Lua < Formula
 
   def pc_file; <<-EOS.undent
     V= 5.2
-    R= 5.2.3
+    R= 5.2.4
     prefix=#{HOMEBREW_PREFIX}
     INSTALL_BIN= ${prefix}/bin
     INSTALL_INC= ${prefix}/include
@@ -121,7 +119,7 @@ class Lua < Formula
 
     Name: Lua
     Description: An Extensible Extension Language
-    Version: 5.2.3
+    Version: 5.2.4
     Requires:
     Libs: -L${libdir} -llua -lm
     Cflags: -I${includedir}
@@ -135,9 +133,6 @@ class Lua < Formula
     This is, for now, unavoidable. If this is troublesome for you, you can build
     rocks with the `--tree=` command to a special, non-conflicting location and
     then add that to your `$PATH`.
-
-    If you have existing Rocks trees in $HOME, you will need to migrate them to the new
-    location manually. You will only have to do this once.
     EOS
   end
 

--- a/Library/Formula/lua51.rb
+++ b/Library/Formula/lua51.rb
@@ -6,7 +6,7 @@ class Lua51 < Formula
   url "http://www.lua.org/ftp/lua-5.1.5.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
   sha256 "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
-  revision 1
+  revision 2
 
   bottle do
     revision 2
@@ -78,7 +78,7 @@ class Lua51 < Formula
     system "make", "macosx", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}", "INSTALL_INC=#{include}/lua-5.1"
     system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}", "INSTALL_INC=#{include}/lua-5.1"
 
-    (lib+"pkgconfig").install "etc/lua.pc"
+    (lib/"pkgconfig").install "etc/lua.pc"
 
     # Renaming from Lua to Lua51.
     # Note that the naming must be both lua-version & lua.version.
@@ -101,11 +101,11 @@ class Lua51 < Formula
 
         system "./configure", "--prefix=#{libexec}", "--rocks-tree=#{HOMEBREW_PREFIX}",
                               "--sysconfdir=#{etc}/luarocks51", "--with-lua=#{prefix}",
-                              "--lua-version=5.1", "--versioned-rocks-dir", "--force-config=#{etc}/luarocks51"
+                              "--lua-version=5.1", "--versioned-rocks-dir"
         system "make", "build"
         system "make", "install"
 
-        (share+"lua/5.1/luarocks").install_symlink Dir["#{libexec}/share/lua/5.1/luarocks/*"]
+        (share/"lua/5.1/luarocks").install_symlink Dir["#{libexec}/share/lua/5.1/luarocks/*"]
         bin.install_symlink libexec/"bin/luarocks-5.1"
         bin.install_symlink libexec/"bin/luarocks-admin-5.1"
 
@@ -127,9 +127,6 @@ class Lua51 < Formula
     This is, for now, unavoidable. If this is troublesome for you, you can build
     rocks with the `--tree=` command to a special, non-conflicting location and
     then add that to your `$PATH`.
-
-    If you have existing Rocks trees in $HOME, you will need to migrate them to the new
-    location manually. You will only have to do this once.
     EOS
   end
 


### PR DESCRIPTION
* Version bump to Lua, and permit users to use their own configuration files again.
* Permit user configuration files for Lua51
* Remove unnecessary pointers in libquvi.

On the configuration files issue, we/I deliberately disabled them for a while because there was a potential for it to not sit well with the integrate Luarocks into Lua changes. On the back of a lack of mayhem on that front, and a request we reconsider the config forcing, I did some local testing and am happy enough reverting that individual change won't cause breakage.

Long term I want to try and do something with the way we handle Lua resources, similar to how we already handle Python resources, but baby-steps.