### PR TITLE
mysql-connector-odbc: remove mysql dependency, update home page.

### DIFF
--- a/Library/Formula/mysql-connector-odbc.rb
+++ b/Library/Formula/mysql-connector-odbc.rb
@@ -1,6 +1,6 @@
 class MysqlConnectorOdbc < Formula
   desc "Standardized database driver"
-  homepage "https://dev.mysql.com/doc/refman/5.1/en/connector-odbc.html"
+  homepage "https://dev.mysql.com/doc/connector-odbc/en/index.html"
   url "https://cdn.mysql.com/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.4-src.tar.gz"
   sha256 "a5f7a490f2958f2768d18b8a57f71909f9699a8619c82776b3ad1c02b8abce0d"
 
@@ -11,7 +11,6 @@ class MysqlConnectorOdbc < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "mysql"
   depends_on "unixodbc"
   depends_on "openssl"
 
@@ -28,5 +27,15 @@ class MysqlConnectorOdbc < Formula
 
     system "cmake", ".", *args
     system "make", "install"
+  end
+
+  test do
+    system "#{bin}/myodbc-installer -d -l"
+  end
+
+  def caveats; <<-EOS.undent
+    This MySQL Connector/ODBC is built against unixODBC, not iODBC. System
+    applications using iODBC (like Microsoft Office) will not see it.
+    EOS
   end
 end


### PR DESCRIPTION
Fixes #39126

Removes the `mysql` dependency. The MySQL Connector/ODBC is just a client-side driver, built from a standalone distribution. It does not depend on a local installation of the MySQL server, which is what the `mysql` formula is.

Updates the homepage based on a redirect found at the previous home page URL.

Adds caveats about unixODBC/iODBC and a minimal test.

I've built from source on OS X 10.9.5 using this new definition. Builds fine, and the `myodbc-installer` runs to register and deregister drivers.