### PR TITLE
dhcping, dnstracer: add mirrors

### DIFF
--- a/Library/Formula/dhcping.rb
+++ b/Library/Formula/dhcping.rb
@@ -2,6 +2,7 @@ class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
   homepage "http://www.mavetju.org/unix/general.php"
   url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 
   bottle do

--- a/Library/Formula/dnstracer.rb
+++ b/Library/Formula/dnstracer.rb
@@ -2,6 +2,7 @@ class Dnstracer < Formula
   desc "Trace a chain of DNS servers to the source"
   homepage "http://www.mavetju.org/unix/dnstracer.php"
   url "http://www.mavetju.org/download/dnstracer-1.9.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
 
   bottle do


### PR DESCRIPTION
Fixes  #42475. (#42645 added a mirror for dhcpdump, but there are two other formulae hosted on the same site.)

The mavetju.org site is back up now, but since it's a small site and has a history of going offline, may as well preemptively add the mirrors for a major host.