### PR TITLE
gobject-introspection add dependancies on bison and flex

### DIFF
--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -16,8 +16,11 @@ class GobjectIntrospection < Formula
   depends_on "pkg-config" => :run
   depends_on "glib"
   depends_on "libffi"
-  depends_on "bison"
-  depends_on "flex"
+
+  if OS.linux?
+    depends_on "bison"
+    depends_on "flex"
+  end
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -16,6 +16,8 @@ class GobjectIntrospection < Formula
   depends_on "pkg-config" => :run
   depends_on "glib"
   depends_on "libffi"
+  depends_on "bison"
+  depends_on "flex"
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",


### PR DESCRIPTION
In a clean install on Ubuntu Trusty, it says its missing bison and flex. Adding them in fixes the issue.
Andrew