### PR TITLE
ngircd support for "debug" and "sniffer" compile options

### DIFF
--- a/Library/Formula/ngircd.rb
+++ b/Library/Formula/ngircd.rb
@@ -13,6 +13,8 @@ class Ngircd < Formula
 
   option "with-iconv", "Enable character conversion using libiconv."
   option "with-pam", "Enable user authentication using PAM."
+  option "with-sniffer", "Enable IRC traffic sniffer (also enables additional debug output)."
+  option "with-debug", "Enable additional debug output."
 
   # Older Formula used the next option by default, so keep it unless
   # deactivated by the user:
@@ -23,7 +25,6 @@ class Ngircd < Formula
 
   def install
     args = %W[
-      --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
       --sysconfdir=#{HOMEBREW_PREFIX}/etc
@@ -34,6 +35,8 @@ class Ngircd < Formula
     args << "--with-iconv" if build.with? "iconv"
     args << "--with-ident" if build.with? "ident"
     args << "--with-pam" if build.with? "pam"
+    args << "--enable-debug" if build.with? "debug"
+    args << "--enable-sniffer" if build.with? "sniffer"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Previous the ngircd formula explicitly specified "--disable-debug" and did not support "--enable-sniffer". This made it impossible to create a debug-able build using the stock Homebrew formula.  While I can understand defaulting to a non-debug and non-sniffer build for privacy reasons, precluding the options seems overly restrictive. 

Note that building with debug of sniffer enabled does not cause the features to be active at runtime, as per the following output:

> ./ngircd --help
> ngIRCd 22.1-DEBUG+IDENT+IPv6+IRCPLUS+PAM+SNIFFER+SSL+SYSLOG+ZLIB x86_64/apple/darwin14.4.0
>Copyright (c)2001-2014 Alexander Barton (<alex@barton.de>) and Contributors.
>Homepage: <http://ngircd.barton.de/>
>
>This is free software; see the source for copying conditions. There is NO
>warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
>
> -d, --debug        log extra debug messages
>  -f, --config <f>   use file <f> as configuration file
>  -n, --nodaemon     don't fork and don't detach from controlling terminal
>  -p, --passive      disable automatic connections to other servers
>  -s, --sniffer      enable network sniffer and display all IRC traffic
>  -t, --configtest   read, validate and display configuration; then exit
>  -V, --version      output version information and exit
>  -h, --help         display this help and exit

A user who wants to enable these features will have to specify the install time options and edit the launchd plist to include the appropriate switches.