### PR TITLE
findutils: fix test when built with the --default-names option

### DIFF
--- a/Library/Formula/findutils.rb
+++ b/Library/Formula/findutils.rb
@@ -28,6 +28,7 @@ class Findutils < Formula
   end
 
   test do
-    system "#{bin}/gfind", "--version"
+    gfind_binary = build.without?("default-names") ? "#{bin}/gfind" : "#{bin}/find"
+    system gfind_binary, "--version"
   end
 end


### PR DESCRIPTION
If `findutils` is built with the `--default-names` option, then the `find` binary would be `bin/find` instead of `bin/gfind`.