### PR TITLE
ctl: bump revision for ilmbase update

### DIFF
--- a/Library/Formula/ctl.rb
+++ b/Library/Formula/ctl.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Ctl < Formula
   desc "Programming language for digital color management"
   homepage "https://github.com/ampas/CTL"
   url "https://github.com/ampas/CTL/archive/ctl-1.5.2.tar.gz"
-  sha1 "2c4aff2d514eeadfac89c6f041d5ffa2e853a79d"
+  sha256 "d7fac1439332c4d84abc3c285b365630acf20ea041033b154aa302befd25e0bd"
+  revision 1
 
   bottle do
     sha256 "860d6ce8218cf26830ac61327c45d862df1dd33b58996278d37341b34c8062e6" => :yosemite
@@ -20,11 +19,16 @@ class Ctl < Formula
 
   def install
     ENV.delete "CTL_MODULE_PATH"
+
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "check"
       system "make", "install"
     end
+  end
+
+  test do
+    assert_match /transforms an image/, shell_output("#{bin}/ctlrender -help", 1)
   end
 end


### PR DESCRIPTION
The test here is awful, but it will at least raise an error if we update `ilmbase` in future and the dylib version changes again causing ctl breakage.

If you know a better, practical test, we welcome another PR!

Closes #42033