### PR TITLE
tika 1.10

### DIFF
--- a/Library/Formula/tika.rb
+++ b/Library/Formula/tika.rb
@@ -1,12 +1,12 @@
 class Tika < Formula
   desc "Content analysis toolkit"
   homepage "https://tika.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.9.jar"
-  sha256 "b67bb2d3979517c5e1f43e865e8ba8f55a70dcce20fae7d4c4437c5906181fc8"
+  url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.10.jar"
+  sha256 "21ac3c156c2b53c451599f1b2c441c7898fce8efb7e912f6894e5e543d7cd48c"
 
   resource "server" do
-    url "https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.9/tika-server-1.9.jar"
-    sha256 "ae20919b4ab150613bf5c1037031aef0920c0755fff96523e3ed3ccbc89ca7c6"
+    url "https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.10/tika-server-1.10.jar"
+    sha256 "d1977896455d78c4a080886d460726393360329a4b8e7d0b290ee24571aede39"
   end
 
   def install


### PR DESCRIPTION
https://dist.apache.org/repos/dist/release/tika/CHANGES-1.10.txt
https://tika.apache.org/1.10/index.html

Note the new requirement for Java 7, dropping support for Java 6:
https://issues.apache.org/jira/browse/TIKA-1536