### PR TITLE
webarchiver (new formula)

### DIFF
--- a/Library/Formula/webarchiver.rb
+++ b/Library/Formula/webarchiver.rb
@@ -5,6 +5,8 @@ class Webarchiver < Formula
   sha256 "8ea826038e923c72e75a4bbb1416910368140a675421f6aaa51fd0dea703f75c"
   head "https://github.com/newzealandpaul/webarchiver.git"
 
+  depends_on :macos => :mavericks
+
   def install
     xcodebuild
     bin.install "./build/Release/webarchiver"

--- a/Library/Formula/webarchiver.rb
+++ b/Library/Formula/webarchiver.rb
@@ -5,7 +5,7 @@ class Webarchiver < Formula
   sha256 "8ea826038e923c72e75a4bbb1416910368140a675421f6aaa51fd0dea703f75c"
   head "https://github.com/newzealandpaul/webarchiver.git"
 
-  depends_on :macos => :mavericks
+  depends_on :xcode => ["6.0.1", :build]
 
   def install
     xcodebuild

--- a/Library/Formula/webarchiver.rb
+++ b/Library/Formula/webarchiver.rb
@@ -1,0 +1,19 @@
+class Webarchiver < Formula
+  desc "allows you to create Safari .webarchive files"
+  homepage "https://github.com/newzealandpaul/webarchiver"
+  url "https://github.com/newzealandpaul/webarchiver/archive/0.9.tar.gz"
+  sha256 "8ea826038e923c72e75a4bbb1416910368140a675421f6aaa51fd0dea703f75c"
+  head "https://github.com/newzealandpaul/webarchiver.git"
+
+  def install
+    xcodebuild
+    bin.install "./build/Release/webarchiver"
+  end
+
+  test do
+    mktemp do
+      system "webarchiver", "-url", "http://www.google.com", "-output", "foo.webarchive"
+      assert_match /Apple binary property list/, shell_output("file foo.webarchive", 0)
+    end
+  end
+end

--- a/Library/Formula/webarchiver.rb
+++ b/Library/Formula/webarchiver.rb
@@ -13,9 +13,7 @@ class Webarchiver < Formula
   end
 
   test do
-    mktemp do
-      system "webarchiver", "-url", "http://www.google.com", "-output", "foo.webarchive"
-      assert_match /Apple binary property list/, shell_output("file foo.webarchive", 0)
-    end
+    system "webarchiver", "-url", "http://www.google.com", "-output", "foo.webarchive"
+    assert_match /Apple binary property list/, shell_output("file foo.webarchive", 0)
   end
 end


### PR DESCRIPTION
Webarchiver allows you to create Safari .webarchive files from the command line. Webarchives are a convenient way to store a webpage and its associated files (images, css, javascript, etc) in a single file. It is very simple to use:

./webarchiver -url http://www.google.com -output google.webarchive
