### PR TITLE
Bump scw

### DIFF
--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -35,6 +35,6 @@ class Scw < Formula
 
   test do
     output = shell_output(bin/"scw version")
-    assert output.include? "OS/Arch (client): darwin/amd64"
+    assert_match "OS/Arch (client): darwin/amd64", output
   end
 end

--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Scw < Formula
   desc "Manage BareMetal Servers from Command Line (as easily as with Docker)"
   homepage "https://github.com/scaleway/scaleway-cli"
-  url "https://github.com/scaleway/scaleway-cli/archive/v1.2.1.tar.gz"
-  sha256 "e3ae09558a5f451935831381177f1ee3ce50aec438a1e11269dfc380e0e196c9"
+  url "https://github.com/scaleway/scaleway-cli/archive/v1.3.0.tar.gz"
+  sha256 "b02ed007f831b9ffd79be0b670c6c1bfa59a87ba87ac54dea48005cfb305f5c7"
 
   head "https://github.com/scaleway/scaleway-cli.git"
 
@@ -17,22 +17,6 @@ class Scw < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/tools/godep" do
-    url "https://github.com/tools/godep.git", :revision => "58d90f262c13357d3203e67a33c6f7a9382f9223"
-  end
-
-  go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
-  end
-
-  go_resource "golang.org/x/tools" do
-    url "https://github.com/golang/tools.git", :revision => "473fd854f8276c0b22f17fb458aa8f1a0e2cf5f5"
-  end
-
-  go_resource "golang.org/x/crypto" do
-    url "https://github.com/golang/crypto.git", :revision => "8b27f58b78dbd60e9a26b60b0d908ea642974b6d"
-  end
-
   def install
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
@@ -42,11 +26,7 @@ class Scw < Formula
     ln_s buildpath, buildpath/"src/github.com/scaleway/scaleway-cli"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    cd "src/github.com/tools/godep" do
-      system "go", "install"
-    end
-
-    system "./bin/godep", "go", "build", "-o", "scw"
+    system "go", "build", "-o", "scw", "."
     bin.install "scw"
 
     bash_completion.install "contrib/completion/bash/scw"


### PR DESCRIPTION
Since `scaleway-cli` do not use `godep` for building anymore, the formula is now much simpler

Tested with stable and `--HEAD`