### PR TITLE
exim: fix URL for 4.85

### DIFF
--- a/Library/Formula/exim.rb
+++ b/Library/Formula/exim.rb
@@ -3,9 +3,9 @@ require "formula"
 class Exim < Formula
   desc "Complete replacement for sendmail"
   homepage "http://exim.org"
-  url "http://ftp.exim.org/pub/exim/exim4/exim-4.85.tar.bz2"
-  mirror "http://www.mirrorservice.org/sites/ftp.exim.org/pub/exim/exim4/exim-4.85.tar.bz2"
-  sha1 "6b40d5a6ae59f86b4780ad50aaf0d930330d7b67"
+  url "http://ftp.exim.org/pub/exim/exim4/old/exim-4.85.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.exim.org/pub/exim/exim4/old/exim-4.85.tar.bz2"
+  sha256 "13211f2bbc5400d095a9b4be075eb1347e0d98676fdfe4be8a3b4d56281daaa4"
 
   bottle do
     revision 1


### PR DESCRIPTION
There's also a new 4.86 release, but it could take some work to adapt the Homebrew patches to it. This'll keep the existing 4.85 version working in the mean time.