### PR TITLE
Tap: allow enumerate non-git taps

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -27,7 +27,7 @@ module Homebrew
     # this procedure will be removed in the future if it seems unnecessasry
     rename_taps_dir_if_necessary
 
-    Tap.each do |tap|
+    Tap.select(&:git?).each do |tap|
       tap.path.cd do
         updater = Updater.new(tap.path)
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -37,7 +37,7 @@ class Tap
   # e.g. `https://github.com/user/homebrew-repo`
   def remote
     @remote ||= if installed?
-      if (@path/".git").exist?
+      if git?
         @path.cd do
           Utils.popen_read("git", "config", "--get", "remote.origin.url").chomp
         end
@@ -47,6 +47,11 @@ class Tap
     else
       raise TapUnavailableError, name
     end
+  end
+
+  # True if this {Tap} is a git repository.
+  def git?
+    (@path/".git").exist?
   end
 
   def to_s
@@ -117,9 +122,7 @@ class Tap
 
     TAP_DIRECTORY.subdirs.each do |user|
       user.subdirs.each do |repo|
-        if (repo/".git").directory?
-          yield new(user.basename.to_s, repo.basename.to_s.sub("homebrew-", ""))
-        end
+        yield new(user.basename.to_s, repo.basename.to_s.sub("homebrew-", ""))
       end
     end
   end


### PR DESCRIPTION
Also add a `Tap#git?` method to indicate whether the tap is a git
repository.