### PR TITLE
Add JSON support and devel/beta build to suricata

### DIFF
--- a/Library/Formula/suricata.rb
+++ b/Library/Formula/suricata.rb
@@ -4,6 +4,12 @@ class Suricata < Formula
   url "https://www.openinfosecfoundation.org/download/suricata-2.0.8.tar.gz"
   sha256 "7af6394cb81e464f5c1ac88a1444030e30940caab6e53688a6d9eb652226d1be"
 
+  devel do
+    url 'http://www.openinfosecfoundation.org/download/suricata-2.1beta4.tar.gz'
+    sha256 '12b3c98a7464ef6fb631884aa648b53a9cbb04279f754009fdc9ae2a6b605b95'
+    version '2.1beta4'
+  end
+
   bottle do
     sha256 "269066b7601a3cd2c47d7e0e3c789ff2c334d1eff7dfa47221b1fb66233a7014" => :yosemite
     sha256 "08ea538e48680b7712324dc8fe19a682aa0d485193823408f251f0441f62ec59" => :mavericks

--- a/Library/Formula/suricata.rb
+++ b/Library/Formula/suricata.rb
@@ -25,6 +25,7 @@ class Suricata < Formula
   depends_on "geoip" => :optional
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
+  depends_on "jansson" => :optional
 
   resource "argparse" do
     url "https://pypi.python.org/packages/source/a/argparse/argparse-1.3.0.tar.gz"
@@ -73,6 +74,12 @@ class Suricata < Formula
       args << "--with-libgeoip-libs=#{geoip.opt_lib}"
     end
 
+    if build.with? "jansson"
+      jansson = Formula['jansson']
+      args << "--with-libjansson-includes=#{jansson.opt_include}"
+      args << "--with-libjansson-libraries=#{jansson.opt_lib}"
+    end
+
     system "./configure", *args
     system "make", "install-full"
 
@@ -83,6 +90,6 @@ class Suricata < Formula
   end
 
   test do
-    assert_match /#{version}/, shell_output("#{bin}/suricata --build-info")
+    assert_match(/#{version}/, shell_output("#{bin}/suricata --build-info"))
   end
 end


### PR DESCRIPTION
JSON is needed for eve-log output and to stop:
```
29/6/2015 -- 16:30:38 - <Warning> - [ERRCODE: SC_ERR_NOT_SUPPORTED(225)] - Eve-log support not compiled in. Reconfigure/recompile with libjansson and its development files installed to add eve-log support.
```

Final build output (for me)

```
% suricata --build-info
This is Suricata version 2.1beta4 RELEASE
Features: PCAP_SET_BUFF LIBPCAP_VERSION_MAJOR=1 HAVE_PACKET_FANOUT LIBNET1.1 HAVE_HTP_URI_NORMALIZE_HOOK PCRE_JIT HAVE_LIBJANSSON TLS
SIMD support: SSE_4_2 SSE_4_1 SSE_3
Atomic intrisics: 1 2 4 8 16 byte(s)
64-bits, Little-endian architecture
GCC version 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53), C version 199901
compiled with -fstack-protector
compiled with _FORTIFY_SOURCE=2
L1 cache line size (CLS)=64
thread local storage method: __thread
compiled with LibHTP v0.5.17, linked against LibHTP v0.5.17

Suricata Configuration:
  AF_PACKET support:                       no
  PF_RING support:                         no
  NFQueue support:                         no
  NFLOG support:                           no
  IPFW support:                            no
  Netmap support:                          no
  DAG enabled:                             no
  Napatech enabled:                        no
  Unix socket enabled:                     yes
  Detection enabled:                       yes

  libnss support:                          no
  libnspr support:                         no
  libjansson support:                      yes
  Prelude support:                         no
  PCRE jit:                                yes
  LUA support:                             no
  libluajit:                               no
  libgeoip:                                no
  Non-bundled htp:                         no
  Old barnyard2 support:                   no
  CUDA enabled:                            no

  Suricatasc install:                      yes

  Unit tests enabled:                      no
  Debug output enabled:                    no
  Debug validation enabled:                no
  Profiling enabled:                       no
  Profiling locks enabled:                 no
  Coccinelle / spatch:                     no

Generic build parameters:
  Installation prefix (--prefix):          /usr/local/Cellar/suricata/2.1beta4
  Configuration directory (--sysconfdir):  /usr/local/etc/suricata/
  Log directory (--localstatedir) :        /usr/local/var/log/suricata/

  Host:                                    x86_64-apple-darwin14.4.0
  GCC binary:                              clang
  GCC Protect enabled:                     no
  GCC march native enabled:                yes
  GCC Profile enabled:                     no
```