### PR TITLE
czmq: rename executable

### DIFF
--- a/Library/Formula/czmq.rb
+++ b/Library/Formula/czmq.rb
@@ -3,6 +3,7 @@ class Czmq < Formula
   homepage "http://czmq.zeromq.org/"
   url "http://download.zeromq.org/czmq-3.0.2.tar.gz"
   sha256 "8bca39ab69375fa4e981daf87b3feae85384d5b40cef6adbe9d5eb063357699a"
+  revision 1
 
   bottle do
     cellar :any
@@ -42,5 +43,8 @@ class Czmq < Formula
     system "make", "check"
     system "make", "install"
     rm Dir["#{bin}/*.gsl"]
+
+    # makecert clashes with Mono. Rename it less generically.
+    mv bin/"makecert", bin/"czmq-makecert"
   end
 end


### PR DESCRIPTION
The curse of generic naming strikes again.

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/makecert
Target /usr/local/bin/makecert
is a symlink belonging to czmq. You can unlink it:
  brew unlink czmq

To force the link and overwrite all conflicting files:
  brew link --overwrite mono

To list all files that would be deleted:
  brew link --overwrite --dry-run mono

Possible conflicting files are:
/usr/local/bin/makecert -> /usr/local/Cellar/czmq/3.0.2/bin/makecert
```

Since czmq tends to be used as a library more than for cert generation, let's rename this one.

CC @Homebrew/owners