### PR TITLE
Explicitly pass `--ff` and `--no-rebase` to `git pull` on `brew update`

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -196,6 +196,7 @@ class Updater
     safe_system "git", "config", "core.autocrlf", "false"
 
     args = ["pull"]
+    args << "--ff"
     args << ((ARGV.include? "--rebase") ? "--rebase" : "--no-rebase")
     args += quiet
     args << "origin"

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -196,7 +196,7 @@ class Updater
     safe_system "git", "config", "core.autocrlf", "false"
 
     args = ["pull"]
-    args << "--rebase" if ARGV.include? "--rebase"
+    args << ((ARGV.include? "--rebase") ? "--rebase" : "--no-rebase")
     args += quiet
     args << "origin"
     # the refspec ensures that 'origin/master' gets updated

--- a/Library/Homebrew/test/test_updater.rb
+++ b/Library/Homebrew/test/test_updater.rb
@@ -61,7 +61,7 @@ class UpdaterTests < Homebrew::TestCase
     @updater.in_repo_expect("git symbolic-ref --short HEAD", "master")
     @updater.in_repo_expect("git rev-parse -q --verify HEAD", "1234abcd")
     @updater.in_repo_expect("git config core.autocrlf false")
-    @updater.in_repo_expect("git pull --quiet origin refs/heads/master:refs/remotes/origin/master")
+    @updater.in_repo_expect("git pull --ff --no-rebase --quiet origin refs/heads/master:refs/remotes/origin/master")
     @updater.in_repo_expect("git rev-parse -q --verify HEAD", "3456cdef")
     @updater.pull!(:silent => true)
     @updater.in_repo_expect("git rev-parse -q --verify HEAD", "3456cdef")


### PR DESCRIPTION
This overrides any global or per-repository `pull.rebase` and `pull.ff` config settings the user may have set.