### PR TITLE
Don't link fontforge extension modules to libpython

### DIFF
--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -39,6 +39,11 @@ class Fontforge < Formula
   # https://github.com/Homebrew/homebrew/issues/37803
   depends_on "fontconfig"
 
+  resource "gnulib" do
+    url "git://git.savannah.gnu.org/gnulib.git",
+        :revision => "9a417cf7d48fa231c937c53626da6c45d09e6b3e"
+  end
+
   fails_with :llvm do
     build 2336
     cause "Compiling cvexportdlg.c fails with error: initializer element is not constant"
@@ -77,7 +82,8 @@ class Fontforge < Formula
     ENV.prepend_path "PKG_CONFIG_PATH", "#{pydir}/lib/pkgconfig"
 
     # Bootstrap in every build: https://github.com/fontforge/fontforge/issues/1806
-    system "./bootstrap"
+    resource("gnulib").fetch
+    system "./bootstrap", "--gnulib-srcdir=#{resource("gnulib").cached_download}"
     system "./configure", *args
     system "make"
     system "make", "install"

--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -1,10 +1,9 @@
 class Fontforge < Formula
   desc "Outline and bitmap font editor/converter for many formats"
   homepage "https://fontforge.github.io"
-  url "https://github.com/fontforge/fontforge/archive/20150430.tar.gz"
-  sha256 "430c6d02611c7ca948df743e9241994efe37eda25f81a94aeadd9b6dd286ff37"
+  url "https://github.com/fontforge/fontforge/archive/20150612.tar.gz"
+  sha256 "af4997a07c96f7057f08cb5c7d71b19a0e8ac6336e0c48476471b471c0574247"
   head "https://github.com/fontforge/fontforge.git"
-  revision 3
 
   bottle do
     sha256 "32351316ee4effb89c199a7a8abe3c2cab1782d326abe506b92d61b004590a9d" => :yosemite


### PR DESCRIPTION
Let's just pull this for now since it's been discussed upstream in fontforge/fontforge#2353 and fontforge/fontforge#2356.