### PR TITLE
audit --online: check homepage reachability

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -428,6 +428,13 @@ class FormulaAuditor
          %r[^http://code\.google\.com/]
       problem "Please use https:// for #{homepage}"
     end
+
+    return unless @online
+    begin
+      nostdout { curl "--connect-timeout", "15", "-IL", "-o", "/dev/null", homepage }
+    rescue ErrorDuringExecution
+      problem "The homepage is not reachable (curl exit code #{$?.exitstatus})"
+    end
   end
 
   def audit_github_repository


### PR DESCRIPTION
Example output:

```
brew audit --online ddar gd freealut
ddar:
 * Stable: SHA1 checksums are deprecated, please use SHA256
 * The homepage is not reachable (curl exit code 28)
 * Dependency protobuf does not define option "with-python"
 * Dependency protobuf does not define option "with-python"

gd:
 * The homepage is not reachable (curl exit code 60)

freealut:
 * Stable: SHA1 checksums are deprecated, please use SHA256
 * The homepage is not reachable (curl exit code 6)

Error: 7 problems in 3 formulae
```

(note that we should fix those)

cc @Homebrew/owners