### PR TITLE
Formatting corrections to Homebrew's core

### DIFF
--- a/Library/Homebrew/blacklist.rb
+++ b/Library/Homebrew/blacklist.rb
@@ -1,4 +1,4 @@
-def blacklisted? name
+def blacklisted?(name)
   case name.downcase
   when 'screen', /^rubygems?$/ then <<-EOS.undent
     Apple distributes #{name} with OS X, you can find it in /usr/bin.

--- a/Library/Homebrew/bottles.rb
+++ b/Library/Homebrew/bottles.rb
@@ -2,13 +2,13 @@ require 'tab'
 require 'os/mac'
 require 'extend/ARGV'
 
-def built_as_bottle? f
+def built_as_bottle?(f)
   return false unless f.installed?
   tab = Tab.for_keg(f.installed_prefix)
   tab.built_as_bottle
 end
 
-def bottle_file_outdated? f, file
+def bottle_file_outdated?(f, file)
   filename = file.basename.to_s
   return unless f.bottle && filename.match(Pathname::BOTTLE_EXTNAME_RX)
 
@@ -38,11 +38,11 @@ def bottle_tag
   end
 end
 
-def bottle_receipt_path bottle_file
+def bottle_receipt_path(bottle_file)
   Utils.popen_read("tar", "-tzf", bottle_file, "*/*/INSTALL_RECEIPT.json").chomp
 end
 
-def bottle_resolve_formula_names bottle_file
+def bottle_resolve_formula_names(bottle_file)
   receipt_file_path = bottle_receipt_path bottle_file
   receipt_file = Utils.popen_read("tar", "-xOzf", bottle_file, receipt_file_path)
   name = receipt_file_path.split("/").first
@@ -57,7 +57,7 @@ def bottle_resolve_formula_names bottle_file
   [name, full_name]
 end
 
-def bottle_resolve_version bottle_file
+def bottle_resolve_version(bottle_file)
   Version.new bottle_receipt_path(bottle_file).split("/")[1]
 end
 

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -148,7 +148,7 @@ class Build
     keg.detect_cxx_stdlibs(:skip_executables => true)
   end
 
-  def fixopt f
+  def fixopt(f)
     path = if f.linked_keg.directory? and f.linked_keg.symlink?
       f.linked_keg.resolved_path
     elsif f.prefix.directory?

--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -4,11 +4,11 @@ class BuildOptions
     @options = options
   end
 
-  def include? name
+  def include?(name)
     @args.include?("--#{name}")
   end
 
-  def with? val
+  def with?(val)
     name = val.respond_to?(:option_name) ? val.option_name : val
 
     if option_defined? "with-#{name}"
@@ -20,7 +20,7 @@ class BuildOptions
     end
   end
 
-  def without? name
+  def without?(name)
     not with? name
   end
 
@@ -67,7 +67,7 @@ class BuildOptions
 
   private
 
-  def option_defined? name
+  def option_defined?(name)
     @options.include? name
   end
 end

--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -7,7 +7,7 @@
 class Cleaner
 
   # Create a cleaner for the given formula
-  def initialize f
+  def initialize(f)
     @f = f
   end
 
@@ -32,7 +32,7 @@ class Cleaner
 
   private
 
-  def observe_file_removal path
+  def observe_file_removal(path)
     path.extend(ObserverPathnameExtension).unlink if path.exist?
   end
 
@@ -76,7 +76,7 @@ class Cleaner
   #
   # lib may have a large directory tree (see Erlang for instance), and
   # clean_dir applies cleaning rules to the entire tree
-  def clean_dir d
+  def clean_dir(d)
     d.find do |path|
       path.extend(ObserverPathnameExtension)
 

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -16,7 +16,7 @@ module Homebrew
     end
   end
 
-  def build_env_keys env
+  def build_env_keys(env)
     %w[
       CC CXX LD OBJC OBJCXX
       HOMEBREW_CC HOMEBREW_CXX
@@ -30,7 +30,7 @@ module Homebrew
       ACLOCAL_PATH PATH CPATH].select { |key| env.key?(key) }
   end
 
-  def dump_build_env env, f=$stdout
+  def dump_build_env(env, f=$stdout)
     keys = build_env_keys(env)
     keys -= %w[CC CXX OBJC OBJCXX] if env["CC"] == env["HOMEBREW_CC"]
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -78,7 +78,7 @@ module Homebrew
 end
 
 class FormulaText
-  def initialize path
+  def initialize(path)
     @text = path.open("rb", &:read)
     @lines = @text.lines.to_a
   end
@@ -99,11 +99,11 @@ class FormulaText
     /\Z\n/ =~ @text
   end
 
-  def =~ regex
+  def =~(regex)
     regex =~ @text
   end
 
-  def line_number regex
+  def line_number(regex)
     index = @lines.index { |line| line =~ regex }
     index ? index + 1 : nil
   end
@@ -881,7 +881,7 @@ class FormulaAuditor
 
   private
 
-  def problem p
+  def problem(p)
     @problems << p
   end
 
@@ -1116,7 +1116,7 @@ class ResourceAuditor
     end
   end
 
-  def problem text
+  def problem(text)
     @problems << text
   end
 end

--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -33,10 +33,10 @@ BOTTLE_ERB = <<-EOS
 EOS
 
 module Homebrew
-  def keg_contains string, keg, ignores
+  def keg_contains(string, keg, ignores)
     @put_string_exists_header, @put_filenames = nil
 
-    def print_filename string, filename
+    def print_filename(string, filename)
       unless @put_string_exists_header
         opoo "String '#{string}' still exists in these files:"
         @put_string_exists_header = true
@@ -107,12 +107,12 @@ module Homebrew
     result
   end
 
-  def bottle_output bottle
+  def bottle_output(bottle)
     erb = ERB.new BOTTLE_ERB
     erb.result(bottle.instance_eval { binding }).gsub(/^\s*$\n/, '')
   end
 
-  def bottle_formula f
+  def bottle_formula(f)
     unless f.installed?
       return ofail "Formula not installed or up-to-date: #{f.full_name}"
     end

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -39,7 +39,7 @@ module Homebrew
     end
   end
 
-  def cleanup_formula f
+  def cleanup_formula(f)
     if f.installed?
       eligible_kegs = f.rack.subdirs.map { |d| Keg.new(d) }.select { |k| f.pkg_version > k.version }
       if eligible_kegs.any? && eligible_for_cleanup?(f)
@@ -54,7 +54,7 @@ module Homebrew
     end
   end
 
-  def cleanup_keg keg
+  def cleanup_keg(keg)
     if keg.linked?
       opoo "Skipping (old) #{keg} due to it being linked"
     else

--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -59,7 +59,7 @@ module Homebrew
     if origin.empty? then "(none)" else origin end
   end
 
-  def describe_path path
+  def describe_path(path)
     return "N/A" if path.nil?
     realpath = path.realpath
     if realpath == path then path else "#{path} => #{realpath}" end

--- a/Library/Homebrew/cmd/create.rb
+++ b/Library/Homebrew/cmd/create.rb
@@ -76,7 +76,7 @@ class FormulaCreator
   attr_reader :url, :sha256
   attr_accessor :name, :version, :path, :mode
 
-  def url= url
+  def url=(url)
     @url = url
     path = Pathname.new(url)
     if @name.nil?

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -70,7 +70,7 @@ module Homebrew
     end
   end
 
-  def recursive_deps_tree f, prefix
+  def recursive_deps_tree(f, prefix)
     reqs = f.requirements.select(&:default_formula?)
     max = reqs.length - 1
     reqs.each_with_index do |req, i|

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -9,7 +9,7 @@ class Volumes
     @volumes = get_mounts
   end
 
-  def which path
+  def which(path)
     vols = get_mounts path
 
     # no volume found
@@ -25,7 +25,7 @@ class Volumes
     return vol_index
   end
 
-  def get_mounts path=nil
+  def get_mounts(path=nil)
     vols = []
     # get the volume of path, if path is nil returns all volumes
 
@@ -52,7 +52,7 @@ class Checks
   # Finds files in HOMEBREW_PREFIX *and* /usr/local.
   # Specify paths relative to a prefix eg. "include/foo.h".
   # Sets @found for your convenience.
