### PR TITLE
[formula: natalie] Compile natalie.swift for performance

### DIFF
--- a/Library/Formula/natalie.rb
+++ b/Library/Formula/natalie.rb
@@ -8,14 +8,15 @@ class Natalie < Formula
   depends_on :xcode => "6.3"
 
   def install
-    bin.install "natalie.swift"
+    system "xcrun -sdk macosx swiftc -O natalie.swift -o natalie"
+    bin.install "natalie"
     share.install "NatalieExample"
   end
 
   test do
     example_path = "#{share}/NatalieExample"
     output_path = testpath/"Storyboards.swift"
-    generated_code = `#{bin}/natalie.swift #{example_path}`
+    generated_code = `#{bin}/natalie #{example_path}`
     output_path.write(generated_code)
     line_count = `wc -l #{output_path}`
     assert line_count.to_i > 1

--- a/Library/Formula/natalie.rb
+++ b/Library/Formula/natalie.rb
@@ -8,8 +8,8 @@ class Natalie < Formula
   depends_on :xcode => "6.3"
 
   def install
-    system *%W[mv natalie.swift natalie-script.swift]
-    system *%W[xcrun -sdk macosx swiftc -O natalie-script.swift -o natalie.swift]
+    system "mv", "natalie.swift", "natalie-script.swift"
+    system "xcrun", "-sdk", "macosx", "swiftc", "-O", "natalie-script.swift", "-o", "natalie.swift"
     bin.install "natalie.swift"
     share.install "NatalieExample"
   end

--- a/Library/Formula/natalie.rb
+++ b/Library/Formula/natalie.rb
@@ -8,15 +8,16 @@ class Natalie < Formula
   depends_on :xcode => "6.3"
 
   def install
-    system "xcrun -sdk macosx swiftc -O natalie.swift -o natalie"
-    bin.install "natalie"
+    system *%W[mv natalie.swift natalie-script.swift]
+    system *%W[xcrun -sdk macosx swiftc -O natalie-script.swift -o natalie.swift]
+    bin.install "natalie.swift"
     share.install "NatalieExample"
   end
 
   test do
     example_path = "#{share}/NatalieExample"
     output_path = testpath/"Storyboards.swift"
-    generated_code = `#{bin}/natalie #{example_path}`
+    generated_code = `#{bin}/natalie.swift #{example_path}`
     output_path.write(generated_code)
     line_count = `wc -l #{output_path}`
     assert line_count.to_i > 1

--- a/Library/Formula/natalie.rb
+++ b/Library/Formula/natalie.rb
@@ -8,7 +8,7 @@ class Natalie < Formula
   depends_on :xcode => "6.3"
 
   def install
-    system "mv", "natalie.swift", "natalie-script.swift"
+    mv "natalie.swift", "natalie-script.swift"
     system "xcrun", "-sdk", "macosx", "swiftc", "-O", "natalie-script.swift", "-o", "natalie.swift"
     bin.install "natalie.swift"
     share.install "NatalieExample"


### PR DESCRIPTION
This commit adds the compilation of `natalie.swift` during the installation process, resulting in a greatly improved execution time. This is very important because when `natalie` is part of an app build process, having a fast build phase for generating Storyboard code greatly improves build times.

Using the original `natalie.swift` script:
```
$ time ./natalie.swift NatalieExample/
// Output
3.04 real         2.85 user         0.12 sys
```

Using a compiled version:
```
$ time natalie NatalieExample/
// Output
0.07 real         0.01 user         0.03 sys
```

@krzyzanowskim (original author of the program): Let me know what you think.