### PR TITLE
update: print advice on bad permissions

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -1,5 +1,4 @@
 require 'cmd/tap'
-require 'tempfile'
 
 module Homebrew
   def update
@@ -24,7 +23,7 @@ module Homebrew
     begin
       master_updater.pull!
     rescue ErrorDuringExecution => e
-      unless homebrew_repository_writable?
+      unless HOMEBREW_REPOSITORY.writable_real?
         onoe "Can't write to #{HOMEBREW_REPOSITORY}"
         $stderr.puts <<-EOS.undent
           You may be able to fix this error by running
@@ -126,14 +125,6 @@ module Homebrew
   def load_tap_migrations
     require 'tap_migrations'
   rescue LoadError
-    false
-  end
-
-  def homebrew_repository_writable?
-    tf = Tempfile.new(".homebrew-write-probe", tmpdir=HOMEBREW_REPOSITORY)
-    tf.close!
-    true
-  rescue Errno::EACCES
     false
   end
 end

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -31,7 +31,7 @@ module Homebrew
           to reset ownership to your current user account.
         EOS
       end
-      raise e
+      raise
     end
     report.update(master_updater.report)
 

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -22,7 +22,7 @@ module Homebrew
     master_updater = Updater.new(HOMEBREW_REPOSITORY)
     begin
       master_updater.pull!
-    rescue ErrorDuringExecution => e
+    rescue ErrorDuringExecution
       unless HOMEBREW_REPOSITORY.writable_real?
         onoe "Can't write to #{HOMEBREW_REPOSITORY}"
         $stderr.puts <<-EOS.undent


### PR DESCRIPTION
Print a friendlier error message if we don't have write permission to HOMEBREW_REPOSITORY. Should address situations where OS upgrades change the permissions on /usr/local, like in #41665, #41690, and #41150.