### PR TITLE
sdl2_mixer: add more optional deps

### DIFF
--- a/Library/Formula/sdl2_mixer.rb
+++ b/Library/Formula/sdl2_mixer.rb
@@ -6,17 +6,23 @@ class Sdl2Mixer < Formula
 
   head "http://hg.libsdl.org/SDL_mixer", :using => :hg
 
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "sdl2"
   depends_on "flac" => :optional
+  depends_on "fluid-synth" => :optional
+  depends_on "smpeg2" => :optional
   depends_on "libmikmod" => :optional
   depends_on "libvorbis" => :optional
-
-  option :universal
 
   def install
     ENV.universal_binary if build.universal?
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    if build.with? "smpeg2"
+      ENV["SMPEG_CONFIG"] = "#{Formula["smpeg2"].bin}/smpeg2-config"
+    end
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking"


### PR DESCRIPTION
Added `fluid-synth` and `smpeg2` (#21885) as optional dependencies.

Almost same as #42714 for SDL1, but had to export `SMPEG_CONFIG` to make `smpeg2-config` picked up.