### PR TITLE
openssl 1.0.2d

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -17,9 +17,6 @@ class Openssl < Formula
 
   depends_on "makedepend" => :build
 
-  keg_only :provided_by_osx,
-    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
-
   def arch_args
     {
       :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
@@ -114,7 +111,7 @@ class Openssl < Formula
     )
 
     valid_certs = certs.select do |cert|
-      IO.popen('openssl x509 -inform pem -checkend 0 -noout', 'w') do |openssl_io|
+      IO.popen("openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
         openssl_io.write(cert)
         openssl_io.close_write
       end

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,9 +1,10 @@
 class Openssl < Formula
   desc "OpenSSL SSL/TLS cryptography library"
-  homepage "https://openssl.org"
-  url "https://www.openssl.org/source/openssl-1.0.2c.tar.gz"
-  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.2c.tar.gz"
-  sha256 "0038ba37f35a6367c58f17a7a7f687953ef8ce4f9684bbdec63e62515ed36a83"
+  homepage "https://openssl.org/"
+  url "https://www.openssl.org/source/openssl-1.0.2d.tar.gz"
+  mirror "https://raw.githubusercontent.com/DomT4/LibreMirror/master/OpenSSL/openssl-1.0.2d.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2d.tar.gz"
+  sha256 "671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8"
 
   bottle do
     sha256 "b8f497f8d75d04fbeba3adb93af9823f49f4441583f8e007ccac8ff0aa38d3ae" => :yosemite
@@ -142,8 +143,8 @@ class Openssl < Formula
 
     # Check OpenSSL itself functions as expected.
     (testpath/"testfile.txt").write("This is a test file")
-    expected_checksum = "91b7b0b1e27bfbf7bc646946f35fa972c47c2d32"
-    system "#{bin}/openssl", "dgst", "-sha1", "-out", "checksum.txt", "testfile.txt"
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system "#{bin}/openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
     open("checksum.txt") do |f|
       checksum = f.read(100).split("=").last.strip
       assert_equal checksum, expected_checksum


### PR DESCRIPTION
With the dawning of OS X 10.11 Apple has seemingly removed the OpenSSL headers from public availability. This has meant that unless we specifically point things at our OpenSSL, or our OpenSSL is in the `PATH` things are failing to build in unusual ways.

To work around this, we are removing the `keg_only` status on OpenSSL. This means from today OpenSSL will symlink into your `HOMEBREW_PREFIX` and be available for all and any thing to compile against, and presuming you have `HOMEBREW_PREFIX` at the front of your `PATH` will be used over the older system OpenSSL.

Things that compile against Homebrew's OpenSSL but don't have an OpenSSL `depends_on` should still be reported to Homebrew. We will need to fix the link so our bottles rely on our OpenSSL rather than linking the system's still, and it allows us to revision things when the security landscape dictates that it is necessary.

There are no plans to unkeg LibreSSL at this time. It conflicts with the other OpenSSL versions and at the moment there's still a lot that won't build against it. If that changes in future we aren't rigid and unbending towards useful change, but for now don't file PRs asking for LibreSSL to be unkegged, Thanks!

Please report any issues you discover to Homebrew and we'll endeavour to fix them as quickly and thoroughly as possible.