### PR TITLE
giflib: fix "ld: library not found for -lSM"

### DIFF
--- a/Library/Formula/giflib.rb
+++ b/Library/Formula/giflib.rb
@@ -15,6 +15,8 @@ class Giflib < Formula
     sha256 "d38a310aa80f627a23b65b71e97baf6d08d8daa8281595f523e8116f5d4eace1" => :mountain_lion
   end
 
+  depends_on :x11
+  
   option :universal
 
   def install

--- a/Library/Formula/giflib.rb
+++ b/Library/Formula/giflib.rb
@@ -16,7 +16,7 @@ class Giflib < Formula
   end
 
   depends_on :x11
-  
+
   option :universal
 
   def install


### PR DESCRIPTION
I got this on os x 10.6.8 :
```
==> Downloading https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2
Already downloaded: /Library/Caches/Homebrew/giflib-4.2.3.tar.bz2
==> ./configure --prefix=/usr/local/Cellar/giflib/4.2.3
==> make install
libtool: link: gcc-4.2 -dynamiclib  -o .libs/libgif.4.dylib  .libs/dgif_lib.o .libs/egif_lib.o .libs/gif_font.o .libs/gif_hash.o .libs/gifalloc.o .libs/gif_err.o   -L/usr/X11/lib -lSM -lICE -lX11  -O2   -install_name  /usr/local/Cellar/giflib/4.2.3/lib/libgif.4.dylib -compatibility_version 6 -current_version 6.7 -Wl,-single_module
ld: library not found for -lSM
collect2: ld returned 1 exit status
make[1]: *** [libgif.la] Error 1
make: *** [install-recursive] Error 1
```