### PR TITLE
Various GNU Fixes

### DIFF
--- a/Library/Formula/a2ps.rb
+++ b/Library/Formula/a2ps.rb
@@ -2,8 +2,8 @@ class A2ps < Formula
   desc "Any-to-PostScript filter"
   homepage "https://www.gnu.org/software/a2ps/"
   url "http://ftpmirror.gnu.org/a2ps/a2ps-4.14.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/a2ps/a2ps-4.14.tar.gz"
-  sha1 "365abbbe4b7128bf70dad16d06e23c5701874852"
+  mirror "https://ftp.gnu.org/gnu/a2ps/a2ps-4.14.tar.gz"
+  sha256 "f3ae8d3d4564a41b6e2a21f237d2f2b104f48108591e8b83497500182a3ab3a4"
 
   bottle do
     sha1 "c33f22a088a0b1ed22efff0165722e87495a4bd0" => :yosemite
@@ -14,15 +14,15 @@ class A2ps < Formula
   # Software was last updated in 2007, so take MacPorts patches to get
   # it working on 10.6. See:
   # https://svn.macports.org/ticket/20867
-  # http://trac.macports.org/ticket/18255
+  # https://trac.macports.org/ticket/18255
   patch :p0 do
     url "https://trac.macports.org/export/56498/trunk/dports/print/a2ps/files/patch-contrib_sample_Makefile.in"
-    sha1 "9b385295c2377e5362d62991e84d138d1713aabd"
+    sha256 "5a34c101feb00cf52199a28b1ea1bca83608cf0a1cb123e6af2d3d8992c6011f"
   end
 
   patch :p0 do
     url "https://trac.macports.org/export/56498/trunk/dports/print/a2ps/files/patch-lib__xstrrpl.c"
-    sha1 "106e13409a96d68df0fdea0b89790ddfc0893f8b"
+    sha256 "89fa3c95c329ec326e2e76493471a7a974c673792725059ef121e6f9efb05bf4"
   end
 
   def install

--- a/Library/Formula/binutils.rb
+++ b/Library/Formula/binutils.rb
@@ -2,8 +2,8 @@ class Binutils < Formula
   desc "FSF Binutils for native development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
   url "http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
-  sha1 "f10c64e92d9c72ee428df3feaf349c4ecb2493bd"
+  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
+  sha256 "cccf377168b41a52a76f46df18feb8f7285654b3c1bd69fc8265cb0fc6902f2d"
 
   # No --default-names option as it interferes with Homebrew builds.
 
@@ -30,7 +30,6 @@ class Binutils < Formula
   end
 
   test do
-    assert `#{bin}/gnm #{bin}/gnm`.include? 'main'
-    assert_equal 0, $?.exitstatus
+    assert_match /main/, shell_output("#{bin}/gnm #{bin}/gnm")
   end
 end

--- a/Library/Formula/clisp.rb
+++ b/Library/Formula/clisp.rb
@@ -1,14 +1,12 @@
-require 'formula'
-
 class Clisp < Formula
   desc "GNU CLISP, a Common Lisp implementation"
-  homepage 'http://www.clisp.org/'
-  url 'http://ftpmirror.gnu.org/clisp/release/2.49/clisp-2.49.tar.bz2'
-  mirror 'http://ftp.gnu.org/gnu/clisp/release/2.49/clisp-2.49.tar.bz2'
-  sha1 '7e8d585ef8d0d6349ffe581d1ac08681e6e670d4'
+  homepage "http://www.clisp.org/"
+  url "http://ftpmirror.gnu.org/clisp/release/2.49/clisp-2.49.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/clisp/release/2.49/clisp-2.49.tar.bz2"
+  sha256 "8132ff353afaa70e6b19367a25ae3d5a43627279c25647c220641fed00f8e890"
 
-  depends_on 'libsigsegv'
-  depends_on 'readline'
+  depends_on "libsigsegv"
+  depends_on "readline"
 
   fails_with :llvm do
     build 2334
@@ -16,18 +14,19 @@ class Clisp < Formula
   end
 
   patch :DATA
+
   patch :p0 do
     url "https://trac.macports.org/export/89054/trunk/dports/lang/clisp/files/patch-src_lispbibl_d.diff"
