### PR TITLE
qca: fix build with Qt 5.5

### DIFF
--- a/Library/Formula/qca.rb
+++ b/Library/Formula/qca.rb
@@ -1,12 +1,18 @@
-require "formula"
-
 class Qca < Formula
   desc "Qt Cryptographic Architecture (QCA)"
   homepage "http://delta.affinix.com/qca/"
   url "http://delta.affinix.com/download/qca/2.0/qca-2.1.0.tar.gz"
-  sha1 "2b582b3ccc7e6098cd14d6f52a829ae1539e9cc8"
+  sha256 "226dcd76138c3738cdc15863607a96b3758a4c3efd3c47295939bcea4e7a9284"
 
   head "git://anongit.kde.org/qca.git"
+
+  # Fixes build with Qt 5.5 by adding a missing include (already fixed in HEAD).
+  stable do
+    patch do
+      url "http://quickgit.kde.org/?p=qca.git&a=commitdiff&h=7207e6285e932044cd66d49d0dc484666cfb0092&o=plain"
+      sha256 "b3ab2eb010f4a16f85349e4b858d0ee17a84ba2927311b79aeeff1bb2465cd3d"
+    end
+  end
 
   bottle do
     revision 1


### PR DESCRIPTION
This fixes the `brew install qca --with-qt5 --without-qt` build with the latest Qt 5.5.0.

Also minor adjustments for `brew audit --strict` compliance.