### PR TITLE
pidgin: set tcl/tk config paths regardless of whether building gui

### DIFF
--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -63,9 +63,9 @@ class Pidgin < Formula
     args << "--disable-perl" if build.without? "perl"
     args << "--enable-cyrus-sasl" if build.with? "gsasl"
 
+    args << "--with-tclconfig=#{MacOS.sdk_path}/usr/lib"
+    args << "--with-tkconfig=#{MacOS.sdk_path}/usr/lib"
     if build.without? "gui"
-      args << "--with-tclconfig=#{MacOS.sdk_path}/usr/lib"
-      args << "--with-tkconfig=#{MacOS.sdk_path}/usr/lib"
       args << "--disable-gtkui"
     else
       args << "--disable-idn"


### PR DESCRIPTION
Sets the Tcl/Tk configuration paths regardless of whether the GUI is being built or not. This allows the build including the GUI to work on systems that don't have the CLT installed.

Fixes #41968

Tck/Tk is used at the lower purple protocol library level, so it's used by both Finch and Pidgin and needed regardless of whether you're building the GUI or not. The fact that it's currently only being configured for the `without-gui` option seems to be a historical quirk of how the `finch` and `pidgin` formulae were merged in 7537f3663d0ca35e5848d0a9644ebc86c92d267f: the `finch` formula was designed to work without CLT, and `pidgin` wasn't; it's not an inherent requirement of on but not the other.

####   Testing Notes   ####

Tested on 10.9.5, 10.10, 10.11, all without CLT installed. Succeeds on 10.10 and 10.11. Succeeds on 10.9 if CLT is installed.

With this patch, `brew install --build-from-source pidgin` will still fail on OS X 10.9 boxes that do not have the CLT installed, citing a Python link error. I think this is an unrelated error due to how the OS X 10.9 SDK lacks Python. It is not a regression: `brew install --build-from-source` on 10.9 w/o CLT fails for me with the current `pidgin` formula definition, too.