### PR TITLE
Make launchd config listen safer

### DIFF
--- a/Library/Formula/bitlbee.rb
+++ b/Library/Formula/bitlbee.rb
@@ -74,6 +74,8 @@ class Bitlbee < Formula
           <string>IPv4</string>
           <key>SockProtocol</key>
           <string>TCP</string>
+	  <key>SockNodeName</key>
+	  <string>127.0.0.1</string>
           <key>SockServiceName</key>
           <string>6667</string>
           <key>SockType</key>


### PR DESCRIPTION
Having it listen on localhost only seems a safer default choice.