### PR TITLE
Install examples to subdirectories

### DIFF
--- a/Library/Formula/hiredis.rb
+++ b/Library/Formula/hiredis.rb
@@ -18,14 +18,14 @@ class Hiredis < Formula
     ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
 
     system "make", "install", "PREFIX=#{prefix}"
-    share.install "examples"
+    pkgshare.install "examples"
   end
 
   test do
     # running `./test` requires a database to connect to, so just make
     # sure it compiles
     system ENV.cc, "-I#{include}/hiredis", "-L#{lib}", "-lhiredis",
-           share/"examples/example.c", "-o", testpath/"test"
+           pkgshare/"examples/example.c", "-o", testpath/"test"
     File.exist? testpath/"test"
   end
 end

--- a/Library/Formula/libhttpserver.rb
+++ b/Library/Formula/libhttpserver.rb
@@ -35,11 +35,11 @@ class Libhttpserver < Formula
       system "../configure", *args
       system "make", "install"
     end
-    share.install "examples"
+    pkgshare.install "examples"
   end
 
   test do
-    system ENV.cxx, "#{share}/examples/hello_world.cpp",
+    system ENV.cxx, pkgshare/"examples/hello_world.cpp",
       "-o", "hello_world", "-lhttpserver", "-lcurl"
     pid = fork { exec "./hello_world" }
     sleep 1 # grace time for server start

--- a/Library/Formula/mongoose.rb
+++ b/Library/Formula/mongoose.rb
@@ -29,7 +29,7 @@ class Mongoose < Formula
     system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib"
     include.install "mongoose.h"
     lib.install "libmongoose.dylib"
-    share.install "examples", "jni"
+    pkgshare.install "examples", "jni"
     doc.install Dir["docs/*"]
   end
 


### PR DESCRIPTION
Install these examples to subdirectories to avoid collisions when linked to `HOMEBREW_PREFIX/share/examples`.