### PR TITLE
[GSoC] Allow Prioritization of Taps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /Library/LinkedKegs
 /Library/PinnedKegs
 /Library/Taps
+/Library/PinnedTaps

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -29,7 +29,11 @@ module Homebrew
       ARGV.named.each_with_index do |f, i|
         puts unless i == 0
         begin
-          info_formula Formulary.factory(f)
+          if f.include?("/") || File.exist?(f)
+            info_formula Formulary.factory(f)
+          else
+            info_formula Formulary.find_with_priority(f)
+          end
         rescue FormulaUnavailableError
           # No formula with this name, try a blacklist lookup
           if (blacklist = blacklisted?(f))

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -24,12 +24,15 @@ module Homebrew
       tap_count = 0
       formula_count = 0
       command_count = 0
+      pinned_count = 0
       Tap.each do |tap|
         tap_count += 1
         formula_count += tap.formula_files.size
         command_count += tap.command_files.size
+        pinned_count += 1 if tap.pinned?
       end
       info = "#{tap_count} tap#{plural(tap_count)}"
+      info += ", #{pinned_count} pinned"
       info += ", #{formula_count} formula#{plural(formula_count, "e")}"
       info += ", #{command_count} command#{plural(command_count)}"
       info += ", #{Tap::TAP_DIRECTORY.abv}" if Tap::TAP_DIRECTORY.directory?

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -39,6 +39,7 @@ module Homebrew
         puts unless i == 0
         info = "#{tap}: "
         if tap.installed?
+          info += tap.pinned? ? "pinned, " : "unpinned, "
           formula_count = tap.formula_files.size
           info += "#{formula_count} formula#{plural(formula_count, "e")} " if formula_count > 0
           command_count = tap.command_files.size

--- a/Library/Homebrew/cmd/tap-pin.rb
+++ b/Library/Homebrew/cmd/tap-pin.rb
@@ -1,0 +1,13 @@
+require "cmd/tap"
+
+module Homebrew
+  def tap_pin
+    taps = ARGV.named.map do |name|
+      Tap.new(*tap_args(name))
+    end
+    taps.each do |tap|
+      tap.pin
+      ohai "Pinned #{tap.name}"
+    end
+  end
+end

--- a/Library/Homebrew/cmd/tap-unpin.rb
+++ b/Library/Homebrew/cmd/tap-unpin.rb
@@ -1,0 +1,13 @@
+require "cmd/tap"
+
+module Homebrew
+  def tap_unpin
+    taps = ARGV.named.map do |name|
+      Tap.new(*tap_args(name))
+    end
+    taps.each do |tap|
+      tap.unpin
+      ohai "Unpinned #{tap.name}"
+    end
+  end
+end

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -10,6 +10,8 @@ module Homebrew
       raise TapUnavailableError, tap.name unless tap.installed?
       puts "Untapping #{tap}... (#{tap.path.abv})"
 
+      tap.unpin if tap.pinned?
+
       formula_count = tap.formula_files.size
       tap.path.rmtree
       tap.path.dirname.rmdir_if_possible

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -98,6 +98,17 @@ class TapUnavailableError < RuntimeError
   end
 end
 
+class TapPinStatusError < RuntimeError
+  attr_reader :name, :pinned
+
+  def initialize name, pinned
+    @name = name
+    @pinned = pinned
+
+    super pinned ? "#{name} is already pinned." : "#{name} is already unpinned."
+  end
+end
+
 class OperationInProgressError < RuntimeError
   def initialize(name)
     message = <<-EOS.undent

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -13,7 +13,13 @@ module HomebrewArgvExtension
 
   def formulae
     require "formula"
-    @formulae ||= (downcased_unique_named - casks).map { |name| Formulary.factory(name, spec) }
+    @formulae ||= (downcased_unique_named - casks).map do |name|
+      if name.include?("/") || File.exist?(name)
+        Formulary.factory(name, spec)
+      else
+        Formulary.find_with_priority(name, spec)
+      end
+    end
   end
 
   def resolved_formulae

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -394,6 +394,13 @@ Note that these flags should only appear after a command.
 
     See the docs for examples of using the JSON:
     <https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md>
