### PR TITLE
thefuck 2.4

### DIFF
--- a/Library/Formula/thefuck.rb
+++ b/Library/Formula/thefuck.rb
@@ -1,8 +1,8 @@
 class Thefuck < Formula
   desc "Programatically correct mistyped console commands"
   homepage "https://github.com/nvbn/thefuck"
-  url "https://pypi.python.org/packages/source/t/thefuck/thefuck-2.3.tar.gz"
-  sha256 "260da6b4c698871098f9939a88deedbb0761e72c2096ef3e25cb7773156cd0c0"
+  url "https://pypi.python.org/packages/source/t/thefuck/thefuck-2.4.tar.gz"
+  sha256 "e942e6613e1bf2619d01476c5404fae67abce7adfae88c713689f41f0f51213e"
 
   head "https://github.com/nvbn/thefuck.git"
 


### PR DESCRIPTION
Upgrade thefuck from 2.3. This new release brings three new rules: `git_fix_stash`, `docker_not_command` and `gulp_not_task` and a few bug fixes. I've tested the formula on Yosemite. Thanks!