### PR TITLE
test-bot: check file extname when calculating formulae diff

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -252,8 +252,10 @@ module Homebrew
           "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
           start_revision, end_revision, "--", path
         ).lines.map do |line|
-          File.basename(line.chomp, ".rb")
-        end
+          file = line.chomp
+          next unless File.extname(file) == ".rb"
+          File.basename(file, ".rb")
+        end.compact
       end
 
       def brew_update


### PR DESCRIPTION
To solve:
```
==> brew uses Homebrew/games/formula_renames.json			Error: No available formula for homebrew/games/formula_renames.json 
 FAILED
```

cc @mikemcquaid @vladshablinsky 