### PR TITLE
cake: 0.5.1 - C# Make (new formula)

### DIFF
--- a/Library/Formula/cake.rb
+++ b/Library/Formula/cake.rb
@@ -1,0 +1,40 @@
+class Cake < Formula
+  desc "Cake (C# Make) is a build automation system with a C# DSL."
+  homepage "http://cakebuild.net/"
+  url "https://github.com/cake-build/cake/releases/download/v0.5.1/Cake-bin-v0.5.1.zip"
+  sha256 "ff431d845575b0be9e355caa9f44a82ea015d8b849eeafcdaee0904c3fb6da53"
+
+  # Xamarin will maintain a current mono install, may not actually need it
+  depends_on "mono" => :recommended
+
+  def install
+    libexec.install Dir["*.dll"]
+    libexec.install Dir["*.exe"]
+    libexec.install Dir["*.xml"]
+
+    # write a simple bash wrapper to execute `mono Cake.exe [args]` with the cake alias
+    bin.mkpath
+    (bin/"cake").write <<-EOS.undent
+      #!/bin/bash
+      mono #{libexec}/Cake.exe "$@"
+    EOS
+  end
+
+  test do
+    test_str = "Hello Homebrew"
+    test_name = "build.cake"
+    (testpath/test_name).write <<-EOS.undent
+
+      var target = Argument ("target", "info");
+
+      Task("info").Does(() =>
+      {
+        Information ("Hello Homebrew");
+      });
+
+      RunTarget ("info");
+
+    EOS
+    assert_match test_str, shell_output("#{bin}/cake ./build.cake").strip
+  end
+end


### PR DESCRIPTION
This adds a new formula for [cake](http://cakebuild.net) (C# Make).  The NuGet package is an existing feed of binary distributions for the project so it is used.  The executable bin installed is a bash wrapper around the `mono Cake.exe [args]` command, meaning simply `cake ./build.cake` can be invoked.  The package depends conditionally on mono.  Some software installations such as Xamarin already ensure mono is installed and kept up to date, so mono should not be installed through homebrew if it already exists from another installation.  This is determined by invoking `which mono` and looking at the output (if nothing is found, mono through homebrew is required.

Tests are included which 1) run cake to make sure there is an ok exit code, and 2) build a simple script to run and check the output of.