### PR TITLE
show caveats after post_install

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -176,7 +176,6 @@ module Homebrew
     fi.debug               = ARGV.debug?
     fi.prelude
     fi.install
-    fi.caveats
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError
     # We already attempted to install f as part of the dependency tree of

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -27,7 +27,6 @@ module Homebrew
     fi.debug               = ARGV.debug?
     fi.prelude
     fi.install
-    fi.caveats
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError
     # next

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -67,7 +67,6 @@ module Homebrew
     outdated_keg.unlink if outdated_keg
 
     fi.install
-    fi.caveats
     fi.finish
 
     # If the formula was pinned, and we were force-upgrading it, unpin and

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -364,7 +364,6 @@ class FormulaInstaller
     fi.prelude
     oh1 "Installing #{formula.full_name} dependency: #{Tty.green}#{dep.name}#{Tty.reset}"
     fi.install
-    fi.caveats
     fi.finish
   rescue Exception
     ignore_interrupts do
@@ -408,6 +407,8 @@ class FormulaInstaller
         post_install
       end
     end
+
+    caveats
 
     ohai "Summary" if verbose? || show_summary_heading?
     puts summary


### PR DESCRIPTION
So I was doing a brew -v install postgresql yesterday, and I ended up going to #machomebrew to ask why there wasn't a launchctl config for it, when this is clearly described in the caveats.

The problem was that the post_install for postgresql runs initdb, which creates the database directory and displays its own instructions for how to start the database, and I thought these were the instructions from homebrew.

So to reduce possible confusion for other users, I wrote this patch which moves the caveats display to after the post_install. More details in the commit message.