### PR TITLE
python3: don't run ensurepip during build

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -95,6 +95,7 @@ class Python < Formula
       --datarootdir=#{share}
       --datadir=#{share}
       --enable-framework=#{frameworks}
+      --without-ensurepip
     ]
 
     args << "--without-gcc" if ENV.compiler == :clang

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -101,6 +101,7 @@ class Python3 < Formula
       --datarootdir=#{share}
       --datadir=#{share}
       --enable-framework=#{frameworks}
+      --without-ensurepip
     ]
 
     args << "--without-gcc" if ENV.compiler == :clang


### PR DESCRIPTION
We don't want to run ensurepip, which installs an old version of pip; we
take care of this ourselves in postinstall.

On flat (i.e. non-Framework) builds, ensurepip causes an error in
postinstall because the pip-3.4 script already exists in prefix/bin.

Will resolve Homebrew/linuxbrew#469.