### PR TITLE
Upgrade from Mapnik v2.2.0 to v3.0.0

### DIFF
--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -4,7 +4,6 @@ class Mapnik < Formula
   head "https://github.com/mapnik/mapnik.git"
   url "https://s3.amazonaws.com/mapnik/dist/v3.0.0/mapnik-v3.0.0.tar.bz2"
   sha256 "c88b1ce48899ffe0d75f9e753dcd427e2b6fd3186b40e04508608b2151c0e7b0"
-  revision 1
 
   bottle do
     sha256 "1c362e8436c60b47664dfba2bfd18eab7ef281db3e0f376274676bcb1c66685d" => :yosemite

--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -24,8 +24,11 @@ class Mapnik < Formula
   depends_on "gdal" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional
+  
+  needs :cxx11
 
   def install
+    ENV.cxx11
     icu = Formula["icu4c"].opt_prefix
     boost = Formula["boost"].opt_prefix
     proj = Formula["proj"].opt_prefix

--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -2,9 +2,9 @@ class Mapnik < Formula
   desc "Toolkit for developing mapping applications"
   homepage "http://www.mapnik.org/"
   head "https://github.com/mapnik/mapnik.git"
-  url "https://s3.amazonaws.com/mapnik/dist/v2.2.0/mapnik-v2.2.0.tar.bz2"
-  sha256 "9b30de4e58adc6d5aa8478779d0a47fdabe6bf8b166b67a383b35f5aa5d6c1b0"
-  revision 6
+  url "https://s3.amazonaws.com/mapnik/dist/v3.0.0/mapnik-v3.0.0.tar.bz2"
+  sha256 "c88b1ce48899ffe0d75f9e753dcd427e2b6fd3186b40e04508608b2151c0e7b0"
+  revision 1
 
   bottle do
     sha256 "1c362e8436c60b47664dfba2bfd18eab7ef281db3e0f376274676bcb1c66685d" => :yosemite
@@ -12,33 +12,19 @@ class Mapnik < Formula
     sha256 "6ee18c569252ef0d25f5756a57e7be64ea7dea38f04a7e0fc8c544558f07a64a" => :mountain_lion
   end
 
-  stable do
-    # can be removed at Mapnik > 2.2.0
-    # https://github.com/mapnik/mapnik/issues/1973
-    patch :DATA
-
-    # boost 1.56 compatibility
-    # concatenated from https://github.com/mapnik/mapnik/issues/2428
-    patch do
-      url "https://gist.githubusercontent.com/tdsmith/22aeb0bfb9691de91463/raw/3064c193466a041d82e011dc5601312ccadc9e15/mapnik-boost-megadiff.diff"
-      sha1 "63939ad5e197c83f7fe09e321484248dfd96d0f3"
-    end
-  end
-
   depends_on "pkg-config" => :build
   depends_on "freetype"
+  depends_on "harfbuzz"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "proj"
   depends_on "icu4c"
   depends_on "jpeg"
+  depends_on "webp"
   depends_on "boost"
-  depends_on "boost-python"
   depends_on "gdal" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional
-
-  depends_on "py2cairo" if build.with? "cairo"
 
   def install
     icu = Formula["icu4c"].opt_prefix
@@ -48,23 +34,22 @@ class Mapnik < Formula
     libpng = Formula["libpng"].opt_prefix
     libtiff = Formula["libtiff"].opt_prefix
     freetype = Formula["freetype"].opt_prefix
-
-    # mapnik compiles can take ~1.5 GB per job for some .cpp files
-    # so lets be cautious by limiting to CPUS/2
-    jobs = ENV.make_jobs.to_i
-    jobs /= 2 if jobs > 2
+    harfbuzz = Formula["harfbuzz"].opt_prefix
+    webp = Formula["webp"].opt_prefix
 
     args = ["CC=\"#{ENV.cc}\"",
             "CXX=\"#{ENV.cxx}\"",
-            "JOBS=#{jobs}",
             "PREFIX=#{prefix}",
             "ICU_INCLUDES=#{icu}/include",
             "ICU_LIBS=#{icu}/lib",
-            "PYTHON_PREFIX=#{prefix}",  # Install to Homebrew's site-packages
             "JPEG_INCLUDES=#{jpeg}/include",
             "JPEG_LIBS=#{jpeg}/lib",
             "PNG_INCLUDES=#{libpng}/include",
             "PNG_LIBS=#{libpng}/lib",
+            "HB_INCLUDES=#{harfbuzz}/include",
+            "HB_LIBS=#{harfbuzz}/lib",
+            "WEBP_INCLUDES=#{webp}/include",
+            "WEBP_LIBS=#{webp}/lib",
             "TIFF_INCLUDES=#{libtiff}/include",
             "TIFF_LIBS=#{libtiff}/lib",
             "BOOST_INCLUDES=#{boost}/include",
@@ -72,6 +57,8 @@ class Mapnik < Formula
             "PROJ_INCLUDES=#{proj}/include",
             "PROJ_LIBS=#{proj}/lib",
             "FREETYPE_CONFIG=#{freetype}/bin/freetype-config",
+            "NIK2IMG=False",
+            "CPP_TESTS=False" # too long to compile to be worth it
            ]
 
     if build.with? "cairo"
@@ -82,26 +69,8 @@ class Mapnik < Formula
     args << "GDAL_CONFIG=#{Formula["gdal"].opt_bin}/gdal-config" if build.with? "gdal"
     args << "PG_CONFIG=#{Formula["postgresql"].opt_bin}/pg_config" if build.with? "postgresql"
 
-    system "python", "scons/scons.py", "configure", *args
-    system "python", "scons/scons.py", "install"
+    system "./configure", *args
+    system "make"
+    system "make", "install"
   end
 end
-
-__END__
-diff --git a/bindings/python/mapnik_text_placement.cpp b/bindings/python/mapnik_text_placement.cpp
-index 0520132..4897c28 100644
---- a/bindings/python/mapnik_text_placement.cpp
-+++ b/bindings/python/mapnik_text_placement.cpp
-@@ -194,7 +194,11 @@ struct ListNodeWrap: formatting::list_node, wrapper<formatting::list_node>
-     ListNodeWrap(object l) : formatting::list_node(), wrapper<formatting::list_node>()
-     {
-         stl_input_iterator<formatting::node_ptr> begin(l), end;
--        children_.insert(children_.end(), begin, end);
-+        while (begin != end)
-+        {
-+            children_.push_back(*begin);
-+            ++begin;
-+        }
-     }
-
-     /* TODO: Add constructor taking variable number of arguments.

--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -24,7 +24,13 @@ class Mapnik < Formula
   depends_on "gdal" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional
-  
+
+  if MacOS.version < :mavericks
+    depends_on "boost" => "c++11"
+  else
+    depends_on "boost"
+  end
+
   needs :cxx11
 
   def install

--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -20,7 +20,6 @@ class Mapnik < Formula
   depends_on "icu4c"
   depends_on "jpeg"
   depends_on "webp"
-  depends_on "boost"
   depends_on "gdal" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional


### PR DESCRIPTION
Key changes:

  - Mapnik 3.x no longer bundles python bindings. So now homebrew will just install the C++ library. Python bindings can be pip installed from https://github.com/mapnik/python-mapnik
  - New dependencies of harfbuzz and webp
  - Removed patches no longer needed
  - Now using Mapnik's `Makefile` shim instead of calling Scons directly (recommended by upstream)

More details on 3.0.0 release:

 - http://mapnik.org/news/release-3.0.0/
 - https://github.com/mapnik/mapnik/milestones/Mapnik%203.0.0