### PR TITLE
OCaml 4.02.3 update

### DIFF
--- a/Library/Formula/camlp4.rb
+++ b/Library/Formula/camlp4.rb
@@ -5,6 +5,7 @@ class Camlp4 < Formula
   sha1 "6dd7e591dfde94c44576dba9b847279ffb92c889"
   version "4.02.2+6"
   head "https://github.com/ocaml/camlp4.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/camlp5.rb
+++ b/Library/Formula/camlp5.rb
@@ -1,8 +1,8 @@
 class Camlp5 < Formula
   desc "Camlp5 is a preprocessor and pretty-printer for OCaml"
   homepage "http://camlp5.gforge.inria.fr/"
-  url "http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.13.tgz"
-  sha256 "d1e948c04079e417d2b616f03f57cda9b6111c563d7ce59a8956ac93772e4aa9"
+  url "http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.14.tgz"
+  sha256 "09f9ed12893d2ec39c88106af2306865c966096bedce0250f2fe52b67d2480e2"
 
   bottle do
     sha256 "aa844f23752518cdfceba1513388c90b273a78219f1b671809791acebe71fb87" => :yosemite

--- a/Library/Formula/coccinelle.rb
+++ b/Library/Formula/coccinelle.rb
@@ -5,6 +5,7 @@ class Coccinelle < Formula
   homepage 'http://coccinelle.lip6.fr/'
   url 'http://coccinelle.lip6.fr/distrib/coccinelle-1.0.0-rc21.tgz'
   sha1 'edc008da552eb8f4ef7712fc99b4dc630ab6fb35'
+  revision 1
 
   bottle do
     sha1 "907762ffd74c58637cfc1968c0812cf324ad8ac1" => :yosemite

--- a/Library/Formula/coq.rb
+++ b/Library/Formula/coq.rb
@@ -16,6 +16,7 @@ class Coq < Formula
   url "https://coq.inria.fr/distrib/V8.4pl6/files/coq-8.4pl6.tar.gz"
   version "8.4pl6"
   sha256 "a540a231a9970a49353ca039f3544616ff86a208966ab1c593779ae13c91ebd6"
+  revision 1
 
   head "git://scm.gforge.inria.fr/coq/coq.git", :branch => "trunk"
 

--- a/Library/Formula/objective-caml.rb
+++ b/Library/Formula/objective-caml.rb
@@ -15,15 +15,10 @@ class ObjectiveCaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
   head "http://caml.inria.fr/svn/ocaml/trunk", :using => :svn
-  revision 1
 
   stable do
-    url "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.bz2"
-    sha256 "b18265582b1c2fd5c1e67da3f744bf1ff474d194bb277c3a9ceb5eb16a1ea703"
-
-    # Upstream fix for a GC crash issue introduced in 4.02.2
-    # See http://caml.inria.fr/mantis/view.php?id=6919
-    patch :DATA
+    url "http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz"
+    sha256 "928fb5f64f4e141980ba567ff57b62d8dc7b951b58be9590ffb1be2172887a72"
   end
 
   bottle do
@@ -53,17 +48,3 @@ class ObjectiveCaml < Formula
     assert_match "#{HOMEBREW_PREFIX}", shell_output("ocamlc -where")
   end
 end
-__END__
-diff --git a/byterun/minor_gc.c b/byterun/minor_gc.c
-index 4aaec96..859a72a 100644
---- a/byterun/minor_gc.c
-+++ b/byterun/minor_gc.c
-@@ -259,6 +259,8 @@ void caml_empty_minor_heap (void)
-     ++ caml_stat_minor_collections;
-     caml_final_empty_young ();
-     if (caml_minor_gc_end_hook != NULL) (*caml_minor_gc_end_hook) ();
-+  } else {
-+    caml_final_empty_young ();
-   }
- #ifdef DEBUG
-   {

--- a/Library/Formula/opam.rb
+++ b/Library/Formula/opam.rb
@@ -4,6 +4,7 @@ class Opam < Formula
   url "https://github.com/ocaml/opam/archive/1.2.2.tar.gz"
   sha256 "3e4a05df6ff8deecba019d885ebe902eb933acb6e2fc7784ffee1ee14871e36a"
   head "https://github.com/ocaml/opam.git"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- ocaml: update to 4.02.3 and remove upstreamed patch for GC crash
- camlp5: update to 6.14 with ocaml 4.02.3 compatibility
- bump revisions of camlp4, coccinelle, coq, opam due to OCaml 4.02.3 update
