### PR TITLE
Rebuild libgcrypt (1.6.3) bottle to use current libgpg-error (1.19) library.

### DIFF
--- a/Library/Formula/libgcrypt.rb
+++ b/Library/Formula/libgcrypt.rb
@@ -4,7 +4,8 @@ class Libgcrypt < Formula
   url "ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.3.tar.bz2"
   mirror "http://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.3.tar.bz2"
   mirror "ftp://mirror.tje.me.uk/pub/mirrors/ftp.gnupg.org/libgcrypt/libgcrypt-1.6.3.tar.bz2"
-  sha1 "9456e7b64db9df8360a1407a38c8c958da80bbf1"
+  sha256 "41b4917b93ae34c6a0e2127378d7a4d66d805a2a86a09911d4f9bd871db7025f"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,14 +14,14 @@ class Libgcrypt < Formula
     sha1 "3bf6ac3f6bc55a8fbd51b3fc9d7fd6677469d14e" => :mountain_lion
   end
 
-  depends_on "libgpg-error"
-
   option :universal
+
+  depends_on "libgpg-error"
 
   resource "config.h.ed" do
     url "http://trac.macports.org/export/113198/trunk/dports/devel/libgcrypt/files/config.h.ed"
     version "113198"
-    sha1 "136f636673b5c9d040f8a55f59b430b0f1c97d7a"
+    sha256 "d02340651b18090f3df9eed47a4d84bed703103131378e1e493c26d7d0c7aab1"
   end
 
   def install


### PR DESCRIPTION
update libgcrypt to use current libgpg-error library.