### PR TITLE
audit: deprecate sha1 always.

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -939,12 +939,8 @@ class ResourceAuditor
       problem "MD5 checksums are deprecated, please use SHA256"
       return
     when :sha1
-      if ARGV.include? "--strict"
-        problem "SHA1 checksums are deprecated, please use SHA256"
-        return
-      else
-        len = 40
-      end
+      problem "SHA1 checksums are deprecated, please use SHA256"
+      return
     when :sha256 then len = 64
     end
 


### PR DESCRIPTION
Rather than just when --strict is set. We're asking people to do these on most PRs now anyway so feels better to let them find this out with `brew audit`. CC @Homebrew/owners for thoughts