### PR TITLE
internetarchive: fix build with newer versions of clang

### DIFF
--- a/Library/Formula/internetarchive.rb
+++ b/Library/Formula/internetarchive.rb
@@ -3,8 +3,8 @@ require "utils/json"
 class Internetarchive < Formula
   desc "Python wrapper for the various Internet Archive APIs"
   homepage "https://github.com/jjjake/internetarchive"
-  url "https://pypi.python.org/packages/source/i/internetarchive/internetarchive-0.8.5.tar.gz"
-  sha256 "2ba5e8db802953b1ac25a73c88d0955df2e4cd947bc664d94d6000003b91f14e"
+  url "https://pypi.python.org/packages/source/i/internetarchive/internetarchive-0.9.8.tar.gz"
+  sha256 "d89a0e04ea99e65ead8f5a00114c807e0d75108b76eaf34be4abd9f0c41bf73e"
 
   bottle do
     cellar :any
@@ -14,8 +14,8 @@ class Internetarchive < Formula
   end
 
   resource "PyYAML" do
-    url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.10.tar.gz"
-    sha256 "e713da45c96ca53a3a8b48140d4120374db622df16ab71759c9ceb5b8d46fe7c"
+    url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.11.tar.gz"
+    sha256 "c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8"
   end
 
   resource "args" do
@@ -34,8 +34,8 @@ class Internetarchive < Formula
   end
 
   resource "docopt" do
-    url "https://pypi.python.org/packages/source/d/docopt/docopt-0.6.1.tar.gz"
-    sha256 "71ad940a773fbc23be6093e9476ad57b2ecec446946a28d30127501f3b29aa35"
+    url "https://pypi.python.org/packages/source/d/docopt/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
   end
 
   resource "requests" do
@@ -44,13 +44,13 @@ class Internetarchive < Formula
   end
 
   resource "py" do
-    url "https://pypi.python.org/packages/source/p/py/py-1.4.30.tar.gz"
-    sha256 "b703e57685ed7c280b1a51c496a4984d83d89def2a930b5e9e5da5a6ca151514"
+    url "https://pypi.python.org/packages/source/p/py/py-1.4.31.tar.gz"
+    sha256 "a6501963c725fc2554dabfece8ae9a8fb5e149c0ac0a42fd2b02c5c1c57fc114"
   end
 
   resource "pytest" do
-    url "https://pypi.python.org/packages/source/p/pytest/pytest-2.3.4.zip"
-    sha256 "5616f744a311c5f5fbb44943aaa41c32df70ba132159a0a9fb6c999060d7645c"
+    url "https://pypi.python.org/packages/source/p/pytest/pytest-2.8.5.zip"
+    sha256 "44bb32fb3925b5a284ceee1af55e0a63d25436ec415232089403eed3a347667e"
   end
 
   resource "jsonpatch" do
@@ -59,22 +59,22 @@ class Internetarchive < Formula
   end
 
   resource "cython" do
-    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.23.tar.gz"
-    sha256 "9fd01e8301c24fb3ba0411ad8eb16f5d9f9f8e66b1281fbe7aba2a9bd9d343dc"
+    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.23.4.tar.gz"
+    sha256 "fec42fecee35d6cc02887f1eef4e4952c97402ed2800bfe41bbd9ed1a0730d8e"
   end
 
   resource "greenlet" do
-    url "https://pypi.python.org/packages/source/g/greenlet/greenlet-0.4.7.zip"
-    sha256 "f32c4fa4e06443e1bdb0d32b69e7617c25ff772c3ffc6d0aa63d192e9fd795fe"
+    url "https://pypi.python.org/packages/source/g/greenlet/greenlet-0.4.9.tar.gz"
+    sha256 "79f9b8bbbb1c599c66aed5e643e8b53bae697cae46e0acfc4ee461df48a90012"
   end
 
   # For "speedups": https://pypi.python.org/pypi/internetarchive, Installation
+
   resource "ujson" do
-    url "https://pypi.python.org/packages/source/u/ujson/ujson-1.33.zip"
-    sha256 "68cf825f227c82e1ac61e423cfcad923ff734c27b5bdd7174495d162c42c602b"
+    url "https://pypi.python.org/packages/source/u/ujson/ujson-1.34.tar.gz"
+    sha256 "3d09807685ecf2eed3b68985aca4f7ad619eadfae9054d1e23a20c54ea861102"
   end
 
