### PR TITLE
Update the set of conflicts between certain Markdown tools

### DIFF
--- a/Library/Formula/discount.rb
+++ b/Library/Formula/discount.rb
@@ -13,8 +13,8 @@ class Discount < Formula
 
   option "with-fenced-code", "Enable Pandoc-style fenced code blocks."
 
-  conflicts_with "markdown",
-    :because => "both discount and markdown ship a `markdown` executable."
+  conflicts_with "markdown", :because => "both install `markdown` binaries"
+  conflicts_with "multimarkdown", :because => "both install `markdown` binaries"
 
   def install
     args = %W[

--- a/Library/Formula/markdown.rb
+++ b/Library/Formula/markdown.rb
@@ -4,8 +4,7 @@ class Markdown < Formula
   url "http://daringfireball.net/projects/downloads/Markdown_1.0.1.zip"
   sha256 "6520e9b6a58c5555e381b6223d66feddee67f675ed312ec19e9cee1b92bc0137"
 
-  conflicts_with "discount",
-    :because => "both markdown and discount ship a `markdown` executable."
+  conflicts_with "discount", :because => "both install `markdown` binaries"
   conflicts_with "multimarkdown", :because => "both install `markdown` binaries"
 
   def install

--- a/Library/Formula/multimarkdown.rb
+++ b/Library/Formula/multimarkdown.rb
@@ -15,6 +15,7 @@ class Multimarkdown < Formula
 
   conflicts_with "mtools", :because => "both install `mmd` binaries"
   conflicts_with "markdown", :because => "both install `markdown` binaries"
+  conflicts_with "discount", :because => "both install `markdown` binaries"
 
   def install
     ENV.append "CFLAGS", "-g -O3 -include GLibFacade.h"


### PR DESCRIPTION
`discount` and `multimarkdown` conflict with one another, but this wasn’t reflected in their formulae. While  updating the conflicts, I also revised the messages for consistency.