### PR TITLE
Include git sha1 in --version output

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -40,7 +40,7 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_version
-    assert_equal HOMEBREW_VERSION.to_s,
+    assert_match HOMEBREW_VERSION.to_s,
                  cmd("--version")
   end
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -155,6 +155,10 @@ module Homebrew
     HOMEBREW_REPOSITORY.cd { `git show -s --format="%cd" --date=short HEAD 2>/dev/null`.chuzzle }
   end
 
+  def self.homebrew_version_string
+    "#{HOMEBREW_VERSION} (git revision #{Homebrew.git_head || "unknown"}; last commit #{Homebrew.git_last_commit_date || "unknown"})"
+  end
+
   def self.install_gem_setup_path!(gem, version = nil, executable = gem)
     require "rubygems"
     ENV["PATH"] = "#{Gem.user_dir}/bin:#{ENV["PATH"]}"

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -151,6 +151,10 @@ module Homebrew
     HOMEBREW_REPOSITORY.cd { `git show -s --format="%cr" HEAD 2>/dev/null`.chuzzle }
   end
 
+  def self.git_last_commit_date
+    HOMEBREW_REPOSITORY.cd { `git show -s --format="%cd" --date=short HEAD 2>/dev/null`.chuzzle }
+  end
+
   def self.install_gem_setup_path!(gem, version = nil, executable = gem)
     require "rubygems"
     ENV["PATH"] = "#{Gem.user_dir}/bin:#{ENV["PATH"]}"

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -147,6 +147,10 @@ module Homebrew
     HOMEBREW_REPOSITORY.cd { `git rev-parse --verify -q HEAD 2>/dev/null`.chuzzle }
   end
 
+  def self.git_short_head
+    HOMEBREW_REPOSITORY.cd { `git rev-parse --short=4 --verify -q HEAD 2>/dev/null`.chuzzle }
+  end
+
   def self.git_last_commit
     HOMEBREW_REPOSITORY.cd { `git show -s --format="%cr" HEAD 2>/dev/null`.chuzzle }
   end
@@ -156,7 +160,13 @@ module Homebrew
   end
 
   def self.homebrew_version_string
-    "#{HOMEBREW_VERSION} (git revision #{Homebrew.git_head || "unknown"}; last commit #{Homebrew.git_last_commit_date || "unknown"})"
+    pretty_revision = git_short_head
+    if pretty_revision
+      last_commit = git_last_commit_date
+      "#{HOMEBREW_VERSION} (git revision #{pretty_revision}; last commit #{last_commit})"
+    else
+      "#{HOMEBREW_VERSION} (no git repository)"
+    end
   end
 
   def self.install_gem_setup_path!(gem, version = nil, executable = gem)

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -15,10 +15,10 @@ $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
 if ARGV.first == "--version"
-  puts HOMEBREW_VERSION
+  puts "#{HOMEBREW_VERSION} (#{Homebrew.git_head || "unknown"}; #{Homebrew.git_last_commit_date || "unknown"})"
   exit 0
 elsif ARGV.first == "-v"
-  puts "Homebrew #{HOMEBREW_VERSION}"
+  puts "Homebrew #{HOMEBREW_VERSION} (#{Homebrew.git_head || "unknown"}; #{Homebrew.git_last_commit_date || "unknown"})"
   # Shift the -v to the end of the parameter list
   ARGV << ARGV.shift
   # If no other arguments, just quit here.

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -15,10 +15,10 @@ $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
 if ARGV.first == "--version"
-  puts "#{HOMEBREW_VERSION} (#{Homebrew.git_head || "unknown"}; #{Homebrew.git_last_commit_date || "unknown"})"
+  puts Homebrew.homebrew_version_string
   exit 0
 elsif ARGV.first == "-v"
-  puts "Homebrew #{HOMEBREW_VERSION} (#{Homebrew.git_head || "unknown"}; #{Homebrew.git_last_commit_date || "unknown"})"
+  puts "Homebrew #{Homebrew.homebrew_version_string}"
   # Shift the -v to the end of the parameter list
   ARGV << ARGV.shift
   # If no other arguments, just quit here.


### PR DESCRIPTION
HOMEBREW_VERSION doesn't change very often; the repository state is more
interesting.

Does this need more robust error handling? I can't think of a way this will fail.