### PR TITLE
'brew tests' optional coverage measure added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /Library/Homebrew/test/.bundle
 /Library/Homebrew/test/bin
 /Library/Homebrew/test/vendor
+/Library/Homebrew/test/coverage
 /Library/LinkedKegs
 /Library/PinnedKegs
 /Library/Taps

--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -2,6 +2,7 @@ module Homebrew
   def tests
     (HOMEBREW_LIBRARY/"Homebrew/test").cd do
       ENV["TESTOPTS"] = "-v" if ARGV.verbose?
+      ENV["HOMEBREW_TESTS_COVERAGE"] = "1" if ARGV.flag? "--coverage"
       Homebrew.install_gem_setup_path! "bundler"
       quiet_system("bundle", "check") || \
         system("bundle", "install", "--path", "vendor/bundle")

--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem "mocha", "~> 1.1"
 gem "minitest", "~> 5.3"
 gem "rake", "~> 10.3"
+gem "simplecov", "~> 0.10.0", :require => false

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -1,11 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    docile (1.1.5)
+    json (1.8.3)
     metaclass (0.0.4)
     minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     rake (10.4.2)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
 
 PLATFORMS
   ruby
@@ -14,3 +21,4 @@ DEPENDENCIES
   minitest (~> 5.3)
   mocha (~> 1.1)
   rake (~> 10.3)
+  simplecov (~> 0.10.0)

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -1,6 +1,22 @@
 $:.unshift File.expand_path("../..", __FILE__)
 $:.unshift File.expand_path("../lib", __FILE__)
 
+# This must be at the top
+if ENV["HOMEBREW_TESTS_COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    tests_path = File.dirname(__FILE__)
+
+    minimum_coverage 50
+    coverage_dir File.expand_path("#{tests_path}/coverage")
+    root File.expand_path("#{tests_path}/..")
+
+    add_filter "Homebrew/test"
+    add_filter "vendor/bundle"
+    add_filter "Homebrew/vendor"
+  end
+end
+
 require "global"
 
 # Test environment setup


### PR DESCRIPTION
See #41883.

This measures the code coverage of `brew tests` if `--coverage` is passed:

```
$ brew tests --coverage
Run options: --seed 6892

# Running:

...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 5.459945s, 101.6494 runs/s, 226.7422 assertions/s.

555 runs, 1238 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /usr/local/Library/Homebrew/coverage. 4154 / 6971 LOC (59.59%) covered.
```

It generates a nice report in `/usr/local/Library/Homebrew/coverage/index.html` that looks like this:

![screenshot](https://cloud.githubusercontent.com/assets/1334295/8765257/875a0f46-2e04-11e5-9798-3dc41141c1c8.png)

You can then click on each file to see the coverage:

![screenshot](https://cloud.githubusercontent.com/assets/1334295/8765263/b81286b8-2e04-11e5-93a6-211a90e323e2.png)
