### PR TITLE
docker-compose 1.3.2

### DIFF
--- a/Library/Formula/fig.rb
+++ b/Library/Formula/fig.rb
@@ -1,8 +1,8 @@
 class Fig < Formula
   desc "Isolated development environments using Docker"
   homepage "https://docs.docker.com/compose/"
-  url "https://github.com/docker/compose/archive/1.3.1.tar.gz"
-  sha256 "04b60b805dc305543d5fe9a0880b8e1ad5818c440587a26b0eb01f9e3e8e79eb"
+  url "https://github.com/docker/compose/archive/1.3.2.tar.gz"
+  sha256 "61e26f9eaed839d2df69f85579239afd2d305b7c2d10bb96b03d8b92b4690d72"
 
   bottle do
     sha256 "e37e96200d6319f27524f5db76796bc9a8aea0deef52929d2d23ccea496f989d" => :yosemite
@@ -19,8 +19,8 @@ class Fig < Formula
   depends_on "boot2docker" => :recommended
 
   resource "docker-py" do
-    url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.2.3.tar.gz"
-    sha256 "5328a7f4a2d812da166b3fb59211fca976c9f48bb9f8b17d9f3fd4ef7c765ac5"
+    url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.3.0.tar.gz"
+    sha256 "ac4c960e84a44f5dbbcee775c46c3a8a194241e37767f60d64aa84d704c95dfd"
   end
 
   resource "pyyaml" do
@@ -54,8 +54,8 @@ class Fig < Formula
   end
 
   resource "websocket-client" do
-    url "https://github.com/liris/websocket-client/archive/v0.29.0.tar.gz"
-    sha256 "011487a1fd3158ec670f3c25a40bbe7523f6d22fa342ca870fefe0fa2168aeec"
+    url "https://github.com/liris/websocket-client/archive/v0.32.0.tar.gz"
+    sha256 "255d07ffa677f571b5f51c11703f2f4bd5f331b58442677bcb4395dfa1809a5f"
   end
 
   resource "backports.ssl_match_hostname" do


### PR DESCRIPTION
In order to upgrade to docker-compose 1.3.2, both the websocket-client and docker-py packages need to be updated as well.