### PR TITLE
zopfli: rework HEAD build

### DIFF
--- a/Library/Formula/zopfli.rb
+++ b/Library/Formula/zopfli.rb
@@ -1,21 +1,27 @@
-require 'formula'
-
 class Zopfli < Formula
   desc "New zlib (gzip, deflate) compatible compressor"
-  homepage 'https://code.google.com/p/zopfli/'
-  url 'https://zopfli.googlecode.com/files/zopfli-1.0.0.zip'
-  sha1 '98ea00216e296bf3a13e241d7bc69490042ea7ce'
-  head 'https://code.google.com/p/zopfli/', :using => :git
+  homepage "https://github.com/google/zopfli"
+  url "https://zopfli.googlecode.com/files/zopfli-1.0.0.zip"
+  sha256 "e20d73b56620285e6cce5b510d8e5da6835a81940e48cdf35a69090e666f3adb"
+  head "https://github.com/google/zopfli.git"
 
   def install
-    # Makefile hardcodes gcc
-    inreplace 'makefile', 'gcc', ENV.cc
-    system 'make', '-f', 'makefile'
-    bin.install 'zopfli'
-    if build.head?
-      system 'make', '-f', 'makefile', 'zopflipng'
-      bin.install 'zopflipng'
+    if build.stable?
+      # Makefile hardcodes gcc
+      inreplace "makefile", "gcc", ENV.cc
+      system "make", "-f", "makefile"
+    else
+      inreplace "Makefile", "gcc", ENV.cc
+      inreplace "Makefile", "g++", ENV.cxx
+      inreplace "Makefile", "-soname", "-o"
+      system "make", "zopfli", "zopflipng", "libzopfli", "libzopflipng"
+      bin.install "zopflipng"
+      lib.install "libzopfli.so.1" => "libzopfli.dylib"
+      lib.install "libzopflipng.so.1" => "libzopflipng.dylib"
+      include.install "src/zopfli/"
+      include.install "src/zopflipng/"
     end
+    bin.install "zopfli"
   end
 
   test do


### PR DESCRIPTION
Zopfli development was moved to github & libzopfli/libzopflipng shared libs was added.
There is an issue with formula: src/zopfli{,png}/ contains both headers & .c files, so right now .c files are also installed, which is wrong.

I'm not sure how should I deal with it, is something like 
```ruby
%w(zopfli zopflipng zopflipng/lodepng).each do |dir|
  Dir["src/#{dir}/*.h"].each { |f| include.install i => dir }
end
```
ok or there is a better way to archive the same?