### PR TITLE
audit: recommend use of assert_match.

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -791,6 +791,10 @@ class FormulaAuditor
       problem "Use the `#{method}` Ruby method instead of `system #{system}`"
     end
 
+    if line =~ /assert .*\.include?/
+      problem "Use `assert_match` instead of `assert ...include?`"
+    end
+
     if @strict
       if line =~ /system (["'][^"' ]*(?:\s[^"' ]*)+["'])/
         bad_system = $1


### PR DESCRIPTION
It produces significantly easier output to debug than doing `assert` and `.include?` (which just shows if it passed or failed).