### PR TITLE
midnight-commander: Fix `man` invocation

### DIFF
--- a/Library/Formula/midnight-commander.rb
+++ b/Library/Formula/midnight-commander.rb
@@ -28,6 +28,7 @@ class MidnightCommander < Formula
                           "--with-screen=slang",
                           "--enable-vfs-sftp"
     system "make", "install"
+    inreplace libexec/"mc/ext.d/text.sh", "man -P cat -l ", "man -P cat "
   end
 
   test do


### PR DESCRIPTION
mc calls `man -l` to display man page files, which is not correct on OS X, so patch out the `-l` to make it work.