### PR TITLE
csup: revision for openssl

### DIFF
--- a/Library/Formula/csup.rb
+++ b/Library/Formula/csup.rb
@@ -3,7 +3,11 @@ class Csup < Formula
   homepage "https://bitbucket.org/mux/csup"
   url "https://bitbucket.org/mux/csup/get/REL_20120305.tar.gz"
   sha256 "6b9a8fa2d2e70d89b2780cbc3f93375915571497f59c77230d4233a27eef77ef"
+  revision 1
+
   head "https://bitbucket.org/mux/csup", :using => :hg
+
+  depends_on "openssl"
 
   def install
     system "make"


### PR DESCRIPTION
Linking against the defunct system OpenSSL on <10.11? Bad.
Linking against the defunct system OpenSSL headers on 10.11? Fatal.

Closes #42396.