### PR TITLE
allegro: drop unused deps, adjust cmake build

### DIFF
--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -30,14 +30,13 @@ class Allegro < Formula
   depends_on "libvorbis" => :recommended
   depends_on "freetype" => :recommended
   depends_on "flac" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "jpeg" => :recommended
   depends_on "physfs" => :recommended
 
   def install
-    args = std_cmake_args + ["-DWANT_DOCS=OFF"]
-    system "cmake", ".", *args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", "-DWANT_DOCS=OFF", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
While tackling #35371, I noticed that Allegro was not linking to the jpeg or libpng libraries. I don't think this is a build configuration error, though; it seems as if Allegro just doesn't care about those libraries in OS X, preferring to use the standard OS X frameworks instead.

For that reason, I've dropped the dependencies on jpeg and libpng. I'm not sure if that matters for Linux, though; is linuxbrew still a consideration?

At the same time, I've added a step that creates a "build" subdirectory for CMake to do its building, since that seems to be the CMake way.