### PR TITLE
Prioritization of Tap in Dependency Resolution

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -31,6 +31,8 @@ class Dependency
   end
 
   def to_formula
+    return @formula unless @formula.nil?
+
     if owner_tap.nil? || name =~ HOMEBREW_TAP_FORMULA_REGEX
       formula = Formulary.factory(name)
     else
@@ -49,7 +51,8 @@ class Dependency
       end
     end
     formula.build = BuildOptions.new(options, formula.options)
-    formula
+    @formula = formula
+    return formula
   end
 
   def installed?

--- a/Library/Homebrew/ld64_dependency.rb
+++ b/Library/Homebrew/ld64_dependency.rb
@@ -4,7 +4,7 @@ require "dependency"
 # formula is used as gcc's ld in place of the old version
 # that comes with the OS.
 class LD64Dependency < Dependency
-  def initialize(name = "ld64", tags = [:build], env_proc = nil)
+  def initialize(name = "ld64", tags = [:build], owner_tap = nil, env_proc = nil)
     super
     @env_proc = proc { ENV.ld64 }
   end

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -10,9 +10,10 @@ class Requirement
   include Dependable
 
   attr_reader :tags, :name, :cask, :download, :default_formula
+  attr_accessor :owner_tap
   alias_method :option_name, :name
 
-  def initialize(tags = [])
+  def initialize(tags = [], owner_tap = nil)
     @default_formula = self.class.default_formula
     @cask ||= self.class.cask
     @download ||= self.class.download
@@ -24,6 +25,7 @@ class Requirement
     @tags = tags
     @tags << :build if self.class.build
     @name ||= infer_name
+    @owner_tap = owner_tap
   end
 
   # The message to show when the requirement is not met.
@@ -118,9 +120,9 @@ class Requirement
     f = self.class.default_formula
     raise "No default formula defined for #{inspect}" if f.nil?
     if HOMEBREW_TAP_FORMULA_REGEX === f
-      TapDependency.new(f, tags, nil, method(:modify_build_environment), name)
+      TapDependency.new(f, tags, @owner_tap, method(:modify_build_environment), name)
     else
-      Dependency.new(f, tags, nil, method(:modify_build_environment), name)
+      Dependency.new(f, tags, @owner_tap, method(:modify_build_environment), name)
     end
   end
 

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -118,9 +118,9 @@ class Requirement
     f = self.class.default_formula
     raise "No default formula defined for #{inspect}" if f.nil?
     if HOMEBREW_TAP_FORMULA_REGEX === f
-      TapDependency.new(f, tags, method(:modify_build_environment), name)
+      TapDependency.new(f, tags, nil, method(:modify_build_environment), name)
     else
-      Dependency.new(f, tags, method(:modify_build_environment), name)
+      Dependency.new(f, tags, nil, method(:modify_build_environment), name)
     end
   end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -47,6 +47,7 @@ class SoftwareSpec
   def owner=(owner)
     @name = owner.name
     @full_name = owner.full_name
+    @dependency_collector.deps.each { |dep| dep.owner_tap = owner.tap }
     @bottle_specification.tap = owner.tap
     @owner = owner
     @resource.owner = self

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -48,6 +48,7 @@ class SoftwareSpec
     @name = owner.name
     @full_name = owner.full_name
     @dependency_collector.deps.each { |dep| dep.owner_tap = owner.tap }
+    @dependency_collector.requirements.each { |req| req.owner_tap = owner.tap }
     @bottle_specification.tap = owner.tap
     @owner = owner
     @resource.owner = self

--- a/Library/Homebrew/test/test_dependency_expansion.rb
+++ b/Library/Homebrew/test/test_dependency_expansion.rb
@@ -72,7 +72,7 @@ class DependencyExpansionTests < Homebrew::TestCase
 
   def test_merger_preserves_env_proc
     env_proc = stub
-    dep = Dependency.new("foo", [], env_proc)
+    dep = Dependency.new("foo", [], nil, env_proc)
     dep.stubs(:to_formula).returns(stub(:deps => []))
     @deps.replace [dep]
     assert_equal env_proc, Dependency.expand(@f).first.env_proc


### PR DESCRIPTION
This pr implements tap prioritization in dependency resolution. While resolving dependency for a formula `user/repo/foobar`, it will try to look for its dependencies in tap `user/repo` first. If it is not found, it will then use `foobar` formula from core. It will never use dependency formulae from taps other than `user/repo`.

This behavior is suggested by @jacknagel [here](https://github.com/Homebrew/homebrew/issues/14089#issuecomment-39590767).

~~This pr has a little dependency on #41736 as it requires the new behavior of `Formulary#factory` about fully qualified names like `Homebrew/homebrew/foobar`.~~ This behavior is already merged separately in #42550.