### PR TITLE
minizinc 2.0.6

### DIFF
--- a/Library/Formula/minizinc.rb
+++ b/Library/Formula/minizinc.rb
@@ -4,13 +4,8 @@ class Minizinc < Formula
   head "https://github.com/MiniZinc/libminizinc.git", :branch => "develop"
 
   stable do
-    url "http://www.minizinc.org/downloads/release-2.0.1/libminizinc-2.0.1.tar.gz"
-    sha256 "b2dedd456d71d5670b24ec4b159a05d53c00e2aae232171c0e3be31cec915aff"
-
-    patch do
-      url "https://github.com/MiniZinc/libminizinc/commit/5c9341c32df7f6d1f11249bc93ef62fd860444ab.diff"
-      sha256 "30562c42e08bda8f79ff87e53054c7def125ce5e4a7ee1d74599068bdd572505"
-    end
+    url "https://github.com/MiniZinc/libminizinc/archive/2.0.6.tar.gz"
+    sha256 "95b413c82f510e406f32bbb779fe1221a3b6bf2931854f61ca44bcefc0788f50"
   end
   bottle do
     cellar :any
@@ -25,8 +20,7 @@ class Minizinc < Formula
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
-      system "cmake", "--build", "."
-      system "make", "install"
+      system "cmake", "--build", ".", "--target", "install"
     end
   end
 


### PR DESCRIPTION
The change of `cmake --build ...` is just to match with what the [minizinc doc says](https://github.com/MiniZinc/libminizinc/blob/master/INSTALL.txt#L35).