### PR TITLE
pbc-sig: fix install and add test

### DIFF
--- a/Library/Formula/pbc-sig.rb
+++ b/Library/Formula/pbc-sig.rb
@@ -1,16 +1,51 @@
-require 'formula'
-
 class PbcSig < Formula
   desc "Signatures library"
-  homepage 'http://crypto.stanford.edu/pbc/sig/'
-  url 'http://crypto.stanford.edu/pbc/sig/files/pbc_sig-0.0.8.tar.gz'
-  sha256 '7a343bf342e709ea41beb7090c78078a9e57b833454c695f7bcad2475de9c4bb'
+  homepage "http://crypto.stanford.edu/pbc/sig/"
+  url "http://crypto.stanford.edu/pbc/sig/files/pbc_sig-0.0.8.tar.gz"
+  sha256 "7a343bf342e709ea41beb7090c78078a9e57b833454c695f7bcad2475de9c4bb"
 
-  depends_on 'pbc'
+  depends_on "pbc"
+
+  # https://groups.google.com/forum/#!topic/pbc-devel/ZmFCHZmrhcw
+  patch :DATA
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <pbc/pbc.h>
+      #include <pbc/pbc_sig.h>
+
+      int main()
+      {
+        pbc_param_t param;
+        pairing_t pairing;
+        bls_sys_param_t bls_param;
+        pbc_param_init_a_gen(param, 160, 512);
+        pairing_init_pbc_param(pairing, param);
+        bls_gen_sys_param(bls_param, pairing);
+        bls_clear_sys_param(bls_param);
+        pairing_clear(pairing);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-o", "test", "-lpbc", "-lpbc_sig"
+    system "./test"
   end
 end
+
+__END__
+diff --git a/sig/bbs.c b/sig/bbs.c
+index ed1b437..8aa8331 100644
+--- a/sig/bbs.c
++++ b/sig/bbs.c
+@@ -1,4 +1,5 @@
+ //see Boneh, Boyen and Shacham, "Short Group Signatures"
++#include <stdint.h>
+ #include <pbc/pbc_utils.h>
+ #include "pbc_sig.h"
+ #include "pbc_hash.h"


### PR DESCRIPTION
The project is 5 years old. So it's unlikely for upstream to accept the patch.
Closes #41272.