### PR TITLE
jemalloc: remove prefix

### DIFF
--- a/Library/Formula/jemalloc.rb
+++ b/Library/Formula/jemalloc.rb
@@ -4,6 +4,7 @@ class Jemalloc < Formula
   url "http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2"
   sha256 "e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe"
   head "https://github.com/jemalloc/jemalloc.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,7 @@ class Jemalloc < Formula
   end
 
   def install
-    system "./configure", "--disable-debug", "--prefix=#{prefix}"
+    system "./configure", "--disable-debug", "--prefix=#{prefix}", "--with-jemalloc-prefix="
     system "make", "install"
 
     # This otherwise conflicts with google-perftools


### PR DESCRIPTION
This option controls what prefix, if any, should be added to all the
function names in the library. The default on platforms other than OS X
is to not use a prefix, but for whatever reason, one is added on OS X.
This change overrides that back to the default on other platforms, which
is necessary for any code using jemalloc which wants to be portable
between OS X and Linux.

(MacPorts does this too, FWIW.)