### PR TITLE
improve TapLoader and TapFormulaUnavailableError

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -51,17 +51,17 @@ class FormulaUnavailableError < RuntimeError
 end
 
 class TapFormulaUnavailableError < FormulaUnavailableError
-  attr_reader :user, :repo, :shortname
+  attr_reader :tap
 
-  def initialize name
-    super
-    @user, @repo, @shortname = name.split("/", 3)
+  def initialize tap, name
+    @tap = tap
+    super "#{tap}/#{name}"
   end
 
-  def to_s; <<-EOS.undent
-      No available formula for #{shortname} #{dependent_s}
-      Please tap it and then try again: brew tap #{user}/#{repo}
-    EOS
+  def to_s
+    s = super
+    s += "\nPlease tap it and then try again: brew tap #{tap}" unless tap.installed?
+    s
   end
 end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -131,14 +131,13 @@ class Formulary
 
   # Loads tapped formulae.
   class TapLoader < FormulaLoader
-    attr_reader :tapped_name
+    attr_reader :tap
 
     def initialize tapped_name
-      @tapped_name = tapped_name
       user, repo, name = tapped_name.split("/", 3).map(&:downcase)
-      tap = Tap.new user, repo
-      path = tap.formula_files.detect { |file| file.basename(".rb").to_s == name }
-      path ||= tap.path/"#{name}.rb"
+      @tap = Tap.new user, repo.sub(/^homebrew-/, "")
+      path = @tap.formula_files.detect { |file| file.basename(".rb").to_s == name }
+      path ||= @tap.path/"#{name}.rb"
 
       super name, path
     end
@@ -146,7 +145,7 @@ class Formulary
     def get_formula(spec)
       super
     rescue FormulaUnavailableError => e
-      raise TapFormulaUnavailableError, tapped_name, e.backtrace
+      raise TapFormulaUnavailableError.new(tap, name), "", e.backtrace
     end
   end
 


### PR DESCRIPTION
* Restore the ability to load formula by `user/homebrew-repo/foo`.
* Only suggest to install tap when tap isn't installed.