### PR TITLE
dnscrypt-proxy 1.6.0

### DIFF
--- a/Library/Formula/dnscrypt-proxy.rb
+++ b/Library/Formula/dnscrypt-proxy.rb
@@ -1,9 +1,9 @@
 class DnscryptProxy < Formula
   desc "Secure communications between a client and a DNS resolver"
   homepage "http://dnscrypt.org"
-  url "https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.5.0/dnscrypt-proxy-1.5.0.tar.bz2"
-  mirror "http://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-proxy-1.5.0.tar.bz2"
-  sha256 "dd1a09baff5685cf939c429ba0258f66a79d464bc5ac130d8d30e667fb8ee3b2"
+  url "https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.6.0/dnscrypt-proxy-1.6.0.tar.bz2"
+  mirror "http://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-proxy-1.6.0.tar.bz2"
+  sha256 "e0cce91dc6ab4ed76478579a899b2abb888b1d7ed133cb55294c2f9ce24edc7d"
 
   bottle do
     sha256 "e7062b1b7be9232ae720c10a8408947979d067309f858876d69f840682f4c232" => :yosemite
@@ -20,6 +20,7 @@ class DnscryptProxy < Formula
   end
 
   option "with-plugins", "Support plugins and install example plugins."
+
   deprecated_option "plugins" => "with-plugins"
 
   depends_on "libsodium"
@@ -28,11 +29,13 @@ class DnscryptProxy < Formula
     system "autoreconf", "-if" if build.head?
 
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
+
     if build.with? "plugins"
       args << "--enable-plugins"
       args << "--enable-relaxed-plugins-permissions"
       args << "--enable-plugins-root"
     end
+
     system "./configure", *args
     system "make", "install"
   end
@@ -45,23 +48,18 @@ class DnscryptProxy < Formula
     can click "+" and enter 127.0.0.1 in the "DNS Servers" section.
 
     By default, dnscrypt-proxy runs on localhost (127.0.0.1), port 53,
-    and under the "nobody" user using the default OpenDNS DNSCrypt-enabled
-    resolver. If you would like to change these settings (e.g., switching to
-    a DNSCrypt-enabled resolver with DNSSEC support), you will have to edit the
-    plist file (e.g., --resolver-address, --provider-name, --provider-key, etc.)
+    and under the "nobody" user using the dnscrypt.eu-dk DNSCrypt-enabled
+    resolver. If you would like to change these settings, you will have to edit
+    the plist file (e.g., --resolver-address, --provider-name, --provider-key, etc.)
 
     To check that dnscrypt-proxy is working correctly, open Terminal and enter the
-    following command:
+    following command. Replace en1 with whatever network interface you're using:
 
-        dig txt debug.opendns.com
+        sudo tcpdump -i en1 -vvv 'port 443'
 
     You should see a line in the result that looks like this:
 
-        debug.opendns.com.	0	IN	TXT	"dnscrypt enabled (......)"
-
-    Note: This will only work if you are using the default OpenDNS DNSCrypt-enabled
-    resolver. If you are using a different resolver, you can use a tool like tcpdump
-    to verify that everything is working correctly.
+        resolver2.dnscrypt.eu.https
     EOS
   end
 
@@ -81,8 +79,10 @@ class DnscryptProxy < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_sbin}/dnscrypt-proxy</string>
+          <string>--ephemeral-keys</string>
+          <string>--resolvers-list=#{share}/dnscrypt-proxy/dnscrypt-resolvers.csv</string>
+          <string>--resolver-name=dnscrypt.eu-dk</string>
           <string>--user=nobody</string>
-          <string>--resolver-name=opendns</string>
         </array>
         <key>UserName</key>
         <string>root</string>


### PR DESCRIPTION
Changes:

* Version bump
* Switch from `OpenDNS` to `dnscrypt.eu-dk` - OpenDNS has been acquired by [Cisco](http://newsroom.cisco.com/press-release-content?type=webcontent&articleId=1667697) and now declares that it logs, so it's not ideal for a privacy tool.
* Caveats updated according to the above.
* Now using Ephemeral Keys, which upstream recommends and provides enhanced privacy.