### PR TITLE
keybase 0.8.6

### DIFF
--- a/Library/Formula/keybase.rb
+++ b/Library/Formula/keybase.rb
@@ -1,8 +1,8 @@
 class Keybase < Formula
   desc "Command-line interface to Keybase.io"
   homepage "https://keybase.io/"
-  url "https://github.com/keybase/node-client/archive/v0.7.9.tar.gz"
-  sha256 "69798709139a8ff5a45886b8973abba17e55d76caa83ac86d6dfc262e858ec88"
+  url "https://github.com/keybase/node-client/archive/v0.8.6.tar.gz"
+  sha256 "b469b481def07e7466177d30d93bc4e98ad164bbd855bd722dbb7fff07569eda"
   head "https://github.com/keybase/node-client.git"
 
   depends_on "node"
@@ -24,6 +24,8 @@ class Keybase < Formula
   end
 
   test do
-    system "#{bin}/keybase", "id", "maria"
+    # Keybase requires a valid GPG keychain to be set up. Fetch Homebrew's pubkey.
+    system "gpg", "--keyserver", "pgp.mit.edu", "--recv-keys", "0xE33A3D3CCE59E297"
+    system "#{bin}/keybase", "id", "homebrew"
   end
 end


### PR DESCRIPTION
Test fails due to stricter error handling. Prior to 0.8.x:

```
🐙  brew test -v keybase
Testing keybase
==> /usr/local/Cellar/keybase/0.7.9/bin/keybase id maria
warn: No config file found; tried '/private/tmp/keybase20150704-58522-x3y291/.config/keybase/config.json'
warn: When checking maria: GpgError: exit code 2
warn: Likely this is a bug or transient error; but the server could be compromised
info: Creating temporary keyring dir: /private/tmp/keybase20150704-58522-x3y291/.cache/keybase/tmp_keyrings
✔ public key fingerprint: 97BC 8ED6 9489 989F CE16 3213 2CE8 7F7C 35CB 1002
```

Now:
```
🐙  brew test -v keybase
Testing keybase
==> /usr/local/Cellar/keybase/0.8.6/bin/keybase id maria
warn: No config file found; tried '/private/tmp/keybase20150704-58758-12okf3/.config/keybase/config.json'
error: `gpg` exited with code 2
warn: gpg: keyblock resource `/private/tmp/keybase20150704-58758-12okf3/.gnupg/pubring.gpg': No such file or directory
warn: gpg: Fatal: /private/tmp/keybase20150704-58758-12okf3/.gnupg: directory does not exist!
Error: keybase: failed
```

Not sure how to make a new, useful, test.