### PR TITLE
Suricata: disable broken explicit non-debug build.

### DIFF
--- a/Library/Formula/suricata.rb
+++ b/Library/Formula/suricata.rb
@@ -45,7 +45,6 @@ class Suricata < Formula
     end
 
     args = %W[
-      --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}


### PR DESCRIPTION
Due to https://github.com/OISF/libhtp/issues/106 passing
--disable-debug will actually cause libhtp to be built in debug
mode.  Until that issue is closed the fix is to just not specify
--disable-debug and let it build a non-debug version anyway.

```
bash-3.2# suricata --build-info | grep -i debug
  Debug output enabled:                    no
  Debug validation enabled:                no
bash-3.2# suricata --build-info | grep -i htp
Features: PCAP_SET_BUFF LIBPCAP_VERSION_MAJOR=1 HAVE_PACKET_FANOUT LIBNET1.1 HAVE_HTP_URI_NORMALIZE_HOOK PCRE_JIT
compiled with LibHTP v0.5.17, linked against LibHTP v0.5.17
  Non-bundled htp:                         no
```