### PR TITLE
dwarfutils 20150507 (new formula)

### DIFF
--- a/Library/Formula/dwarfutils.rb
+++ b/Library/Formula/dwarfutils.rb
@@ -1,0 +1,52 @@
+class Dwarfutils < Formula
+  desc "lib and utility to dump and produce DWARF debug info in ELF objects"
+  homepage "http://www.prevanders.net/dwarf.html"
+  url "http://www.prevanders.net/libdwarf-20150507.tar.gz"
+  sha256 "29aa8d07db659d7d7af7079854cf42c09bf74d303942159cbfee82d655549870"
+
+  depends_on "libelf" => :build
+
+  def install
+    system "./configure"
+    system "make"
+
+    bin.install "dwarfdump/dwarfdump"
+    man1.install "dwarfdump/dwarfdump.1"
+    lib.install "libdwarf/libdwarf.a"
+    include.install "libdwarf/dwarf.h"
+    include.install "libdwarf/libdwarf.h"
+  end
+
+  test do
+    # Extensively testing dwarfdump is difficult, since we don't have an ELF
+    # image around to play with, and generating one on OS X is hard. Just do a
+    # very basic smoke test.
+    system "#{bin}/dwarfdump", "-V"
+
+    (testpath/"test.c").write <<-EOS.undent
+      #include <dwarf.h>
+      #include <libdwarf.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      int main(void) {
+        const char *out = NULL;
+        int res = dwarf_get_children_name(0, &out);
+
+        if (res != DW_DLV_OK) {
+          printf("Getting name failed\\n");
+          return 1;
+        }
+
+        if (strcmp(out, "DW_children_no") != 0) {
+          printf("Name did not match: %s\\n", out);
+          return 1;
+        }
+
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-L#{lib}", "-I#{include}", "-ldwarf", "test.c", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Add the dwarfutils formula, a library (libdwarf) and a utility
(dwarfdump) to produce and dump DWARF debugging information in ELF
object files.

This package is named "dwarfutils" since, although the upstream website
and tarball are plastered with "libdwarf", that's only one part of what
this package provides. The Debian source package is named the same:
https://packages.debian.org/source/sid/dwarfutils