### PR TITLE
Change PyQT5 url back to sourceforge

### DIFF
--- a/Library/Formula/pyqt5.rb
+++ b/Library/Formula/pyqt5.rb
@@ -1,7 +1,7 @@
 class Pyqt5 < Formula
   desc "Python bindings for v5 of Qt"
   homepage "http://www.riverbankcomputing.co.uk/software/pyqt/download5"
-  url "http://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt-gpl-5.5.tar.gz"
+  url "https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.5/PyQt-gpl-5.5.tar.gz"
   sha256 "cdd1bb55b431acdb50e9210af135428a13fb32d7b1ab86e972ac7101f6acd814"
 
   bottle do


### PR DESCRIPTION
In #42038 I upgraded SIP and PyQT5 and the urls were changed from sourceforge to self hosting at riverbank (Sourceforge was down at the time) As discovered by @acogneau  in #42361 these links no longer work. The link to SIP was changed back. This changes the remaining link to PyQt5