### PR TITLE
Don't try to link symlinks over their targets

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -421,6 +421,7 @@ class Keg
 
       if src.symlink? || src.file?
         Find.prune if File.basename(src) == ".DS_Store"
+        Find.prune if src.realpath == dst
         # Don't link pyc files because Python overwrites these cached object
         # files and next time brew wants to link, the pyc file is in the way.
         if src.extname == ".pyc" && src.to_s =~ /site-packages/


### PR DESCRIPTION
If we have lib/python3.4/site-packages, which is a symlink to
HOMEBREW_PREFIX/lib/python3.4/site-packages, link will be confused. This
only appears after unlinking and relinking because this symlink is
created in post_install, which runs after the first link.

Fixes Homebrew/linuxbrew#502.