### PR TITLE
afl-fuzz: 1.85b

### DIFF
--- a/Library/Formula/afl-fuzz.rb
+++ b/Library/Formula/afl-fuzz.rb
@@ -1,9 +1,8 @@
 class AflFuzz < Formula
   desc "American fuzzy lop: Security-oriented fuzzer"
   homepage "http://lcamtuf.coredump.cx/afl/"
-  url "http://lcamtuf.coredump.cx/afl/releases/afl-1.84b.tgz"
-  sha256 "d8201a4a06c2174060cc9bb7058034fcb66e02fa94488d03cd9f0408a57a1f4d"
-
+  url "http://lcamtuf.coredump.cx/afl/releases/afl-1.85b.tgz"
+  sha256 "feb2bf6008d9f3a5c3e26295a9063168e98a2797e86b97b24ad8faa50fab8456"
   head "http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz"
 
   bottle do


### PR DESCRIPTION
```
--------------
Version 1.85b:
--------------

  - Fixed a garbled sentence in notes on parallel fuzzing. Thanks to Jakub Wilk.

  - Fixed a minor glitch in afl-cmin. Spotted by Jonathan Foote.
```