### PR TITLE
Formula-Cookbook: avoid non-with options

### DIFF
--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -861,17 +861,11 @@ end
 if build.without? "ham"
   # works as you'd expect. True if `--without-ham` was given.
 end
-
-if build.include? "enable-ham"
-  # the deprecated style, only useful for options other than `with`/`without` style
-end
 ```
 
-Option names should be prefixed with one of the words `with`, `without`, `no`, or a verb in the imperative tense describing the action to be taken. For example, an option to run a test suite should be named `--with-test` or `--with-check` rather than `--test`, and an option to enable a shared library should be named `--enable-shared` rather than `--shared`.
+Option names should be prefixed with the words `with` or `without`. For example, an option to run a test suite should be named `--with-test` or `--with-check` rather than `--test`, and an option to enable a shared library `--with-shared` rather than `--shared` or `--enable-shared`.
 
 Note that options that aren’t ` build.with? ` or ` build.without? ` should be actively deprecated where possible. See [wget](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/wget.rb#L27-L31) for an example.
-
-See the [graphviz](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/graphviz.rb) formula for an example.
 
 
 ## File level operations


### PR DESCRIPTION
The wording here has created some confusion recently, in particular:

>Option names should be prefixed with one of the words `with`, `without`, `no`, or a verb in the        imperative tense describing the action to be taken.

Which contradicts 

> Note that options that aren’t ` build.with? ` or ` build.without? ` should be actively deprecated where possible.

Most of the deprecated style has been transitioned by now so I don't think the cookbook should encourage their further use. Whether or not another verb might fit better, any option can be prefixed by with or without.