### PR TITLE
fuseki: fix URL for 1.1.2

### DIFF
--- a/Library/Formula/fuseki.rb
+++ b/Library/Formula/fuseki.rb
@@ -1,7 +1,7 @@
 class Fuseki < Formula
   desc "SPARQL server"
   homepage "https://jena.apache.org/documentation/serving_data/"
-  url "https://www.apache.org/dist/jena/binaries/jena-fuseki1-1.1.2-distribution.tar.gz"
+  url "https://archive.apache.org/dist/jena/binaries/jena-fuseki1-1.1.2-distribution.tar.gz"
   version "1.1.2"
   sha256 "78bd92b4e32f9e918d89946d11aed9789416f4058b127af60b251b4a8636b5f0"
 


### PR DESCRIPTION
The current download URL for 404. Switches to "archive.apache.org" where old versions live on.

There's a new fuseki 1.3.0 version out, which Apache recommends switching to. That'll take a little more work since the formula has patches.