### PR TITLE
Stop flagging explicit from-source modified builds

### DIFF
--- a/Library/Formula/a2ps.rb
+++ b/Library/Formula/a2ps.rb
@@ -29,6 +29,7 @@ class A2ps < Formula
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
+    system "echo dog"
     system "make", "install"
   end
 

--- a/Library/Formula/a2ps.rb
+++ b/Library/Formula/a2ps.rb
@@ -29,7 +29,6 @@ class A2ps < Formula
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "echo dog"
     system "make", "install"
   end
 

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -32,6 +32,7 @@ module Homebrew
   def fetch_bottle? f
     return true if ARGV.force_bottle? && f.bottle
     return false unless f.bottle && f.pour_bottle?
+    return false if ARGV.build_from_source? || ARGV.build_bottle?
     if f.file_modified?
       filename = f.path.to_s.gsub("#{HOMEBREW_PREFIX}/", "")
       opoo "Formula file is modified!"
@@ -39,7 +40,6 @@ module Homebrew
       puts "To fetch the bottle instead, run with --force-bottle"
       return false
     end
-    return false if ARGV.build_from_source? || ARGV.build_bottle?
     return false unless f.bottle.compatible_cellar?
     return true
   end

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -500,7 +500,7 @@ module Homebrew
       # Don't care about e.g. bottle failures for dependencies.
       run_as_not_developer do
         test "brew", "install", "--only-dependencies", *install_args unless dependencies.empty?
-        test "brew", "install", *install_args
+        test "brew", "install", "--build-from-source", *install_args
       end
       install_passed = steps.last.passed?
       audit_args = [canonical_formula_name]

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -180,7 +180,7 @@ class FormulaInstaller
     build_bottle_preinstall if build_bottle?
 
     unless @poured_bottle
-      if formula.file_modified?
+      if formula.file_modified? && !build_from_source?
         filename = formula.path.to_s.gsub("#{HOMEBREW_PREFIX}/", "")
         opoo "Formula file is modified!"
         puts "Building from source because #{filename} has local changes"

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -61,11 +61,10 @@ class FormulaInstaller
     return false if @pour_failed
 
     bottle = formula.bottle
-    return true  if force_bottle? && bottle
+    return true if (force_bottle? && bottle) || formula.local_bottle_path
     return false if build_from_source? || build_bottle? || interactive? || formula.file_modified?
     return false unless options.empty?
 
-    return true if formula.local_bottle_path
     return false unless bottle && formula.pour_bottle?
 
     unless bottle.compatible_cellar?


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/homebrew/commit/1134222baf2e91d3e2581d7651494d92de513715.

Essentially at the moment we're seeing it where even when I locally tell `brew` I'll be doing `-fs` installation it throws the warning at me about having modified the file and it'll be installing from source. I know it'll be installing from source, I just told it to :wink::

![screen shot 2015-07-19 at 16 13 23](https://cloud.githubusercontent.com/assets/6998367/8767499/dbfbeea0-2e56-11e5-9003-02bb8cab5ae8.png)

It's also popping up on the [test-bot](http://bot.brew.sh/job/Homebrew%20Pull%20Requests/29868/version=mountain_lion/console).

I'm happy to wrap the new changes in `HOMEBREW_DEVELOPER` if people are happier with that. The warning formulae have been modified is still potentially useful to people who don't regularly pull and make local changes all over the place, but on the test-bot and when developers explicitly pass `fs` it's a bit redundant and potentially confusing.