### PR TITLE
download_strategy: kill special ssl3 support

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -397,12 +397,8 @@ class CurlPostDownloadStrategy < CurlDownloadStrategy
   end
 end
 
-# Download from an SSL3-only host.
-class CurlSSL3DownloadStrategy < CurlDownloadStrategy
-  def _curl_opts
-    super << '-3'
-  end
-end
+# @deprecated
+CurlSSL3DownloadStrategy = CurlDownloadStrategy
 
 # Use this strategy to download but not unzip a file.
 # Useful for installing jars.


### PR DESCRIPTION
We tagged this `deprecated` in `audit` 9 months ago in https://github.com/Homebrew/homebrew/commit/c3e4dbbc34b930f111a6431a17f05457204a1e53.

9 months would seem enough time to have flushed it out of any semi-regularly active taps using this method, and a search for `CurlSSL3DownloadStrategy` across Github only revealed forks of the `download_strategy` using the method.

I think it's reasonably fair to kill it off at this point. CC @Homebrew/owners for thoughts.