### PR TITLE
check_emacs_lisp(): bail unless site-lisp exists

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -174,7 +174,7 @@ module FormulaCellarChecks
   end
 
   def check_emacs_lisp(share, name)
-    return unless share.directory?
+    return unless (share/"emacs/site-lisp").directory?
 
     # Emacs itself can do what it wants
     return if name == "emacs"


### PR DESCRIPTION
Otherwise we get a lot of silly errors:
```
🔥  brew install openjpeg
==> Downloading https://homebrew.bintray.com/bottles/openjpeg-1.5.1_1.yos
Already downloaded: /Library/Caches/Homebrew/openjpeg-1.5.1_1.yosemite.bottle.tar.gz
==> Pouring openjpeg-1.5.1_1.yosemite.bottle.tar.gz
Error: No such file or directory - /usr/local/Cellar/openjpeg/1.5.1_1/share/emacs/site-lisp
```