### PR TITLE
dcmtk 3.6.1_20150629

### DIFF
--- a/Library/Formula/dcmtk.rb
+++ b/Library/Formula/dcmtk.rb
@@ -3,9 +3,9 @@ class Dcmtk < Formula
   homepage "http://dicom.offis.de/dcmtk.php.en"
 
   # Current snapshot used for stable now.
-  url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20150217.tar.gz"
-  sha256 "3cf8f3e52ed8a5240a7facc3a118de411aa54bc9beccba0cf7a975735da35304"
-  version "3.6.1-20150217"
+  url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20150629.tar.gz"
+  sha256 "6af8a4683a8f4995cefbad00e727fd760e0e5f535d7c4ad622ce280a701888e2"
+  version "3.6.1-20150629"
 
   head "git://git.dcmtk.org/dcmtk.git"
 


### PR DESCRIPTION
dcmtk: bump to 3.6.1_20150629. Fixes a 404 error with the previous version.