### PR TITLE
pull: stop printing warning on test-bot

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -99,7 +99,7 @@ module Homebrew
       branch = `git symbolic-ref --short HEAD`.strip
 
       unless branch == "master"
-        opoo "Current branch is #{branch}: do you need to pull inside master?"
+        opoo "Current branch is #{branch}: do you need to pull inside master?" unless ARGV.include? "--clean"
       end
 
       pull_url url
@@ -189,10 +189,11 @@ module Homebrew
               "-u#{bintray_user}:#{bintray_key}", "-X", "POST",
               "-d", '{"publish_wait_for_secs": -1}',
               "https://api.bintray.com/content/homebrew/#{repo}/#{package}/#{version}/publish"
+            sleep 5
             success = system "brew", "fetch", "--retry", "--force-bottle", f.full_name
             unless success
-              ohai "That didn't work; waiting for 15 seconds and trying again..."
-              sleep 15
+              ohai "That didn't work; sleeping another 10 and trying again..."
+              sleep 10
               system "brew", "fetch", "--retry", "--force-bottle", f.full_name
             end
           end


### PR DESCRIPTION
The `opoo` change handles [this situation](http://bot.brew.sh/job/Homebrew%20Pull%20Requests/30177/version=mountain_lion/testReport/junit/brew-test-bot/mountain_lion/pull___clean_https___github_com_Homebrew_homebrew_pull_42091/) where the error is printed on the test-bot where it isn't particularly relevant.

The other change is to try sleeping for 5 before the initial bottle fetch, and then falling back on another 10 sleep if that fails. Every single pull has failed to fetch on the initial command so I think we might as well give up on the "Instant fetch" idea and give it a few seconds.