### PR TITLE
jed: configure using --with-slang to set proper path to S-Lang

### DIFF
--- a/Library/Formula/jed.rb
+++ b/Library/Formula/jed.rb
@@ -26,9 +26,8 @@ class Jed < Formula
         system "make"
       end
     end
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-slang=#{Formula["s-lang"].opt_prefix}"
     system "make"
     system "make", "xjed" if build.with? "x11"
     ENV.deparallelize


### PR DESCRIPTION
I was unable to build jed in a non-/usr/local installation of Homebrew without giving the configure script the `--with-slang` option to set the path to S-Lang.
