### PR TITLE
chuck: update version detection to support 10.11 (and 10.12, 10.13)

### DIFF
--- a/Library/Formula/chuck.rb
+++ b/Library/Formula/chuck.rb
@@ -11,6 +11,9 @@ class Chuck < Formula
     sha256 "d5f7372ca9f939763a4ffd3894d8384797417cdb3455899f80da0f188c84f812" => :mountain_lion
   end
 
+  # Fixes OS X version detection to include 10.11 through (thinking ahead) 10.13
+  patch :DATA
+
   def install
     system "make", "-C", "src", "osx"
     bin.install "src/chuck"
@@ -21,3 +24,18 @@ class Chuck < Formula
     assert_match /probe \[success\]/m, shell_output("#{bin}/chuck --probe 2>&1")
   end
 end
+
+__END__
+diff --git a/src/makefile.osx b/src/makefile.osx
+index a2c06ba..ac95278 100644
+--- a/src/makefile.osx
++++ b/src/makefile.osx
+@@ -1,7 +1,7 @@
+ # uncomment the following to force 32-bit compilation
+ # FORCE_M32=-m32
+ 
+-ifneq ($(shell sw_vers -productVersion | egrep '10\.(6|7|8|9|10)(\.[0-9]+)?'),)
++ifneq ($(shell sw_vers -productVersion | egrep '10\.(6|7|8|9|10|11|12|13)(\.[0-9]+)?'),)
+ SDK=$(shell xcodebuild -sdk macosx -version | grep '^Path:' | sed 's/Path: \(.*\)/\1/')
+ ISYSROOT=-isysroot $(SDK)
+ LINK_EXTRAS=-F/System/Library/PrivateFrameworks \


### PR DESCRIPTION
Fixes #42382 

I've also submitted the patch to the [ChucK developer list](https://lists.cs.princeton.edu/mailman/listinfo/chuck-dev).