### PR TITLE
packer 0.8.1

### DIFF
--- a/Library/Formula/packer.rb
+++ b/Library/Formula/packer.rb
@@ -20,17 +20,17 @@ class Packer < Formula
 
   go_resource "github.com/mitchellh/gox" do
     url "https://github.com/mitchellh/gox.git",
-      :tag => "v0.3.0", :revision => "54b619477e8932bbb6314644c867e7e6db7a9c71"
+      :revision => "a5a468f84d74eb51ece602cb113edeb37167912f"
   end
 
   go_resource "github.com/mitchellh/iochan" do
     url "https://github.com/mitchellh/iochan.git",
-      :revision => "b584a329b193e206025682ae6c10cdbe03b0cd77"
+      :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
   end
 
   go_resource "github.com/hashicorp/atlas-go" do
     url "https://github.com/hashicorp/atlas-go.git",
-      :revision => "6a87d5f443991e9916104392cd5fc77678843e1d"
+      :revision => "1b403631cd2d44764a68a9549874213cf95b285e"
   end
 
   go_resource "github.com/hashicorp/go-checkpoint" do
@@ -40,7 +40,7 @@ class Packer < Formula
 
   go_resource "github.com/hashicorp/go-msgpack" do
     url "https://github.com/hashicorp/go-msgpack.git",
-      :revision => "71c2886f5a673a35f909803f38ece5810165097b"
+      :revision => "fa3f63826f7c23912c15263591e65d54d080b458"
   end
 
   go_resource "github.com/hashicorp/go-version" do
@@ -55,12 +55,12 @@ class Packer < Formula
 
   go_resource "github.com/mitchellh/cli" do
     url "https://github.com/mitchellh/cli.git",
-      :revision => "6cc8bc522243675a2882b81662b0b0d2e04b99c9"
+      :revision => "8102d0ed5ea2709ade1243798785888175f6e415"
   end
 
   go_resource "github.com/mitchellh/mapstructure" do
     url "https://github.com/mitchellh/mapstructure.git",
-      :revision => "442e588f213303bec7936deba67901f8fc8f18b1"
+      :revision => "2caf8efc93669b6c43e0441cdc6aed17546c96f3"
   end
 
   go_resource "github.com/mitchellh/osext" do
@@ -85,7 +85,7 @@ class Packer < Formula
 
   go_resource "github.com/mitchellh/go-fs" do
     url "https://github.com/mitchellh/go-fs.git",
-      :revision => "faaa223588dd7005e49bf66fa2d19e35c8c4d761"
+      :revision => "a34c1b9334e86165685a9449b782f20465eb8c69"
   end
 
   go_resource "github.com/mitchellh/goamz" do
@@ -105,44 +105,42 @@ class Packer < Formula
 
   go_resource "github.com/ActiveState/tail" do
     url "https://github.com/ActiveState/tail.git",
-      :revision => "068b72961a6bc5b4a82cf4fc14ccc724c0cfa73a"
+      :revision => "4b368d1590196ade29993d6a0896591403180bbd"
   end
 
-  go_resource "code.google.com/p/google-api-go-client" do
-    url "https://code.google.com/p/google-api-go-client/",
-      :using => :hg, :revision => "6ddfebb10ece847f1ae09c701834f1b15abbd8b2"
+  go_resource "google.golang.org/api" do
+    url "https://github.com/google/google-api-go-client.git",
+      :revision => "a09229c13c2f13bbdedf7b31b506cad4c83ef3bf"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "74f810a0152f4c50a16195f6b9ff44afc35594e8"
+      :revision => "2f677ffe0a128ed6d4e3ecb565e4d29a6c6365da"
   end
 
-  # Note that this is *not* the latest commit; the API was changed after this
-  # commit and Packer 0.7.5 can't build against the newer version.
   go_resource "golang.org/x/oauth2" do
-    url "https://go.googlesource.com/oauth2.git", :revision => "b3f9a68f05ff3f8b323cd6917f1f237cdbc6edaa"
+    url "https://go.googlesource.com/oauth2.git",
+    :revision => "8914e5017ca260f2a3a1575b1e6868874050d95e"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "e0403b4e005737430c05a57aac078479844f919c"
+      :revision => "d9558e5c97f85372afee28cf2b6059d7d3818919"
   end
 
