### PR TITLE
caveats.rb: don't print elisp_caveats for keg-only

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -134,6 +134,7 @@ class Caveats
   end
 
   def elisp_caveats
+    return if f.keg_only?
     if keg && keg.elisp_installed?
       <<-EOS.undent
         Emacs Lisp files have been installed to:


### PR DESCRIPTION
Since they won't have been installed into `#{HOMEBREW_PREFIX}/share/emacs/site-lisp/`