-  # For "speedups": https://pypi.python.org/pypi/internetarchive, Installation
   resource "gevent" do
     url "https://pypi.python.org/packages/source/g/gevent/gevent-1.0.2.tar.gz"
     sha256 "3ae1ca0f533ddcb17aab16ce66b424b3f3b855ff3b9508526915d3c6b73fba31"

--- a/Library/Formula/internetarchive.rb
+++ b/Library/Formula/internetarchive.rb
@@ -44,8 +44,8 @@ class Internetarchive < Formula
   end
 
   resource "py" do
-    url "https://pypi.python.org/packages/source/p/py/py-1.4.26.tar.gz"
-    sha256 "28dd0b90d29b386afb552efc4e355c889f4639ce93658a7872a2150ece28bb89"
+    url "https://pypi.python.org/packages/source/p/py/py-1.4.30.tar.gz"
+    sha256 "b703e57685ed7c280b1a51c496a4984d83d89def2a930b5e9e5da5a6ca151514"
   end
 
   resource "pytest" do
@@ -58,14 +58,9 @@ class Internetarchive < Formula
     sha256 "43d725fb21d31740b4af177d482d9ae53fe23daccb13b2b7da2113fe80b3191e"
   end
 
-  resource "ujson" do
-    url "https://pypi.python.org/packages/source/u/ujson/ujson-1.33.zip"
-    sha256 "68cf825f227c82e1ac61e423cfcad923ff734c27b5bdd7174495d162c42c602b"
-  end
-
   resource "cython" do
-    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.18.tar.gz"
-    sha256 "cf4ad7faed6bcfdb76da42492ce26ebf927129da3d4849d6982dd2e843d7de8c"
+    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.23.tar.gz"
+    sha256 "9fd01e8301c24fb3ba0411ad8eb16f5d9f9f8e66b1281fbe7aba2a9bd9d343dc"
   end
 
   resource "greenlet" do
@@ -73,12 +68,22 @@ class Internetarchive < Formula
     sha256 "f32c4fa4e06443e1bdb0d32b69e7617c25ff772c3ffc6d0aa63d192e9fd795fe"
   end
 
+  # For "speedups": https://pypi.python.org/pypi/internetarchive, Installation
+  resource "ujson" do
+    url "https://pypi.python.org/packages/source/u/ujson/ujson-1.33.zip"
+    sha256 "68cf825f227c82e1ac61e423cfcad923ff734c27b5bdd7174495d162c42c602b"
+  end
+
+  # For "speedups": https://pypi.python.org/pypi/internetarchive, Installation
   resource "gevent" do
-    url "https://pypi.python.org/packages/source/g/gevent/gevent-1.0.tar.gz"
-    sha256 "bfa9d846db91a7d8b6a36e87353eed641c7e3e7d0bfa0b9975796d227f2db4eb"
+    url "https://pypi.python.org/packages/source/g/gevent/gevent-1.0.2.tar.gz"
+    sha256 "3ae1ca0f533ddcb17aab16ce66b424b3f3b855ff3b9508526915d3c6b73fba31"
   end
 
   def install
+    # Required with Apple clang 7.0.0+/LLVM clang 3.6.0+ for gevent < 1.1.
+    ENV.append "CFLAGS", "-std=gnu99" if ENV.compiler == :clang
+
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     resources.each do |r|
       r.stage do


### PR DESCRIPTION
The introduction of the 'speedups' dependencies in 21b7ec4 causes build failure with newer versions of clang (i.e., that included in latest Xcode betas), due to change to `-std=gnu11` as default. This is a known issue with known workaround, see: https://github.com/NixOS/nixpkgs/issues/7275

Specific error is:
```
clang -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -U__llvm__ -arch x86_64 -arch i386 -pipe -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.macosx-10.10-intel-2.7/libev -Ilibev -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c gevent/gevent.core.c -o build/temp.macosx-10.10-intel-2.7/gevent/gevent.core.o
In file included from gevent/gevent.core.c:249:
In file included from gevent/libev.h:2:
libev/ev.c:1029:42: error: '_Noreturn' keyword must precede function declarator
  ecb_inline void ecb_unreachable (void) ecb_noreturn;
                                         ^~~~~~~~~~~~
  _Noreturn
libev/ev.c:832:26: note: expanded from macro 'ecb_noreturn'
  #define ecb_noreturn   _Noreturn
                         ^
1 error generated.
error: command 'clang' failed with exit status 1
```
The culprit is the older version of `libev` being used in the `gevent` PyPi package.

Another alternative solution would be to remove `gevent` and `ujson`  as these are optional deps. I have opted to mark them as such in comments, instead.

Also have bumped dependency resources where applicable.

CC: @mistydemeo 