### PR TITLE
fontforge: add --skip-git to bootstrap options

### DIFF
--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -85,8 +85,12 @@ class Fontforge < Formula
     ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
 
     # Bootstrap in every build: https://github.com/fontforge/fontforge/issues/1806
+    # "--skip-git" tells the bootstrap script not to pull the latest master
+    # branch of gnulib and just use the commit we've checked out.
     resource("gnulib").fetch
-    system "./bootstrap", "--gnulib-srcdir=#{resource("gnulib").cached_download}"
+    system "./bootstrap",
+           "--gnulib-srcdir=#{resource("gnulib").cached_download}",
+           "--skip-git"
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
This adds `--skip-git` to the options given to the bootstrap script. Otherwise, it will still try to fetch the latest master branch for gnulib, foiling this formula's attempt to pin to a specific commit.