### PR TITLE
boost (fix test for multi-threading)

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -164,7 +164,13 @@ class Boost < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-std=c++1y", "-lboost_system", "-o", "test"
+    test_args = ["-std=c++1y"]
+    if build.with? "single"
+      test_args << "-lboost_system"
+    else
+      test_args << "-lboost_system-mt"
+    end
+    system ENV.cxx, "test.cpp", *test_args, "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
This formula provides a flag to build the library without a
single-threaded variant ("--without-single").  The library will
build successfully, but the test case will still fail, since the
provided test assumes the single-threaded variant exists.
(Specifically, the test includes a linker flag to the single-
threaded variant.)

This can be fixed by adding a bit more logic to the test, so that
if the single-threaded variant has been excluded, it will try to
link to the multi-threaded variant.

(Naming convention for the boost library variants:
http://www.boost.org/doc/libs/1_58_0/more/getting_started/unix-variants.html#library-naming)

The original bug can be reproduced by:
``` brew install boost --without-single && brew test boost```
which, when compiled with clang, returns the error:
```
ld: library not found for -lboost_system
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: boost: failed
```
