### PR TITLE
Add ‘desc’-related functionality

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -189,6 +189,18 @@ _brew_deps ()
     __brew_complete_formulae
 }
 
+_brew_desc ()
+{
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    case "$cur" in
+    --*)
+        __brewcomp "--search"
+        return
+        ;;
+    esac
+    __brew_complete_formulae
+}
+
 _brew_doctor () {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     __brewcomp "$(brew doctor --list-checks)"
@@ -593,6 +605,7 @@ _brew ()
     cleanup)                    _brew_cleanup ;;
     create)                     _brew_create ;;
     deps)                       _brew_deps ;;
+    desc)                       _brew_desc ;;
     doctor|dr)                  _brew_doctor ;;
     diy|configure)              _brew_diy ;;
     fetch)                      _brew_fetch ;;

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -1,0 +1,7 @@
+require 'descriptions'
+
+module Homebrew
+  def desc
+    Descriptions.print(ARGV.named)
+  end
+end

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -1,4 +1,5 @@
 require 'cmd/tap'
+require 'Descriptions'
 
 module Homebrew
   def update
@@ -296,7 +297,11 @@ class Report
     formula = select_formula(key)
     unless formula.empty?
       ohai title
-      puts_columns formula
+      if (ARGV.include? '--desc') && (key != :D)
+        Descriptions.print formula
+      else
+        puts_columns formula
+      end
     end
   end
 end

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -1,0 +1,27 @@
+require 'formula'
+
+# TODO: Add support for full names.
+
+class Descriptions
+  def self.get(names)
+    descriptions = {}
+
+    names.inject({}) do |descriptions, name|
+      formula = Formulary.factory(name)
+      descriptions[formula.name] = formula.desc
+      descriptions
+    end
+  end
+
+
+  def self.print(names)
+    descriptions = self.get(names)
+    max_len = descriptions.keys.map(&:length).max
+    template = "%#{max_len}s: %s\n"
+
+    descriptions.each do |name, desc|
+      printf(template, name, desc)
+    end
+  end
+
+end

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -126,6 +126,9 @@ Note that these flags should only appear after a command.
     type dependencies, pass `--skip-build`. Similarly, pass `--skip-optional`
     to skip `:optional` dependencies.
 
+  * `desc` <formula>:
+    Display <formula>'s name and one-line description.
+
   * `diy [--name=<name>] [--version=<version>]`:
     Automatically determine the installation prefix for non-Homebrew software.
 
@@ -437,11 +440,15 @@ Note that these flags should only appear after a command.
   * `untap` <tap>:
     Remove a tapped repository.
 
-  * `update [--rebase]`:
+  * `update [--rebase] [--desc]`:
     Fetch the newest version of Homebrew and all formulae from GitHub using
      `git`(1).
 
     If `--rebase` is specified then `git pull --rebase` is used.
+
+    If `--desc` is specified, update will print the names and descriptions of
+    the new and updated formulae, one per line, rather than just the names in
+    table form.
 
   * `upgrade [install-options]` [<formulae>]:
     Upgrade outdated, unpinned brews.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -204,8 +204,8 @@ def puts_columns items, star_items=[]
     # determine the best width to display for different console sizes
     console_width = `/bin/stty size`.chomp.split(" ").last.to_i
     console_width = 80 if console_width <= 0
-    longest = items.sort_by { |item| item.length }.last
-    optimal_col_width = (console_width.to_f / (longest.length + 2).to_f).floor
+    max_len = items.map(&:length).max
+    optimal_col_width = (console_width.to_f / (max_len + 2).to_f).floor
     cols = optimal_col_width > 1 ? optimal_col_width : 1
 
     IO.popen("/usr/bin/pr -#{cols} -t -w#{console_width}", "w"){|io| io.puts(items) }

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -204,7 +204,7 @@ def puts_columns items, star_items=[]
     # determine the best width to display for different console sizes
     console_width = `/bin/stty size`.chomp.split(" ").last.to_i
     console_width = 80 if console_width <= 0
-    max_len = items.map(&:length).max
+    max_len = items.reduce(0) { |max, item| l = item.length ; l > max ? l : max }
     optimal_col_width = (console_width.to_f / (max_len + 2).to_f).floor
     cols = optimal_col_width > 1 ? optimal_col_width : 1
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -128,6 +128,9 @@ If \fB\-\-installed\fR is passed, show dependencies for all installed formulae\.
 By default, \fBdeps\fR shows dependencies for \fIformulae\fR\. To skip the \fB:build\fR type dependencies, pass \fB\-\-skip\-build\fR\. Similarly, pass \fB\-\-skip\-optional\fR to skip \fB:optional\fR dependencies\.
 .
 .IP "\(bu" 4
+\fBdesc\fR \fIformula\fR: Display \fIformula\fR\'s name and one\-line description\.
+.
+.IP "\(bu" 4
 \fBdiy [\-\-name=<name>] [\-\-version=<version>]\fR: Automatically determine the installation prefix for non\-Homebrew software\.
 .
 .IP
@@ -415,10 +418,13 @@ If \fB\-\-git\fR is passed, a Git repository will be initalized in the unpacked 
 \fBuntap\fR \fItap\fR: Remove a tapped repository\.
 .
 .IP "\(bu" 4
-\fBupdate [\-\-rebase]\fR: Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1)\.
+\fBupdate [\-\-rebase] [\-\-desc]\fR: Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1)\.
 .
 .IP
 If \fB\-\-rebase\fR is specified then \fBgit pull \-\-rebase\fR is used\.
+.
+.IP
+If \fB\-\-desc\fR is specified, update will print the names and descriptions of the new and updated formulae, one per line, rather than just the names in table form\.
 .
 .IP "\(bu" 4
 \fBupgrade [install\-options]\fR [\fIformulae\fR]: Upgrade outdated, unpinned brews\.


### PR DESCRIPTION
This does three principal things:

1. Introduces a `Descriptions` class with which to retrieve and pretty-present formula descriptions.
2. Adds a `--desc` option to `brew update` which makes it pretty-present name-and-description, one per line, for new and updated formulae.
3. Resurrects the original `brew desc` command (albeit, at present, without any search facility and with slightly modified result formatting). It also adds bash completion for said command.

(It also, purely incidentally, modifies `utils.rb` to determine the longest string in an array by mapping `length` onto the array, and then taking the maximum of the result, instead of sorting the lengths and taking the largest. According my test this halves the duration of the maximum-length computation.)

**Rationale for the desc changes**:
*(with a tip of the hat to [xkcd](https://xkcd.com)’s “[Workflow](https://xkcd.com/1172/)”)*

I am always looking for new and undiscovered tools, but reading through the descriptions of all 3000+ formulae at once would be overwhelming. Since I usually run `brew update` once a day, looking into the day’s updates is manageable. Back when `homebrew-desc` existed as a separate tool, I’d just select the table of updated formulae in iTerm 2, and then run `brew desc $(echo $(pbpaste) | rs -T -C" ")` to get a list of descriptions.

It would be even better (for me, anyway) if I had the option of telling `brew update` to pretty-print the descriptions for all of the new and updated formulae to begin with.

The separate `desc` command is still useful, though, for things like processing the results of a `brew update` run without the `--desc` flag, or for summarizing your own installed formula set: `brew desc $(brew list)`