### PR TITLE
Build llvm with optimizations and NDEBUG flag

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -130,6 +130,8 @@ class Llvm < Formula
     args = %w[
       -DLLVM_OPTIMIZED_TABLEGEN=On
     ]
+    
+    args << "-DCMAKE_CXX_FLAGS_RELEASE='-O3 -DNDEBUG'"
 
     args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
 

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -130,12 +130,14 @@ class Llvm < Formula
     args = %w[
       -DLLVM_OPTIMIZED_TABLEGEN=On
     ]
-    
-    args << "-DCMAKE_CXX_FLAGS_RELEASE='-O3 -DNDEBUG'"
 
     args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
 
-    args << "-DLLVM_ENABLE_ASSERTIONS=On" if build.with? "assertions"
+    if build.with? "assertions"
+      args << "-DLLVM_ENABLE_ASSERTIONS=On"
+    else
+      args << "-DCMAKE_CXX_FLAGS_RELEASE='-DNDEBUG'"
+    end
 
     if build.universal?
       ENV.permit_arch_flags

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -133,11 +133,8 @@ class Llvm < Formula
 
     args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
 
-    if build.with? "assertions"
-      args << "-DLLVM_ENABLE_ASSERTIONS=On"
-    else
-      args << "-DCMAKE_CXX_FLAGS_RELEASE='-DNDEBUG'"
-    end
+    args << "-DLLVM_ENABLE_ASSERTIONS=ON" if build.with? "assertions"
+    args << "-DCMAKE_CXX_FLAGS_RELEASE='-DNDEBUG'" if build.without? "assertions"
 
     if build.universal?
       ENV.permit_arch_flags

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -133,7 +133,7 @@ class Llvm < Formula
 
     args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
 
-    args << "-DLLVM_ENABLE_ASSERTIONS=ON" if build.with? "assertions"
+    args << "-DLLVM_ENABLE_ASSERTIONS=On" if build.with? "assertions"
     args << "-DCMAKE_CXX_FLAGS_RELEASE='-DNDEBUG'" if build.without? "assertions"
 
     if build.universal?


### PR DESCRIPTION
I don't know why, but std_cmake_args clears default release flags for the compiler (`-DCMAKE_CXX_FLAGS_RELEASE=`). As the result the LLVM is built without optimization (-O3) and NDEBUG macro being set (-DNDEBUG).