### PR TITLE
Enable gnome-pty-helper in vte3

### DIFF
--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -16,7 +16,8 @@ class Vte3 < Formula
       "--disable-dependency-tracking",
       "--prefix=#{prefix}",
       "--disable-Bsymbolic",
-      "--enable-introspection=yes"
+      "--enable-introspection=yes",
+      "--enable-gnome-pty-helper"
     ]
 
     system "./configure", *args


### PR DESCRIPTION
This makes the vte3 formula behave the way it used to (when vte 0.36 was being used). The current version doesn't enable gnome-pty-helper by default, which means many use-cases for VteTerminal are broken.