### PR TITLE
fix migrator bug

### DIFF
--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -223,7 +223,7 @@ class Migrator
   # Link keg to opt if it was linked before migrating.
   def link_oldname_opt
     if old_opt_record
-      old_opt_record.delete if old_opt_record.symlink? || old_opt_record.exist?
+      old_opt_record.delete if old_opt_record.symlink?
       old_opt_record.make_relative_symlink(formula.installed_prefix)
     end
   end
@@ -241,8 +241,9 @@ class Migrator
   # Remove opt/oldname link if it belongs to newname.
   def unlink_oldname_opt
     return unless old_opt_record
-    if old_opt_record.symlink? && formula.installed_prefix.exist? \
-              && formula.installed_prefix.realpath == old_opt_record.realpath
+    if (old_opt_record.symlink? && old_opt_record.exist?) \
+        && formula.installed_prefix.exist? \
+        && formula.installed_prefix.realpath == old_opt_record.realpath
       old_opt_record.unlink
       old_opt_record.parent.rmdir_if_possible
     end


### PR DESCRIPTION
```
brew install go-app-engine-32
brew unlink go-app-engine-32
brew install go-app-engine-64
```

then rename `go-app-engine-32` to `app-engine-go-32`
and `migrate` or `update` and we have:

```
==> Migrating go-app-engine-32 to app-engine-go-32
==> Unlinking go-app-engine-32
Moving to: /usr/local/Cellar/app-engine-go-32
==> Linking app-engine-go-32
Error: Error while executing `brew link` step on app-engine-go-32
Could not symlink bin/appcfg.py
Target /usr/local/bin/appcfg.py
is a symlink belonging to go-app-engine-64. You can unlink it:
  brew unlink go-app-engine-64

To force the link and overwrite all conflicting files:
  brew link --overwrite app-engine-go-32

To list all files that would be deleted:
  brew link --overwrite --dry-run app-engine-go-32

Possible conflicting files are:
/usr/local/bin/appcfg.py -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/appcfg.py
/usr/local/bin/bulkload_client.py -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/bulkload_client.py
/usr/local/bin/bulkloader.py -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/bulkloader.py
/usr/local/bin/dev_appserver.py -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/dev_appserver.py
/usr/local/bin/download_appstats.py -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/download_appstats.py
/usr/local/bin/goapp -> /usr/local/Cellar/go-app-engine-64/1.9.24/bin/goapp
Error: error occured while migrating.
Backuping...
Error: No such file or directory - /usr/local/Cellar/go-app-engine-32
```

This happens because we try to link app-engine-go-32
 even if go-app-engine-32 wasn’t linked.

Backup fails because it uses realpath on the file that doesn't exist.

* Fix backup
* Don't link unlinked kegs.

cc @mikemcquaid @xu-cheng 