### PR TITLE
Update recipie to new luvi / lit / luvit system

### DIFF
--- a/Library/Formula/lit.rb
+++ b/Library/Formula/lit.rb
@@ -1,0 +1,18 @@
+class Lit < Formula
+  desc "Toolkit for developing, sharing, and running luvit programs and libraries."
+  homepage "https://github.com/luvit/lit"
+  url "https://lit.luvit.io/packages/luvit/lit/v2.2.4.zip"
+  sha256 "4d0ad9dce10c89e2f1cf483435c4670f5b3a22f69f73f834804b8b232411791f"
+
+  depends_on "luvi" => :build
+
+  def install
+    system "luvi", buildpath, "--", "make"
+    bin.install "lit"
+  end
+
+  test do
+    system "#{bin}/lit"
+  end
+end
+

--- a/Library/Formula/luvi.rb
+++ b/Library/Formula/luvi.rb
@@ -1,0 +1,19 @@
+class Luvi < Formula
+  desc "A project in-between luv and luvit, lua packages."
+  homepage "https://github.com/luvit/luvi"
+  url "https://github.com/luvit/luvi/releases/download/v2.1.8/luvi-src-v2.1.8.tar.gz"
+  sha256 "1ef449c6a76bcf7a03c8bbcdd5423b0366d63b10c52fd463ca2ba8aaf9248781"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "make", "regular-asm"
+    system "make"
+    bin.install "build/luvi"
+  end
+
+  test do
+    system "#{bin}/luvi", "samples/test.app", "--", "1", "2", "3", "4"
+  end
+end
+

--- a/Library/Formula/luvit.rb
+++ b/Library/Formula/luvit.rb
@@ -1,31 +1,18 @@
 class Luvit < Formula
-  desc "Asynchronous I/O for Lua"
-  homepage "https://luvit.io"
-  url "https://luvit.io/dist/latest/luvit-0.8.2.tar.gz"
-  sha256 "c2639348d1716c38ac3cd66ea4c4ff1c8a72f4610dbd6e50cf31426d3956c5ff"
-  head "https://github.com/luvit/luvit.git"
-  revision 1
+  desc "Asynchronous I/O for Lua (node.js style powered by luajit and libuv)"
+  homepage "https://luvit.io/"
+  url "https://lit.luvit.io/packages/luvit/luvit/v2.4.2.zip"
+  sha256 "e4173ffae63b364c6f1c37fc4a7ce28880e4a4cda65f894cf436d268055fce17"
 
-  bottle do
-    cellar :any
-    sha256 "3c7250314f67d320d8bc36f14e8d055860a2098bf5528b53eb58ff7d93244881" => :yosemite
-    sha256 "1f4616aa1be7802088900bcec2f284e8a85a4b82ee6fc9873a4c20d30ac6ac47" => :mavericks
-    sha256 "ef23e4e0cf252074738d85b1b2b2e02fd58e3a5239e00362d6f1e4dc2c58862c" => :mountain_lion
-  end
-
-  depends_on "pkg-config" => :build
-  depends_on "luajit"
-  depends_on "openssl"
+  depends_on "lit" => :build
 
   def install
-    ENV["USE_SYSTEM_SSL"] = "1"
-    ENV["USE_SYSTEM_LUAJIT"] = "1"
-    ENV["PREFIX"] = prefix
-    system "make"
-    system "make", "install"
+    system "lit", "make", buildpath
+    bin.install "luvit"
   end
 
   test do
-    system bin/"luvit", "--cflags", "--libs"
+    system "#{bin}/luvit", "-v"
   end
 end
+


### PR DESCRIPTION
This builds luvi from the source tarball (with locally built luajit, libuv, and openssl statically linked).  Then using luvi, lit builds itself from zipball and then lit builds luvit from zipball.

Including openssl, luajit, and libuv statically is the default behavior in luvit, but this could be changed to depend on the homebrew versions of these dependencies.

See luvit/luvit#787 and #42019 

Thanks for the help and encouragement from @tzudot.