### PR TITLE
scons: 3.2.4 is latest on sourceforge

### DIFF
--- a/Library/Formula/scons.rb
+++ b/Library/Formula/scons.rb
@@ -3,8 +3,8 @@ require "formula"
 class Scons < Formula
   desc "Substitute for classic 'make' tool with autoconf/automake functionality"
   homepage "http://www.scons.org"
-  url "https://downloads.sourceforge.net/scons/scons-2.3.5.tar.gz"
-  sha256 "8a8993e1914801ace5ce83c92bf4c43127669750e9dec8eb93574e57729e9c42"
+  url "https://downloads.sourceforge.net/scons/scons-2.3.4.tar.gz"
+  sha1 "8c55f8c15221c1b3536a041d46056ddd7fa2d23a"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Signed-off-by: Drew Wells <drew.wells00@gmail.com>

Scons 3.2.5 has disappeared from Sourceforge. This reverts back to the working 3.2.4 download.