### PR TITLE
bullet: 2.83.6 release

### DIFF
--- a/Library/Formula/bullet.rb
+++ b/Library/Formula/bullet.rb
@@ -1,8 +1,8 @@
 class Bullet < Formula
   desc "Physics SDK"
   homepage "http://bulletphysics.org/wordpress/"
-  url "https://github.com/bulletphysics/bullet3/archive/2.83.5.tar.gz"
-  sha256 "df6d58898d3d3bf117854dd64467dbd09625e048624c797649b46bf1c595b152"
+  url "https://github.com/bulletphysics/bullet3/archive/2.83.6.tar.gz"
+  sha256 "dcd5448f31ded71c7bd22fddd7d816ac590ae7b97e1fdda8d1253f8ff3655571"
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do
@@ -11,8 +11,6 @@ class Bullet < Formula
     sha256 "cac6c51229ea72bb3ba4c174ed302d235a2bd34050e7834ff19af05931ff654b" => :mavericks
     sha256 "1e3e54e77cba617722599ccb0dde40b9b7858b054f1d24032fd458d4e0a04030" => :mountain_lion
   end
-
-  depends_on "cmake" => :build
 
   deprecated_option "framework" => "with-framework"
   deprecated_option "shared" => "with-shared"
@@ -26,6 +24,8 @@ class Bullet < Formula
   option "with-demo",             "Build demo applications"
   option "with-extra",            "Build extra library"
   option "with-double-precision", "Use double precision"
+
+  depends_on "cmake" => :build
 
   def install
     args = []


### PR DESCRIPTION
Also move `depends_on` after `option`'s to comply with `brew audit --strict`.