### PR TITLE
Merge test gitignore into root version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@
 !/share/man/man1/brew.1
 .DS_Store
 /Library/Homebrew/doc
+/Library/Homebrew/test/.bundle
+/Library/Homebrew/test/bin
+/Library/Homebrew/test/vendor
 /Library/LinkedKegs
 /Library/PinnedKegs
 /Library/Taps
-/Library/Formula/.gitignore

--- a/Library/Homebrew/test/.gitignore
+++ b/Library/Homebrew/test/.gitignore
@@ -1,3 +1,0 @@
-/.bundle/
-/bin/
-/vendor/


### PR DESCRIPTION
libgit2 clients struggle at parsing these otherwise because of how we set up our ignore rules.

And remove now unneeded formula ignore rule.

CC @Homebrew/owners any objections? Would make my life a bit easier (and anyone else using the GitHub GUI).