### PR TITLE
center-im: fix 10.11 build

### DIFF
--- a/Library/Formula/center-im.rb
+++ b/Library/Formula/center-im.rb
@@ -2,7 +2,7 @@ class CenterIm < Formula
   desc "Text-mode multi-protocol instant messaging client"
   homepage "http://www.centerim.org/index.php/Main_Page"
   url "http://www.centerim.org/download/releases/centerim-4.22.10.tar.gz"
-  sha1 "46fbac7a55f33b0d4f42568cca21ed83770650e5"
+  sha256 "93ce15eb9c834a4939b5aa0846d5c6023ec2953214daf8dc26c85ceaa4413f6e"
   revision 1
 
   bottle do
@@ -19,15 +19,17 @@ class CenterIm < Formula
   # Fix build with clang; 4.22.10 is an outdated release and 5.0 is a rewrite,
   # so this is not reported upstream
   patch :DATA
+
   patch :p0 do
     url "https://trac.macports.org/export/113135/trunk/dports/net/centerim/files/patch-libjabber_jconn.c.diff"
-    sha1 "70bf1cb777e086fb773d99aadbcaa8db77b19bec"
+    sha256 "ed8d10075c23c7dec2a782214cb53be05b11c04e617350f6f559f3c3bf803cfe"
   end
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--disable-msn"
+                          "--disable-msn",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
     system "make", "install"
 
     # /bin/gawk does not exist on OS X


### PR DESCRIPTION
Unless you specifically point this formula towards the correct OpenSSL directory it checks `/usr/local/include` and `/usr/include` for OpenSSL headers.

Obviously that's a problem on 10.11 where the headers have gone through the pearly gates. It becomes a bigger problem because when those headers aren't found it falls back on defunct GnuTLS logic and fails to compile.

Closes #42381.