### PR TITLE
glassfish: fix URL

### DIFF
--- a/Library/Formula/glassfish.rb
+++ b/Library/Formula/glassfish.rb
@@ -3,8 +3,8 @@ require "formula"
 class Glassfish < Formula
   desc "Java EE application server"
   homepage "https://glassfish.java.net"
-  url "http://dlc.sun.com.edgesuite.net/glassfish/4.1/release/glassfish-4.1.zip"
-  sha1 "704a90899ec5e3b5007d310b13a6001575827293"
+  url "http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip"
+  sha256 "3edc5fc72b8be241a53eae83c22f274479d70e15bdfba7ba2302da5260f23e9d"
 
   def install
     rm_rf Dir["bin/*.bat"]


### PR DESCRIPTION
The current download URL for glassfish is returning 400 Forbidden errors, for at least a couple days now. Found an alternate download on the main Glassfish site.