### PR TITLE
add space around URL of pull request in output

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -214,7 +214,7 @@ class BuildError < RuntimeError
     puts
     unless RUBY_VERSION < "1.8.7" || issues.empty?
       puts "These open issues may also help:"
-      puts issues.map{ |i| "#{i['title']}: #{i['html_url']}" }.join("\n")
+      puts issues.map{ |i| "#{i['title']} #{i['html_url']}" }.join("\n")
     end
 
     if MacOS.version >= "10.11"

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -214,7 +214,7 @@ class BuildError < RuntimeError
     puts
     unless RUBY_VERSION < "1.8.7" || issues.empty?
       puts "These open issues may also help:"
-      puts issues.map{ |i| "#{i['title']} ( #{i['html_url']} )" }.join("\n")
+      puts issues.map{ |i| "#{i['title']}: #{i['html_url']}" }.join("\n")
     end
 
     if MacOS.version >= "10.11"

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -214,7 +214,7 @@ class BuildError < RuntimeError
     puts
     unless RUBY_VERSION < "1.8.7" || issues.empty?
       puts "These open issues may also help:"
-      puts issues.map{ |i| "#{i['title']} (#{i['html_url']})" }.join("\n")
+      puts issues.map{ |i| "#{i['title']} ( #{i['html_url']} )" }.join("\n")
     end
 
     if MacOS.version >= "10.11"


### PR DESCRIPTION
With default setting of iTerm.app, selecting URL of pull request with right-click results in like this:

<img width="405" alt="scr 2015-07-11 at 10 49 04" src="https://cloud.githubusercontent.com/assets/685936/8632741/2e94254e-27e3-11e5-91ad-20a481ac9b5b.png">
<img width="1154" alt="scr 2015-07-11 at 10 49 20" src="https://cloud.githubusercontent.com/assets/685936/8632739/2b566f90-27e3-11e5-8fca-04c9061d1fb5.png">

This pr fixes that by appending space around the URL.