+    
+  * `tap-pin` <tap>:
+    Pin <tap>, prioritizing its formulae over core when formula names are supplied
+    by the user. See also `tap-unpin`.
+
+  * `tap-unpin` <tap>:
+    Unpin <tap> so its formulae are no longer prioritized. See also `tap-pin`.
 
   * `test` [--devel|--HEAD] [--debug] <formula>:
     A few formulae provide a test method. `brew test <formula>` runs this

--- a/share/doc/homebrew/brew-tap.md
+++ b/share/doc/homebrew/brew-tap.md
@@ -54,14 +54,39 @@ edavis/emacs
 
 ## Formula duplicate names
 
-If your tap contains a formula that is also present in master, that's fine, but
-it means that you must install it explicitly.
+If your tap contains a formula that is also present in master, that's fine, 
+but it means that you must install it explicitly by default.
 
-For example, you can create a tap for an alternative `vim` formula, but in that
-case when you install from there you must run the command with a more explicit
-installation target:
+If you would like to prioritize a tap over master, you can use 
+`brew tap-pin username/repo` to pin the tap, 
+and use `brew tap-unpin username/repo` to revert the pin.
+
+Whenever a `brew install foo` command is issued, brew will find which formula 
+to use by searching in the following order:
+
+* Pinned taps
+* Core formulas
+* Other taps
+
+If you need a formula to be installed from a particular tap, you can use fully 
+qualified names to refer to them.
+
+For example, you can create a tap for an alternative `vim` formula. Without 
+pinning it, the behavior will be
 
 ```bash
-brew install vim                 # installs from Homebrew/homebrew
-brew install username/repo/vim   # installs from your custom repo
+brew install vim                     # installs from Homebrew/homebrew
+brew install username/repo/vim       # installs from your custom repo
 ```
+
+However if you pin the tap with `brew tap-pin username/repo`, you will need to 
+use `homebrew/homebrew` to refer to the core formula.
+
+```bash
+brew install vim                     # installs from your custom repo
+brew install homebrew/homebrew/vim   # installs from Homebrew/homebrew
+```
+
+Do note that pinned taps are prioritized only when the formula name is directly 
+given by you. i.e., it will not influence formulae automatically installed as 
+dependencies.

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -379,6 +379,12 @@ Pass \fB\-\-installed\fR to get information on installed taps\.
 See the docs for examples of using the JSON: \fIhttps://github\.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying\-Brew\.md\fR
 .
 .IP "\(bu" 4
+\fBtap\-pin\fR \fItap\fR: Pin \fItap\fR, prioritizing its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.
+.
+.IP "\(bu" 4
+\fBtap\-unpin\fR \fItap\fR: Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
+.
+.IP "\(bu" 4
 \fBtest\fR [\-\-devel|\-\-HEAD] [\-\-debug] \fIformula\fR: A few formulae provide a test method\. \fBbrew test <formula>\fR runs this test method\. There is no standard output or return code, but it should generally indicate to the user if something is wrong with the installed formula\.
 .
 .IP


### PR DESCRIPTION
This replaces pr #40991 

This pr implements a simplified version of tap priority system as discussed in the original pr. There are now only three levels of priority (pinned taps > core > unpinned taps) and only few commands respect the priority.

* Users can use commands `brew tap-pin user/repo` and `brew tap-unpin user/repo` to change the pinned status of taps.
* Commands that use `ARGV.formulae` now finds formulae in the following order (i.e., it does not affect other things like dependency resolution):
    * URL / bottle / fully qualified names / file path
    * Find any pinned taps provide the formula (If only one exists, return; if more than one, raise `TapFormulaAmbiguityError`.). If found pinned formula but the formula is also provided by core, a warning message will be shown.
    * Find in core formulae
    * Other taps, etc. (Keep the same with `formulary.factory`)