### PR TITLE
gwyddion 2.41

### DIFF
--- a/Library/Formula/gwyddion.rb
+++ b/Library/Formula/gwyddion.rb
@@ -1,9 +1,8 @@
 class Gwyddion < Formula
   desc "Scanning Probe Microscopy visualization and analysis tool"
   homepage "http://gwyddion.net/"
-  url "http://gwyddion.net/download/2.40/gwyddion-2.40.tar.gz"
-  sha256 "b3838dab5a4ff8e1f62d2ab859fabb42c3a8c31f5dc4f72dc679a46de2b67bab"
-  revision 1
+  url "http://gwyddion.net/download/2.41/gwyddion-2.41.tar.gz"
+  sha256 "093e5e20e85cbfc14786a8dcc319943ad30419bffd5ab883e7d0400161fb3cd4"
 
   bottle do
     revision 1
@@ -23,6 +22,14 @@ class Gwyddion < Formula
   depends_on "gtksourceview" if build.with? "python"
 
   def install
+    # Add Python library path and prevent explicit linkage for the gwy module.
+    # Upstream patch: <http://sourceforge.net/p/gwyddion/mailman/message/34347458/>
+    inreplace "configure", 'PYTHON_LIBS=-l$libpython',
+                           %(py_prefix=`$PYTHON -c "import sys; print sys.prefix"`
+                           PYTHON_LIBS="-L${py_prefix}/lib -l$libpython")
+    inreplace "modules/pygwy/Makefile.in", '$(PYTHON_LIBS) $(PYGTK_LIBS) @GTK_LIBS@',
+                                           '-undefined dynamic_lookup $(PYGTK_LIBS) @GTK_LIBS@'
+
     system "./configure", "--disable-dependency-tracking",
                           "--disable-desktop-file-update",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
Update Gwyddion to 2.41. Also, add Python search path to prevent linking the
wrong library.