### PR TITLE
pango: Apply patch from GNOME Bug 736697

### DIFF
--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -1,9 +1,22 @@
 class Pango < Formula
   desc "Framework for layout and rendering of i18n text"
   homepage "http://www.pango.org/"
-  url "https://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz"
-  sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://download.gnome.org/sources/pango/1.36/pango-1.36.8.tar.xz"
+    sha256 "18dbb51b8ae12bae0ab7a958e7cf3317c9acfc8a1e1103ec2f147164a0fc2d07"
+
+    # [coretext] NULL check in ct_font_descriptor_get_weight()
+    # This fixes crashes when displaying certain Unicode characters. For example,
+    # this fixes an issue where `frama-c-gui` would crash when attempting to
+    # display the 'ℤ' character.
+    # See: https://bugzilla.gnome.org/show_bug.cgi?id=736697
+    patch do
+      url "https://bug736697.bugzilla-attachments.gnome.org/attachment.cgi?id=286234"
+      sha256 "08d803ddedfa98d99b1897c22a61b908cff05bd0e43982f3063f0d77e05ddb17"
+    end
+  end
 
   head do
     url "https://git.gnome.org/browse/pango.git"


### PR DESCRIPTION
This fixes a SegFault issue when displaying certain Unicode characters.
For example, this fixes an issue where `frama-c-gui` would crash from
attempting to display the 'ℤ' character.