### PR TITLE
Fix jq 1.4 tarball location

### DIFF
--- a/Library/Formula/jq.rb
+++ b/Library/Formula/jq.rb
@@ -1,7 +1,7 @@
 class Jq < Formula
   desc "Lightweight and flexible command-line JSON processor"
   homepage "https://stedolan.github.io/jq/"
-  url "https://stedolan.github.io/jq/download/source/jq-1.4.tar.gz"
+  url "https://github.com/stedolan/jq/releases/download/jq-1.4/jq-1.4.tar.gz"
   sha256 "998c41babeb57b4304e65b4eb73094279b3ab1e63801b6b4bddd487ce009b39d"
 
   bottle do


### PR DESCRIPTION
We moved downloadables for jq out of the gh-pages branch and into github releases.  This means that the URL for the jq 1.4 tarball changed.  Sadly, github has no way to configure redirects.