### PR TITLE
Update Harfbuzz dependencies (optional graphite2)

### DIFF
--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -12,7 +12,7 @@ class Harfbuzz < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "cairo" => :optional
+  depends_on "cairo"
   depends_on "icu4c" => :recommended
   depends_on "graphite2" => :optional
   depends_on "freetype"

--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -12,8 +12,9 @@ class Harfbuzz < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "cairo"
+  depends_on "cairo" => :optional
   depends_on "icu4c" => :recommended
+  depends_on "graphite2" => :optional
   depends_on "freetype"
   depends_on "gobject-introspection"
 
@@ -31,6 +32,7 @@ class Harfbuzz < Formula
     ]
 
     args << "--with-icu" if build.with? "icu4c"
+    args << "--with-graphite2" if build.with? "graphite2"
     system "./configure", *args
     system "make", "install"
   end


### PR DESCRIPTION
Now that graphite2 is available in Homebrew, allow Harfbuzz to use it for shaping if the user wants it.