### PR TITLE
upx: resource lzma 15.05

### DIFF
--- a/Library/Formula/upx.rb
+++ b/Library/Formula/upx.rb
@@ -17,15 +17,15 @@ class Upx < Formula
   depends_on "ucl"
 
   resource "lzma" do
-    url "https://downloads.sourceforge.net/project/sevenzip/LZMA%20SDK/lzma938.7z"
-    sha256 "721f4f15378e836686483811d7ea1282463e3dec1932722e1010d3102c5c3b20"
+    url "https://downloads.sourceforge.net/project/sevenzip/LZMA%20SDK/lzma1505.7z"
+    sha256 "0ec15e40c4cba2b4b0350b7b4f479816efa1ed3bc6749947fd2679785ca92ff5"
   end
 
   def install
     inreplace "src/compress_lzma.cpp", "C/Types.h", "C/7zTypes.h"
     (buildpath/"lzmasdk").install resource("lzma")
     ENV["UPX_LZMADIR"] = buildpath/"lzmasdk"
-    ENV["UPX_LZMA_VERSION"] = "0x938"
+    ENV["UPX_LZMA_VERSION"] = "0x1505"
     system "make", "all"
     bin.install "src/upx.out" => "upx"
     man1.install "doc/upx.1"


### PR DESCRIPTION
LZMA-SDK 15.05: Some bugs were fixed.
* The BUG in 15.01-15.02 was fixed:
  * 7-Zip created incorrect ZIP archives, if ZipCrypto encryption was used.
  * 7-Zip 9.20 can extract such incorrect ZIP archives.
  * 7-Zip didn't restore NTFS permissions for folders during extracting from WIM archives.
  * The command line version: if the command "rn" (Rename) was called with more 
    than one pair of paths, 7-Zip used only first rename pair.
  * 7-Zip crashed for ZIP/LZMA/AES/AES-NI.
* Speed optimizations for BCJ2 filter and SHA-1 and SHA-256 calculation.
* 7-Zip now uses new installer.
* 7-Zip now can create 7z, xz and zip archives with 1536 MB dictionary for LZMA/LZMA2.
* 7-Zip File Manager now can operate with alternate file streams at NTFS volumes via "File / Alternate Streams" menu command.
* 7-Zip now can extract `.zipx` (WinZip) archives that use xz compression.
* new optional "section size" parameter for BCJ2 filter for compression ratio improving.
  Example: `-mf=BCJ2:d9M`, if largest executable section in files is smaller than 9 MB.
* Console version now uses stderr stream for error messages.
* Console version now shows names of processed files only in progress line by default.
* new `-bb[0-3]` switch to set output log level. `-bb1` shows names of processed files in log.
* new `-bs[o|e|p][0|1|2]` switch to set stream for output messages;
* o: output, e: error, p: progress line; 0: disable, 1: stdout, 2: stderr.
* new `-bt` switch to show execution time statistics.
* new `-myx[0-9]` switch to set level of file analysis.
* new `-mmtf-` switch to set single thread mode for filters.
* Some bugs were fixed.* 

http://sourceforge.net/p/sevenzip/discussion/45797/thread/967f51bb/#b8f8