### PR TITLE
ARGV#resolved_formulae: auto resolve spec

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -20,9 +20,14 @@ module HomebrewArgvExtension
     require "formula"
     @resolved_formulae ||= (downcased_unique_named - casks).map do |name|
       if name.include?("/")
-        Formulary.factory(name, spec)
+        f = Formulary.factory(name, spec)
+        if spec(default=nil).nil? && f.any_version_installed?
+          installed_spec = Tab.for_formula(f).spec
+          f.set_active_spec(installed_spec) if f.send(installed_spec)
+        end
+        f
       else
-        Formulary.from_rack(HOMEBREW_CELLAR/name, spec)
+        Formulary.from_rack(HOMEBREW_CELLAR/name, spec(default=nil))
       end
     end
   end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -190,13 +190,13 @@ module HomebrewArgvExtension
 
   private
 
-  def spec
+  def spec(default=:stable)
     if include?("--HEAD")
       :head
     elsif include?("--devel")
       :devel
     else
-      :stable
+      default
     end
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -67,9 +67,6 @@ class Formula
   # @see #active_spec
   attr_reader :active_spec_sym
 
-  # The {PkgVersion} for this formula with version and {#revision} information.
-  attr_reader :pkg_version
-
   # Used for creating new Homebrew versions of software without new upstream
   # versions.
   # @see .revision
@@ -118,7 +115,6 @@ class Formula
       :stable
     end
     validate_attributes!
-    @pkg_version = PkgVersion.new(version, revision)
     @build = active_spec.build
     @pin = FormulaPin.new(self)
   end
@@ -205,6 +201,11 @@ class Formula
   # @see .version
   def version
     active_spec.version
+  end
+
+  # The {PkgVersion} for this formula with {version} and {#revision} information.
+  def pkg_version
+    PkgVersion.new(version, revision)
   end
 
   # A named Resource for the currently active {SoftwareSpec}.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -274,6 +274,12 @@ class Formula
     (dir = installed_prefix).directory? && dir.children.length > 0
   end
 
+  # If at least one version of {Formula} is installed.
+  def any_version_installed?
+    require "tab"
+    rack.directory? && rack.subdirs.any? { |keg| (keg/Tab::FILENAME).file? }
+  end
+
   # @private
   # The `LinkedKegs` directory for this {Formula}.
   # You probably want {#opt_prefix} instead.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -119,6 +119,16 @@ class Formula
     @pin = FormulaPin.new(self)
   end
 
+  # @private
+  def set_active_spec(spec_sym)
+    spec = send(spec_sym)
+    raise FormulaSpecificationError, "#{spec_sym} spec is not available for #{full_name}" unless spec
+    @active_spec = spec
+    @active_spec_sym = spec_sym
+    validate_attributes!
+    @build = active_spec.build
+  end
+
   private
 
   def set_spec(name)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -62,6 +62,11 @@ class Formula
   attr_reader :active_spec
   protected :active_spec
 
+  # A symbol to indicate currently active {SoftwareSpec}.
+  # It's either :stable, :devel or :head
+  # @see #active_spec
+  attr_reader :active_spec_sym
+
   # The {PkgVersion} for this formula with version and {#revision} information.
   attr_reader :pkg_version
 
@@ -105,6 +110,13 @@ class Formula
     set_spec :head
 
     @active_spec = determine_active_spec(spec)
+    @active_spec_sym = if head?
+      :head
+    elsif devel?
+      :devel
+    else
+      :stable
+    end
     validate_attributes!
     @pkg_version = PkgVersion.new(version, revision)
     @build = active_spec.build
@@ -590,9 +602,7 @@ class Formula
   end
 
   def inspect
-    s = "#<Formula #{name} ("
-    s << if head? then "head" elsif devel? then "devel" else "stable" end
-    s << ") #{path}>"
+    "#<Formula #{name} (#{active_spec_sym}) #{path}>"
   end
 
   def file_modified?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -284,10 +284,12 @@ class Formula
   # The latest prefix for this formula. Checks for {#head}, then {#devel}
   # and then {#stable}'s {#prefix}
   def installed_prefix
-    if head && (head_prefix = prefix(head.version)).directory?
+    if head && (head_prefix = prefix(PkgVersion.new(head.version, revision))).directory?
       head_prefix
-    elsif devel && (devel_prefix = prefix(devel.version)).directory?
+    elsif devel && (devel_prefix = prefix(PkgVersion.new(devel.version, revision))).directory?
       devel_prefix
+    elsif stable && (stable_prefix = prefix(PkgVersion.new(stable.version, revision))).directory?
+      stable_prefix
     else
       prefix
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -175,13 +175,16 @@ class Formulary
   end
 
   # Return a Formula instance for the given rack.
-  def self.from_rack(rack, spec=:stable)
+  # It will auto resolve formula's spec when requested spec is nil
+  def self.from_rack(rack, spec=nil)
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
 
     keg = kegs.detect(&:linked?) || kegs.detect(&:optlinked?) || kegs.max_by(&:version)
