### PR TITLE
yaggo 1.5.5 (new formula)

### DIFF
--- a/Library/Formula/yaggo.rb
+++ b/Library/Formula/yaggo.rb
@@ -1,0 +1,17 @@
+class Yaggo < Formula
+  desc "Generate command-line parsers for C++"
+  homepage "https://github.com/gmarcais/yaggo"
+  url "https://github.com/gmarcais/yaggo/archive/v1.5.5.tar.gz"
+  sha256 "8aae8024c3d832bf6a93513276a85413a129513d00c4f10c317124414d6a3f50"
+  head "https://github.com/gmarcais/yaggo.git"
+
+  def install
+    bin.mkpath
+    system "make", "DEST=#{bin}"
+    doc.install "README.md"
+  end
+
+  test do
+    system "#{bin}/yaggo", "--version"
+  end
+end


### PR DESCRIPTION
It's been suggested we move this formula from homebrew-science to core (Homebrew/homebrew-science#2490). If this gets the :+1: I'll update that PR to remove it from the science repo.