### PR TITLE
bazaar fixes

### DIFF
--- a/Library/Formula/bazaar.rb
+++ b/Library/Formula/bazaar.rb
@@ -3,7 +3,7 @@ class Bazaar < Formula
   homepage "http://bazaar.canonical.com/"
   url "https://launchpad.net/bzr/2.6/2.6.0/+download/bzr-2.6.0.tar.gz"
   sha256 "0994797182eb828867eee81cccc79480bd2946c99304266bc427b902cf91dab0"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -26,27 +26,7 @@ class Bazaar < Formula
     inreplace "bzr", "#! /usr/bin/env python", "#!/usr/bin/python"
     libexec.install "bzr", "bzrlib"
 
-    bin.install_symlink libexec/"bzr"
-  end
-
-  def post_install
-    # Install the plugins under /var/bazaar/plugins/
-    plugins_orig = libexec/"bzrlib/plugins"
-    plugins_new = var/"bazaar/plugins"
-
-    Dir[plugins_orig/"*"].each do |plugin|
-      path = Pathname.new plugin
-      plugins_new.install plugin unless File.exist? (plugins_new/path.basename)
-    end
-
-    rm_rf plugins_orig
-    ln_s plugins_new, plugins_orig
-  end
-
-  def caveats; <<-EOS
-      The plugins directory is located at:
-        #{var}/bazaar/plugins
-    EOS
+    (bin/"bzr").write_env_script(libexec/"bzr", :BZR_PLUGIN_PATH => "+user:#{HOMEBREW_PREFIX}/share/bazaar/plugins")
   end
 
   test do

--- a/Library/Formula/bzr-fastimport.rb
+++ b/Library/Formula/bzr-fastimport.rb
@@ -3,6 +3,7 @@ class BzrFastimport < Formula
   homepage "https://launchpad.net/bzr-fastimport"
   url "https://launchpad.net/bzr-fastimport/trunk/0.13.0/+download/bzr-fastimport-0.13.0.tar.gz"
   sha256 "5e296dc4ff8e9bf1b6447e81fef41e1217656b43368ee4056a1f024221e009eb"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,8 +16,8 @@ class BzrFastimport < Formula
   depends_on "bazaar"
 
   resource "python-fastimport" do
-    url "https://launchpad.net/python-fastimport/trunk/0.9.0/+download/python-fastimport-0.9.0.tar.gz"
-    sha256 "07d1d3800b1cfaa820b62c5a88c40cc7e32be9b14d9c6d3298721f32df8e1dec"
+    url "https://launchpad.net/python-fastimport/trunk/0.9.2/+download/python-fastimport-0.9.2.tar.gz"
+    sha256 "fd60f1173e64a5da7c5d783f17402f795721b7548ea3a75e29c39d89a60f261e"
   end
 
   def install
@@ -24,33 +25,20 @@ class BzrFastimport < Formula
       system "python", *Language::Python.setup_install_args(libexec/"vendor")
     end
 
-    libexec.install Dir["*"]
-
-    # The plugin must be symlinked in bazaar/plugins to work
-    target = var/"bazaar/plugins/fastimport"
-    # we need to remove the target before symlinking it because if we don't and
-    # the symlink exists from a previous installation the new symlink will be
-    # created inside libexec instead of overriding the previous one because ln
-    # itself follows symlinks.
-    rm_rf target if target.exist?
-    ln_s libexec, target
+    (share/"bazaar/plugins/fastimport").install Dir["*"]
   end
 
   def caveats; <<-EOS.undent
     In order to use this plugin you must set your PYTHONPATH in your ~/.bashrc:
 
-      export PYTHONPATH="#{libexec}/vendor/lib/python2.7/site-packages:$PYTHONPATH"
+      export PYTHONPATH="#{opt_libexec}/vendor/lib/python2.7/site-packages:$PYTHONPATH"
 
   EOS
   end
 
   test do
-    bazaar = Formula["bazaar"]
-    assert File.exist?(bazaar.libexec/"bzrlib/plugins/fastimport/__init__.py"),
-      "The fastimport plugin must have been symlinked under bzrlib/plugins/"
-
-    bzr = bazaar.bin/"bzr"
     ENV.prepend_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    bzr = Formula["bazaar"].bin/"bzr"
     system bzr, "init"
     assert_match(/fastimport #{version}/,
                  shell_output("#{bzr} plugins --verbose"))


### PR DESCRIPTION
With the changes in a838988c4da05db3da941f1fa1f4ae0192753fc9, plugins included with bzr are copied into `var/bazaar/plugins/`. There's a few issues with this:

1. It's not necessary to copy anything into `var/bazaar/plugins/`, because bzr knows where its included plugins are.
2. `var/bazaar/plugins/` is not a default path bzr searches in for plugins, so it doesn't actually load anything from there.
3. The files copied into `var/bazaar/plugins/` will not be removed if the user uninstalls bzr.

I assume this change was made so that the bzr-fastimport formula could work, added in af04a73456ad98ad45397e20e4a3de3b60174eb4. However, it won't actually work due to Point `2`. Point `3` also applies. Currently, the test for bzr-fastimport is failing.

@bfontaine: I bet you already had bzr-fastimport installed in `~/.bazaar/plugins`, so the test passed on your system.
