### PR TITLE
ffmpegthumbnailer 2.0.10

### DIFF
--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Ffmpegthumbnailer < Formula
   desc "Create thumbnails for your video files"
-  homepage 'http://code.google.com/p/ffmpegthumbnailer/'
-  url 'https://ffmpegthumbnailer.googlecode.com/files/ffmpegthumbnailer-2.0.8.tar.gz'
-  sha1 '2c54ca16efd953f46547e22799cfc40bd9c24533'
+  homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
+  url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.0.10.tar.gz"
+  sha256 "68125d98d72347a676ab2f9bc93ddd3537ff39d6a81145e2a58a6de5d3958e4e"
+
   bottle do
     cellar :any
     sha1 "b33cd322e1dd892c3ff492647a9d7fc4b8766388" => :mavericks
@@ -12,16 +11,25 @@ class Ffmpegthumbnailer < Formula
     sha1 "052f2227429e215db559dcbddb2cdca838111d59" => :lion
   end
 
-  revision 2
-
-  depends_on 'pkg-config' => :build
-  depends_on 'jpeg'
-  depends_on 'libpng'
-  depends_on 'ffmpeg'
+  # Look for upstream to replace the GNU build process with CMake in the future
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "ffmpeg"
 
   def install
+    system "./autogen.sh"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/ffmpegthumbnailer", "-i", test_fixtures("test.jpg"),
+      "-o", "out.jpg"
+    assert File.exist?(testpath/"out.jpg")
   end
 end


### PR DESCRIPTION
* New upstream version
* Home moved from Google Code to GitHub
* Build process changed from GNU-style configure et al. to CMake, so add new patch and inreplace to massage the build for Homebrew
* Add test
* Other changes for `brew audit --strict`