### PR TITLE
harfbuzz: enable Core Text support

### DIFF
--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -29,6 +29,7 @@ class Harfbuzz < Formula
       --prefix=#{prefix}
       --enable-introspection=yes
       --with-gobject=yes
+      --with-coretext=yes
     ]
 
     args << "--with-icu" if build.with? "icu4c"


### PR DESCRIPTION
Core Text is needed to support AAT fonts (many of the bundled systems
fonts for complex scripts) since HarfBuzz does not have native AAT
support yet.