### PR TITLE
brew: print bug report URL for internal commands only

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -68,6 +68,7 @@ begin
   empty_argv = ARGV.empty?
   help_regex = /(-h$|--help$|--usage$|-\?$|^help$)/
   help_flag = false
+  internal_cmd = true
   cmd = nil
 
   ARGV.dup.each_with_index do |arg, i|
@@ -157,8 +158,10 @@ rescue RuntimeError, SystemCallError => e
   exit 1
 rescue Exception => e
   onoe e
-  puts "#{Tty.white}Please report this bug:"
-  puts "    #{Tty.em}#{OS::ISSUES_URL}#{Tty.reset}"
+  if internal_cmd
+    puts "#{Tty.white}Please report this bug:"
+    puts "    #{Tty.em}#{OS::ISSUES_URL}#{Tty.reset}"
+  end
   puts e.backtrace
   exit 1
 else


### PR DESCRIPTION
I don’t think we should print the Homebrew bug report URL when an external command fails. We *could* print the tap if it comes from a `cmd/` directory, but some external commands don’t come from a tap.

This is tricky, because the failure might be related to Homebrew (or not).