### PR TITLE
Default to not using bottles for edited formula.

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -32,7 +32,7 @@ module Homebrew
   def fetch_bottle? f
     return true if ARGV.force_bottle? && f.bottle
     return false unless f.bottle && f.pour_bottle?
-    return false if ARGV.build_from_source? || ARGV.build_bottle?
+    return false if ARGV.build_from_source? || ARGV.build_bottle? || f.adulterated?
     return false unless f.bottle.compatible_cellar?
     return true
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -75,6 +75,15 @@ class FormulaInstaller
       return false
     end
 
+    if formula_adulterated?
+       opoo <<-EOS.undent
+        You've made changes to #{formula.name}'s formula, so we're building it from scratch.
+        To use the bottled version, run this command again with --force-bottle
+        (or set HOMEBREW_FORCE_BOTTLE)
+       EOS
+       return false
+     end
+
     true
   end
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -244,6 +244,10 @@ def which_editor
   editor
 end
 
+def git_available?
+  return false unless which("git")
+end
+
 def exec_editor *args
   safe_exec(which_editor, *args)
 end


### PR DESCRIPTION
Added `formula.adulterated`, which uses git in the formula's repo
directory to check for alterations (with `git status --porcelain`).

Altered `pour_bottle?` in formula_installer to check for adulterated
formula, after all commandline flags.  Adulterated formula will output a
warning and then build from source.  Forcing a bottle install with
`--force-bottle` will still work.

Also works for `fetch`.

Closes #36068, Compare with https://github.com/Homebrew/homebrew/pull/41397.