### PR TITLE
use ohai headers at the top of search results

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -87,9 +87,9 @@ module Homebrew
       else
         ofail e.message
         query = query_regexp(e.name)
-        puts "Searching formulae..."
+        ohai "Searching formulae..."
         puts_columns(search_formulae(query))
-        puts "Searching taps..."
+        ohai "Searching taps..."
         puts_columns(search_taps(query))
 
         # If they haven't updated in 48 hours (172800 seconds), that

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -433,7 +433,7 @@ module GitHub extend self
 
   def print_pull_requests_matching(query)
     return [] if ENV['HOMEBREW_NO_GITHUB_API']
-    puts "Searching pull requests..."
+    ohai "Searching pull requests..."
 
     open_or_closed_prs = issues_matching(query, :type => "pr")
 


### PR DESCRIPTION
Just a visual thing that's been bugging me:

Before:
![z](https://cloud.githubusercontent.com/assets/985416/8754716/68a889fa-2c7a-11e5-8820-ef57496e3f62.png)
![zzz](https://cloud.githubusercontent.com/assets/985416/8754717/6ae822f2-2c7a-11e5-954b-18489dc52eda.png)

After:
![zz](https://cloud.githubusercontent.com/assets/985416/8754721/6ffe7fd4-2c7a-11e5-9f81-f66e83e0d4cf.png)
![zzzz](https://cloud.githubusercontent.com/assets/985416/8754722/72e1d16a-2c7a-11e5-8e5d-20a9697c71b9.png)

