### PR TITLE
rds-command-line-tools: install credential-file-path.template to etc directory

### DIFF
--- a/Library/Formula/rds-command-line-tools.rb
+++ b/Library/Formula/rds-command-line-tools.rb
@@ -9,6 +9,7 @@ class RdsCommandLineTools < Formula
   def install
     env = Language::Java.java_home_env.merge(:AWS_RDS_HOME => libexec)
     rm Dir["bin/*.cmd"] # Remove Windows versions
+    etc.install "credential-file-path.template"
     libexec.install Dir["*"]
     Pathname.glob("#{libexec}/bin/*") do |file|
       next if file.directory?


### PR DESCRIPTION
- Install `credential-file-path.template` file to etc directory
- Add explanation about this file to caveats section