### PR TITLE
rtags 2.0 (new formula)

### DIFF
--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -2,31 +2,22 @@ class Rtags < Formula
   desc "ctags-like source code cross-referencer with a clang frontend"
   homepage "https://github.com/Andersbakken/rtags"
 
-  head "https://github.com/Andersbakken/rtags.git"
+  url "https://github.com/Andersbakken/rtags.git",
+      :tag => "v2.0",
+      :revision => "ba85598841648490e64246be802fc2dcdd45bc3c"
 
-  stable do
-    url "https://github.com/Andersbakken/rtags.git",
-        :tag => "v2.0",
-        :revision => "ba85598841648490e64246be802fc2dcdd45bc3c"
-  end
+  head "https://github.com/Andersbakken/rtags.git"
 
   depends_on "cmake" => :build
   depends_on "llvm" => "with-clang"
   depends_on "openssl"
 
   def install
-    # we use brew's LLVM instead of the macosx llvm because the macosx one
-    # doesn't include libclang.
-    ENV.prepend_path "PATH", "#{opt_libexec}/llvm/bin"
-
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
     ENV.append("LDFLAGS", "-lc++abi")
 
     mkdir "build" do
-      args = std_cmake_args
-      args << ".."
-
-      system "cmake", *args
+      system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -1,13 +1,14 @@
 class Rtags < Formula
+  desc "ctags-like source code cross-referencer with a clang frontend"
   homepage "https://github.com/Andersbakken/rtags"
+
+  head "https://github.com/Andersbakken/rtags.git"
 
   stable do
     url "https://github.com/Andersbakken/rtags.git",
         :tag => "v2.0",
         :revision => "ba85598841648490e64246be802fc2dcdd45bc3c"
   end
-
-  head "https://github.com/Andersbakken/rtags.git"
 
   depends_on "cmake" => :build
   depends_on "llvm" => "with-clang"
@@ -19,7 +20,7 @@ class Rtags < Formula
     ENV.prepend_path "PATH", "#{opt_libexec}/llvm/bin"
 
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
-    ENV.append("LDFLAGS", '-lc++abi')
+    ENV.append("LDFLAGS", "-lc++abi")
 
     mkdir "build" do
       args = std_cmake_args

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -23,6 +23,10 @@ class Rtags < Formula
   end
 
   test do
-    system "sh", "-c", "rc >/dev/null --help  ; test $? == 1"
+    # not using shell_output because on HEAD the exit code will be 0, but on
+    # stable it will be 1.
+    cmd = "#{bin}/rc --help"
+    ohai cmd
+    assert_match /rc options/, `#{cmd}`
   end
 end

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -1,7 +1,6 @@
 class Rtags < Formula
   desc "ctags-like source code cross-referencer with a clang frontend"
   homepage "https://github.com/Andersbakken/rtags"
-
   url "https://github.com/Andersbakken/rtags.git",
       :tag => "v2.0",
       :revision => "ba85598841648490e64246be802fc2dcdd45bc3c"

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -26,7 +26,6 @@ class Rtags < Formula
     # not using shell_output because on HEAD the exit code will be 0, but on
     # stable it will be 1.
     cmd = "#{bin}/rc --help"
-    ohai cmd
     assert_match /rc options/, `#{cmd}`
   end
 end

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -2,12 +2,9 @@ class Rtags < Formula
   homepage "https://github.com/Andersbakken/rtags"
 
   stable do
-    url "https://github.com/Andersbakken/rtags/archive/v2.0.tar.gz"
-    sha256 "36733945ea34517903a0e5b800b06a41687ee25d3ab360072568523e5d610d6f"
-
-    resource "rct" do
-      url "https://github.com/Andersbakken/rct.git", :revision => "10700c615179f07d4832d459e6453eed736cfaef"
-    end
+    url "https://github.com/Andersbakken/rtags.git",
+        :tag => "v2.0",
+        :revision => "ba85598841648490e64246be802fc2dcdd45bc3c"
   end
 
   head "https://github.com/Andersbakken/rtags.git"
@@ -17,10 +14,6 @@ class Rtags < Formula
   depends_on "openssl"
 
   def install
-    unless build.head?
-      (buildpath/"src/rct").install resource("rct")
-    end
-
     # we use brew's LLVM instead of the macosx llvm because the macosx one
     # doesn't include libclang.
     ENV.prepend_path "PATH", "#{opt_libexec}/llvm/bin"

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -35,7 +35,11 @@ class Rtags < Formula
     (testpath/"src/README").write(<<-END.undent)
         42
       END
-    rdm = spawn("sh", "-c", "#{bin}/rdm -L log >/dev/null 2>&1")
+    rdm = fork do
+      $stdout.reopen("/dev/null")
+      $stderr.reopen("/dev/null")
+      exec "#{bin}/rdm", "-L", "log"
+    end
     def pause
       slept = 0
       while slept < 5

--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -1,0 +1,44 @@
+class Rtags < Formula
+  homepage "https://github.com/Andersbakken/rtags"
+
+  stable do
+    url "https://github.com/Andersbakken/rtags/archive/v2.0.tar.gz"
+    sha256 "36733945ea34517903a0e5b800b06a41687ee25d3ab360072568523e5d610d6f"
+
+    resource "rct" do
+      url "https://github.com/Andersbakken/rct.git", :revision => "10700c615179f07d4832d459e6453eed736cfaef"
+    end
+  end
+
+  head "https://github.com/Andersbakken/rtags.git"
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => "with-clang"
+  depends_on "openssl"
+
+  def install
+    unless build.head?
+      (buildpath/"src/rct").install resource("rct")
+    end
+
+    # we use brew's LLVM instead of the macosx llvm because the macosx one
+    # doesn't include libclang.
+    ENV.prepend_path "PATH", "#{opt_libexec}/llvm/bin"
+
+    # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
+    ENV.append("LDFLAGS", '-lc++abi')
+
+    mkdir "build" do
+      args = std_cmake_args
+      args << ".."
+
+      system "cmake", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "sh", "-c", "rc >/dev/null --help  ; test $? == 1"
+  end
+end


### PR DESCRIPTION
rtags is a ctags-like source code cross-referencer with a clang frontend.

from rtags README:

RTags is a client/server application that indexes C/C++ code and keeps a
persistent in-memory database of references, declarations, definitions,
symbolnames etc. There’s also limited support for ObjC/ObjC++. It allows you to
find symbols by name (including class and namespace scope). Most importantly we
give you proper follow-symbol and find-references support. We also have neat
little things like rename-symbol, integration with clang’s “fixits”
(http://clang.llvm.org/diagnostics.html). We also integrate with flymake using
clang’s vastly superior errors and warnings. Since RTags constantly will reindex
“dirty” files you get live updating of compiler errors and warnings. Since we
already know how to compile your sources we have a way to quickly bring up the
preprocessed output of the current source file in a buffer.

While existing taggers like gnu global, cscope, etags, ctags etc do a good job
for C they often fall a little bit short for C++. With its incredible lexical
complexity, parsing C++ is an incredibly hard task and we make no bones about
the fact that the only reason we are able to improve on the current tools is
because of clang (http://clang.llvm.org/). RTags is named RTags in recognition
of Roberto Raggi on whose C++ parser we intended to base this project but he
assured us clang was the way to go. The name stuck though # Please enter the
commit message for your changes. Lines starting # with '#' will be ignored, and
an empty message aborts the commit.  # On branch rtags2.0 # Changes to be
committed: # new file: Library/Formula/rtags.rb #