### PR TITLE
stdman 0.2 (new formula)

### DIFF
--- a/Library/Formula/stdman.rb
+++ b/Library/Formula/stdman.rb
@@ -10,6 +10,6 @@ class Stdman < Formula
   end
 
   test do
-    assert File.exist? shell_output("/usr/bin/man -w std::string").strip
+    system "man", "-w", "std::string"
   end
 end

--- a/Library/Formula/stdman.rb
+++ b/Library/Formula/stdman.rb
@@ -8,4 +8,8 @@ class Stdman < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
+
+  test do
+    assert File.exist? shell_output("/usr/bin/man -w std::string").strip
+  end
 end

--- a/Library/Formula/stdman.rb
+++ b/Library/Formula/stdman.rb
@@ -1,0 +1,11 @@
+class Stdman < Formula
+  desc "Formatted C++11/14 stdlib man pages from cppreference.com"
+  homepage "https://github.com/jeaye/stdman"
+  url "https://github.com/jeaye/stdman/archive/v0.2.tar.gz"
+  sha256 "9591835b0f57f88698d7c46ef645064a4af646644535cf2a052152656d73329a"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Only manual pages.

```
$ brew audit --strict stdman
==> brew style stdman

1 file inspected, no offenses detected

==> audit problems
stdman:
 * A `test do` test block should be added

Error: 1 problem in 1 formula

```
Any advice on how to implement a `test do` block in such a case?