### PR TITLE
gimme 0.2.4 (new formula)

### DIFF
--- a/Library/Formula/gimme.rb
+++ b/Library/Formula/gimme.rb
@@ -1,0 +1,14 @@
+class Gimme < Formula
+  desc "A shell script to install any Go version"
+  homepage "https://github.com/travis-ci/gimme"
+  url "https://github.com/travis-ci/gimme/archive/v0.2.4.tar.gz"
+  sha256 "feb9c25d96cc6a4e735200a180070ec3458fea7d1795439abf8acad45edfc194"
+
+  def install
+    bin.install "gimme"
+  end
+
+  test do
+    system "#{bin}/gimme", "-l"
+  end
+end


### PR DESCRIPTION
`gimme` is the script used by Travis-CI to install Go versions.