### PR TITLE
Add optional libntlm dependency to gsasl

### DIFF
--- a/Library/Formula/gsasl.rb
+++ b/Library/Formula/gsasl.rb
@@ -5,6 +5,8 @@ class Gsasl < Formula
   mirror "https://ftp.gnu.org/gsasl/gsasl-1.8.0.tar.gz"
   sha256 "310262d1ded082d1ceefc52d6dad265c1decae8d84e12b5947d9b1dd193191e5"
 
+  depends_on "libntlm" => :optional
+
   bottle do
     cellar :any
     revision 2


### PR DESCRIPTION
If libntlm is installed, I should be able to build gsasl with the ntlm functionality enabled. This, along with #41969 enables NTLM authentication in msmtp.