-  # This specific commit is needed by the version of oauth2 in use
   go_resource "google.golang.org/appengine" do
     url "https://github.com/golang/appengine.git",
-      :revision => "c98f627282072b1230c8795abe98e2914c8a1de9"
+      :revision => "e335b53aaf7a699963a1cfea40b65ee3bf09f711"
   end
 
   go_resource "google.golang.org/cloud" do
     url "https://github.com/GoogleCloudPlatform/gcloud-golang.git",
-      :revision => "de1c38e5af44da22abe7c3b14a1edcf6264dae55"
+      :revision => "feda659df33f28fe2d0524fad496b4d01a2015af"
   end
 
   go_resource "github.com/golang/protobuf" do
     url "https://github.com/golang/protobuf.git",
-      :revision => "abd3b412d3c2460d848b6b81478fcb4e542d6327"
+      :revision => "a1463b958edbdb9d1fa8daa3a0a469bf678a1b89"
   end
 
   go_resource "github.com/mitchellh/gophercloud-fork-40444fb" do
@@ -162,7 +160,7 @@ class Packer < Formula
 
   go_resource "github.com/mitchellh/go-vnc" do
     url "https://github.com/mitchellh/go-vnc.git",
-      :revision => "03f3462e6e86a197451e1a13dc8eee68c970db57"
+      :revision => "723ed9867aed0f3209a81151e52ddc61681f0b01"
   end
 
   go_resource "github.com/howeyc/fsnotify" do

--- a/Library/Formula/packer.rb
+++ b/Library/Formula/packer.rb
@@ -6,38 +6,13 @@ class Packer < Formula
 
   # buildscript requires the .git directory be present
   url "https://github.com/mitchellh/packer.git",
-    :tag => "v0.7.5", :revision => "9cd66feeacbd9cb318b72eb5ed59428c5b8c37ac"
+    :tag => "v0.8.1", :revision => "872e78d5b0a387eb3b87ddeef210264c3199d178"
 
   bottle do
     cellar :any
     sha256 "4c62e5691329f9c274001400df487c090f5a0debbf3067cf977ac96e356f883e" => :yosemite
     sha256 "6c6894eb419f8677c13c34027e8897716f40a5f14bf0561869d99c8c6b4d8740" => :mavericks
     sha256 "1e6676f09ec0c145223f025254d7cf636cf13a240fc274d3711319970cafebf0" => :mountain_lion
-  end
-
-  # All of these patches come from the upstream repo and will be in the next release.
-  #
-  # Fixes reference to "BuildID" field in an atlas struct
-  patch do
-    url "https://github.com/mitchellh/packer/commit/ddb966061f88709537c93f16f7c4066ddf2b8adf.patch"
-    sha256 "f3fd4a516da76b7fd9623bc02ac020766c0f13f3f85931d74b75e0d50b99fdb8"
-  end
-
-  # "multiple-value c.client.CreateBuildConfig() in single-value context"
-  patch do
-    url "https://github.com/mitchellh/packer/commit/17d4c4396c182ba77518d9d06f639b0ee49f295c.patch"
-    sha256 "3850821cb6e6a82de3581e3e65b55c662d4a2f3443823805abca7176a8aa8ccd"
-  end
-
-  # next two patches: "not enough arguments in call to c.client.UploadBuildConfigVersion"
-  patch do
-    url "https://github.com/mitchellh/packer/commit/8e0c7ace3aac455b0e51d20009c014406060aa21.patch"
-    sha256 "d5755e6e6f8028ae928bbf0d0779c6ac6119cd3ae18ba41632490a0066968c59"
-  end
-
-  patch do
-    url "https://gist.githubusercontent.com/mistydemeo/23f749fa73296deacd5a/raw/7e0441edfb22841f6c2ba6dbf9bc7c9ecdce01d3/packer-push-message.patch"
-    sha256 "add040cd165240dd3b6a925886f01cd8c24611c121529a654cac246d7e0686d5"
   end
 
   depends_on :hg => :build


### PR DESCRIPTION
Since the creation of #41190, #41251 and #41237 regarding 0.8.0, packer 0.8.1 has been released.

This pull requests is based on #41237, updated to 0.8.1. Builds on my machine (Yosemite), go + mercurial from bottle. Test passed.