-    return factory(rack.basename.to_s, spec) unless keg
+    return factory(rack.basename.to_s, spec || :stable) unless keg
 
-    tap = Tab.for_keg(keg).tap
+    tab = Tab.for_keg(keg)
+    tap = tab.tap
+    spec ||= tab.spec
 
     if tap.nil? || tap == "Homebrew/homebrew" || tap == "mxcl/master"
       factory(rack.basename.to_s, spec)

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -24,6 +24,7 @@ class Tab < OpenStruct
       "source" => {
         "path" => formula.path.to_s,
         "tap" => formula.tap,
+        "spec" => formula.active_spec_sym.to_s,
       },
     }
 
@@ -42,6 +43,15 @@ class Tab < OpenStruct
     tapped_from = attributes["tapped_from"]
     unless tapped_from.nil? || tapped_from == "path or URL"
       attributes["source"]["tap"] = attributes.delete("tapped_from")
+    end
+
+    if attributes["source"]["spec"].nil?
+      version = PkgVersion.parse path.to_s.split("/")[-2]
+      if version.head?
+        attributes["source"]["spec"] = "head"
+      else
+        attributes["source"]["spec"] = "stable"
+      end
     end
 
     new(attributes)
@@ -97,7 +107,7 @@ class Tab < OpenStruct
     else
       tab = empty
       tab.unused_options = f.options.as_flags
-      tab.source = { "path" => f.path.to_s, "tap" => f.tap }
+      tab.source = { "path" => f.path.to_s, "tap" => f.tap, "spec" => f.active_spec_sym.to_s }
     end
 
     tab
@@ -116,6 +126,7 @@ class Tab < OpenStruct
       "source" => {
         "path" => nil,
         "tap" => nil,
+        "spec" => nil,
       },
     }
 
@@ -179,6 +190,10 @@ class Tab < OpenStruct
 
   def tap=(tap)
     source["tap"] = tap
+  end
+
+  def spec
+    source["spec"].to_sym
   end
 
   def to_json

--- a/Library/Homebrew/test/fixtures/receipt_old.json
+++ b/Library/Homebrew/test/fixtures/receipt_old.json
@@ -9,13 +9,9 @@
   ],
   "built_as_bottle": false,
   "poured_from_bottle": true,
+  "tapped_from": "Homebrew/homebrew",
   "time": 1403827774,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
   "stdlib": "libcxx",
-  "compiler": "clang",
-  "source": {
-      "path": "/usr/local/Library/Formula/foo.rb",
-      "tap": "Homebrew/homebrew",
-      "spec": "stable"
-  }
+  "compiler": "clang"
 }

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -19,6 +19,7 @@ class TabTests < Homebrew::TestCase
       "source"             => {
         "tap" => "Homebrew/homebrew",
         "path" => nil,
+        "spec" => "stable",
       },
     })
   end
@@ -66,6 +67,22 @@ class TabTests < Homebrew::TestCase
     assert_predicate @tab, :poured_from_bottle
   end
 
+  def test_from_old_version_file
+    path = Pathname.new(TEST_DIRECTORY).join("fixtures", "receipt_old.json")
+    tab = Tab.from_file(path)
+
+    assert_equal @used.sort, tab.used_options.sort
+    assert_equal @unused.sort, tab.unused_options.sort
+    refute_predicate tab, :built_as_bottle
+    assert_predicate tab, :poured_from_bottle
+    assert_equal "Homebrew/homebrew", tab.tap
+    assert_equal :stable, tab.spec
+    refute_nil tab.time
+    assert_equal TEST_SHA1, tab.HEAD
+    assert_equal :clang, tab.cxxstdlib.compiler
+    assert_equal :libcxx, tab.cxxstdlib.type
+  end
+
   def test_from_file
     path = Pathname.new(TEST_DIRECTORY).join("fixtures", "receipt.json")
     tab = Tab.from_file(path)
@@ -75,6 +92,7 @@ class TabTests < Homebrew::TestCase
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
     assert_equal "Homebrew/homebrew", tab.tap
+    assert_equal :stable, tab.spec
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD
     assert_equal :clang, tab.cxxstdlib.compiler
@@ -88,6 +106,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.built_as_bottle, tab.built_as_bottle
     assert_equal @tab.poured_from_bottle, tab.poured_from_bottle
     assert_equal @tab.tap, tab.tap
+    assert_equal @tab.spec, tab.spec
     assert_equal @tab.time, tab.time
     assert_equal @tab.HEAD, tab.HEAD
     assert_equal @tab.compiler, tab.compiler


### PR DESCRIPTION
For `ARGV#resolved_formulae` and `Formulary#from_rack`, it will try to resolve the formula's spec when:
* Formula is installed.
* No `--devel` or `--HEAD` in ARGV.

The codes still need some work. cc @Homebrew/owners for review.

Fixes #42147