### PR TITLE
Fix heroku-toolbelt.rb URL

### DIFF
--- a/Library/Formula/heroku-toolbelt.rb
+++ b/Library/Formula/heroku-toolbelt.rb
@@ -20,7 +20,7 @@ class HerokuToolbelt < Formula
     <<-EOS.undent
       Unlike the standalone download for Heroku Toolbelt, the Homebrew package
       does not come with Foreman. It is available via RubyGems, direct download,
-      and other installation methods. See theforeman.org for more info.
+      and other installation methods. See https://ddollar.github.io/foreman/ for more info.
     EOS
   end
 


### PR DESCRIPTION
The caveat has the wrong URL, using a different project with the same name.