### PR TITLE
update: always report changes to branch 'master'

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -202,6 +202,8 @@ class Updater
 
     reset_on_interrupt { safe_system "git", *args }
 
+    @current_revision = read_current_revision
+
     if @initial_branch != "master" && !@initial_branch.empty?
       safe_system "git", "checkout", @initial_branch, *quiet
     end
@@ -214,8 +216,6 @@ class Updater
       end
       @stashed = false
     end
-
-    @current_revision = read_current_revision
   end
 
   def reset_on_interrupt

--- a/Library/Homebrew/test/test_updater.rb
+++ b/Library/Homebrew/test/test_updater.rb
@@ -64,6 +64,7 @@ class UpdaterTests < Homebrew::TestCase
     @updater.in_repo_expect("git pull --quiet origin refs/heads/master:refs/remotes/origin/master")
     @updater.in_repo_expect("git rev-parse -q --verify HEAD", "3456cdef")
     @updater.pull!(:silent => true)
+    @updater.in_repo_expect("git rev-parse -q --verify HEAD", "3456cdef")
     @report.update(@updater.report)
     assert_equal @updater.expected, @updater.called
   end


### PR DESCRIPTION
**(I don't think this initial version of the PR should be commited as-is. See “Problem” part below.)**

If the user's working copy is *not* on the 'master' branch, the revision recorded after the update to the 'master' branch is not the one of the updated 'master' branch but that of whatever the user's current branch is. This tends to be not very helpful.

This change records the revision *after* the update to the 'master' branch, but *before* switching back to the user's current branch prior to the update, effectively causing the report to show changes to the 'master' branch.

Since `brew update` tries very hard to retain/restore the state of the working copy if the user is *not* on the 'master' branch, I believe this behavior to be more useful.

*Problem:* Since generating the report (added, deleted, updated formulae) also relies on the state of the working copy, I see two solutions to get a report that always shows the updates to the 'master' branch:

1. Forcibly generate the report before switching back to the user's branch. (I did this in my second commit, but in a rather hackish way. This is more of a proof of concept.)
2. Teach `Updater#report` to work directly with the Git repository for both the previous and current revision instead of relying on the state of the working copy.

Do others agree that the change in behavior, that I implemented here, is desirable? If so, what would be the best/cleanest way to solve the outlined reporting problem? (I need some guidance here, as I'm coming close to the limits of my understanding of Homebrew/Ruby.)