### PR TITLE
macvim 7.4-77

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -4,7 +4,7 @@ class Macvim < Formula
   homepage 'https://code.google.com/p/macvim/'
   url 'https://github.com/macvim-dev/macvim/archive/snapshot-77.tar.gz'
   version '7.4-77'
-  sha1 '65223f19da35f1a3edc5fb399180c19953b754eb'
+  sha256 '6b7f4b48ecef4a00dca17efef551884fcea1aa9897005497d31f52da7304bc5f'
 
   head 'https://github.com/macvim-dev/macvim.git'
 

--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -2,9 +2,9 @@
 class Macvim < Formula
   desc "A GUI for vim, made for OS X"
   homepage 'https://code.google.com/p/macvim/'
-  url 'https://github.com/macvim-dev/macvim/archive/Snapshot-76.tar.gz'
-  version '7.4-76'
-  sha1 'bced599503faa65c146394eb951d7a43b49510a4'
+  url 'https://github.com/macvim-dev/macvim/archive/snapshot-77.tar.gz'
+  version '7.4-77'
+  sha1 '65223f19da35f1a3edc5fb399180c19953b754eb'
 
   head 'https://github.com/macvim-dev/macvim.git'
 


### PR DESCRIPTION
MacVim 7.4-77, which fixes the fullscreen problem under OS X Yosemite and on secondary monitors. :-)