### PR TITLE
Build libfreenect with OpenNI2 support by default, new formula for libfreenect2

### DIFF
--- a/Library/Formula/libfreenect.rb
+++ b/Library/Formula/libfreenect.rb
@@ -4,7 +4,7 @@ class Libfreenect < Formula
   desc "Drivers and libraries for the Xbox Kinect device"
   homepage "http://openkinect.org"
   url "https://github.com/OpenKinect/libfreenect/archive/v0.5.1.tar.gz"
-  sha1 "1f7296e50c27c07e2f57ee906c195cabf97c1438"
+  sha256 "97e5dd11a0f292b6a3014d1a31c7af16a21cd6574a63057ed7a364064a7614d0"
 
   head "https://github.com/OpenKinect/libfreenect.git"
 
@@ -22,6 +22,7 @@ class Libfreenect < Formula
 
   def install
     args = std_cmake_args
+    args << "-DBUILD_OPENNI2_DRIVER=ON"
 
     if build.universal?
       ENV.universal_binary

--- a/Library/Formula/libfreenect2.rb
+++ b/Library/Formula/libfreenect2.rb
@@ -1,0 +1,36 @@
+require "formula"
+
+class Libfreenect2 < Formula
+  desc "Drivers and libraries for the Xbox Kinect device version 2"
+  homepage "http://openkinect.org"
+
+  head "https://github.com/OpenKinect/libfreenect2.git"
+
+  option :universal
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+  depends_on "jpeg-turbo"
+
+  def install
+    args = std_cmake_args
+
+    inreplace "examples/protonect/include/libfreenect2/protocol/usb_control.h", /libusb\.h/, "libusb-1\.0\/libusb\.h"
+    inreplace "examples/protonect/include/libfreenect2/usb/transfer_pool.h", /libusb\.h/, "libusb-1\.0\/libusb\.h"
+    inreplace "examples/protonect/src/event_loop.cpp", /libusb\.h/, "libusb-1\.0\/libusb\.h"
+    inreplace "examples/protonect/include/libfreenect2/protocol/command_transaction.h", /libusb\.h/, "libusb-1\.0\/libusb\.h"
+    inreplace "examples/protonect/src/libfreenect2.cpp", /libusb\.h/, "libusb-1\.0\/libusb\.h"
+    inreplace "examples/protonect/CMakeLists.txt", /  \$\{LibUSB_LIBRARIES\}/, "usb-1.0"
+
+    if build.universal?
+      ENV.universal_binary
+      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
+    end
+
+    mkdir "build" do
+      system "cmake", "../examples/protonect", *args
+      system "make install"
+    end
+  end
+end


### PR DESCRIPTION
1. Build libfreenect with OpenNI2 support by default
2. New formula for libfreenect2 (some dirty hack applied to workaround `libusb-1.0` #41647)