### PR TITLE
Making a new alias, golang -> go

### DIFF
--- a/Library/Aliases/golang
+++ b/Library/Aliases/golang
@@ -1,0 +1,1 @@
+../Formula/go.rb


### PR DESCRIPTION
The Go community generally searches for things related to the language by
'golang' rather than 'go', since searching for 'go' returns so many
unrelated results. (see http://golang.org/)