### PR TITLE
gnome-themes-standard: new formula

### DIFF
--- a/Library/Formula/gnome-themes-standard.rb
+++ b/Library/Formula/gnome-themes-standard.rb
@@ -1,0 +1,25 @@
+class GnomeThemesStandard < Formula
+  desc "Default themes for the GNOME desktop environment"
+  homepage "https://git.gnome.org/browse/gnome-themes-standard/"
+  url "https://download.gnome.org/sources/gnome-themes-standard/3.16/gnome-themes-standard-3.16.2.tar.xz"
+  sha256 "59eb79a59d44b5cd8daa8de1e7559fb5186503dcd78e47d0b72cb896d8654b9f"
+
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext" => :build
+  depends_on "gtk+"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--disable-gtk3-engine"
+
+    system "make", "install"
+  end
+
+  test do
+    assert (share/"icons/HighContrast/scalable/actions/document-open-recent.svg").exist?
+    assert (lib/"gtk-2.0/2.10.0/engines/libadwaita.so").exist?
+  end
+end


### PR DESCRIPTION
see also #29742
This package is quite useful for Gtk+ but almost pointless for Gtk+3.
For Gtk+ it offers two themes: Adwaita and HighContrast, while these are
both included in Gtk+3 since 3.14.0.
It also offers the HighContrast icon theme, which could be used for both
Gtk+ and Gtk+3 if the users explicitly choose to do so in their settings.
Unless switched off with `--disable-gtk3-engine`, there is a hard
dependency on Gtk+3 in `configure.ac`, which appears to be completely
useless as it is nowhere used in any of the `Makefile.am`'s in a
meaningful way. I will file a bug over this.