### PR TITLE
pidgin: revise description to reflect GUI inclusion

### DIFF
--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -1,5 +1,5 @@
 class Pidgin < Formula
-  desc "GUI-less chat client (e.g., Finch-only)"
+  desc "Multi-protocol chat client"
   homepage "https://pidgin.im/"
   url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.10.11/pidgin-2.10.11.tar.bz2"
   sha256 "f2ae211341fc77efb9945d40e9932aa535cdf3a6c8993fe7919fca8cc1c04007"
@@ -13,7 +13,7 @@ class Pidgin < Formula
   end
 
   option "with-perl", "Build Pidgin with Perl support"
-  option "without-gui", "Build Finch instead of Pidgin"
+  option "without-gui", "Build only Finch, the command-line client"
 
   deprecated_option "perl" => "with-perl"
   deprecated_option "without-GUI" => "without-gui"


### PR DESCRIPTION
Updates `pidgin` description to reflect that the formula does include a GUI by default.

Old description called it a "GUI-less chat client". But it does have a GUI, at least by default.

Also, the old description for `--without-gui` said "Build Finch instead of Pidgin", which implies that Finch is not built in the default case. The default is to build both Finch (CLI) and Pidgin (GUI). Revised description to indicate `--without-gui` is just disabling Pidgin, and isn't required to get Finch to build.