### PR TITLE
doxygen 1.8.10

### DIFF
--- a/Library/Formula/doxygen.rb
+++ b/Library/Formula/doxygen.rb
@@ -1,10 +1,10 @@
 class Doxygen < Formula
   desc "Generate documentation for several programming languages"
   homepage "http://www.doxygen.org/"
+  url "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.10.src.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.8.10/doxygen-1.8.10.src.tar.gz"
+  sha256 "cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93"
   head "https://github.com/doxygen/doxygen.git"
-  url "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.9.1.src.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.8.9.1/doxygen-1.8.9.1.src.tar.gz"
-  sha256 "d4ab6e28d4d45d8956cad17470aade3fbe2356e8f64b92167e738c1887feccec"
 
   bottle do
     cellar :any
@@ -19,56 +19,22 @@ class Doxygen < Formula
 
   deprecated_option "with-dot" => "with-graphviz"
 
+  depends_on "cmake" => :build
   depends_on "graphviz" => :optional
   depends_on "qt" if build.with? "doxywizard"
   depends_on "llvm" => "with-clang" if build.with? "libclang"
 
-  # Fixes for --with-doxywizard and --with-libclang
-  patch :DATA
-
   def install
-    args = ["--prefix", prefix]
+    args = std_cmake_args
+    args << "-Dbuild_wizard=ON" if build.with? "doxywizard"
+    args << "-Duse_libclang=ON -DLLVM_CONFIG=#{Formula["llvm"].opt_bin}/llvm-config" if build.with? "libclang"
 
-    if build.with? "doxywizard"
-      args << "--with-doxywizard"
-      ENV["QTDIR"] = Formula["qt"].opt_prefix
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
     end
-
-    if build.with? "libclang"
-      args << "--with-libclang-static"
-      llvm = Formula["llvm"]
-      inreplace "configure" do |s|
-        s.gsub! /libclang_hdr_dir=\".*$/, "libclang_hdr_dir=\"#{llvm.opt_include}\""
-        s.gsub! /libclang_lib_dir=\".*$/, "libclang_lib_dir=\"#{llvm.opt_lib}\""
-      end
-    end
-
-    system "./configure", *args
-
-    # Per MacPorts:
-    # https://trac.macports.org/browser/trunk/dports/textproc/doxygen/Portfile#L92
-    inreplace %w[ tmake/lib/macosx-c++/tmake.conf
-                  tmake/lib/macosx-intel-c++/tmake.conf
-                  tmake/lib/macosx-uni-c++/tmake.conf ] do |s|
-      # makefiles hardcode both cc and c++
-      s.gsub! /cc$/, ENV.cc
-      s.gsub! /c\+\+$/, ENV.cxx
-    end
-
-    # This is a terrible hack; configure finds lex/yacc OK but
-    # one Makefile doesn't get generated with these, so pull
-    # them out of a known good file and cram them into the other.
-    lex = ""
-    yacc = ""
-
-    inreplace "src/libdoxycfg.t" do |s|
-      lex = s.get_make_var "LEX"
-      yacc = s.get_make_var "YACC"
-    end
-
-    system "make"
-    # MAN1DIR, relative to the given prefix
-    system "make", "MAN1DIR=share/man/man1", "install"
+    bin.install Dir["build/bin/*"]
+    man1.install Dir["doc/*.1"]
   end
 
   test do
@@ -76,35 +42,3 @@ class Doxygen < Formula
     system "#{bin}/doxygen", "Doxyfile"
   end
 end
-
-__END__
-# On Mac OS Qt builds an application bundle rather than a binary.  We need to
-# give install the correct path to the doxywizard binary.  This is similar to
-# what macports does:
-diff --git a/addon/doxywizard/Makefile.in b/addon/doxywizard/Makefile.in
-index 727409a..8b0d00f 100644
---- a/addon/doxywizard/Makefile.in
-+++ b/addon/doxywizard/Makefile.in
-@@ -30,7 +30,7 @@ distclean: Makefile.doxywizard
- 
- install:
- 	$(INSTTOOL) -d $(INSTALL)/bin	
--	$(INSTTOOL) -m 755 ../../bin/doxywizard $(INSTALL)/bin	
-+	$(INSTTOOL) -m 755 ../../bin/doxywizard.app/Contents/MacOS/doxywizard $(INSTALL)/bin
- 	$(INSTTOOL) -d $(INSTALL)/$(MAN1DIR)
- 	cat ../../doc/doxywizard.1 | sed -e "s/DATE/$(DATE)/g" -e "s/VERSION/$(VERSION)/g" > doxywizard.1
- 	$(INSTTOOL) -m 644 doxywizard.1 $(INSTALL)/$(MAN1DIR)/doxywizard.1
-# Additional libraries needed to link clang
-diff --git a/configure b/configure
-index 1020492..c88a012 100755
---- a/configure
-+++ b/configure
-@@ -578,7 +578,7 @@ if test "$f_libclang" = YES; then
-           if test "$f_libclangstatic" = NO; then
-             libclang_link="-L $i -lclang"
-           else
--            libclang_link="$i/libclang.a $i/libclangFrontend.a $i/libclangSerialization.a $i/libclangParse.a $i/libclangSema.a $i/libclangAnalysis.a $i/libclangStaticAnalyzerCore.a $i/libclangAST.a $i/libclangBasic.a $i/libclangDriver.a $i/libclangEdit.a $i/libclangLex.a $i/libclangRewriteCore.a $i/libLLVMBitReader.a $i/libLLVMMC.a $i/libLLVMMCParser.a $i/libLLVMSupport.a -ldl -lpthread"
-+            libclang_link="$i/libclang.a $i/libclangFrontend.a $i/libclangSerialization.a $i/libclangParse.a $i/libclangSema.a $i/libclangAnalysis.a $i/libclangStaticAnalyzerCore.a $i/libclangAST.a $i/libclangBasic.a $i/libclangDriver.a $i/libclangEdit.a $i/libclangFormat.a $i/libclangLex.a $i/libclangRewrite.a $i/libclangTooling.a $i/libLLVMBitReader.a $i/libLLVMMC.a $i/libLLVMMCParser.a $i/libLLVMSupport.a $i/libClangIndex.a -ldl -lpthread -lncurses -lLLVM-3.5 -lz"
-           fi
-           break
-         fi


### PR DESCRIPTION
Doxygen switched from `configure` to `cmake`.

Instead of manually installing the files (`bin.install Dir["build/bin/*"`) I would have like to use
`make install`, unfortunately that fails, since documentation files are missing.

The missing documentation files are created with `make docs`, unfortunately that fails, since `epstopdf` is used when building the doxygen reference manual and I found no way on how to customise this using CMake definitions.

I find the proposed solution more straightforward than patching the appropriate `CMakeLists.txt` files.
If I find some spare time I'll report this upstream and may propose even some changes.