-    sha1 "8324152a1db755db6c66ce5c059092d55576f37b"
+    sha256 "fd4e8a0327e04c224fb14ad6094741034d14cb45da5b56a2f3e7c930f84fd9a0"
   end
 
   def install
-    ENV.j1 # This build isn't parallel safe.
+    ENV.deparallelize # This build isn't parallel safe.
     ENV.O0 # Any optimization breaks the build
 
     # Clisp requires to select word size explicitly this way,
     # set it in CFLAGS won't work.
-    ENV['CC'] = "#{ENV.cc} -m#{MacOS.prefer_64_bit? ? 64 : 32}"
+    ENV["CC"] = "#{ENV.cc} -m#{MacOS.prefer_64_bit? ? 64 : 32}"
 
     system "./configure", "--prefix=#{prefix}",
                           "--with-readline=yes"
@@ -36,22 +35,24 @@ class Clisp < Formula
       # Multiple -O options will be in the generated Makefile,
       # make Homebrew's the last such option so it's effective.
       inreplace "Makefile" do |s|
-        s.change_make_var! 'CFLAGS', "#{s.get_make_var('CFLAGS')} #{ENV['CFLAGS']}"
+        s.change_make_var! "CFLAGS", "#{s.get_make_var("CFLAGS")} #{ENV["CFLAGS"]}"
       end
 
       # The ulimit must be set, otherwise `make` will fail and tell you to do so
       system "ulimit -s 16384 && make"
 
       if MacOS.version >= :lion
-        opoo "`make check` fails on Lion, so we are skipping it."
-        puts "But it probably means there will be other issues too."
-        puts "Please take them upstream to the clisp project itself."
+        opoo <<-EOS.undent
+           `make check` fails so we are skipping it.
+           However, there will likely be other issues present.
+           Please take them upstream to the clisp project itself.
+        EOS
       else
         # Considering the complexity of this package, a self-check is highly recommended.
-        system "make check"
+        system "make", "check"
       end
 
-      system "make install"
+      system "make", "install"
     end
   end
 

--- a/Library/Formula/enscript.rb
+++ b/Library/Formula/enscript.rb
@@ -1,22 +1,20 @@
-require 'formula'
-
 class Enscript < Formula
   desc "Convert text to Postscript, HTML, or RTF, with syntax highlighting"
-  homepage 'http://www.gnu.org/software/enscript/'
-  url 'http://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz'
-  mirror 'http://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz'
-  sha1 '1f1e97a2ebb3d77f48c57487fe39e64139fb2beb'
+  homepage "https://www.gnu.org/software/enscript/"
+  url "http://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz"
+  sha256 "6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb"
 
-  head 'git://git.savannah.gnu.org/enscript.git'
+  head "git://git.savannah.gnu.org/enscript.git"
 
   keg_only :provided_pre_mountain_lion
 
-  depends_on 'gettext'
+  depends_on "gettext"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
   end
 
   test do

--- a/Library/Formula/gcal.rb
+++ b/Library/Formula/gcal.rb
@@ -1,14 +1,17 @@
-require 'formula'
-
 class Gcal < Formula
   desc "Gcal is a program for calculating and printing calendars"
-  homepage 'http://www.gnu.org/software/gcal/'
-  url 'http://ftpmirror.gnu.org/gcal/gcal-3.6.3.tar.xz'
-  mirror 'http://ftp.gnu.org/gnu/gcal/gcal-3.6.3.tar.xz'
-  sha1 'a5d68216d8b0735c9b095fb81a08d6dbf5cdeedd'
+  homepage "https://www.gnu.org/software/gcal/"
+  url "http://ftpmirror.gnu.org/gcal/gcal-3.6.3.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gcal/gcal-3.6.3.tar.xz"
+  sha256 "6742913a1d011ac109ad713ef4a8263eaf4c5cfd315471626a92f094e3e4b31b"
 
   def install
-    system './configure', "--prefix=#{prefix}", '--disable-dependency-tracking'
-    system "make install"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "make", "install"
+  end
+
+  test do
+    date = shell_output("date +%Y")
+    assert_match date, shell_output("#{bin}/gcal")
   end
 end


### PR DESCRIPTION
Mostly intended to fix the `http://ftp.gnu.org` mirror problem, which can and should be `https://`. Was planning to do it in bulk (There's not many) but a lot of this stuff hasn't been updated in yonks and needs bottles adding, so two birds, one stone, etc.