### PR TITLE
Move bottle fetch from pull to a pre-push hook

### DIFF
--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -25,7 +25,7 @@ def commits_between(beginning, end):
     return git("rev-list", "{}..{}".format(beginning, end)).split("\n")
 
 def push_okay(remote_name, remote_url, updates_file):
-    if "omebrew/homebrew" not in remote_url:
+    if "homebrew/homebrew" not in remote_url.lower():
         return True
     updates = [line.strip().split() for line in updates_file.readlines()]
     # remote_ref (at commit remote_sha) will  be updated by local_ref (to commit local_sha)

--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# Makes sure bottles are fetchable after BrewTestBot modifies a formula.
+# Only checks pushes to master on Homebrew/homebrew* remotes.
+# To use, `ln -s $(brew --repository)/Library/Contributions/pre-push
+# $(brew --repository)/.git/hooks`.
+
+import re
+import os
+import subprocess
+import sys
+
+FORMULA_RE = re.compile(r"^(Library/Formula/)?([A-Za-z0-9-]+)\.rb")
+TESTBOT_EMAILS = ["brew-test-bot@googlegroups.com"]
+
+def git(*args):
+    return subprocess.check_output(["git"] + list(args)).strip()
+
+def commit_author_email(commit_sha):
+    return git("show", "-s", "--pretty=%ae", commit_sha)
+
+def files_touched_by_commit(commit_sha):
+    return git("diff-tree", "--name-only", "-r", "--no-commit-id", commit_sha).split("\n")
+
+def commits_between(beginning, end):
+    return git("rev-list", "{}..{}".format(beginning, end)).split("\n")
+
+def push_okay(remote_name, remote_url, updates_file):
+    if "omebrew/homebrew" not in remote_url:
+        return True
+    updates = [line.strip().split() for line in updates_file.readlines()]
+    # remote_ref (at commit remote_sha) will  be updated by local_ref (to commit local_sha)
+    for local_ref, local_sha, remote_ref, remote_sha in updates:
+        if remote_ref != "refs/heads/master": continue
+        for commit_sha in commits_between(remote_sha, local_sha):
+            if commit_author_email(commit_sha) not in TESTBOT_EMAILS: continue
+            for filename in files_touched_by_commit(commit_sha):
+                match = FORMULA_RE.match(filename)
+                if match is None: continue
+                errorlevel = subprocess.call(["brew", "fetch", "--force-bottle", match.group(2)])
+                if errorlevel > 0:
+                    return False
+    return True
+
+if __name__ == "__main__":
+    if os.environ.get("HOMEBREW_SKIP_FETCH", "0") != "0":
+        sys.exit(0)
+    sys.exit(0 if push_okay(sys.argv[1], sys.argv[2], sys.stdin) else 1)

--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -13,7 +13,7 @@ FORMULA_RE = re.compile(r"^(Library/Formula/)?([A-Za-z0-9-]+)\.rb")
 TESTBOT_EMAILS = {"brew-test-bot@googlegroups.com"}
 
 def git(*args):
-    return subprocess.check_output(["git"] + list(args)).strip()
+    return subprocess.check_output(("git",) + args).strip()
 
 def commit_author_email(commit_sha):
     return git("show", "-s", "--pretty=%ae", commit_sha)

--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -44,4 +44,7 @@ def push_okay(remote_name, remote_url, updates_file):
 if __name__ == "__main__":
     if os.environ.get("HOMEBREW_SKIP_FETCH", "0") != "0":
         sys.exit(0)
+    if len(sys.argv) < 3:
+        print >> sys.stderr, "{}: Expected at least two arguments".format(sys.argv[0])
+        sys.exit(1)
     sys.exit(0 if push_okay(sys.argv[1], sys.argv[2], sys.stdin) else 1)

--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -10,7 +10,7 @@ import subprocess
 import sys
 
 FORMULA_RE = re.compile(r"^(Library/Formula/)?([A-Za-z0-9-]+)\.rb")
-TESTBOT_EMAILS = ["brew-test-bot@googlegroups.com"]
+TESTBOT_EMAILS = {"brew-test-bot@googlegroups.com"}
 
 def git(*args):
     return subprocess.check_output(["git"] + list(args)).strip()

--- a/Library/Contributions/pre-push
+++ b/Library/Contributions/pre-push
@@ -36,7 +36,7 @@ def push_okay(remote_name, remote_url, updates_file):
             for filename in files_touched_by_commit(commit_sha):
                 match = FORMULA_RE.match(filename)
                 if match is None: continue
-                errorlevel = subprocess.call(["brew", "fetch", "--force-bottle", match.group(2)])
+                errorlevel = subprocess.call(["brew", "fetch", "--retry", "--force-bottle", match.group(2)])
                 if errorlevel > 0:
                     return False
     return True

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -189,8 +189,6 @@ module Homebrew
               "-u#{bintray_user}:#{bintray_key}", "-X", "POST",
               "https://api.bintray.com/content/homebrew/#{repo}/#{package}/#{version}/publish"
             puts
-            sleep 20
-            safe_system "brew", "fetch", "--retry", "--force-bottle", f.full_name
           end
         else
           opoo "You must set BINTRAY_USER and BINTRAY_KEY to add or update bottles on Bintray!"

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -191,12 +191,12 @@ module Homebrew
             puts
           end
           unless (Pathname.pwd/".git/hooks/pre-push").exist?
-            opoo "Pre-push hook missing"
+            ohai "Creating pre-push hook"
             puts <<-EOS.undent
-              Please consider symlinking #{HOMEBREW_CONTRIB}/pre-push into
-              #{Pathname.pwd}/.git/hooks to add a check that bottles are published
-              correctly before pushing to master.
+              Adding a pre-push hook to check that bottles are published
+              correctly before pushing to master...
             EOS
+            FileUtils.ln_s HOMEBREW_CONTRIB/"pre-push", Pathname.pwd/".git/hooks"
           end
         else
           opoo "You must set BINTRAY_USER and BINTRAY_KEY to add or update bottles on Bintray!"

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -190,6 +190,14 @@ module Homebrew
               "https://api.bintray.com/content/homebrew/#{repo}/#{package}/#{version}/publish"
             puts
           end
+          unless (Pathname.pwd/".git/hooks/pre-push").exist?
+            opoo "Pre-push hook missing"
+            puts <<-EOS.undent
+              Please consider symlinking #{HOMEBREW_CONTRIB}/pre-push into
+              #{Pathname.pwd}/.git/hooks to add a check that bottles are published
+              correctly before pushing to master.
+            EOS
+          end
         else
           opoo "You must set BINTRAY_USER and BINTRAY_KEY to add or update bottles on Bintray!"
         end


### PR DESCRIPTION
Publishing a bottle on Bintray is asynchronous. Instead of waiting a long time in `pull` before checking whether the bottle was published correctly, move the check to a pre-push hook.

I have a terrible feeling you're going to ask me to rewrite this in Ruby. Call it a strawman for discussion, anyway.