### PR TITLE
Update autojump repo location.

### DIFF
--- a/Library/Formula/autojump.rb
+++ b/Library/Formula/autojump.rb
@@ -1,10 +1,10 @@
 class Autojump < Formula
   desc "Shell extension to jump to frequently used directories"
-  homepage "https://github.com/joelthelion/autojump"
-  url "https://github.com/joelthelion/autojump/archive/release-v22.2.4.tar.gz"
+  homepage "https://github.com/wting/autojump"
+  url "https://github.com/wting/autojump/archive/release-v22.2.4.tar.gz"
   sha256 "816badb0721f735e2b86bdfa8b333112f3867343c7c2263c569f75b4ec91f475"
 
-  head "https://github.com/joelthelion/autojump.git"
+  head "https://github.com/wting/autojump.git"
 
   def install
     system "./install.py", "-d", prefix, "-z", zsh_completion


### PR DESCRIPTION
This repo has been migrated to a new location. To confirm, visiting the old location should redirect to the new: https://github.com/joelthelion/autojump