### PR TITLE
KegOnlyReason: print only the explanation if there’s one

### DIFF
--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -23,28 +23,23 @@ class KegOnlyReason
   end
 
   def to_s
+    return @explanation unless @explanation.empty?
     case @reason
     when :provided_by_osx then <<-EOS
 OS X already provides this software and installing another version in
 parallel can cause all kinds of trouble.
-
-#{@explanation}
 EOS
     when :shadowed_by_osx then <<-EOS
 OS X provides similar software, and installing this software in
 parallel can cause all kinds of trouble.
-
-#{@explanation}
 EOS
     when :provided_pre_mountain_lion then <<-EOS
 OS X already provides this software in versions before Mountain Lion.
-
-#{@explanation}
 EOS
     when :provided_until_xcode43
-      "Xcode provides this software prior to version 4.3.\n\n#{@explanation}"
+      "Xcode provides this software prior to version 4.3."
     when :provided_until_xcode5
-      "Xcode provides this software prior to version 5.\n\n#{@explanation}"
+      "Xcode provides this software prior to version 5."
     else
       @reason
     end.strip

--- a/Library/Homebrew/test/test_formula_support.rb
+++ b/Library/Homebrew/test/test_formula_support.rb
@@ -1,0 +1,13 @@
+require "testing_env"
+
+class KegOnlyReasonTests < Homebrew::TestCase
+  def test_to_s_explanation
+    r = KegOnlyReason.new :provided_by_osx, "test"
+    assert_equal "test", r.to_s
+  end
+
+  def test_to_s_no_explanation
+    r = KegOnlyReason.new :provided_by_osx, ""
+    assert_match(/^OS X already provides/, r.to_s)
+  end
+end


### PR DESCRIPTION
The way we tell users a formula is `keg_only` seems inconsistent regarding the `reason`/`explanation`: some formulae have an `explanation` that covers the reason but we print both of them, e.g. `gettext`:

```
OS X provides similar software, and installing this software in
parallel can cause all kinds of trouble.

OS X provides the BSD gettext library and some software gets confused if both are in the library path.
```

Some others seems to use the `explanation` for “why this is provided by Homebrew” instead of “why this is not symlinked”, e.g.:

```
OS X already provides this software and installing another version in
parallel can cause all kinds of trouble.

Some formulae require a newer version of flex.
```

and some do provide a reason that provides more info than the default message:

```
OS X already provides this software and installing another version in
parallel can cause all kinds of trouble.

OS X provides an older sqlite3.
```

In this PR I’m doing a similar thing that what we do with auto-generated `--with-*` options: if an explanation was given for a `keg_only`, print it. If not, fallback on a more generic reason.

I haven’t done extensive testing of this one, thought.