### PR TITLE
syncthing: Fixed not being able to stop process through web UI

### DIFF
--- a/Library/Formula/syncthing.rb
+++ b/Library/Formula/syncthing.rb
@@ -35,8 +35,6 @@ class Syncthing < Formula
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
       <dict>
-        <key>KeepAlive</key>
-        <true/>
         <key>Label</key>
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
@@ -45,8 +43,13 @@ class Syncthing < Formula
           <string>-no-browser</string>
           <string>-no-restart</string>
         </array>
-        <key>RunAtLoad</key>
-        <true/>
+        <key>KeepAlive</key>
+        <dict>
+          <key>Crashed</key>
+          <true/>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
         <key>ProcessType</key>
         <string>Background</string>
         <key>StandardErrorPath</key>


### PR DESCRIPTION
First I removed RunAtLoad from the plist because RunAtLoad isn't needed if KeepAlive is set. Both run the process at load, but KeepAlive keeps the process alive no matter what.

Because KeepAlive was set to true if you went to the Web UI and tried to stop syncthing launchd would simply restart the process. However, if you set SuccessfulExit to false it will allow you to manually stop the process as intended through the Web UI. Also set Crashed to true so that if it does crash launchd will still restart it.