### PR TITLE
Pathname#abv: handle the case `du` returns empty string

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -393,7 +393,9 @@ class Pathname
     out = ""
     n = Utils.popen_read("find", expand_path.to_s, "-type", "f", "!", "-name", ".DS_Store").split("\n").size
     out << "#{n} files, " if n > 1
-    out << Utils.popen_read("/usr/bin/du", "-hs", expand_path.to_s).split("\t")[0].strip
+    size = Utils.popen_read("/usr/bin/du", "-hs", expand_path.to_s).split("\t")[0]
+    size ||= "0B"
+    out << size.strip
     out
   end
 


### PR DESCRIPTION
This can happen when read permission is denied.

Fixes #41925.