### PR TITLE
groovysdk 2.4.4

### DIFF
--- a/Library/Formula/groovysdk.rb
+++ b/Library/Formula/groovysdk.rb
@@ -4,7 +4,7 @@ class Groovysdk < Formula
   desc "SDK for Groovy: a Java-based scripting language"
   homepage "http://www.groovy-lang.org"
   url "https://dl.bintray.com/groovy/maven/apache-groovy-sdk-2.4.4.zip"
-  sha1 "6f738f4167509c72d75926a67126512f56e23df2"
+  sha256 "2e794749f38386c81101c05e83b2ddd2bc3675d1cb01101f3ee2be6cf67b2fc9"
 
   def install
     ENV["GROOVY_HOME"] = libexec

--- a/Library/Formula/groovysdk.rb
+++ b/Library/Formula/groovysdk.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Groovysdk < Formula
   desc "SDK for Groovy: a Java-based scripting language"
-  homepage "http://groovy.codehaus.org/"
-  url "http://dl.bintray.com/groovy/maven/groovy-sdk-2.4.3.zip"
-  sha1 "a3aa1161422132dc116f8b8171914b36668b3839"
+  homepage "http://www.groovy-lang.org"
+  url "https://dl.bintray.com/groovy/maven/apache-groovy-sdk-2.4.4.zip"
+  sha1 "6f738f4167509c72d75926a67126512f56e23df2"
 
   def install
     ENV["GROOVY_HOME"] = libexec


### PR DESCRIPTION
Groovy SDK has been updated to 2.4.4. It is now released under the Apache Software Foundation.

https://mail-archives.apache.org/mod_mbox/incubator-groovy-users/201507.mbox/%3CCADQzvmk%3D3TwWzeGMN-HXwv4CUkbPBENusioviPf29_uJ%3DzLi0w%40mail.gmail.com%3E