### PR TITLE
mycli 1.0.0 (new formula)

### DIFF
--- a/Library/Formula/mycli.rb
+++ b/Library/Formula/mycli.rb
@@ -1,0 +1,74 @@
+class Mycli < Formula
+  desc "CLI for MySQL with auto-completion and syntax highlighting"
+  homepage "http://mycli.net/"
+  url "https://pypi.python.org/packages/source/m/mycli/mycli-1.0.0.tar.gz"
+  sha256 "4d9258440b3a569066dc3c74a29d787bf89b0914aace080e6baa7dbf7ddb5f40"
+
+  bottle do
+    cellar :any
+    sha256 "e777938c9c25c9a3c0077a414d5d2ecf48e2fe91e769ce193d403308a36dc24a" => :yosemite
+    sha256 "07a2a41835ae74229d7866d3cfb95bf4b3027c6eb0c55e73dfb3a747f635db54" => :mavericks
+    sha256 "d6c8bf046088a100a2a9989c9406a5b590c733d0a29ea32a7eddc73f114a04b8" => :mountain_lion
+  end
+
+  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "openssl"
+
+  resource "click" do
+    url "https://pypi.python.org/packages/source/c/click/click-4.1.tar.gz"
+    sha256 "e339ed09f25e2145314c902a870bc959adcb25653a2bd5cc1b48d9f56edf8ed8"
+  end
+
+  resource "configobj" do
+    url "https://pypi.python.org/packages/source/c/configobj/configobj-5.0.6.tar.gz"
+    sha256 "a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902"
+  end
+
+  resource "prompt_toolkit" do
+    url "https://pypi.python.org/packages/source/p/prompt_toolkit/prompt_toolkit-0.38.tar.gz"
+    sha256 "6cee2959747580a1f93e3e14ef2826f1d89845d19e5bc32f374c23988e2d5e66"
+  end
+
+  resource "Pygments" do
+    url "https://pypi.python.org/packages/source/P/Pygments/Pygments-2.0.2.tar.gz"
+    sha256 "7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51"
+  end
+
+  resource "PyMySQL" do
+    url "https://pypi.python.org/packages/source/P/PyMySQL/PyMySQL-0.6.6.tar.gz"
+    sha256 "c18e62ca481c5ada6c7bee1b81fc003d6ceae932c878db384cd36808010b3774"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
+  end
+
+  resource "sqlparse" do
+    url "https://pypi.python.org/packages/source/s/sqlparse/sqlparse-0.1.14.tar.gz"
+    sha256 "e561e31853ab9f3634a1a2bd53035f9e47dfb203d56b33cc6569047ba087daf0"
+  end
+
+  resource "wcwidth" do
+    url "https://pypi.python.org/packages/source/w/wcwidth/wcwidth-0.1.4.tar.gz"
+    sha256 "906d3123045d77027b49fe912458e1a1e1d6ca1a51558a4bd9168d143b129d2b"
+  end
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    %w[click prompt_toolkit PyMySQL sqlparse Pygments wcwidth six configobj].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    system bin/"mycli", "--help"
+  end
+end

--- a/Library/Formula/mycli.rb
+++ b/Library/Formula/mycli.rb
@@ -4,13 +4,6 @@ class Mycli < Formula
   url "https://pypi.python.org/packages/source/m/mycli/mycli-1.0.0.tar.gz"
   sha256 "4d9258440b3a569066dc3c74a29d787bf89b0914aace080e6baa7dbf7ddb5f40"
 
-  bottle do
-    cellar :any
-    sha256 "e777938c9c25c9a3c0077a414d5d2ecf48e2fe91e769ce193d403308a36dc24a" => :yosemite
-    sha256 "07a2a41835ae74229d7866d3cfb95bf4b3027c6eb0c55e73dfb3a747f635db54" => :mavericks
-    sha256 "d6c8bf046088a100a2a9989c9406a5b590c733d0a29ea32a7eddc73f114a04b8" => :mountain_lion
-  end
-
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "openssl"
 
@@ -53,6 +46,7 @@ class Mycli < Formula
     url "https://pypi.python.org/packages/source/w/wcwidth/wcwidth-0.1.4.tar.gz"
     sha256 "906d3123045d77027b49fe912458e1a1e1d6ca1a51558a4bd9168d143b129d2b"
   end
+
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     %w[click prompt_toolkit PyMySQL sqlparse Pygments wcwidth six configobj].each do |r|


### PR DESCRIPTION
`mycli` is a python application. It is a command line application to interact with MySQL database. 

This is not a python library, but it's an application that happens to be written in Python. 

The best installation test for mycli is to invoke it with the `--help` option. Which exercises all the libraries used by the app, which will be a robust test to see if all the dependencies are installed correctly. 