### PR TITLE
olsrd 0.9.0.2

### DIFF
--- a/Library/Formula/olsrd.rb
+++ b/Library/Formula/olsrd.rb
@@ -1,23 +1,23 @@
-require 'formula'
-
 class Olsrd < Formula
   desc "Implementation of the optimized link state routing protocol"
-  homepage 'http://www.olsr.org'
-  url 'http://www.olsr.org/releases/0.6/olsrd-0.6.6.1.tar.bz2'
-  sha1 '0d74708dd94ad978af061a44758f8ea31845261f'
-
-  #Release is broken and assumes git repository
-  patch :DATA
+  homepage "http://www.olsr.org"
+  url "http://www.olsr.org/releases/0.9/olsrd-0.9.0.2.tar.bz2"
+  sha256 "cc464b29c7740354d815d5faa753fd27c0677d71e8eb42e78abc382996892845"
 
   def install
+    inreplace "make/Makefile.osx",
+              "PLUGIN_FULLNAME ?= $(PLUGIN_NAME).so.$(PLUGIN_VER)",
+              "PLUGIN_FULLNAME ?= $(PLUGIN_NAME).$(PLUGIN_VER).dylib"
+
     lib.mkpath
     args = %W[
       DESTDIR=#{prefix}
       USRDIR=#{prefix}
       LIBDIR=#{lib}
+      ETCDIR=#{etc}
     ]
-    system 'make', 'build_all', *args
-    system 'make', 'install_all', *args
+    system "make", "build_all", *args
+    system "make", "install_all", *args
   end
 
   plist_options :startup => true, :manual => "olsrd -f #{HOMEBREW_PREFIX}/etc/olsrd.conf"
@@ -44,19 +44,8 @@ class Olsrd < Formula
     </plist>
     EOS
   end
-end
 
-__END__
-diff --git a/Makefile b/Makefile
-index 2df56aa..a24fa98 100644
---- a/Makefile
-+++ b/Makefile
-@@ -88,7 +88,7 @@ switch:
- src/builddata.c:
- 	$(MAKECMDPREFIX)$(RM) "$@"
- 	$(MAKECMDPREFIX)echo "#include \"defs.h\"" >> "$@" 
--	$(MAKECMDPREFIX)echo "const char olsrd_version[] = \"olsr.org -  $(VERS)`./make/hash_source.sh`\";"  >> "$@"
-+	$(MAKECMDPREFIX)echo "const char olsrd_version[] = \"olsr.org -  $(VERS)\";" >> "$@"
- 	$(MAKECMDPREFIX)date +"const char build_date[] = \"%Y-%m-%d %H:%M:%S\";" >> "$@" 
- 	$(MAKECMDPREFIX)echo "const char build_host[] = \"$(shell hostname)\";" >> "$@" 
- 
+  test do
+    assert_match version.to_s, shell_output("#{sbin}/olsrd", 1)
+  end
+end


### PR DESCRIPTION
Should these be `s/so/dylib/`?
```
 * Non-libraries were installed to "/usr/local/Cellar/olsrd/0.9.0.2/lib"
Installing non-libraries to "lib" is discouraged.
The offending files are:
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_dot_draw.so.0.3
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_httpinfo.so.0.1
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_jsoninfo.so.0.0
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_mini.so.0.1
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_nameservice.so.0.3
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_pgraph.so.1.1
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_secure.so.0.6
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_txtinfo.so.0.1
  /usr/local/Cellar/olsrd/0.9.0.2/lib/olsrd_watchdog.so.0.1
```