### PR TITLE
Added git-webui formula

### DIFF
--- a/Library/Formula/git-webui.rb
+++ b/Library/Formula/git-webui.rb
@@ -1,0 +1,25 @@
+class GitWebui < Formula
+  desc "A standalone local web based user interface for git repositories"
+  homepage "https://github.com/alberthier/git-webui"
+  url "https://github.com/alberthier/git-webui/archive/e8cbb49edeb09b4e5de65b1bf01d9cf672f9611d.tar.gz"
+  sha256 "e89e6470e23459f59fd5a3cb0a42b40d2de35ebd78a44b9f0bc669564c72cda5"
+  version "0.1.0" # as it appears on the project's package.json
+  head "https://github.com/alberthier/git-webui.git"
+
+  depends_on :python
+
+  def install
+    # there's no setup.py, the tarball contains a release dir with everything in it
+    prefix.install Dir["release/*"]
+
+    # ok, now lets symlink the executable to our local #{prefix}/bin path
+    bin.install_symlink prefix/"libexec/git-core/git-webui"
+
+    # and make sure the original script resolves the path to the assets correctly
+    inreplace libexec/"git-core/git-webui", ".abspath(sys.argv[0])", ".realpath(sys.argv[0])"
+  end
+
+  test do
+    system "git-webui", "--help"
+  end
+end


### PR DESCRIPTION
A nice, web-based alternative to Gitg or the likes:

![Screenshot](http://dist.alternativeto.net/s/0bb346c6-545c-e411-80dd-000d3a1003b1_2_full.png?format=jpg&width=1900)

The project does not provide versioned releases so I just used the tarball for the latest commit ref. 

I also had to modify the script's `path.abspath(sys.argv[0])` call for `path.realpath(sys.argv[0])`, which is used to determine the location of the webpage assets. This is necessary given that `sys.argv[0]` refers to homebrew's symlink and not the real file, so without it the script cannot find the assets and renders a 404 error.