### PR TITLE
lldpd 0.7.16

### DIFF
--- a/Library/Formula/lldpd.rb
+++ b/Library/Formula/lldpd.rb
@@ -1,8 +1,8 @@
 class Lldpd < Formula
   desc "Implementation library for LLDP"
   homepage "https://vincentbernat.github.io/lldpd/"
-  url "http://media.luffy.cx/files/lldpd/lldpd-0.7.15.tar.gz"
-  sha256 "c891d6d4480a6a890561ac43d8cc923bd027deb82a3999d65f37d96ca368c246"
+  url "http://media.luffy.cx/files/lldpd/lldpd-0.7.16.tar.gz"
+  sha256 "a0b85a5e685b8e7dad08b6f20ea79d8bec47d8dbf39daef419bd20ad7f37d63f"
 
   bottle do
     sha256 "168901752a250081bcfb46a44ec627fc5694716a1a5c76ad85685777f50d3adb" => :yosemite

--- a/Library/Formula/lldpd.rb
+++ b/Library/Formula/lldpd.rb
@@ -22,6 +22,8 @@ class Lldpd < Formula
   def install
     readline = Formula["readline"]
     args = ["--prefix=#{prefix}",
+            "--sysconfdir=#{etc}",
+            "--localstatedir=#{var}",
             "--with-xml",
             "--with-readline",
             "--with-privsep-chroot=/var/empty",
@@ -30,8 +32,8 @@ class Lldpd < Formula
             "--with-launchddaemonsdir=no",
             "CPPFLAGS=-I#{readline.include} -DRONLY=1",
             "LDFLAGS=-L#{readline.lib}"]
-    args << "--with-snmp" if build.with? "snmp"
-    args << "--with-json" if build.with? "json"
+    args << (build.with?("snmp") ? "--with-snmp" : "--without-snmp")
+    args << (build.with?("json") ? "--with-json" : "--without-json")
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Update lldpd to 0.7.16.

Also push some unrelated changes that would also fit 0.7.15:

 1. Move configuration files from `#{prefix}/etc` to `#{etc}`. Also, the local state dir, where the daemon is putting its socket, is moved from `#{prefix}/var` to `#{var}`. I am unsure if we can do that as is. Should there be a warning for configuration files? Users are very unlikely to have any configuration file.

 2. SNMP and JSON support are now autodetected. Ensure we disable them if the user didn't request them.