### PR TITLE
rust 1.2.0 / cargo 0.4.0 / El Cap Fix

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -3,23 +3,18 @@ class Rust < Formula
   homepage "https://www.rust-lang.org/"
 
   stable do
-    url "https://static.rust-lang.org/dist/rustc-1.1.0-src.tar.gz"
-    sha256 "cb09f443b37ec1b81fe73c04eb413f9f656859cf7d00bc5088008cbc2a63fa8a"
+    url "https://static.rust-lang.org/dist/rustc-1.2.0-src.tar.gz"
+    sha256 "ea6eb983daf2a073df57186a58f0d4ce0e85c711bec13c627a8c85d51b6a6d78"
 
     resource "cargo" do
-      url "https://github.com/rust-lang/cargo.git", :revision => "b030d35d5cf6b35bf8a6bfd218ab4df9d6a86361"
+      # git required because of submodules
+      url "https://github.com/rust-lang/cargo.git", :tag => "0.4.0", :revision => "553b363bcfcf444c5bd4713e30382a6ffa2a52dd"
     end
 
     # name includes date to satisfy cache
-    resource "cargo-nightly-2015-06-25" do
-      url "https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/2015-06-25/cargo-nightly-x86_64-apple-darwin.tar.gz"
-      sha256 "b2e07bbee79cb8ad1e4f91a43cc3d93603e068a46b89bbe934d01ff97bfb0060"
-    end
-
-    # name includes date to satisfy cache
-    resource "rustc-nightly-2015-06-25" do
-      url "https://static-rust-lang-org.s3.amazonaws.com/dist/2015-06-25/rustc-nightly-x86_64-apple-darwin.tar.gz"
-      sha256 "c4eb0a639b6deb3e2aceb1713afe6570118d1055bf189f1057a839238dbe7165"
+    resource "cargo-nightly-2015-08-12" do
+      url "https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/2015-08-12/cargo-nightly-x86_64-apple-darwin.tar.gz"
+      sha256 "3d0ea9e20215e6450e2ae3977bbe20b9fb2bbf51ce145017ab198ea3409ffda2"
     end
   end
 
@@ -64,26 +59,21 @@ class Rust < Formula
       cargo_stage_path = pwd
 
       if build.stable?
-        resource("rustc-nightly-2015-06-25").stage do
-          system "./install.sh", "--prefix=#{cargo_stage_path}/rustc"
-        end
-
-        resource("cargo-nightly-2015-06-25").stage do
+        resource("cargo-nightly-2015-08-12").stage do
           system "./install.sh", "--prefix=#{cargo_stage_path}/target/snapshot/cargo"
           # satisfy make target to skip download
           touch "#{cargo_stage_path}/target/snapshot/cargo/bin/cargo"
         end
       end
 
-      args = ["--prefix=#{prefix}"]
-
-      if build.head?
-        args << "--local-rust-root=#{prefix}"
-      else
-        args << "--local-rust-root=#{cargo_stage_path}/rustc"
+      # Fix for El Capitan DYLD_LIBRARY_PATH behavior
+      # https://github.com/rust-lang/cargo/issues/1816
+      inreplace "Makefile.in" do |s|
+        s.gsub! '"$$(CFG_RUSTC)"', '$$(CFG_RUSTC)'
+        s.gsub! '"$$(CARGO)"', '$$(CARGO)'
       end
 
-      system "./configure", *args
+      system "./configure", "--prefix=#{prefix}", "--local-rust-root=#{prefix}"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
* Update rust to 1.2.0
* Update cargo to 1.4.0
* Simplify formula head/stable differences
* Add cargo Makefile fix for DYLD_LIBRARY_PATH on 10.11

This builds on the work done in #42642, but adds the above fixes.