### PR TITLE
freeimage: use canonical domain for homepage

### DIFF
--- a/Library/Formula/freeimage.rb
+++ b/Library/Formula/freeimage.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class FreeimageHttpDownloadStrategy < CurlDownloadStrategy
   def stage
     # need to convert newlines or patch chokes
@@ -10,11 +8,11 @@ end
 
 class Freeimage < Formula
   desc "Library for FreeImage, a dependency-free graphics library"
-  homepage 'http://sf.net/projects/freeimage'
-  url 'https://downloads.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip',
+  homepage "https://sourceforge.net/projects/freeimage"
+  url "https://downloads.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip",
     :using => FreeimageHttpDownloadStrategy
-  version '3.17.0'
-  sha256 'fbfc65e39b3d4e2cb108c4ffa8c41fd02c07d4d436c594fff8dab1a6d5297f89'
+  version "3.17.0"
+  sha256 "fbfc65e39b3d4e2cb108c4ffa8c41fd02c07d4d436c594fff8dab1a6d5297f89"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Also:
* try homepage with https first, which will be redirected 
to plaintext for non-logged-in users. Before this commit 
the ratio of https vs. http protocol access for sf.net top 
domain in formulae is: 11:41.
* styling nits