### PR TITLE
capnp 0.5.3

### DIFF
--- a/Library/Formula/capnp.rb
+++ b/Library/Formula/capnp.rb
@@ -1,8 +1,8 @@
 class Capnp < Formula
   desc "Data interchange format and capability-based RPC system"
   homepage "https://capnproto.org/"
-  url "https://capnproto.org/capnproto-c++-0.5.2.tar.gz"
-  sha256 "23145a0127c2b1629c4b72e6000e04991640e551947fa39fd06710d64bd942a8"
+  url "https://capnproto.org/capnproto-c++-0.5.3.tar.gz"
+  sha256 "cdb17c792493bdcd4a24bcd196eb09f70ee64c83a3eccb0bc6534ff560536afb"
 
   bottle do
     sha256 "df70e870b12a65442ced879e21418554e1594de20e86691f68c6a1ec17e60bf4" => :yosemite
@@ -11,21 +11,16 @@ class Capnp < Formula
   end
 
   needs :cxx11
-  option "without-shared", "Disable building shared library variant"
+  depends_on "cmake" => :build
 
   def install
-    args = %W[
-      --disable-debug
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --prefix=#{prefix}
-    ]
+    ENV.cxx11
 
-    args << "--disable-shared" if build.without? "shared"
-
-    system "./configure", *args
-    system "make", "check"
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "check"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
The extra `ENV` is a guess at fixing this error in Mountain Lion https://github.com/Homebrew/homebrew-science/pull/2605:
```
checking capnp/common.h usability... no
checking capnp/common.h presence... no
checking for capnp/common.h... no
configure: error: Cap'n Proto headers not found.