### PR TITLE
cmd/deps: --tree shows required dependencies only

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -64,7 +64,7 @@ module Homebrew
 
   def puts_deps_tree(formulae)
     formulae.each do |f|
-      puts f.full_name
+      puts "#{f.full_name} (required dependencies)"
       recursive_deps_tree(f, "")
       puts
     end


### PR DESCRIPTION
Until we figure out how to allow --tree to show optional dependencies in
a way that fits on a normal screen, this helps to explain the
discrepancy between `brew deps` and `brew deps --tree`.

Closes #41841.