### PR TITLE
Don't explicitly enable C++11 for ZNC formula.

### DIFF
--- a/Library/Formula/znc.rb
+++ b/Library/Formula/znc.rb
@@ -28,7 +28,6 @@ class Znc < Formula
   depends_on "icu4c" => :optional
 
   def install
-    ENV.cxx11
     args = ["--prefix=#{prefix}"]
     args << "--enable-debug" if build.with? "debug"
 


### PR DESCRIPTION
Let ./configure to figure it out.
Fix #42822