### PR TITLE
New formula: xcode-coveralls 0.1.0

### DIFF
--- a/Library/Formula/xcode-coveralls.rb
+++ b/Library/Formula/xcode-coveralls.rb
@@ -1,0 +1,14 @@
+class XcodeCoveralls < Formula
+  desc "A tool to upload code coverage from Xcode to coveralls.io."
+  homepage "https://macmade.github.io/xcode-coveralls"
+  url "https://github.com/macmade/xcode-coveralls/archive/0.1.0.tar.gz"
+  sha256 "17e671c39a2c037a40e5f35808744752c802d7884cd16f17bb247fa1bb337d59"
+  depends_on :xcode => 6.0
+  def install
+    xcodebuild "SDKROOT=", "SYMROOT=build"
+    bin.install "build/Release/xcode-coveralls"
+  end
+  test do
+    system "#{bin}/xcode-coveralls", "--version"
+  end
+end


### PR DESCRIPTION
xcode-coveralls is a command line helper tool to upload code coverage data from Xcode projects to coveralls.io.

Having this tool in Homebrew would be very useful on CI platforms supporting Homebrew, like Travis CI.

Homepage: http://macmade.github.io/xcode-coveralls/