### PR TITLE
Lisp checks

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -16,6 +16,7 @@ class Caveats
     caveats << plist_caveats
     caveats << python_caveats
     caveats << app_caveats
+    caveats << elisp_caveats
     caveats.compact.join("\n")
   end
 
@@ -128,6 +129,19 @@ class Caveats
       <<-EOS.undent
         .app bundles were installed.
         Run `brew linkapps #{keg.name}` to symlink these to /Applications.
+      EOS
+    end
+  end
+
+  def elisp_caveats
+    if keg && keg.elisp_installed?
+      <<-EOS.undent
+        Emacs Lisp files have been installed to:
+        #{HOMEBREW_PREFIX}/share/emacs/site-lisp/
+
+        Add the following to your init file to have packages installed by Homebrew added to your load-path:
+        (let ((default-directory "#{HOMEBREW_PREFIX}/share/emacs/site-lisp/"))
+          (normal-top-level-add-subdirs-to-load-path))
       EOS
     end
   end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -173,6 +173,26 @@ module FormulaCellarChecks
     EOS
   end
 
+  def check_emacs_lisp(share, name)
+    return unless share.directory?
+
+    # Emacs itself can do what it wants
+    return if name == "emacs"
+
+    elisps = (share/"emacs/site-lisp").children.select { |file| %w[.el .elc].include? file.extname }
+    return if elisps.empty?
+
+    <<-EOS.undent
+      Emacs Lisp files were linked directly to #{HOMEBREW_PREFIX}/share/emacs/site-lisp
+
+      This may cause conflicts with other packages; install to a subdirectory instead, such as
+      #{share}/emacs/site-lisp/#{name}
+
+      The offending files are:
+        #{elisps * "\n        "}
+    EOS
+  end
+
   def audit_installed
     audit_check_output(check_manpages)
     audit_check_output(check_infopages)
@@ -186,6 +206,7 @@ module FormulaCellarChecks
     audit_check_output(check_easy_install_pth(formula.lib))
     audit_check_output(check_openssl_links)
     audit_check_output(check_python_framework_links(formula.lib))
+    audit_check_output(check_emacs_lisp(formula.share,formula.name))
   end
 
   private

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -243,6 +243,10 @@ class Keg
     Dir["#{path}/{,libexec/}*.app"].any?
   end
 
+  def elisp_installed?
+    Dir["#{path}/share/emacs/site-lisp/**/*.el"].any?
+  end
+
   def version
     require 'pkg_version'
     PkgVersion.parse(path.basename.to_s)


### PR DESCRIPTION
Take 2 of #41791. Changes:

1. In the cellar checks, recommend, but don't insist, that the subdirectory under `site-lisp` has the same name as the formula.
2. In the caveats, since the subdir might not be named `keg.name`, just print the path to `site-lisp`
3. An advantage of having all elisp files dumped straight into `site-lisp` was that only one directory had to be added to the user's `load-path`.  But there's a way to add all subdirectories of a directory, so we recommend they do that:
```elisp
(let ((default-directory "#{HOMEBREW_PREFIX}/share/emacs/site-lisp/"))
  (normal-top-level-add-subdirs-to-load-path))
```