### PR TITLE
Remove keys from comment

### DIFF
--- a/Library/Formula/rds-command-line-tools.rb
+++ b/Library/Formula/rds-command-line-tools.rb
@@ -21,9 +21,7 @@ class RdsCommandLineTools < Formula
 
   def caveats
     <<-EOS.undent
-      Before you can use these tools you must export some variables to your $SHELL.
-        export AWS_ACCESS_KEY="<Your AWS Access ID>"
-        export AWS_SECRET_KEY="<Your AWS Secret Key>"
+      Before you can use these tools you must export a variable to your $SHELL.
         export AWS_CREDENTIAL_FILE="<Path to the credentials file>"
 
       To check that your setup works properly, run the following command:


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/homebrew/pull/41480

If I set `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` but without `AWS_CREDENTIAL_FILE`, it doesn't work. Eventually we have to set  `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` in `AWS_CREDENTIAL_FILE`.  So this instruction seems to be redundant and useless.