### PR TITLE
docker-compose: squelch warnings

### DIFF
--- a/Library/Formula/fig.rb
+++ b/Library/Formula/fig.rb
@@ -76,8 +76,19 @@ class Fig < Formula
 
     bash_completion.install "contrib/completion/bash/docker-compose"
 
+    # allow PYTHONWARNINGS to squelch irrelevant InsecurePlatformWarning
+    # https://github.com/Homebrew/homebrew/issues/41766
+    # https://github.com/shazow/urllib3/issues/602
+    inreplace libexec/"vendor/lib/python2.7/site-packages/requests/packages/urllib3/__init__.py" do |s|
+      s.gsub! "warnings.simplefilter('always', exceptions.SecurityWarning)",
+              "warnings.simplefilter('always', exceptions.SecurityWarning, append=True)"
+      s.gsub! "warnings.simplefilter('default', exceptions.InsecurePlatformWarning)",
+              "warnings.simplefilter('default', exceptions.InsecurePlatformWarning, append=True)"
+    end
+
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"],
+                                            :PYTHONWARNINGS => "ignore")
     ln_s bin/"docker-compose", bin/"fig"
   end
 


### PR DESCRIPTION
Keeps docker-compose from printing an InsecurePlatformWarning.

There are real issues that this ignores, like these:
https://github.com/shazow/urllib3/issues/602#issuecomment-97054951

I don't *think* those are relevant to the typical use of docker-compose, but I welcome comment on that aspect.

The alternative would be to build and install pyOpenSSL and pyca/cryptography, but that doesn't work if we build cryptography against Homebrew's openssl because something in the docker stack is incompatible with openssl 1.0.2. We won't be able to get away with building pyca/cryptography against system openssl once OS X 10.11 is released, since Apple's yanking the headers, so let's not do it now.

I think the warning is correct and benign but it's causing issue reports to us and to the docker-compose developers.