### PR TITLE
cmake: change --without-docs to --with-docs

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -28,7 +28,7 @@ class Cmake < Formula
     sha256 "e1302ea14f218c07a94560d42d6f3cafa1942821896316a5555ca78b2597caad"
   end
 
-  option "without-docs", "Don't build man pages"
+  option "with-docs", "Build man pages"
 
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
 


### PR DESCRIPTION
CMake already provides thorough documentation via the command line. Building the man pages additionally requires Sphinx (and its own dependencies) to be downloaded and installed.  Since all core formulae that depend on CMake use it as a build dependency, having the man pages built by default therefore seems like overkill.