### PR TITLE
ezstream: fix test

### DIFF
--- a/Library/Formula/ezstream.rb
+++ b/Library/Formula/ezstream.rb
@@ -17,11 +17,6 @@ class Ezstream < Formula
   depends_on "speex"
   depends_on "libogg"
 
-  resource "stream" do
-    url "http://dir.xiph.org/listen/5200/listen.m3u"
-    sha256 "ff44097742f92b73a63332760585217eb357389eea7f92465ff769043d365aea"
-  end
-
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -30,12 +25,7 @@ class Ezstream < Formula
   end
 
   test do
-    resource("stream").stage do
-      stream = fork do
-        system bin/"ezstream", "-s", "listen.m3u"
-      end
-      sleep 5
-      Process.kill("TERM", stream)
-    end
+    (testpath/"test.m3u").write "#{test_fixtures("test.mp3")}"
+    system bin/"ezstream", "-s", testpath/"test.m3u"
   end
 end


### PR DESCRIPTION
resource was 404ing, but we can make our own .m3u file