### PR TITLE
sdl_ttf: add patch for broken font rendering

### DIFF
--- a/Library/Formula/sdl_ttf.rb
+++ b/Library/Formula/sdl_ttf.rb
@@ -18,8 +18,16 @@ class SdlTtf < Formula
   depends_on "sdl"
   depends_on "freetype"
 
+  # Fix broken TTF_RenderGlyph_Shaded()
+  # https://bugzilla.libsdl.org/show_bug.cgi?id=1433
+  patch do
+    url "https://gist.githubusercontent.com/tomyun/a8d2193b6e18218217c4/raw/8292c48e751c6a9939db89553d01445d801420dd/sdl_ttf-fix-1433.diff"
+    sha256 "4c2e38bb764a23bc48ae917b3abf60afa0dc67f8700e7682901bf9b03c15be5f"
+  end
+
   def install
     ENV.universal_binary if build.universal?
+    inreplace "SDL_ttf.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
This fixes [an old issue](https://bugzilla.libsdl.org/show_bug.cgi?id=1433) of `sdl_ttf` 2.0.11 that completely breaks some types (e.g. `TTF_RenderGlyph_Shaded`) of font rendering. It has been fixed in the latest version, 2.0.12, but only released under SDL2 (`sdl2_ttf`). There would be likely no more official release for SDL 1.x, I guess.
