### PR TITLE
graphviz HEAD

### DIFF
--- a/Library/Formula/graphviz.rb
+++ b/Library/Formula/graphviz.rb
@@ -4,6 +4,14 @@ class Graphviz < Formula
   url "http://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz"
   sha256 "81aa238d9d4a010afa73a9d2a704fc3221c731e1e06577c2ab3496bdef67859e"
 
+  head do
+    url "https://github.com/ellson/graphviz.git"
+
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
+
   bottle do
     revision 1
     sha1 "a3461628baba501e16c63ceaa0414027f7e26c7f" => :yosemite
@@ -67,7 +75,11 @@ class Graphviz < Formula
                              'PYTHON_LIBS="-L$PYTHON_PREFIX/lib -lpython$PYTHON_VERSION_SHORT"'
     end
 
-    system "./configure", *args
+    if build.head?
+      system "./autogen.sh", *args
+    else
+      system "./configure", *args
+    end
     system "make", "install"
 
     if build.with? "app"


### PR DESCRIPTION
Update graphviz to also build from HEAD

Also update graphviz to just use their standard configuration script, making the patch no longer necessary.

Most people will be using the bottle anyway, so it will not affect them.
But this will allow people to use custom build options and build from head.

**NOTE:** I had thought I would need to add `depends_on "gd" => :build` but brew refuses it. All built fine without it.

For testing:

I built with `--HEAD` and verified a new feature that was added.
I built without any options (but not using bottle). Verified it did converted my sample file.

Thanks all