### PR TITLE
valabind: bump revision

### DIFF
--- a/Library/Formula/valabind.rb
+++ b/Library/Formula/valabind.rb
@@ -1,9 +1,11 @@
 class Valabind < Formula
   desc "Vala bindings for radare, reverse engineering framework"
   homepage "http://radare.org/"
-  head "https://github.com/radare/valabind.git"
   url "https://github.com/radare/valabind/archive/0.9.2.tar.gz"
   sha256 "84cc2be21acb671e737dab50945b3717f1c68917faf23af443d3911774f5e578"
+  revision 1
+
+  head "https://github.com/radare/valabind.git"
 
   bottle do
     cellar :any
@@ -19,5 +21,9 @@ class Valabind < Formula
   def install
     system "make"
     system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system bin/"valabind", "--help"
   end
 end


### PR DESCRIPTION
The test is awful, but is enough to raise an error when the dependencies' dylib versions change, as happened with the Vala update which broke the bottles here.

If someone wants to write up a test binding and have Valabind use that for a real test, we'd welcome a PR!

Closes #42098