### PR TITLE
Add dependency on gnutls to enable newest TLS protocols

### DIFF
--- a/Library/Formula/mutt.rb
+++ b/Library/Formula/mutt.rb
@@ -46,6 +46,7 @@ class Mutt < Formula
   depends_on "automake" => :build
 
   depends_on "openssl"
+  depends_on "gnutls"
   depends_on "tokyo-cabinet"
   depends_on "s-lang" => :optional
   depends_on "gpgme" => :optional


### PR DESCRIPTION
As more and more email providers are disabling SSLv3 and TLS 1.0, the need
the need for the latest and greatest TLS vesrion support is paramount.
This change adds gnutls as dependency which enables default TLS mutt
options like ssl_use_tlsv1_2 to work (see
  http://www.mutt.org/doc/devel/manual.html#ssl-use-sslv3).

Some providers that have already cut users off for using SSLv3 or TLS 1.0
are Office365 and ZohoMail (maybe others). Others are likely to enforce
this option soon as well given the Poodle vulnerability:

  https://access.redhat.com/articles/1232123