### PR TITLE
bib-tool 2.61

### DIFF
--- a/Library/Formula/bib-tool.rb
+++ b/Library/Formula/bib-tool.rb
@@ -1,20 +1,8 @@
-# This is needed because of a problem with the tarball for 2.60
-# Hopefully, it will not be needed for future releases
-# See https://github.com/Homebrew/homebrew/issues/40559
-class BibToolDownloadStrategy < CurlDownloadStrategy
-  def stage
-    with_system_path { safe_system "tar", "xqf", cached_location, "BibTool/doc/bibtool.tex" }
-    with_system_path { safe_system "tar", "xf", cached_location, "--exclude", "BibTool/doc/bibtool.tex" }
-    chdir
-  end
-end
-
 class BibTool < Formula
   desc "Manipulates BibTeX databases"
   homepage "http://www.gerd-neugebauer.de/software/TeX/BibTool/index.en.html"
-  url "http://www.gerd-neugebauer.de/software/TeX/BibTool/BibTool-2.60.tar.gz",
-    :using => BibToolDownloadStrategy
-  sha256 "db84b264df7c069b5b1c8e0778dc70f4e335cd1c39d711dcd65bae02df809ad1"
+  url "https://github.com/ge-ne/bibtool/releases/download/BibTool_2_61/BibTool-2.61.tar.gz"
+  sha256 "8eaf351f1685078345a4446346559698fb58d8d1dfdf057418e5221132f9a8a4"
 
   bottle do
     sha256 "62861fe6407c2953ada2a8066ac23790b52eeab4c748a893a64358cffb7149e4" => :yosemite


### PR DESCRIPTION
The problem in the BibTool tarball from version 2.60 is gone in version 2.61, so the workaround discussed in https://github.com/Homebrew/homebrew/issues/40559 is no longer needed.

So I've deleted the special download strategy for the new version of BibTool.

Also, the pull request (https://github.com/Homebrew/homebrew/pull/40574) that I submitted to fix https://github.com/Homebrew/homebrew/issues/40559 introduced a problem when trying to install BibTool on Linux with Linuxbrew, since Linux doesn't use `bsdtar`, and the `--fast-read` option that was introduced as a workaround is only available in `bsdtar`, not `gnutar`. That was shortsighted on my part. Sorry about that.

This was mentioned in https://github.com/Homebrew/linuxbrew/issues/456 and ultimately fixed with a pull request to Linuxbrew (https://github.com/Homebrew/linuxbrew/pull/457).

In other words, the formulas for BibTool v. 2.60 diverged between Homebrew and Linuxbrew. This new formula for v. 2.61 works with both Homebrew and Linuxbrew (tested on Mac OS 10.10.4 and Ubuntu v. 14.04). I'm not sure how formulas are maintained across Homebrew and Linuxbrew, but there is no longer any need for them to diverge, so this new formula can be used in Linuxbrew, too. Should I submit a separate pull request to Homebrew/Linuxbrew? I don't think the commit can be straight-forwardly cherry-picked, since the formula in Linuxbrew is currently different.

Thanks! :smile: 