### PR TITLE
make path instead of symlink for lib/R

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -300,6 +300,7 @@ class Keg
       when /^perl5/ then :mkpath
       when "php" then :mkpath
       when /^python[23]\.\d/ then :mkpath
+      when /^R/ then :mkpath
       when /^ruby/ then :mkpath
       # Everything else is symlinked to the cellar
       else :link


### PR DESCRIPTION
Moves us towards being able to support formulae that install R bindings,
like nonpareil in homebrew-science.

Some discussion in Homebrew/homebrew-science#2559.