### PR TITLE
jxrlib: New Formula

### DIFF
--- a/Library/Formula/jxrlib.rb
+++ b/Library/Formula/jxrlib.rb
@@ -1,0 +1,12 @@
+require 'formula'
+
+class Jxrlib < Formula
+  desc "Tools for JPEG-XR image encoding/decoding"
+  homepage 'https://jxrlib.codeplex.com/'
+
+  head 'https://git01.codeplex.com/jxrlib', :using => :git
+
+  def install
+    system "make install DIR_INSTALL=#{prefix}"
+  end
+end


### PR DESCRIPTION
This formula provides the `JxrEncApp` and `JxrDecApp` utilities that allow to encode and decode [JPEG-XR](https://en.wikipedia.org/wiki/JPEG_XR) images. The utilities will also be used by imagemagick as a delegate to enable jxr support.

The formula is head only, because the latest stable release is from 2013 and can only be built on windows.