### PR TITLE
swig has been updated to 3.0.6

### DIFF
--- a/Library/Formula/swig.rb
+++ b/Library/Formula/swig.rb
@@ -1,7 +1,7 @@
 class Swig < Formula
   desc "Generate scripting interfaces to C/C++ code"
   homepage "http://www.swig.org/"
-  url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.5/swig-3.0.5.tar.gz"
+  url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.6/swig-3.0.6.tar.gz"
   sha1 "271813b317e4836853d2249fc8ce2df34c2a062a"
 
   bottle do


### PR DESCRIPTION
The SWIG project has released a new version 3.0.6
https://github.com/swig/swig/releases