### PR TITLE
Fix python lib finding on OS X 10.10.4

### DIFF
--- a/Library/Formula/swig.rb
+++ b/Library/Formula/swig.rb
@@ -12,6 +12,8 @@ class Swig < Formula
 
   option :universal
 
+  patch :DATA
+
   depends_on "pcre"
 
   def install
@@ -46,3 +48,17 @@ class Swig < Formula
     assert_equal "2", shell_output("ruby run.rb").strip
   end
 end
+__END__
+diff --git a/configure b/configure
+index 8c2c463..eb036e6 100755
+--- a/configure
++++ b/configure
+@@ -7663,7 +7663,7 @@ $as_echo_n "checking for Python lib dir... " >&6; }
+       PYLIBDIR=`($PYTHON -c "import sys; sys.stdout.write(sys.lib)") 2>/dev/null`
+       if test -z "$PYLIBDIR"; then
+         # Fedora patch Python to add sys.lib, for other distros we assume "lib".
+-        PYLIBDIR="lib"
++        PYLIBDIR="$PYPREFIX/lib"
+       fi
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYLIBDIR" >&5
+ $as_echo "$PYLIBDIR" >&6; }


### PR DESCRIPTION
While trying to install gnuradio I had some issues with python crashing ("PyThreadState_Get: no current thread Abort trap: 6"-type fatal errors) which I narrowed down to swig using the system library when everything else was linked against my homebrew python. This patch fixes that.