### PR TITLE
cfr-decompiler 0.101 (new formula)

### DIFF
--- a/Library/Formula/cfr-decompiler.rb
+++ b/Library/Formula/cfr-decompiler.rb
@@ -1,0 +1,33 @@
+class CfrDecompiler < Formula
+  desc "Yet Another Java Decompiler."
+  homepage "http://www.benf.org/other/cfr/"
+  url "http://www.benf.org/other/cfr/cfr_0_101.jar"
+  sha256 "90e166325ca4443a65663a75876c639cace9a29558713878c6a2b6eb211f947f"
+
+  depends_on :java => "1.6+"
+
+  def install
+    jar_version = version.to_s.gsub(".", "_")
+    libexec.install "cfr_#{jar_version}.jar"
+    bin.write_jar_script libexec/"cfr_#{jar_version}.jar", "cfr-decompiler"
+  end
+
+  test do
+    fixture = <<-EOS.undent
+    import java.io.PrintStream;
+
+    class T {
+        T() {
+        }
+
+        public static void main(String[] arrstring) {
+            System.out.println("Hello brew!");
+        }
+    }
+    EOS
+    (testpath/"T.java").write fixture
+    system "javac", "T.java"
+    output = pipe_output("#{bin}/cfr-decompiler T.class")
+    assert output.include?(fixture), "Different output than expected"
+  end
+end


### PR DESCRIPTION
Adds a new formula for CFR java decompiler, based on the existent one for the Procyon java decompiler.