### PR TITLE
Add sha256 hash for cmake on el_capitan 

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -2,7 +2,7 @@ class Cmake < Formula
   desc "Cross-platform make"
   homepage "http://www.cmake.org/"
   url "http://www.cmake.org/files/v3.2/cmake-3.2.3.tar.gz"
-  sha256 "e7be87a6cfc403785ab9d5846a70be2c27b17fda6a9b7442e9fc7af45c077d63"
+  sha256 MacOS.version == :el_capitan ? "e7be87a6cfc403785ab9d5846a70be2c27b17fda6a9b7442e9fc7af45c077d63" : "a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297"
   head "http://cmake.org/cmake.git"
 
   bottle do

--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -2,7 +2,7 @@ class Cmake < Formula
   desc "Cross-platform make"
   homepage "http://www.cmake.org/"
   url "http://www.cmake.org/files/v3.2/cmake-3.2.3.tar.gz"
-  sha256 "a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297"
+  sha256 "e7be87a6cfc403785ab9d5846a70be2c27b17fda6a9b7442e9fc7af45c077d63"
   head "http://cmake.org/cmake.git"
 
   bottle do


### PR DESCRIPTION
On OS X El capitan I get the bug with sha256 when I try install cmake:
```
$ brew install cmake
Warning: You are using OS X 10.11.
We do not provide support for this pre-release version.
You may encounter build failures or other breakage.
==> Downloading http://www.cmake.org/files/v3.2/cmake-3.2.3.tar.gz
Already downloaded: /Library/Caches/Homebrew/cmake-3.2.3.tar.gz
Error: SHA256 mismatch
Expected: a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297
Actual: e7be87a6cfc403785ab9d5846a70be2c27b17fda6a9b7442e9fc7af45c077d63
Archive: /Library/Caches/Homebrew/cmake-3.2.3.tar.gz
To retry an incomplete download, remove the file above.
```

This commit fix my bug on El capitan but I don't test it on other os x versions.