### PR TITLE
cpp-netlib: revision for openssl

### DIFF
--- a/Library/Formula/cpp-netlib.rb
+++ b/Library/Formula/cpp-netlib.rb
@@ -2,8 +2,9 @@ class CppNetlib < Formula
   desc "C++ libraries for high level network programming"
   homepage "http://cpp-netlib.org"
   url "https://storage.googleapis.com/cpp-netlib-downloads/0.11.1/cpp-netlib-0.11.1-final.tar.bz2"
-  sha256 "8f5a0bb7e5940490b4e409f9c805b752ee4b598e06d740d04adfc76eb5c8e23e"
   version "0.11.1"
+  sha256 "8f5a0bb7e5940490b4e409f9c805b752ee4b598e06d740d04adfc76eb5c8e23e"
+  revision 1
 
   bottle do
     sha256 "c6d9909b1d7a4402782ed86d80c97c612f24e8893e266a7064362dc0a6323324" => :yosemite
@@ -12,6 +13,7 @@ class CppNetlib < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "openssl"
 
   if MacOS.version < :mavericks
     depends_on "boost" => "c++11"
@@ -23,20 +25,21 @@ class CppNetlib < Formula
 
   def install
     ENV.cxx11
-    system "cmake", ".", *std_cmake_args
+
+    system "cmake", *std_cmake_args
     system "make"
     system "make", "install"
   end
 
   test do
     (testpath/"test.cpp").write <<-EOS.undent
-        #include <boost/network/protocol/http/client.hpp>
-        int main(int argc, char *argv[]) {
-            using namespace boost::network;
-            http::client client;
-            http::client::request request("");
-            return 0;
-        }
+      #include <boost/network/protocol/http/client.hpp>
+      int main(int argc, char *argv[]) {
+        using namespace boost::network;
+        http::client client;
+        http::client::request request("");
+        return 0;
+      }
     EOS
     flags = ["-stdlib=libc++", "-I#{include}", "-I#{Formula["boost"].include}", "-L#{lib}", "-L#{Formula["boost"].lib}", "-lboost_thread-mt", "-lboost_system-mt", "-lssl", "-lcrypto", "-lcppnetlib-client-connections", "-lcppnetlib-server-parsers", "-lcppnetlib-uri"] + ENV.cflags.to_s.split
     system ENV.cxx, "-o", "test", "test.cpp", *flags


### PR DESCRIPTION
Linking against the defunct system OpenSSL on <10.11? Bad.
Linking against the defunct system OpenSSL headers on 10.11? Fatal.

Closes #42392.