### PR TITLE
remove --all parameter from FAQ

### DIFF
--- a/share/doc/homebrew/FAQ.md
+++ b/share/doc/homebrew/FAQ.md
@@ -10,7 +10,7 @@ You can now find out what is outdated with:
 
 Upgrade everything with:
 
-    brew upgrade --all
+    brew upgrade
 
 Or upgrade a specific formula with:
 


### PR DESCRIPTION
The --all parameter was reverted in commit https://github.com/Homebrew/homebrew/commit/a45a34db0b2c66f626f3724ae9a52563b4aa94b5
This should be updated in the documentation :)