### PR TITLE
Formula renames improvements

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -60,27 +60,18 @@ module Homebrew
       tabs.each(&:write)
     end if load_tap_migrations
 
-    # Migrate installed renamed formulae from main Homebrew repository.
-    if load_formula_renames
-      report.select_formula(:D).each do |oldname|
-        newname = FORMULA_RENAMES[oldname]
-        next unless newname
-        next unless (dir = HOMEBREW_CELLAR/oldname).directory? && !dir.subdirs.empty?
+    load_formula_renames
+    report.update_renamed
 
-        begin
-          migrator = Migrator.new(Formulary.factory("homebrew/homebrew/#{newname}"))
-          migrator.migrate
-        rescue Migrator::MigratorDifferentTapsError
-        end
+    # Migrate installed renamed formulae from core and taps.
+    report.select_formula(:R).each do |oldname, newname|
+      if oldname.include?("/")
+        user, repo, oldname = oldname.split("/", 3)
+        newname = newname.split("/", 3).last
+      else
+        user, repo = "homebrew", "homebrew"
       end
-    end
 
-    # Migrate installed renamed formulae from taps
-    report.select_formula(:D).each do |oldname|
-      user, repo, oldname = oldname.split("/", 3)
-      next unless user && repo && oldname
-      tap = Tap.new(user, repo)
-      next unless newname = tap.formula_renames[oldname]
       next unless (dir = HOMEBREW_CELLAR/oldname).directory? && !dir.subdirs.empty?
 
       begin
@@ -320,14 +311,45 @@ class Report
 
     dump_formula_report :A, "New Formulae"
     dump_formula_report :M, "Updated Formulae"
+    dump_formula_report :R, "Renamed Formulae"
     dump_formula_report :D, "Deleted Formulae"
   end
 
-  def select_formula(key)
-    fetch(key, []).map do |path|
+  def update_renamed
+    @hash[:R] ||= []
+
+    fetch(:D, []).each do |path|
       case path.to_s
       when HOMEBREW_TAP_PATH_REGEX
-        "#{$1}/#{$2.sub("homebrew-", "")}/#{path.basename(".rb")}"
+        user = $1
+        repo = $2.sub("homebrew-", "")
+        oldname = path.basename(".rb").to_s
+        next unless newname = Tap.new(user, repo).formula_renames[oldname]
+      else
+        oldname = path.basename(".rb").to_s
+        next unless newname = FORMULA_RENAMES[oldname]
+      end
+
+      if fetch(:A, []).include?(newpath = path.dirname.join("#{newname}.rb"))
+        @hash[:R] << [path, newpath]
+      end
+    end
+
+    @hash[:A] -= @hash[:R].map(&:last) if @hash[:A]
+    @hash[:D] -= @hash[:R].map(&:first) if @hash[:D]
+  end
+
+  def select_formula(key)
+    fetch(key, []).map do |path, newpath|
+      if path.to_s =~ HOMEBREW_TAP_PATH_REGEX
+        tap = "#{$1}/#{$2.sub("homebrew-", "")}"
+        if newpath
+          ["#{tap}/#{path.basename(".rb")}", "#{tap}/#{newpath.basename(".rb")}"]
+        else
+          "#{tap}/#{path.basename(".rb")}"
+        end
+      elsif newpath
+        ["#{path.basename(".rb")}", "#{newpath.basename(".rb")}"]
       else
         path.basename(".rb").to_s
       end
@@ -336,6 +358,7 @@ class Report
 
   def dump_formula_report(key, title)
     formula = select_formula(key)
+    formula.map! { |oldname, newname| "#{oldname} -> #{newname}" } if key == :R
     unless formula.empty?
       ohai title
       puts_columns formula

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -302,8 +302,8 @@ Note that these flags should only appear after a command.
     Migrate renamed packages to new name, where <formulae> are old names of
     packages.
 
-    If `--force` is passed and installed <formulae> have nil tap, then treat
-    them like packages installed from core.
+    If `--force` is passed, then treat installed <formulae> and passed <formulae>
+    like if they are from same taps and migrate them anyway.
 
   * `options [--compact] [--all] [--installed]` <formula>:
     Display install options specific to <formula>.

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -27,23 +27,19 @@ class Migrator
 
   class MigratorDifferentTapsError < RuntimeError
     def initialize(formula, tap)
-      if tap.nil?
-        super <<-EOS.undent
-        #{formula.name} from #{formula.tap} is given, but old name #{formula.oldname} wasn't installed from taps or core formulae
-
-        You can try `brew migrate --force #{formula.oldname}`.
-        EOS
-      else
+      msg = if tap == "Homebrew/homebrew"
+        "Please try to use #{formula.oldname} to refer the formula.\n"
+      elsif tap
         user, repo = tap.split("/")
         repo.sub!("homebrew-", "")
-        name = "fully-qualified #{user}/#{repo}/#{formula.oldname}"
-        name = formula.oldname if tap == "Homebrew/homebrew"
-        super <<-EOS.undent
-        #{formula.name} from #{formula.tap} is given, but old name #{formula.oldname} was installed from #{tap}
-
-        Please try to use #{name} to refer the formula
-        EOS
+        "Please try to use fully-qualified #{user}/#{repo}/#{formula.oldname} to refer the formula.\n"
       end
+
+      super <<-EOS.undent
+      #{formula.name} from #{formula.tap} is given, but old name #{formula.oldname} was installed from #{tap ? tap : "path or url"}.
+
+      #{msg}To force migrate use `brew migrate --force #{formula.oldname}`.
+      EOS
     end
   end
 
@@ -67,7 +63,10 @@ class Migrator
 
     @old_tabs = oldpath.subdirs.each.map { |d| Tab.for_keg(Keg.new(d)) }
     @old_tap = old_tabs.first.tap
-    raise MigratorDifferentTapsError.new(formula, old_tap) unless from_same_taps?
+
+    if !ARGV.force? && !from_same_taps?
+      raise MigratorDifferentTapsError.new(formula, old_tap)
+    end
 
     @newpath = HOMEBREW_CELLAR/formula.name
 
@@ -92,9 +91,7 @@ class Migrator
   end
 
   def from_same_taps?
-    if old_tap == nil && formula.core_formula? && ARGV.force?
-      true
-    elsif formula.tap == old_tap
+    if formula.tap == old_tap
       true
     # Homebrew didn't use to update tabs while performing tap-migrations,
     # so there can be INSTALL_RECEIPT's containing wrong information about

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -293,7 +293,7 @@ If no \fIformulae\fR are given, check all installed brews\.
 \fBmigrate [\-\-force]\fR \fIformulae\fR: Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
 .
 .IP
-If \fB\-\-force\fR is passed and installed \fIformulae\fR have nil tap, then treat them like packages installed from core\.
+If \fB\-\-force\fR is passed, then treat installed \fIformulae\fR and passed \fIformulae\fR like if they are from same taps and migrate them anyway\.
 .
 .IP "\(bu" 4
 \fBoptions [\-\-compact] [\-\-all] [\-\-installed]\fR \fIformula\fR: Display install options specific to \fIformula\fR\.


### PR DESCRIPTION
* Add `--force` to skip check whether installed and migrating formulae are from the same taps.
* Add "Renamed Formulae" block to report.

@xu-cheng @mikemcquaid this is a branch for improvements for https://github.com/Homebrew/homebrew/pull/41006.

I'm going to work on improvements on this branch until everybody is happy.

