### PR TITLE
secp256k1

### DIFF
--- a/Library/Formula/secp256k1.rb
+++ b/Library/Formula/secp256k1.rb
@@ -1,0 +1,18 @@
+class Secp256k1 < Formula
+  desc "Optimized C library for EC operations on curve secp256k1"
+  homepage "https://github.com/bitcoin/secp256k1"
+  url "https://github.com/bitcoin/secp256k1.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
This PR adds a formula for [secp256k1](https://github.com/bitcoin/secp256k1), a cryptographic library commonly used in bitcoin-related tools (since bitcoin uses the secp256k1 ECDSA curve).

Unfortunately the source repository does not provide version tags or anything of that sort. The library has been around for a couple of years ago and is considered stable.

It is commonly known as secp256k1 (rather than libsecp256k1) and provides a `secp256k1.h` header. There are Ruby, Python, and Node bindings that use it under this name.