### PR TITLE
online audit: use GET instead of HEAD

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -434,7 +434,7 @@ class FormulaAuditor
 
     return unless @online
     begin
-      nostdout { curl "--connect-timeout", "15", "-IL", "-o", "/dev/null", homepage }
+      nostdout { curl "--connect-timeout", "15", "-o", "/dev/null", homepage }
     rescue ErrorDuringExecution
       problem "The homepage is not reachable (curl exit code #{$?.exitstatus})"
     end


### PR DESCRIPTION
I also removed the `-L` flag which is already present in `HOMEBREW_CURL_ARGS`.

The audit fails on some formulae because the server doesn’t support `HEAD` requests and return a `501 Not Implemented` error, e.g. #41549.