### PR TITLE
pidgin: simplify dependencies and enable IDN even if GUI is built

### DIFF
--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -24,15 +24,14 @@ class Pidgin < Formula
   depends_on "gsasl" => :optional
   depends_on "gnutls"
   depends_on "libgcrypt"
+  depends_on "libidn"
+  depends_on "glib"
 
   if build.with? "gui"
     depends_on "gtk+"
     depends_on "cairo"
     depends_on "pango"
     depends_on "libotr"
-  else
-    depends_on "glib"
-    depends_on "libidn"
   end
 
   # Finch has an equal port called purple-otr but it is a NIGHTMARE to compile
@@ -67,8 +66,6 @@ class Pidgin < Formula
       args << "--with-tclconfig=#{MacOS.sdk_path}/usr/lib"
       args << "--with-tkconfig=#{MacOS.sdk_path}/usr/lib"
       args << "--disable-gtkui"
-    else
-      args << "--disable-idn"
     end
 
     system "./configure", *args


### PR DESCRIPTION
Simplifies the `pidgin` dependency definitions as discussed in comments on a7cb5d386a4bc78bf40d37487dde02a3b3042888.

Pidgin always requires `glib`, so this makes it an unconditional dependency instead of depending on the GTK+ dependency to pull it in indirectly when building the GUI. Eases readability IMO.

Enables IDN support using `libidn` regardless of whether the GUI is being built. Both `pidgin` and `finch` can use IDN. And when you're building this with the GUI, `finch` is still built, to `--with-gui` has the side effect of disabling IDN in the command line tool. Tying IDN to whether the GUI is built seems to be a historical accident of how the `pidgin` and `finch` formulae were combined back in 7537f3663d0ca35e5848d0a9644ebc86c92d267f.

Together, these changes simplify the formula by removing a couple `else` blocks, and make features consistent between the with-GUI and without-GUI builds.