### PR TITLE
pinentry 0.9.5

### DIFF
--- a/Library/Formula/pinentry.rb
+++ b/Library/Formula/pinentry.rb
@@ -1,9 +1,9 @@
 class Pinentry < Formula
   desc "Passphrase entry dialog utilizing the Assuan protocol"
   homepage "https://www.gnupg.org/related_software/pinentry/index.en.html"
-  url "ftp://ftp.gnupg.org/gcrypt/pinentry/pinentry-0.9.4.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/pinentry/pinentry-0.9.4.tar.bz2"
-  sha256 "4b8835bb738d464542b62020ff6b8f649a621540edb61c4cbfe0c894538ee2e0"
+  url "ftp://ftp.gnupg.org/gcrypt/pinentry/pinentry-0.9.5.tar.bz2"
+  mirror "https://mirrors.kernel.org/debian/pool/main/p/pinentry/pinentry_0.9.5.orig.tar.bz2"
+  sha256 "6a57fd3afc0d8aaa5599ffcb3ea4e7c42c113a181e8870122203ea018384688c"
 
   bottle do
     cellar :any
@@ -14,10 +14,8 @@ class Pinentry < Formula
   end
 
   depends_on "pkg-config" => :build
-
-  # Fix backspacing in pinentry-curses.  Remove at next release.
-  # https://bugs.gnupg.org/gnupg/issue2020
-  patch :DATA
+  depends_on "libgpg-error"
+  depends_on "libassuan"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -32,22 +30,3 @@ class Pinentry < Formula
     system "#{bin}/pinentry", "--version"
   end
 end
-
-__END__
-diff --git a/pinentry/pinentry-curses.c b/pinentry/pinentry-curses.c
-index 235435a..784c770 100644
---- a/pinentry/pinentry-curses.c
-+++ b/pinentry/pinentry-curses.c
-@@ -705,7 +705,11 @@ dialog_input (dialog_t diag, int alt, int chr)
-   switch (chr)
-     {
-     case KEY_BACKSPACE:
--    case 'h' - 'a' + 1: /* control-h.  */
-+      /* control-h.  */
-+    case 'h' - 'a' + 1:
-+      /* ASCII DEL.  What Mac OS X apparently emits when the "delete"
-+	 (backspace) key is pressed.  */
-+    case 127:
-       if (diag->pin_len > 0)
-	{
-	  diag->pin_len--;


### PR DESCRIPTION
The changelog for this version:
```
	Release 0.9.5.

	w32: Adjust for use of standard libassuan.
	* autogen.rc: Add gpg-error and libassuan prefix options.
	* w32/Makefile.am (AM_CPPFLAGS): Use COMMON_FLAGS.
	(pinentry_w32_LDADD): Use COMMON_LIBS.

	Distribute files in m4/
```
I guess that explains the new dependencies? cc @chdiza?