### PR TITLE
Use exec instead of system in fork block

### DIFF
--- a/Library/Formula/bigdata.rb
+++ b/Library/Formula/bigdata.rb
@@ -35,7 +35,7 @@ class Bigdata < Formula
 
   test do
     server = fork do
-      system bin/"bigdata"
+      exec bin/"bigdata"
     end
     sleep 5
     Process.kill("TERM", server)

--- a/Library/Formula/chromedriver.rb
+++ b/Library/Formula/chromedriver.rb
@@ -37,7 +37,7 @@ class Chromedriver < Formula
 
   test do
     driver = fork do
-      system bin/"chromedriver",
+      exec bin/"chromedriver",
              "--port=9999", "--log-path=#{testpath}/cd.log"
     end
     sleep 5

--- a/Library/Formula/conserver.rb
+++ b/Library/Formula/conserver.rb
@@ -18,7 +18,7 @@ class Conserver < Formula
 
   test do
     console = fork do
-      system bin/"console", "-n", "-p", "8000", "test"
+      exec bin/"console", "-n", "-p", "8000", "test"
     end
     sleep 1
     Process.kill("TERM",console)

--- a/Library/Formula/consul.rb
+++ b/Library/Formula/consul.rb
@@ -170,7 +170,7 @@ class Consul < Formula
 
   test do
     fork do
-      system "#{bin}/consul", "agent", "-data-dir", "."
+      exec "#{bin}/consul", "agent", "-data-dir", "."
     end
     sleep 3
     system "#{bin}/consul", "leave"

--- a/Library/Formula/epic5.rb
+++ b/Library/Formula/epic5.rb
@@ -24,7 +24,7 @@ class Epic5 < Formula
 
   test do
     connection = fork do
-      system bin/"epic5", "irc.freenode.net"
+      exec bin/"epic5", "irc.freenode.net"
     end
     sleep 5
     Process.kill("TERM", connection)

--- a/Library/Formula/gnu-typist.rb
+++ b/Library/Formula/gnu-typist.rb
@@ -29,7 +29,7 @@ class GnuTypist < Formula
 
   test do
     session = fork do
-      system bin/"gtypist", "-t", "-q", "-l", "DEMO_0", share/"gtypist/demo.typ"
+      exec bin/"gtypist", "-t", "-q", "-l", "DEMO_0", share/"gtypist/demo.typ"
     end
     sleep 2
     Process.kill("TERM", session)

--- a/Library/Formula/jetty.rb
+++ b/Library/Formula/jetty.rb
@@ -31,7 +31,7 @@ class Jetty < Formula
   end
 
   test do
-    pid = fork { system bin/"jetty", "start" }
+    pid = fork { exec bin/"jetty", "start" }
     sleep 5 # grace time for server start
     begin
       assert_match /Jetty running pid=\d+/, shell_output("#{bin}/jetty check")

--- a/Library/Formula/libhttpserver.rb
+++ b/Library/Formula/libhttpserver.rb
@@ -41,7 +41,7 @@ class Libhttpserver < Formula
   test do
     system ENV.cxx, "#{share}/examples/hello_world.cpp",
       "-o", "hello_world", "-lhttpserver", "-lcurl"
-    pid = fork { system "./hello_world" }
+    pid = fork { exec "./hello_world" }
     sleep 1 # grace time for server start
     begin
       assert_match /Hello World!!!/, shell_output("curl http://127.0.0.1:8080/hello")

--- a/Library/Formula/nsq.rb
+++ b/Library/Formula/nsq.rb
@@ -76,19 +76,19 @@ class Nsq < Formula
   test do
     begin
       lookupd = fork do
-        system bin/"nsqlookupd"
+        exec bin/"nsqlookupd"
       end
       sleep 2
       d = fork do
-        system bin/"nsqd", "--lookupd-tcp-address=127.0.0.1:4160"
+        exec bin/"nsqd", "--lookupd-tcp-address=127.0.0.1:4160"
       end
       sleep 2
       admin = fork do
-        system bin/"nsqadmin", "--lookupd-http-address=127.0.0.1:4161"
+        exec bin/"nsqadmin", "--lookupd-http-address=127.0.0.1:4161"
       end
       sleep 2
       to_file = fork do
-        system bin/"nsq_to_file", "--topic=test", "--output-dir=#{testpath}",
+        exec bin/"nsq_to_file", "--topic=test", "--output-dir=#{testpath}",
                "--lookupd-http-address=127.0.0.1:4161"
       end
       sleep 2


### PR DESCRIPTION
Use exec instead of system to avoid forking, because we need to kill it via pid afterwards.