### PR TITLE
Pyqt5:  5.5

### DIFF
--- a/Library/Formula/pyqt5.rb
+++ b/Library/Formula/pyqt5.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Pyqt5 < Formula
   desc "Python bindings for v5 of Qt"
   homepage "http://www.riverbankcomputing.co.uk/software/pyqt/download5"
-  url "https://downloads.sf.net/project/pyqt/PyQt5/PyQt-5.4.2/PyQt-gpl-5.4.2.tar.gz"
-  sha256 "4cd90580558722ef24d499700faafbdc242d930cb36f55cc1a27b5cf67b10290"
+  url "http://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt-gpl-5.5.tar.gz"
+  sha256 "cdd1bb55b431acdb50e9210af135428a13fb32d7b1ab86e972ac7101f6acd814"
 
   bottle do
     sha256 "bb04bac3c3495dbaac4fb3f0a2ccf082e6f26b3576167d256e2eac6ec34d709c" => :yosemite

--- a/Library/Formula/sip.rb
+++ b/Library/Formula/sip.rb
@@ -1,8 +1,8 @@
 class Sip < Formula
   desc "Tool to create Python bindings for C and C++ libraries"
   homepage "http://www.riverbankcomputing.co.uk/software/sip"
-  url "https://downloads.sf.net/project/pyqt/sip/sip-4.16.8/sip-4.16.8.tar.gz"
-  sha256 "d3141b65e48a30c9ce36612f8bcd1730ebf02d044757e4d6c5234927e2063e18"
+  url "http://www.riverbankcomputing.com/static/Downloads/sip4/sip-4.16.9.tar.gz"
+  sha256 "dbe173aa566e26ca0bb5bcbc1d30ef780f416267bb3b5df48149a737ea6b0555"
 
   bottle do
     sha256 "d21f39098b5f241d1ea61c414961664941793e3ff5fea56b478c2ad092b7c166" => :yosemite


### PR DESCRIPTION
Upgrade PyQt5 to 5.5 to match upgrade of Qt5 

Also update sip to the latest version as that is usually best for new pyqt versions. 

Do I need to bump the pyqt4 formula to match the new sip version? 