### PR TITLE
xcode: bump clang version

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -163,7 +163,7 @@ module OS
 
       def latest_version
         case MacOS.version
-        when "10.11" then "700.0.57.2"
+        when "10.11" then "700.0.59"
         when "10.10" then "602.0.53"
         when "10.9"  then "600.0.57"
         when "10.8"  then "503.0.40"


### PR DESCRIPTION
I dumped all this information on the team chat, but by the morning it'll probably be buried in other conversation, and it's probably useful for users who have been wondering why they got outdated messages a few weeks back.

Finally figured out why users on 10.11 repeatedly saw the CLT “not up-to-date” Doctor warning even when they were up-to-date.

Our Clang version detection code isn’t built to handle the (apparently new) forth Clang version number. Clang on 10.11 outputs `Apple LLVM version 7.0.0 (clang-700.0.59.1)`, We use `[%r{clang-(\d+\.\d+\.\d+)}, 1]` to get the version, which only produces `700.0.59`. They are never satisfying the expected number because we only consider three digits.

The errors have stopped being reported for now because I haven’t bumped the Clang version for a few weeks and obviously, `700.0.59` is greater than `700.0.57.2`.

I think `clang-(\d+\.\d+\.\d+\.?\d+)` would capture the new digit as well as preserving support for the existing three-digit Clang version, but we may just want to use `700.0.59` instead as I don’t think the fourth-digit in Clang will stick around. The new regex suggestion works on 10.10 & 10.11 from testing, with three & four digit Clang expectations.