### PR TITLE
reposurgeon: add --with-cython option

### DIFF
--- a/Library/Formula/reposurgeon.rb
+++ b/Library/Formula/reposurgeon.rb
@@ -3,6 +3,7 @@ class Reposurgeon < Formula
   homepage "http://www.catb.org/esr/reposurgeon/"
   url "http://www.catb.org/~esr/reposurgeon/reposurgeon-3.27.tar.gz"
   sha256 "e2c0563384fa29917bb5014214280e586dbe389edd0c7006a3cdecb63c7b2e85"
+  revision 1
 
   head "https://gitlab.com/esr/reposurgeon.git"
 
@@ -13,9 +14,16 @@ class Reposurgeon < Formula
     sha256 "6457aa5a0cb2dd9e89173992ea209a61bdc110b448291fbde376fc4ae64614fc" => :mountain_lion
   end
 
+  option "without-cython", "Don't build a significantly faster tool using cython"
+
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "asciidoc" => :build
   depends_on "xmlto" => :build
+
+  resource "cython" do
+    url "http://cython.org/release/Cython-0.22.1.tar.gz"
+    sha256 "7fff120e65e7b66edb4a42823f5642bad3bc1e5601bf882d66aee50248cf0682"
+  end
 
   def install
     # OSX doesn't provide 'python2', but on some Linux distributions
@@ -28,6 +36,17 @@ class Reposurgeon < Formula
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     system "make", "install", "prefix=#{prefix}"
     (share/"emacs/site-lisp").install "reposurgeon-mode.el"
+
+    if build.with? "cython"
+      resource("cython").stage do
+        system "python", *Language::Python.setup_install_args(buildpath/"vendor")
+      end
+      ENV.prepend_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+      system "make", "install-cyreposurgeon", "prefix=#{prefix}",
+             "CYTHON=#{buildpath}/vendor/bin/cython",
+             "pyinclude=" + `python-config --cflags`.chomp,
+             "pylib=" + `python-config --ldflags`.chomp
+    end
   end
 
   def caveats; <<-EOS.undent
@@ -47,6 +66,10 @@ class Reposurgeon < Formula
     system "git", "add", "homebrew"
     system "git", "commit", "--message", "brewing"
 
-    assert_match "brewing", shell_output("script -q /dev/null #{bin}/reposurgeon read list")
+    assertion = lambda do |prog|
+      assert_match "brewing", shell_output("script -q /dev/null #{bin}/#{prog} read list")
+    end
+    assertion["reposurgeon"]
+    assertion["cyreposurgeon"] if build.with? "cython"
   end
 end

--- a/Library/Formula/reposurgeon.rb
+++ b/Library/Formula/reposurgeon.rb
@@ -13,6 +13,7 @@ class Reposurgeon < Formula
     sha256 "6457aa5a0cb2dd9e89173992ea209a61bdc110b448291fbde376fc4ae64614fc" => :mountain_lion
   end
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "asciidoc" => :build
   depends_on "xmlto" => :build
 


### PR DESCRIPTION
This option builds and installs a `cyreposurgeon` executable.

There are two commits in this pull request, but feel free to squash into one. The python requirement for Snow Leopard is not related to the added `--with-cython` option.

On my machine it took about 50 minutes for clang to compile the 18 MB `.c` file that cython generates, so I added an `ohai` notice stating that it may take a while.
