### PR TITLE
Update fig.rb

### DIFF
--- a/Library/Formula/fig.rb
+++ b/Library/Formula/fig.rb
@@ -79,6 +79,10 @@ class Fig < Formula
 
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    
+    # change shebang from system python to env python
+    inreplace libexec/"bin/docker-compose", "#!/usr/bin/python", "#!/usr/bin/env python"
+    
     ln_s bin/"docker-compose", bin/"fig"
   end
 


### PR DESCRIPTION
Change shebang in the `libexec/"bin/docker-compose"` from the generated:

`#!/usr/bin/python` 

to: 

`#!/usr/bin/env python` 

Since otherwise *docker-composer* will use the system default python currently *Python 2.7.6* on latest *Yosemite* and not the required *python* installed with *brew*.  This resolves the annoying issue `ssl_.py warns of an InsecurePlatformWarning: A true SSLContext object is not available.`, and would resolve the issue [41766](https://github.com/Homebrew/homebrew/issues/41766)