### PR TITLE
rust 1.2.0

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -3,23 +3,23 @@ class Rust < Formula
   homepage "https://www.rust-lang.org/"
 
   stable do
-    url "https://static.rust-lang.org/dist/rustc-1.1.0-src.tar.gz"
-    sha256 "cb09f443b37ec1b81fe73c04eb413f9f656859cf7d00bc5088008cbc2a63fa8a"
+    url "https://static.rust-lang.org/dist/rustc-1.2.0-src.tar.gz"
+    sha256 "ea6eb983daf2a073df57186a58f0d4ce0e85c711bec13c627a8c85d51b6a6d78"
 
     resource "cargo" do
-      url "https://github.com/rust-lang/cargo.git", :revision => "b030d35d5cf6b35bf8a6bfd218ab4df9d6a86361"
+      url "https://github.com/rust-lang/cargo.git", :revision => "c0337700e747f3dc0caac2dc3fd51b65a4cde343"
     end
 
     # name includes date to satisfy cache
-    resource "cargo-nightly-2015-06-25" do
-      url "https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/2015-06-25/cargo-nightly-x86_64-apple-darwin.tar.gz"
-      sha256 "b2e07bbee79cb8ad1e4f91a43cc3d93603e068a46b89bbe934d01ff97bfb0060"
+    resource "cargo-nightly-2015-08-06" do
+      url "https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/2015-08-06/cargo-nightly-x86_64-apple-darwin.tar.gz"
+      sha256 "9170e002cd7aab344cffb8a2b59a37ad5849795447bd4b0d2731ecd9954175e9"
     end
 
     # name includes date to satisfy cache
-    resource "rustc-nightly-2015-06-25" do
-      url "https://static-rust-lang-org.s3.amazonaws.com/dist/2015-06-25/rustc-nightly-x86_64-apple-darwin.tar.gz"
-      sha256 "c4eb0a639b6deb3e2aceb1713afe6570118d1055bf189f1057a839238dbe7165"
+    resource "rustc-nightly-2015-08-06" do
+      url "https://static-rust-lang-org.s3.amazonaws.com/dist/2015-08-06/rustc-nightly-x86_64-apple-darwin.tar.gz"
+      sha256 "d1e4f1b621bca263003e29a43e31d4cef8a82d49e591a272cf6437a991ec5a5b"
     end
   end
 
@@ -64,11 +64,11 @@ class Rust < Formula
       cargo_stage_path = pwd
 
       if build.stable?
-        resource("rustc-nightly-2015-06-25").stage do
+        resource("rustc-nightly-2015-08-06").stage do
           system "./install.sh", "--prefix=#{cargo_stage_path}/rustc"
         end
 
-        resource("cargo-nightly-2015-06-25").stage do
+        resource("cargo-nightly-2015-08-06").stage do
           system "./install.sh", "--prefix=#{cargo_stage_path}/target/snapshot/cargo"
           # satisfy make target to skip download
           touch "#{cargo_stage_path}/target/snapshot/cargo/bin/cargo"


### PR DESCRIPTION
Hey all. This attempts to update rust to 1.2. I've never done this before so I've tried to do this to best of my ability. Rust 1.2 was announced on August 6, 2015, so I chose that day for the nightly/resource URLs (don't really know what those are used for). For cargo, I put it at the latest commit on August 9th since the date for that seemed to be more arbitrary to me (latest commit is just a doc change anyway). Tests ran and all.

P.S. I had to add the remote when pushing with the SSH URL (instead of https) because I've 2 factor authentication on, and didn't want to deal with OAuth.