### PR TITLE
debianutils: fix stale url, version bump to 4.5.1

### DIFF
--- a/Library/Formula/debianutils.rb
+++ b/Library/Formula/debianutils.rb
@@ -1,9 +1,9 @@
 class Debianutils < Formula
   desc "Miscellaneous utilities specific to Debian"
   homepage "https://packages.debian.org/unstable/utils/debianutils"
-  url "https://mirrors.kernel.org/debian/pool/main/d/debianutils/debianutils_4.5.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.5.tar.gz"
-  sha256 "7cfaa53caaaaf36dad16fa69b30dd2b78b8dafebd766aacd53a3c7c78a9d441f"
+  url "https://mirrors.kernel.org/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
+  sha256 "a531c23e0105fe01cfa928457a8343a1e947e2621b3cd4d05f4e9656020c63b7"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The urls for 4.5 are returning 404 now.

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>