### PR TITLE
wgetpaste: add missing wget dependency

### DIFF
--- a/Library/Formula/wgetpaste.rb
+++ b/Library/Formula/wgetpaste.rb
@@ -4,6 +4,8 @@ class Wgetpaste < Formula
   url "http://wgetpaste.zlin.dk/wgetpaste-2.26.tar.bz2"
   sha256 "9265cd0718c815cce19a12c4745f74b288cafce404a26d64daf85ddcbadc8f86"
 
+  depends_on "wget"
+
   def install
     bin.install "wgetpaste"
   end


### PR DESCRIPTION
wgetpaste needs wget so add it as a dependency