### PR TITLE
add passlib to ansible formula; closes #42368

### DIFF
--- a/Library/Formula/ansible.rb
+++ b/Library/Formula/ansible.rb
@@ -282,6 +282,11 @@ class Ansible < Formula
     sha256 "f43f9f15b0b719de94cab2754dcf78ef63b40ee2a12cea296e7af788b28501bb"
   end
 
+  resource "passlib" do
+    url "https://pypi.python.org/packages/source/p/passlib/passlib-1.6.4.tar.gz"
+    sha256 "d41bd7a2d22f9bd7e19ff4eed0eea2316eb737f3ec6a7c361dde6b2785b08cdc"
+  end
+
   def install
     ENV["PYTHONPATH"] = libexec/"vendor/lib/python2.7/site-packages"
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"


### PR DESCRIPTION
I wasn't able to add a specific test for this, because the case I'm covering requires user input. 

A manual test against a playbook such as this works:

```yaml
---
- name: Test
  vars_prompt:
    - name: password
      prompt: Enter Password
      private: yes
      encrypt: sha512_crypt
      confirm: yes
      salt_size: 7
```

...whereas before this change, it failed.