### PR TITLE
chrome-cli: REALLY add support for Chromium

### DIFF
--- a/Library/Formula/chrome-cli.rb
+++ b/Library/Formula/chrome-cli.rb
@@ -31,7 +31,7 @@ class ChromeCli < Formula
     # Chromium builds; see:
     # https://github.com/prasmussen/chrome-cli/issues/31
     rm_rf "build"
-    inreplace "chrome-cli/App.m", "com.google.Chrome", "org.Chromium.chromium"
+    inreplace "chrome-cli/App.m", "com.google.Chrome.canary", "org.Chromium.chromium"
     xcodebuild "SDKROOT=", "SYMROOT=build"
     bin.install "build/Release/chrome-cli" => "chromium-cli"
   end


### PR DESCRIPTION
I have made a BIG mistake in the previous PR: once the app id "com.google.Chrome" gets replaced with "com.google.Chrome.canary", you should replace that with "org.Chromium.chromium", not the other one.
That should fix https://github.com/Homebrew/homebrew/issues/42349 and https://github.com/Homebrew/homebrew/issues/42848, they are the same.