### PR TITLE
Fix for issue #41740

### DIFF
--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -15,7 +15,7 @@ class Qemu < Formula
     # Fix for VENOM <http://venom.fail>
     # Patch from QEMU Git
     url "http://git.qemu.org/?p=qemu.git;a=commitdiff_plain;h=e907746266721f305d67bc0718795fedee2e824c"
-    sha256 "a182ee0e5d6aa040dea51796a410827e8c0b3b928c864846c6e5a1754dde9c88"
+    sha256 "2aaa9ff9ee492dede64df3fcb59032ae0452bf4790c2d5881e05981fa7452368"
   end
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -14,7 +14,7 @@ class Qemu < Formula
   patch do
     # Fix for VENOM <http://venom.fail>
     # Patch from QEMU Git
-    url "http://git.qemu.org/?p=qemu.git;a=commitdiff_plain;h=e907746266721f305d67bc0718795fedee2e824c"
+    url "https://gist.githubusercontent.com/mtpereira/77dd144343bf24552aad/raw/0f22e76e50013f40a4c4d6dee1a6ec2a1ffea18b/qemu-venom.patch"
     sha256 "2aaa9ff9ee492dede64df3fcb59032ae0452bf4790c2d5881e05981fa7452368"
   end
 


### PR DESCRIPTION
Updated SHA256 sum for VENOM patch file on qemu recipe. This fixes issue #41740.
