### PR TITLE
cronolog: update URL to reflect change on server

### DIFF
--- a/Library/Formula/cronolog.rb
+++ b/Library/Formula/cronolog.rb
@@ -3,13 +3,14 @@ require 'formula'
 class Cronolog < Formula
   desc "Web log rotation"
   homepage "http://web.archive.org/web/20140209202032/http://cronolog.org/"
-  url "http://fossies.org/linux/www/cronolog-1.6.2.tar.gz"
-  sha1 "6422b7c5e87241eb31d76809a2e0eea77ae4c64e"
+  url "https://fossies.org/linux/www/old/cronolog-1.6.2.tar.gz"
+  sha256 "65e91607643e5aa5b336f17636fa474eb6669acc89288e72feb2f54a27edb88e"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+                          "--mandir=#{man}",
+                          "--infodir=#{info}"
     system "make install"
   end
 end


### PR DESCRIPTION
The file in the fossies.org archive has moved  a bit. I found the new URL through their search field. 

Fixes this build failure.

```
$ brew install cronolog
Warning: You are using OS X 10.11.
We do not provide support for this pre-release version.
You may encounter build failures or other breakage.
==> Downloading http://fossies.org/linux/www/cronolog-1.6.2.tar.gz

curl: (22) The requested URL returned error: 410 Gone
Error: Failed to download resource "cronolog"
Download failed: http://fossies.org/linux/www/cronolog-1.6.2.tar.gz
```