### PR TITLE
formula_cellar_checks: ignore openssl.

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -104,8 +104,8 @@ module FormulaCellarChecks
   end
 
   def check_shadowed_headers
-    ["libtool", "subversion", "berkeley-db"].each do |formula_name|
-      return if formula.name == formula_name
+    ["libtool", "subversion", "berkeley-db", "openssl"].each do |formula_name|
+      return if formula.name.start_with?(formula_name)
     end
 
     return if MacOS.version < :mavericks && formula.name.start_with?("postgresql")


### PR DESCRIPTION
Also: check based on the beginning of the formula name so these play nicer with e.g. homebrew-versions.