-  def find_relative_paths *relative_paths
+  def find_relative_paths(*relative_paths)
     @found = %W[#{HOMEBREW_PREFIX} /usr/local].uniq.inject([]) do |found, prefix|
       found + relative_paths.map{|f| File.join(prefix, f) }.select{|f| File.exist? f }
     end
@@ -392,7 +392,7 @@ def check_for_bad_install_name_tool
   end
 end
 
-def __check_subdir_access base
+def __check_subdir_access(base)
   target = HOMEBREW_PREFIX+base
   return unless target.exist?
 
@@ -934,7 +934,7 @@ def check_for_autoconf
   end
 end
 
-def __check_linked_brew f
+def __check_linked_brew(f)
   f.rack.subdirs.each do |prefix|
     prefix.find do |src|
       next if src == prefix
@@ -1280,7 +1280,7 @@ module Homebrew
     puts "Your system is ready to brew." unless Homebrew.failed?
   end
 
-  def inject_dump_stats checks
+  def inject_dump_stats(checks)
     checks.extend Module.new {
       def send(method, *)
         time = Time.now

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -29,7 +29,7 @@ module Homebrew
     end
   end
 
-  def fetch_bottle? f
+  def fetch_bottle?(f)
     return true if ARGV.force_bottle? && f.bottle
     return false unless f.bottle && f.pour_bottle?
     return false if ARGV.build_from_source? || ARGV.build_bottle?
@@ -37,7 +37,7 @@ module Homebrew
     return true
   end
 
-  def fetch_resource r
+  def fetch_resource(r)
     puts "Resource: #{r.name}"
     fetch_fetchable r
   rescue ChecksumMismatchError => e
@@ -45,14 +45,14 @@ module Homebrew
     opoo "Resource #{r.name} reports different #{e.hash_type}: #{e.expected}"
   end
 
-  def fetch_formula f
+  def fetch_formula(f)
     fetch_fetchable f
   rescue ChecksumMismatchError => e
     retry if retry_fetch? f
     opoo "Formula reports different #{e.hash_type}: #{e.expected}"
   end
 
-  def fetch_patch p
+  def fetch_patch(p)
     fetch_fetchable p
   rescue ChecksumMismatchError => e
     Homebrew.failed = true
@@ -61,7 +61,7 @@ module Homebrew
 
   private
 
-  def retry_fetch? f
+  def retry_fetch?(f)
     @fetch_failed ||= Set.new
     if ARGV.include?("--retry") && @fetch_failed.add?(f)
       ohai "Retrying download"
@@ -73,7 +73,7 @@ module Homebrew
     end
   end
 
-  def fetch_fetchable f
+  def fetch_fetchable(f)
     f.clear_cache if ARGV.force?
 
     already_fetched = f.cached_download.exist?

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -5,7 +5,7 @@ require 'net/https'
 require 'stringio'
 
 module Homebrew
-  def gistify_logs f
+  def gistify_logs(f)
     files = load_logs(f.logs)
 
     s = StringIO.new
@@ -49,7 +49,7 @@ module Homebrew
     result
   end
 
-  def login request
+  def login(request)
     print 'GitHub User: '
     user = $stdin.gets.chomp
     print 'Password: '
@@ -68,11 +68,11 @@ module Homebrew
     logs
   end
 
-  def create_gist files
+  def create_gist(files)
     post("/gists", { "public" => true, "files" => files })["html_url"]
   end
 
-  def new_issue repo, title, body, auth
+  def new_issue(repo, title, body, auth)
     post("/repos/#{repo}/issues", { "title" => title, "body" => body }, auth)["html_url"]
   end
 

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -62,7 +62,7 @@ module Homebrew
     end
   end
 
-  def github_info f
+  def github_info(f)
     if f.tap?
       user, repo = f.tap.split("/", 2)
       path = f.path.relative_path_from(HOMEBREW_LIBRARY.join("Taps", f.tap))
@@ -76,7 +76,7 @@ module Homebrew
     end
   end
 
-  def info_formula f
+  def info_formula(f)
     specs = []
 
     if stable = f.stable
@@ -140,7 +140,7 @@ module Homebrew
     ohai 'Caveats', c.caveats unless c.empty?
   end
 
-  def decorate_dependencies dependencies
+  def decorate_dependencies(dependencies)
     # necessary for 1.8.7 unicode handling since many installs are on 1.8.7
     tick = ["2714".hex].pack("U*")
     cross = ["2718".hex].pack("U*")

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -147,7 +147,7 @@ module Homebrew
     check_cellar
   end
 
-  def install_formula f
+  def install_formula(f)
     f.print_tap_action
 
     fi = FormulaInstaller.new(f)

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -105,7 +105,7 @@ module Homebrew
 end
 
 class PrettyListing
-  def initialize path
+  def initialize(path)
     Pathname.new(path).children.sort_by { |p| p.to_s.downcase }.each do |pn|
       case pn.basename.to_s
       when 'bin', 'sbin'
@@ -129,7 +129,7 @@ class PrettyListing
     end
   end
 
-  def print_dir root
+  def print_dir(root)
     dirs = []
     remaining_root_files = []
     other = ''
@@ -154,7 +154,7 @@ class PrettyListing
     print_remaining_files remaining_root_files, root, other
   end
 
-  def print_remaining_files files, root, other = ''
+  def print_remaining_files(files, root, other='')
     case files.length
     when 0
       # noop

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -25,7 +25,7 @@ module Homebrew
     end
   end
 
-  def dump_options_for_formula f
+  def dump_options_for_formula(f)
     f.options.sort_by(&:flag).each do |opt|
       puts "#{opt.flag}\n\t#{opt.description}"
     end

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -8,12 +8,12 @@ require 'cmd/tap'
 module Homebrew
   HOMEBREW_PULL_API_REGEX = %r{https://api\.github\.com/repos/([\w-]+)/homebrew(-[\w-]+)?/pulls/(\d+)}
 
-  def tap arg
+  def tap(arg)
     match = arg.match(%r[homebrew-([\w-]+)/])
     match[1].downcase if match
   end
 
-  def pull_url url
+  def pull_url(url)
     # GitHub provides commits/pull-requests raw patches using this URL.
     url += '.patch'
 

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -5,7 +5,7 @@ module Homebrew
     ARGV.resolved_formulae.each { |f| reinstall_formula(f) }
   end
 
-  def reinstall_formula f
+  def reinstall_formula(f)
     tab = Tab.for_formula(f)
     options = tab.used_options | f.build.used_options
 
@@ -38,12 +38,12 @@ module Homebrew
     backup_path(keg).rmtree if backup_path(keg).exist?
   end
 
-  def backup keg
+  def backup(keg)
     keg.unlink
     keg.rename backup_path(keg)
   end
 
-  def restore_backup keg, formula
+  def restore_backup(keg, formula)
     path = backup_path(keg)
     if path.directory?
       path.rename keg
@@ -51,7 +51,7 @@ module Homebrew
     end
   end
 
-  def backup_path path
+  def backup_path(path)
     Pathname.new "#{path}.reinstall"
   end
 end

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -102,7 +102,7 @@ module Homebrew
     end
   end
 
-  def search_tap user, repo, rx
+  def search_tap(user, repo, rx)
     if (HOMEBREW_LIBRARY/"Taps/#{user.downcase}/homebrew-#{repo.downcase}").directory? && \
        "#{user}/#{repo}" != "Caskroom/cask"
       return []
@@ -140,7 +140,7 @@ module Homebrew
     []
   end
 
-  def search_formulae rx
+  def search_formulae(rx)
     aliases = Formula.aliases
     results = (Formula.full_names+aliases).grep(rx).sort
 

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -13,7 +13,7 @@ module Homebrew
     end
   end
 
-  def install_tap user, repo, clone_target=nil
+  def install_tap(user, repo, clone_target=nil)
     tap = Tap.new user, repo
     return false if tap.installed?
     ohai "Tapping #{tap}"

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -35,7 +35,7 @@ module Homebrew
   EMAIL_SUBJECT_FILE = "brew-test-bot.#{MacOS.cat}.email.txt"
   BYTES_IN_1_MEGABYTE = 1024*1024
 
-  def homebrew_git_repo tap=nil
+  def homebrew_git_repo(tap=nil)
     if tap
       user, repo = tap.split "/"
       HOMEBREW_LIBRARY/"Taps/#{user}/homebrew-#{repo}"
@@ -47,7 +47,7 @@ module Homebrew
   class Step
     attr_reader :command, :name, :status, :output, :time
 
-    def initialize test, command, options={}
+    def initialize(test, command, options={})
       @test = test
       @category = test.category
       @command = command
@@ -174,7 +174,7 @@ module Homebrew
   class Test
     attr_reader :log_root, :category, :name, :steps
 
-    def initialize argument, tap=nil
+    def initialize(argument, tap=nil)
       @hash = nil
       @url = nil
       @formulae = []
@@ -231,7 +231,7 @@ module Homebrew
     end
 
     def download
-      def shorten_revision revision
+      def shorten_revision(revision)
         git("rev-parse", "--short", revision).strip
       end
 
@@ -243,11 +243,11 @@ module Homebrew
         git("symbolic-ref", "HEAD").gsub("refs/heads/", "").strip
       end
 
-      def single_commit? start_revision, end_revision
+      def single_commit?(start_revision, end_revision)
         git("rev-list", "--count", "#{start_revision}..#{end_revision}").to_i == 1
       end
 
-      def diff_formulae start_revision, end_revision, path, filter
+      def diff_formulae(start_revision, end_revision, path, filter)
         git(
           "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
           start_revision, end_revision, "--", path
@@ -332,11 +332,11 @@ module Homebrew
       @formulae += @added_formulae + @modified_formula
     end
 
-    def skip formula_name
+    def skip(formula_name)
       puts "#{Tty.blue}==>#{Tty.white} SKIPPING: #{formula_name}#{Tty.reset}"
     end
 
-    def satisfied_requirements? formula, spec, dependency=nil
+    def satisfied_requirements?(formula, spec, dependency=nil)
       requirements = formula.send(spec).requirements
 
       unsatisfied_requirements = requirements.reject do |requirement|
@@ -370,7 +370,7 @@ module Homebrew
       test "brew", "config"
     end
 
-    def formula formula_name
+    def formula(formula_name)
       @category = "#{__method__}.#{formula_name}"
 
       canonical_formula_name = if @tap
@@ -619,11 +619,11 @@ module Homebrew
       changed_formulae + unchanged_formulae
     end
 
-    def head_only_tap? formula
+    def head_only_tap?(formula)
       formula.head && formula.devel.nil? && formula.stable.nil? && formula.tap == "homebrew/homebrew-head-only"
     end
 
-    def devel_only_tap? formula
+    def devel_only_tap?(formula)
       formula.devel && formula.stable.nil? && formula.tap == "homebrew/homebrew-devel-only"
     end
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -43,7 +43,7 @@ module Homebrew
     puts "Use `brew remove --force #{e.name}` to remove all versions."
   end
 
-  def rm_pin rack
+  def rm_pin(rack)
     Formulary.from_rack(rack).unpin rescue nil
   end
 end

--- a/Library/Homebrew/cmd/unlinkapps.rb
+++ b/Library/Homebrew/cmd/unlinkapps.rb
@@ -23,7 +23,7 @@ module Homebrew
 
   private
 
-  def should_unlink? file
+  def should_unlink?(file)
     if ARGV.named.empty?
       file.match(HOMEBREW_CELLAR) || file.match("#{HOMEBREW_PREFIX}/opt")
     else

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -280,7 +280,7 @@ class Report
     dump_formula_report :D, "Deleted Formulae"
   end
 
-  def select_formula key
+  def select_formula(key)
     fetch(key, []).map do |path|
       case path.to_s
       when HOMEBREW_TAP_PATH_REGEX
@@ -291,7 +291,7 @@ class Report
     end.sort
   end
 
-  def dump_formula_report key, title
+  def dump_formula_report(key, title)
     formula = select_formula(key)
     unless formula.empty?
       ohai title

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -46,7 +46,7 @@ module Homebrew
     not ARGV.named.empty?
   end
 
-  def upgrade_formula f
+  def upgrade_formula(f)
     outdated_keg = Keg.new(f.linked_keg.resolved_path) if f.linked_keg.directory?
     tab = Tab.for_formula(f)
 

--- a/Library/Homebrew/compat/fails_with_llvm.rb
+++ b/Library/Homebrew/compat/fails_with_llvm.rb
@@ -1,10 +1,10 @@
 class Formula
-  def fails_with_llvm msg=nil, data=nil
+  def fails_with_llvm(msg=nil, data=nil)
     opoo "Calling fails_with_llvm in the install method is deprecated"
     puts "Use the fails_with DSL instead"
   end
 
-  def self.fails_with_llvm msg=nil, data={}
+  def self.fails_with_llvm(msg=nil, data={})
     data = msg if Hash === msg
     fails_with(:llvm) { build(data.delete(:build).to_i) }
   end

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -16,7 +16,7 @@ class Formula
     "-DCMAKE_INSTALL_PREFIX='#{prefix}' -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -Wno-dev"
   end
 
-  def cxxstdlib_check check_type
+  def cxxstdlib_check(check_type)
     self.class.cxxstdlib_check check_type
   end
 

--- a/Library/Homebrew/compat/formula_specialties.rb
+++ b/Library/Homebrew/compat/formula_specialties.rb
@@ -28,7 +28,7 @@ class AmazonWebServicesFormula < Formula
   alias_method :standard_install, :install
 
   # Use this method to generate standard caveats.
-  def standard_instructions home_name, home_value=libexec
+  def standard_instructions(home_name, home_value=libexec)
     <<-EOS.undent
       Before you can use these tools you must export some variables to your $SHELL.
 

--- a/Library/Homebrew/compat/version.rb
+++ b/Library/Homebrew/compat/version.rb
@@ -1,5 +1,5 @@
 class Version
-  def slice *args
+  def slice(*args)
     opoo "Calling slice on versions is deprecated, use: to_s.slice"
     to_s.slice(*args)
   end

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -23,7 +23,7 @@ class CompilerFailure
   # The cause is no longer used so we need not hold a reference to the string
   def cause(_); end
 
-  def self.for_standard standard
+  def self.for_standard(standard)
     COLLECTIONS.fetch(standard) do
       raise ArgumentError, "\"#{standard}\" is not a recognized standard"
     end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -5,7 +5,7 @@ class AbstractDownloadStrategy
 
   attr_reader :meta, :name, :version, :resource
 
-  def initialize name, resource
+  def initialize(name, resource)
     @name = name
     @resource = resource
     @url = resource.url
@@ -32,7 +32,7 @@ class AbstractDownloadStrategy
     rm_rf(cached_location)
   end
 
-  def expand_safe_system_args args
+  def expand_safe_system_args(args)
     args = args.dup
     args.each_with_index do |arg, ii|
       if arg.is_a? Hash
@@ -49,7 +49,7 @@ class AbstractDownloadStrategy
     args
   end
 
-  def quiet_safe_system *args
+  def quiet_safe_system(*args)
     safe_system(*expand_safe_system_args(args))
   end
 
@@ -104,7 +104,7 @@ end
 class VCSDownloadStrategy < AbstractDownloadStrategy
   REF_TYPES = [:tag, :branch, :revisions, :revision].freeze
 
-  def initialize name, resource
+  def initialize(name, resource)
     super
     @ref_type, @ref = extract_ref(meta)
     @revision = meta[:revision]
@@ -502,7 +502,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     end
   end
 
-  def fetch_repo target, url, revision=nil, ignore_externals=false
+  def fetch_repo(target, url, revision=nil, ignore_externals=false)
     # Use "svn up" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
@@ -555,7 +555,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
     %r{http://llvm\.org},
   ]
 
-  def initialize name, resource
+  def initialize(name, resource)
     super
     @ref_type ||= :branch
     @ref ||= "master"

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -5,7 +5,7 @@ class KegUnspecifiedError < UsageError; end
 class MultipleVersionsInstalledError < RuntimeError
   attr_reader :name
 
-  def initialize name
+  def initialize(name)
     @name = name
     super "#{name} has multiple installed versions"
   end
@@ -16,7 +16,7 @@ class NotAKegError < RuntimeError; end
 class NoSuchKegError < RuntimeError
   attr_reader :name
 
-  def initialize name
+  def initialize(name)
     @name = name
     super "No such keg: #{HOMEBREW_CELLAR}/#{name}"
   end
@@ -37,7 +37,7 @@ class FormulaUnavailableError < RuntimeError
   attr_reader :name
   attr_accessor :dependent
 
-  def initialize name
+  def initialize(name)
     @name = name
   end
 
@@ -53,7 +53,7 @@ end
 class TapFormulaUnavailableError < FormulaUnavailableError
   attr_reader :user, :repo, :shortname
 
-  def initialize name
+  def initialize(name)
     super
     @user, @repo, @shortname = name.split("/", 3)
   end
@@ -68,7 +68,7 @@ end
 class TapFormulaAmbiguityError < RuntimeError
   attr_reader :name, :paths, :formulae
 
-  def initialize name, paths
+  def initialize(name, paths)
     @name = name
     @paths = paths
     @formulae = paths.map do |path|
@@ -87,7 +87,7 @@ end
 class TapUnavailableError < RuntimeError
   attr_reader :name
 
-  def initialize name
+  def initialize(name)
     @name = name
 
     super <<-EOS.undent
@@ -97,7 +97,7 @@ class TapUnavailableError < RuntimeError
 end
 
 class OperationInProgressError < RuntimeError
-  def initialize name
+  def initialize(name)
     message = <<-EOS.undent
       Operation already in progress for #{name}
       Another active Homebrew process is already using #{name}.
@@ -274,7 +274,7 @@ class ChecksumMissingError < ArgumentError; end
 class ChecksumMismatchError < RuntimeError
   attr_reader :expected, :hash_type
 
-  def initialize fn, expected, actual
+  def initialize(fn, expected, actual)
     @expected = expected
     @hash_type = expected.hash_type.to_s.upcase
 

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -67,14 +67,14 @@ module HomebrewArgvExtension
   end
 
   # self documenting perhaps?
-  def include? arg
+  def include?(arg)
     @n=index arg
   end
   def next
     at @n+1 or raise UsageError
   end
 
-  def value arg
+  def value(arg)
     arg = find {|o| o =~ /--#{arg}=(.+)/}
     $1 if arg
   end
@@ -161,7 +161,7 @@ module HomebrewArgvExtension
     switch?("s") || include?("--build-from-source") || !!ENV["HOMEBREW_BUILD_FROM_SOURCE"]
   end
 
-  def flag? flag
+  def flag?(flag)
     options_only.include?(flag) || switch?(flag[2, 1])
   end
 
@@ -170,7 +170,7 @@ module HomebrewArgvExtension
   end
 
   # eg. `foo -ns -i --bar` has three switches, n, s and i
-  def switch? char
+  def switch?(char)
     return false if char.length > 1
     options_only.any? { |arg| arg[1, 1] != "-" && arg.include?(char) }
   end

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -26,7 +26,7 @@ module FileUtils
 
   # A version of mkdir that also changes to that folder in a block.
   alias_method :old_mkdir, :mkdir
-  def mkdir name, &block
+  def mkdir(name, &block)
     old_mkdir(name)
     if block_given?
       chdir name do
@@ -87,20 +87,20 @@ module FileUtils
 
   # Run scons using a Homebrew-installed version, instead of whatever
   # is in the user's PATH
-  def scons *args
+  def scons(*args)
     system Formulary.factory("scons").opt_bin/"scons", *args
   end
 
-  def rake *args
+  def rake(*args)
     system RUBY_BIN/'rake', *args
   end
 
   alias_method :old_ruby, :ruby if method_defined?(:ruby)
-  def ruby *args
+  def ruby(*args)
     system RUBY_PATH, *args
   end
 
-  def xcodebuild *args
+  def xcodebuild(*args)
     removed = ENV.remove_cc_etc
     system "xcodebuild", *args
   ensure

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -9,7 +9,7 @@ class Pathname
 
   BOTTLE_EXTNAME_RX = /(\.[a-z0-9_]+\.bottle\.(\d+\.)?tar\.gz)$/
 
-  def install *sources
+  def install(*sources)
     sources.each do |src|
       case src
       when Resource
@@ -56,7 +56,7 @@ class Pathname
   private :install_p
 
   # Creates symlinks to sources in this folder.
-  def install_symlink *sources
+  def install_symlink(*sources)
     sources.each do |src|
       case src
       when Array
@@ -94,7 +94,7 @@ class Pathname
   end unless method_defined?(:binread)
 
   # NOTE always overwrites
-  def atomic_write content
+  def atomic_write(content)
     require "tempfile"
     tf = Tempfile.new(basename.to_s, dirname)
     begin
@@ -131,7 +131,7 @@ class Pathname
   end
   private :default_stat
 
-  def cp dst
+  def cp(dst)
     opoo "Pathname#cp is deprecated, use FileUtils.cp"
     if file?
       FileUtils.cp to_s, dst
@@ -141,7 +141,7 @@ class Pathname
     return dst
   end
 
-  def cp_path_sub pattern, replacement
+  def cp_path_sub(pattern, replacement)
     raise "#{self} does not exist" unless self.exist?
 
     dst = sub(pattern, replacement)
@@ -189,7 +189,7 @@ class Pathname
     false
   end
 
-  def chmod_R perms
+  def chmod_R(perms)
     opoo "Pathname#chmod_R is deprecated, use FileUtils.chmod_R"
     require 'fileutils'
     FileUtils.chmod_R perms, to_s
@@ -265,7 +265,7 @@ class Pathname
     incremental_hash(Digest::SHA2)
   end
 
-  def verify_checksum expected
+  def verify_checksum(expected)
     raise ChecksumMissingError if expected.nil? or expected.empty?
     actual = Checksum.new(expected.hash_type, send(expected.hash_type).downcase)
     raise ChecksumMismatchError.new(self, expected, actual) unless expected == actual
@@ -328,7 +328,7 @@ class Pathname
   end
 
   # Writes an exec script in this folder for each target pathname
-  def write_exec_script *targets
+  def write_exec_script(*targets)
     targets.flatten!
     if targets.empty?
       opoo "tried to write exec scripts to #{self} for an empty list of targets"
@@ -345,7 +345,7 @@ class Pathname
   end
 
   # Writes an exec script that sets environment variables
-  def write_env_script target, env
+  def write_env_script(target, env)
     env_export = ''
     env.each {|key, value| env_export += "#{key}=\"#{value}\" "}
     dirname.mkpath
@@ -356,7 +356,7 @@ class Pathname
   end
 
   # Writes a wrapper env script and moves all files to the dst
-  def env_script_all_files dst, env
+  def env_script_all_files(dst, env)
     dst.mkpath
     Pathname.glob("#{self}/*") do |file|
       next if file.directory?
@@ -367,7 +367,7 @@ class Pathname
   end
 
   # Writes an exec script that invokes a java jar
-  def write_jar_script target_jar, script_name, java_opts=""
+  def write_jar_script(target_jar, script_name, java_opts="")
     mkpath
     (self+script_name).write <<-EOS.undent
       #!/bin/bash
@@ -375,7 +375,7 @@ class Pathname
     EOS
   end
 
-  def install_metafiles from=Pathname.pwd
+  def install_metafiles(from=Pathname.pwd)
     Pathname(from).children.each do |p|
       next if p.directory?
       next unless Metafiles.copy?(p.basename.to_s)
@@ -457,20 +457,24 @@ module ObserverPathnameExtension
     puts "rm #{to_s}" if ARGV.verbose?
     ObserverPathnameExtension.n += 1
   end
+
   def rmdir
     super
     puts "rmdir #{to_s}" if ARGV.verbose?
     ObserverPathnameExtension.d += 1
   end
+
   def make_relative_symlink src
     super
     puts "ln -s #{src.relative_path_from(dirname)} #{basename}" if ARGV.verbose?
     ObserverPathnameExtension.n += 1
   end
+
   def install_info
     super
     puts "info #{to_s}" if ARGV.verbose?
   end
+
   def uninstall_info
     super
     puts "uninfo #{to_s}" if ARGV.verbose?

--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -35,7 +35,7 @@ module StringInreplaceExtension
     str.errors = []
   end
 
-  def sub! before, after
+  def sub!(before, after)
     result = super
     unless result
       errors << "expected replacement of #{before.inspect} with #{after.inspect}"
@@ -44,7 +44,7 @@ module StringInreplaceExtension
   end
 
   # Warn if nothing was replaced
-  def gsub! before, after, audit_result=true
+  def gsub!(before, after, audit_result=true)
     result = super(before, after)
     if audit_result && result.nil?
       errors << "expected replacement of #{before.inspect} with #{after.inspect}"
@@ -54,14 +54,14 @@ module StringInreplaceExtension
 
   # Looks for Makefile style variable defintions and replaces the
   # value with "new_value", or removes the definition entirely.
-  def change_make_var! flag, new_value
+  def change_make_var!(flag, new_value)
     unless gsub!(/^#{Regexp.escape(flag)}[ \t]*=[ \t]*(.*)$/, "#{flag}=#{new_value}", false)
       errors << "expected to change #{flag.inspect} to #{new_value.inspect}"
     end
   end
 
   # Removes variable assignments completely.
-  def remove_make_var! flags
+  def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
       unless gsub!(/^#{Regexp.escape(flag)}[ \t]*=.*$\n?/, "", false)
@@ -71,7 +71,7 @@ module StringInreplaceExtension
   end
 
   # Finds the specified variable
-  def get_make_var flag
+  def get_make_var(flag)
     self[/^#{Regexp.escape(flag)}[ \t]*=[ \t]*(.*)$/, 1]
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -515,7 +515,7 @@ class Formula
   #   skip_clean "bin/foo", "lib/bar"
   # keep .la files with:
   #   skip_clean :la
-  def skip_clean? path
+  def skip_clean?(path)
     return true if path.extname == '.la' and self.class.skip_clean_paths.include? :la
     to_check = path.relative_path_from(prefix).to_s
     self.class.skip_clean_paths.include? to_check
@@ -575,7 +575,7 @@ class Formula
     @pin.unpin
   end
 
-  def == other
+  def ==(other)
     instance_of?(other.class) &&
       name == other.name &&
       active_spec == other.active_spec
@@ -695,7 +695,7 @@ class Formula
     end
   end
 
-  def print_tap_action options={}
+  def print_tap_action(options={})
     if tap?
       verb = options[:verb] || "Installing"
       ohai "#{verb} #{name} from #{tap}"
@@ -708,7 +708,7 @@ class Formula
   end
 
   # @deprecated
-  def self.path name
+  def self.path(name)
     Formulary.core_path(name)
   end
 
@@ -789,7 +789,7 @@ class Formula
     active_spec.fetch
   end
 
-  def verify_download_integrity fn
+  def verify_download_integrity(fn)
     active_spec.verify_download_integrity(fn)
   end
 
@@ -824,7 +824,7 @@ class Formula
 
   protected
 
-  def setup_test_home home
+  def setup_test_home(home)
     # keep Homebrew's site-packages in sys.path when testing with system Python
     user_site_packages = home/"Library/Python/2.7/lib/python/site-packages"
     user_site_packages.mkpath
@@ -836,7 +836,7 @@ class Formula
 
   # Pretty titles the command and buffers stdout/stderr
   # Throws if there's an error
-  def system cmd, *args
+  def system(cmd, *args)
     verbose = ARGV.verbose?
     # remove "boring" arguments so that the important ones are more likely to
     # be shown considering that we trim long ohai lines to the terminal width
@@ -953,7 +953,7 @@ class Formula
     end
   end
 
-  def self.method_added method
+  def self.method_added(method)
     case method
     when :brew
       raise "You cannot override Formula#brew in class #{name}"
@@ -1019,7 +1019,7 @@ class Formula
     # @!attribute [w] url
     # The URL used to download the source for the {#stable} version of the formula.
     # We prefer `https` for security and proxy reasons.
-    def url val, specs={}
+    def url(val, specs={})
       stable.url(val, specs)
     end
 
@@ -1027,7 +1027,7 @@ class Formula
     # The version string for the {#stable} version of the formula.
     # The version is autodetected from the URL and/or tag so only needs to be
     # declared if it cannot be autodetected correctly.
-    def version val=nil
+    def version(val=nil)
       stable.version(val)
     end
 
@@ -1037,7 +1037,7 @@ class Formula
     # there can be more than one. Generally we add them when the main {.url}
     # is unreliable. If {.url} is really unreliable then we may swap the
     # {.mirror} and {.url}.
-    def mirror val
+    def mirror(val)
       stable.mirror(val)
     end
 
@@ -1056,7 +1056,7 @@ class Formula
       define_method(type) { |val| stable.send(type, val) }
     end
 
-    def bottle *, &block
+    def bottle(*, &block)
       stable.bottle(&block)
     end
 
@@ -1064,19 +1064,19 @@ class Formula
       stable.build
     end
 
-    def stable &block
+    def stable(&block)
       @stable ||= SoftwareSpec.new
       return @stable unless block_given?
       @stable.instance_eval(&block)
     end
 
-    def devel &block
+    def devel(&block)
       @devel ||= SoftwareSpec.new
       return @devel unless block_given?
       @devel.instance_eval(&block)
     end
 
-    def head val=nil, specs={}, &block
+    def head(val=nil, specs={}, &block)
       @head ||= HeadSoftwareSpec.new
       if block_given?
         @head.instance_eval(&block)
@@ -1088,33 +1088,33 @@ class Formula
     end
 
     # Define a named resource using a {SoftwareSpec} style block
-    def resource name, klass=Resource, &block
+    def resource(name, klass=Resource, &block)
       specs.each do |spec|
         spec.resource(name, klass, &block) unless spec.resource_defined?(name)
       end
     end
 
-    def go_resource name, &block
+    def go_resource(name, &block)
       specs.each { |spec| spec.go_resource(name, &block) }
     end
 
-    def depends_on dep
+    def depends_on(dep)
       specs.each { |spec| spec.depends_on(dep) }
     end
 
-    def option name, description=""
+    def option(name, description="")
       specs.each { |spec| spec.option(name, description) }
     end
 
-    def deprecated_option hash
+    def deprecated_option(hash)
       specs.each { |spec| spec.deprecated_option(hash) }
     end
 
-    def patch strip=:p1, src=nil, &block
+    def patch(strip=:p1, src=nil, &block)
       specs.each { |spec| spec.patch(strip, src, &block) }
     end
 
-    def plist_options options
+    def plist_options(options)
       @plist_startup = options[:startup]
       @plist_manual = options[:manual]
     end
@@ -1123,12 +1123,12 @@ class Formula
       @conflicts ||= []
     end
 
-    def conflicts_with *names
+    def conflicts_with(*names)
       opts = Hash === names.last ? names.pop : {}
       names.each { |name| conflicts << FormulaConflict.new(name, opts[:because]) }
     end
 
-    def skip_clean *paths
+    def skip_clean(*paths)
       paths.flatten!
       # Specifying :all is deprecated and will become an error
       skip_clean_paths.merge(paths)
@@ -1138,12 +1138,12 @@ class Formula
       @skip_clean_paths ||= Set.new
     end
 
-    def keg_only reason, explanation=""
+    def keg_only(reason, explanation="")
       @keg_only_reason = KegOnlyReason.new(reason, explanation)
     end
 
     # Pass :skip to this method to disable post-install stdlib checking
-    def cxxstdlib_check check_type
+    def cxxstdlib_check(check_type)
       define_method(:skip_cxxstdlib_check?) { true } if check_type == :skip
     end
 
@@ -1174,15 +1174,15 @@ class Formula
     # fails_with :gcc => '4.8' do
     #   version '4.8.1'
     # end
-    def fails_with compiler, &block
+    def fails_with(compiler, &block)
       specs.each { |spec| spec.fails_with(compiler, &block) }
     end
 
-    def needs *standards
+    def needs(*standards)
       specs.each { |spec| spec.needs(*standards) }
     end
 
-    def test &block
+    def test(&block)
       define_method(:test, &block)
     end
   end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -1,5 +1,5 @@
 module FormulaCellarChecks
-  def check_PATH bin
+  def check_PATH(bin)
     # warn the user if stuff was installed outside of their PATH
     return unless bin.directory?
     return unless bin.children.length > 0
@@ -73,7 +73,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_non_executables bin
+  def check_non_executables(bin)
     return unless bin.directory?
 
     non_exes = bin.children.select { |g| g.directory? or not g.executable? }
@@ -86,7 +86,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_generic_executables bin
+  def check_generic_executables(bin)
     return unless bin.directory?
     generic_names = %w[run service start stop]
     generics = bin.children.select { |g| generic_names.include? g.basename.to_s }
@@ -126,7 +126,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_easy_install_pth lib
+  def check_easy_install_pth(lib)
     pth_found = Dir["#{lib}/python{2.7,3}*/site-packages/easy-install.pth"].map { |f| File.dirname(f) }
     return if pth_found.empty?
 
@@ -156,7 +156,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_python_framework_links lib
+  def check_python_framework_links(lib)
     python_modules = Pathname.glob lib/"python*/site-packages/**/*.so"
     framework_links = python_modules.select do |obj|
       dlls = obj.dynamically_linked_libraries

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -40,7 +40,7 @@ class Formulary
     end
   end
 
-  def self.class_s name
+  def self.class_s(name)
     class_name = name.capitalize
     class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
     class_name.gsub!('+', 'x')
@@ -81,7 +81,7 @@ class Formulary
 
   # Loads formulae from bottles.
   class BottleLoader < FormulaLoader
-    def initialize bottle_name
+    def initialize(bottle_name)
       @bottle_filename = Pathname(bottle_name).realpath
       name, full_name = bottle_resolve_formula_names @bottle_filename
       super name, Formulary.path(full_name)
@@ -95,7 +95,7 @@ class Formulary
   end
 
   class AliasLoader < FormulaLoader
-    def initialize alias_path
+    def initialize(alias_path)
       path = alias_path.resolved_path
       name = path.basename(".rb").to_s
       super name, path
@@ -104,7 +104,7 @@ class Formulary
 
   # Loads formulae from disk using a path
   class FromPathLoader < FormulaLoader
-    def initialize path
+    def initialize(path)
       path = Pathname.new(path).expand_path
       super path.basename(".rb").to_s, path
     end
@@ -114,7 +114,7 @@ class Formulary
   class FromUrlLoader < FormulaLoader
     attr_reader :url
 
-    def initialize url
+    def initialize(url)
       @url = url
       uri = URI(url)
       formula = File.basename(uri.path, ".rb")
@@ -133,7 +133,7 @@ class Formulary
   class TapLoader < FormulaLoader
     attr_reader :tapped_name
 
-    def initialize tapped_name
+    def initialize(tapped_name)
       @tapped_name = tapped_name
       user, repo, name = tapped_name.split("/", 3).map(&:downcase)
       tap = Tap.new user, repo

--- a/Library/Homebrew/hooks/bottles.rb
+++ b/Library/Homebrew/hooks/bottles.rb
@@ -7,12 +7,12 @@
 module Homebrew
   module Hooks
     module Bottles
-      def self.setup_formula_has_bottle &block
+      def self.setup_formula_has_bottle(&block)
         @has_bottle = block
         true
       end
 
-      def self.setup_pour_formula_bottle &block
+      def self.setup_pour_formula_bottle(&block)
         @pour_bottle = block
         true
       end

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -9,17 +9,17 @@ module InstallRenamed
     end
   end
 
-  def cp_path_sub pattern, replacement
+  def cp_path_sub(pattern, replacement)
     super do |src, dst|
       append_default_if_different(src, dst)
     end
   end
 
-  def + path
+  def +(path)
     super(path).extend(InstallRenamed)
   end
 
-  def / path
+  def /(path)
     super(path).extend(InstallRenamed)
   end
 

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -82,7 +82,7 @@ class Keg
   ]
 
   # if path is a file in a keg then this will return the containing Keg object
-  def self.for path
+  def self.for(path)
     path = path.realpath
     while not path.root?
       return Keg.new(path) if path.parent.parent == HOMEBREW_CELLAR.realpath
@@ -94,7 +94,7 @@ class Keg
   attr_reader :path, :name, :linked_keg_record, :opt_record
   protected :path
 
-  def initialize path
+  def initialize(path)
     raise "#{path} is not a valid keg" unless path.parent.parent.realpath == HOMEBREW_CELLAR.realpath
     raise "#{path} is not a directory" unless path.directory?
     @path = path
@@ -218,7 +218,7 @@ class Keg
     FormulaLock.new(name).with_lock { yield }
   end
 
-  def completion_installed? shell
+  def completion_installed?(shell)
     dir = case shell
           when :bash then path.join("etc", "bash_completion.d")
           when :zsh  then path.join("share", "zsh", "site-functions")
@@ -252,7 +252,7 @@ class Keg
     path.find(*args, &block)
   end
 
-  def link mode=OpenStruct.new
+  def link(mode=OpenStruct.new)
     raise AlreadyLinkedError.new(self) if linked_keg_record.directory?
 
     ObserverPathnameExtension.reset_counts!
@@ -335,7 +335,7 @@ class Keg
 
   private
 
-  def resolve_any_conflicts dst, mode
+  def resolve_any_conflicts(dst, mode)
     return unless dst.symlink?
 
     src = dst.resolved_path
@@ -366,7 +366,7 @@ class Keg
     end
   end
 
-  def make_relative_symlink dst, src, mode
+  def make_relative_symlink(dst, src, mode)
     if dst.symlink? && src == dst.resolved_path
       puts "Skipping; link already exists: #{dst}" if ARGV.verbose?
       return
@@ -406,7 +406,7 @@ class Keg
   protected
 
   # symlinks the contents of path+relative_dir recursively into #{HOMEBREW_PREFIX}/relative_dir
-  def link_dir relative_dir, mode
+  def link_dir(relative_dir, mode)
     root = path+relative_dir
     return unless root.exist?
     root.find do |src|

--- a/Library/Homebrew/keg_fix_install_names.rb
+++ b/Library/Homebrew/keg_fix_install_names.rb
@@ -2,7 +2,7 @@ class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@".freeze
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@".freeze
 
-  def fix_install_names options={}
+  def fix_install_names(options={})
     mach_o_files.each do |file|
       file.ensure_writable do
         change_dylib_id(dylib_id_for(file, options), file) if file.dylib?
@@ -18,7 +18,7 @@ class Keg
     end
   end
 
-  def relocate_install_names old_prefix, new_prefix, old_cellar, new_cellar, options={}
+  def relocate_install_names(old_prefix, new_prefix, old_cellar, new_cellar, options={})
     mach_o_files.each do |file|
       file.ensure_writable do
         if file.dylib?
@@ -85,7 +85,7 @@ class Keg
     results.to_a
   end
 
-  def each_unique_file_matching string
+  def each_unique_file_matching(string)
     Utils.popen_read("/usr/bin/fgrep", "-lr", string, to_s) do |io|
       hardlinks = Set.new
 
@@ -126,7 +126,7 @@ class Keg
     path.join("lib")
   end
 
-  def each_install_name_for file, &block
+  def each_install_name_for(file, &block)
     dylibs = file.dynamically_linked_libraries
     dylibs.reject! { |fn| fn =~ /^@(loader_|executable_|r)path/ }
     dylibs.each(&block)
@@ -146,7 +146,7 @@ class Keg
     end
   end
 
-  def find_dylib name
+  def find_dylib(name)
     lib.find { |pn| break pn if pn.basename == name } if lib.directory?
   end
 

--- a/Library/Homebrew/language/go.rb
+++ b/Library/Homebrew/language/go.rb
@@ -6,7 +6,7 @@ module Language
     # building go software.
     # The resource names should be the import name of the package,
     # e.g. `resource "github.com/foo/bar"`
-    def self.stage_deps resources, target
+    def self.stage_deps(resources, target)
       resources.grep(Resource::Go) { |resource| resource.stage(target) }
     end
   end

--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -9,7 +9,7 @@ module Language
         end
       end
 
-      def self.included base
+      def self.included(base)
         base.extend ClassMethods
       end
 
@@ -66,7 +66,7 @@ module Language
         rm_rf lib
       end
 
-      def install_cabal_package args=[]
+      def install_cabal_package(args=[])
         cabal_sandbox do
           # the dependencies are built first and installed locally, and only the
           # current package is actually installed in the destination dir

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -2,7 +2,7 @@ require "utils.rb"
 
 module Language
   module Python
-    def self.major_minor_version python
+    def self.major_minor_version(python)
       version = /\d\.\d/.match `#{python} --version 2>&1`
       return unless version
       Version.new(version.to_s)
@@ -12,7 +12,7 @@ module Language
       HOMEBREW_PREFIX/"lib/python#{version}/site-packages"
     end
 
-    def self.each_python build, &block
+    def self.each_python(build, &block)
       original_pythonpath = ENV["PYTHONPATH"]
       ["python", "python3"].each do |python|
         next if build.without? python
@@ -27,7 +27,7 @@ module Language
       ENV["PYTHONPATH"] = original_pythonpath
     end
 
-    def self.reads_brewed_pth_files? python
+    def self.reads_brewed_pth_files?(python)
       version = major_minor_version python
       return unless homebrew_site_packages(version).directory?
       return unless homebrew_site_packages(version).writable_real?
@@ -40,11 +40,11 @@ module Language
       end
     end
 
-    def self.user_site_packages python
+    def self.user_site_packages(python)
       Pathname.new(`#{python} -c "import site; print(site.getusersitepackages())"`.chomp)
     end
 
-    def self.in_sys_path? python, path
+    def self.in_sys_path?(python, path)
       script = <<-EOS.undent
         import os, sys
         [os.path.realpath(p) for p in sys.path].index(os.path.realpath("#{path}"))
@@ -53,7 +53,7 @@ module Language
     end
 
     # deprecated; use system "python", *setup_install_args(prefix) instead
-    def self.setup_install python, prefix, *args
+    def self.setup_install(python, prefix, *args)
       opoo <<-EOS.undent
         Language::Python.setup_install is deprecated.
         If you are a formula author, please use
@@ -75,7 +75,7 @@ module Language
       system python, "-c", shim, "install", *args
     end
 
-    def self.setup_install_args prefix
+    def self.setup_install_args(prefix)
       shim = <<-EOS.undent
         import setuptools, tokenize
         __file__ = 'setup.py'
@@ -93,7 +93,7 @@ module Language
       ]
     end
 
-    def self.package_available? python, module_name
+    def self.package_available?(python, module_name)
       quiet_system python, "-c", "import #{module_name}"
     end
   end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -19,7 +19,7 @@ module OS
       version.to_sym
     end
 
-    def locate tool
+    def locate(tool)
       # Don't call tools (cc, make, strip, etc.) directly!
       # Give the name of the binary you look for as a string to this method
       # in order to get the full path back as a Pathname.

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -118,7 +118,7 @@ class ExternalPatch
     true
   end
 
-  def owner= owner
+  def owner=(owner)
     resource.owner   = owner
     resource.version = resource.checksum || ERB::Util.url_encode(resource.url)
   end

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -3,7 +3,7 @@ require 'requirement'
 class LanguageModuleRequirement < Requirement
   fatal true
 
-  def initialize language, module_name, import_name=nil
+  def initialize(language, module_name, import_name=nil)
     @language = language
     @module_name = module_name
     @import_name = import_name || module_name

--- a/Library/Homebrew/requirements/mpi_requirement.rb
+++ b/Library/Homebrew/requirements/mpi_requirement.rb
@@ -23,7 +23,7 @@ class MPIRequirement < Requirement
     super(tags)
   end
 
-  def mpi_wrapper_works? compiler
+  def mpi_wrapper_works?(compiler)
     compiler = which compiler
     return false if compiler.nil? or not compiler.executable?
 

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -32,7 +32,7 @@ class X11Requirement < Requirement
     s
   end
 
-  def <=> other
+  def <=>(other)
     return unless X11Requirement === other
     min_version <=> other.min_version
   end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -38,7 +38,7 @@ class Resource
     end
   end
 
-  def initialize name=nil, &block
+  def initialize(name=nil, &block)
     @name = name
     @url = nil
     @version = nil
@@ -114,7 +114,7 @@ class Resource
     cached_download
   end
 
-  def verify_download_integrity fn
+  def verify_download_integrity(fn)
     if fn.file?
       ohai "Verifying #{fn.basename} checksum" if ARGV.verbose?
       fn.verify_checksum(checksum)
@@ -129,7 +129,7 @@ class Resource
     define_method(type) { |val| @checksum = Checksum.new(type, val) }
   end
 
-  def url val=nil, specs={}
+  def url(val=nil, specs={})
     return @url if val.nil?
     @url = val
     @specs.merge!(specs)
@@ -137,11 +137,11 @@ class Resource
     @download_strategy = DownloadStrategyDetector.detect(url, using)
   end
 
-  def version val=nil
+  def version(val=nil)
     @version ||= detect_version(val)
   end
 
-  def mirror val
+  def mirror(val)
     mirrors << val
   end
 
@@ -160,7 +160,7 @@ class Resource
   end
 
   class Go < Resource
-    def stage target
+    def stage(target)
       super(target/name)
     end
   end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -44,7 +44,7 @@ class SoftwareSpec
     @compiler_failures = []
   end
 
-  def owner= owner
+  def owner=(owner)
     @name = owner.name
     @full_name = owner.full_name
     @bottle_specification.tap = owner.tap
@@ -57,7 +57,7 @@ class SoftwareSpec
     patches.each { |p| p.owner = self }
   end
 
-  def url val=nil, specs={}
+  def url(val=nil, specs={})
     return @resource.url if val.nil?
     @resource.url(val, specs)
     dependency_collector.add(@resource)
@@ -68,15 +68,15 @@ class SoftwareSpec
       (bottle_specification.compatible_cellar? || ARGV.force_bottle?)
   end
 
-  def bottle &block
+  def bottle(&block)
     bottle_specification.instance_eval(&block)
   end
 
-  def resource_defined? name
+  def resource_defined?(name)
     resources.has_key?(name)
   end
 
-  def resource name, klass=Resource, &block
+  def resource(name, klass=Resource, &block)
     if block_given?
       raise DuplicateResourceError.new(name) if resource_defined?(name)
       res = klass.new(name, &block)
@@ -87,7 +87,7 @@ class SoftwareSpec
     end
   end
 
-  def go_resource name, &block
+  def go_resource(name, &block)
     resource name, Resource::Go, &block
   end
 
@@ -110,7 +110,7 @@ class SoftwareSpec
     options << opt
   end
 
-  def deprecated_option hash
+  def deprecated_option(hash)
     raise ArgumentError, "deprecated_option hash must not be empty" if hash.empty?
     hash.each do |old_options, new_options|
       Array(old_options).each do |old_option|
@@ -131,7 +131,7 @@ class SoftwareSpec
     @build = BuildOptions.new(Options.create(@flags), options)
   end
 
-  def depends_on spec
+  def depends_on(spec)
     dep = dependency_collector.add(spec)
     add_dep_option(dep) if dep
   end
@@ -144,15 +144,15 @@ class SoftwareSpec
     dependency_collector.requirements
   end
 
-  def patch strip=:p1, src=nil, &block
+  def patch(strip=:p1, src=nil, &block)
     patches << Patch.create(strip, src, &block)
   end
 
-  def fails_with compiler, &block
+  def fails_with(compiler, &block)
     compiler_failures << CompilerFailure.create(compiler, &block)
   end
 
-  def needs *standards
+  def needs(*standards)
     standards.each do |standard|
       compiler_failures.concat CompilerFailure.for_standard(standard)
     end
@@ -181,7 +181,7 @@ class HeadSoftwareSpec < SoftwareSpec
     @resource.version = Version.new('HEAD')
   end
 
-  def verify_download_integrity fn
+  def verify_download_integrity(fn)
     return
   end
 end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -30,11 +30,11 @@ class Tab < OpenStruct
     new(attributes)
   end
 
-  def self.from_file path
+  def self.from_file(path)
     from_file_content(File.read(path), path)
   end
 
-  def self.from_file_content content, path
+  def self.from_file_content(content, path)
     attributes = Utils::JSON.load(content)
     attributes["tabfile"] = path
     attributes["source"] ||= {}
@@ -47,7 +47,7 @@ class Tab < OpenStruct
     new(attributes)
   end
 
-  def self.for_keg keg
+  def self.for_keg(keg)
     path = keg.join(FILENAME)
 
     if path.exist?
@@ -57,11 +57,11 @@ class Tab < OpenStruct
     end
   end
 
-  def self.for_name name
+  def self.for_name(name)
     for_formula(Formulary.factory(name))
   end
 
-  def self.remap_deprecated_options deprecated_options, options
+  def self.remap_deprecated_options(deprecated_options, options)
     deprecated_options.each do |deprecated_option|
       option = options.find { |o| o.name == deprecated_option.old }
       next unless option
@@ -71,7 +71,7 @@ class Tab < OpenStruct
     options
   end
 
-  def self.for_formula f
+  def self.for_formula(f)
     paths = []
 
     if f.opt_prefix.symlink? && f.opt_prefix.directory?
@@ -122,16 +122,16 @@ class Tab < OpenStruct
     new(attributes)
   end
 
-  def with? val
+  def with?(val)
     name = val.respond_to?(:option_name) ? val.option_name : val
     include?("with-#{name}") || unused_options.include?("without-#{name}")
   end
 
-  def without? name
+  def without?(name)
     not with? name
   end
 
-  def include? opt
+  def include?(opt)
     used_options.include? opt
   end
 

--- a/Library/Homebrew/test/testball.rb
+++ b/Library/Homebrew/test/testball.rb
@@ -6,6 +6,7 @@ class Testball < Formula
     end
     super
   end
+
   def install
     prefix.install "bin"
     prefix.install "libexec"

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -24,15 +24,15 @@ module Homebrew
       Version.new(v)
     end
 
-    def assert_version_equal expected, actual
+    def assert_version_equal(expected, actual)
       assert_equal Version.new(expected), actual
     end
 
-    def assert_version_detected expected, url
+    def assert_version_detected(expected, url)
       assert_equal expected, Version.parse(url).to_s
     end
 
-    def assert_version_nil url
+    def assert_version_nil(url)
       assert_nil Version.parse(url)
     end
   end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -28,61 +28,61 @@ class Tty
 
     private
 
-    def color n
+    def color(n)
       escape "0;#{n}"
     end
-    def bold n
+    def bold(n)
       escape "1;#{n}"
     end
-    def underline n
+    def underline(n)
       escape "4;#{n}"
     end
-    def escape n
+    def escape(n)
       "\033[#{n}m" if $stdout.tty?
     end
   end
 end
 
-def ohai title, *sput
+def ohai(title, *sput)
   title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
   puts "#{Tty.blue}==>#{Tty.white} #{title}#{Tty.reset}"
   puts sput
 end
 
-def oh1 title
+def oh1(title)
   title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
   puts "#{Tty.green}==>#{Tty.white} #{title}#{Tty.reset}"
 end
 
-def opoo warning
+def opoo(warning)
   $stderr.puts "#{Tty.yellow}Warning#{Tty.reset}: #{warning}"
 end
 
-def onoe error
+def onoe(error)
   $stderr.puts "#{Tty.red}Error#{Tty.reset}: #{error}"
 end
 
-def ofail error
+def ofail(error)
   onoe error
   Homebrew.failed = true
 end
 
-def odie error
+def odie(error)
   onoe error
   exit 1
 end
 
-def pretty_duration s
+def pretty_duration(s)
   return "2 seconds" if s < 3 # avoids the plural problem ;)
   return "#{s.to_i} seconds" if s < 120
   return "%.1f minutes" % (s/60)
 end
 
-def plural n, s="s"
+def plural(n, s="s")
   (n == 1) ? "" : s
 end
 
-def interactive_shell f=nil
+def interactive_shell(f=nil)
   unless f.nil?
     ENV['HOMEBREW_DEBUG_PREFIX'] = f.prefix
     ENV['HOMEBREW_DEBUG_INSTALL'] = f.full_name
@@ -101,7 +101,7 @@ def interactive_shell f=nil
 end
 
 module Homebrew
-  def self.system cmd, *args
+  def self.system(cmd, *args)
     puts "#{cmd} #{args*' '}" if ARGV.verbose?
     pid = fork do
       yield if block_given?
@@ -160,12 +160,12 @@ def run_as_not_developer(&block)
 end
 
 # Kernel.system but with exceptions
-def safe_system cmd, *args
+def safe_system(cmd, *args)
   Homebrew.system(cmd, *args) or raise ErrorDuringExecution.new(cmd, args)
 end
 
 # prints no output
-def quiet_system cmd, *args
+def quiet_system(cmd, *args)
   Homebrew.system(cmd, *args) do
     # Redirect output streams to `/dev/null` instead of closing as some programs
     # will fail to execute if they can't write to an open stream.
@@ -174,7 +174,7 @@ def quiet_system cmd, *args
   end
 end
 
-def curl *args
+def curl(*args)
   brewed_curl = HOMEBREW_PREFIX/"opt/curl/bin/curl"
   curl = if MacOS.version <= "10.6" && brewed_curl.exist?
     brewed_curl
@@ -193,7 +193,7 @@ def curl *args
   safe_system curl, *args
 end
 
-def puts_columns items, star_items=[]
+def puts_columns(items, star_items=[])
   return if items.empty?
 
   if star_items && star_items.any?
@@ -214,7 +214,7 @@ def puts_columns items, star_items=[]
   end
 end
 
-def which cmd, path=ENV['PATH']
+def which(cmd, path=ENV['PATH'])
   path.split(File::PATH_SEPARATOR).each do |p|
     pcmd = File.expand_path(cmd, p)
     return Pathname.new(pcmd) if File.file?(pcmd) && File.executable?(pcmd)
@@ -244,23 +244,23 @@ def which_editor
   editor
 end
 
-def exec_editor *args
+def exec_editor(*args)
   safe_exec(which_editor, *args)
 end
 
-def exec_browser *args
+def exec_browser(*args)
   browser = ENV['HOMEBREW_BROWSER'] || ENV['BROWSER'] || OS::PATH_OPEN
   safe_exec(browser, *args)
 end
 
-def safe_exec cmd, *args
+def safe_exec(cmd, *args)
   # This buys us proper argument quoting and evaluation
   # of environment variables in the cmd parameter.
   exec "/bin/sh", "-c", "#{cmd} \"$@\"", "--", *args
 end
 
 # GZips the given paths, and returns the gzipped paths
-def gzip *paths
+def gzip(*paths)
   paths.collect do |path|
     with_system_path { safe_system 'gzip', path }
     Pathname.new("#{path}.gz")
@@ -268,7 +268,7 @@ def gzip *paths
 end
 
 # Returns array of architectures that the given command or library is built for.
-def archs_for_command cmd
+def archs_for_command(cmd)
   cmd = which(cmd) unless Pathname.new(cmd).absolute?
   Pathname.new(cmd).archs
 end
@@ -427,7 +427,7 @@ module GitHub extend self
     end
   end
 
-  def issues_for_formula name
+  def issues_for_formula(name)
     issues_matching(name, :state => "open")
   end
 

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -8,7 +8,7 @@ module Utils
   end
 
   module Inreplace
-    def inreplace paths, before=nil, after=nil
+    def inreplace(paths, before=nil, after=nil)
       errors = {}
 
       Array(paths).each do |path|

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -267,12 +267,12 @@ class Version
     end
   end
 
-  def self.parse spec
+  def self.parse(spec)
     version = _parse(spec)
     new(version) unless version.nil?
   end
 
-  def self._parse spec
+  def self._parse(spec)
     spec = Pathname.new(spec) unless spec.is_a? Pathname
 
     spec_s = spec.to_s

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -54,7 +54,7 @@ end
 # odd exceptions. Reduce our support burden by showing a user-friendly error.
 Dir.getwd rescue abort "The current working directory doesn't exist, cannot proceed."
 
-def require? path
+def require?(path)
   require path
 rescue LoadError => e
   # HACK :( because we should raise on syntax errors but


### PR DESCRIPTION
Hello!

These commits correct some minor formatting issues in Homebrew's core, namely missing spacing between methods and missing parentheses in method declarations with arguments.

Each directory's formatting corrections are isolated in its own commit.

Other potential issues I didn't correct, but can if wanted:
- [ ] Remaining heredocs that haven't been converted to use `EOS.undent`
- [ ] Excessively brief method arguments (`f`, `fn`, `val`, etc)
- [ ] Indentation corrections and preference of `""` over `''` (or vice versa)
- [ ] Replacement of Perl-style special variables with Ruby-style ones
