### PR TITLE
keg_relocate: relocate all text files.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -1,5 +1,5 @@
 require "extend/pathname"
-require "keg_fix_install_names"
+require "keg_relocate"
 require "formula_lock"
 require "ostruct"
 


### PR DESCRIPTION
Work out what's text and what's not using `file`. Also, rename `keg_fix_install_names` to `keg_relocate` because that's a more accurate description of what it does now.

CC @xu-cheng 