### PR TITLE
Remove berkeley db4

### DIFF
--- a/Library/Formula/gnu-cobol.rb
+++ b/Library/Formula/gnu-cobol.rb
@@ -1,7 +1,7 @@
 class GnuCobol < Formula
   desc "Implements much of the COBOL 85 and COBOL 2002 standards"
   homepage "http://www.opencobol.org/"
-  revision 1
+  revision 2
 
   stable do
     url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/1.1/gnu-cobol-1.1.tar.gz"
@@ -30,7 +30,7 @@ class GnuCobol < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "berkeley-db4"
+  depends_on "berkeley-db"
   depends_on "gmp"
   depends_on "gcc"
 
@@ -42,7 +42,7 @@ class GnuCobol < Formula
     # the cobol compiler takes these variables for calling cc during its run
     # if the paths to gmp and bdb are not provided, the run of cobc fails
     gmp = Formula["gmp"]
-    bdb = Formula["berkeley-db4"]
+    bdb = Formula["berkeley-db"]
     ENV.append "CPPFLAGS", "-I#{gmp.opt_include} -I#{bdb.opt_include}"
     ENV.append "LDFLAGS", "-L#{gmp.opt_lib} -L#{bdb.opt_lib}"
 

--- a/Library/Formula/gnu-cobol.rb
+++ b/Library/Formula/gnu-cobol.rb
@@ -15,17 +15,17 @@ class GnuCobol < Formula
     end
   end
 
-  devel do
-    version "2.0_nightly_r411"
-    url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/2.0/gnu-cobol-2.0_nightly_r411.tar.gz"
-    sha256 "5d6d767bf0255fa63bc5c26493d53f4749eb0e369b81c626d156f346b3664fe7"
-  end
-
   bottle do
     revision 2
     sha256 "2836f2bf3362ff9e9d9578a42e7207a3c29411d481279e46c723df8ac5189292" => :yosemite
     sha256 "c24443ab3ac33ae5d8f1092cba070e62fdc5fbd4cced94fa813b5494424d8aa4" => :mavericks
     sha256 "3be8e2c52d16b4a829f8669636d2e13f0346855899605e02cb7c6e8c47234b20" => :mountain_lion
+  end
+
+  devel do
+    version "2.0_nightly_r658"
+    url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/2.0/gnu-cobol-2.0_nightly_r658.tar.gz"
+    sha256 "0a210d10624a53904871526afd69a6bef9feab40c2766386f74477598a313ae8"
   end
 
   depends_on "autoconf" => :build

--- a/Library/Formula/jigdo.rb
+++ b/Library/Formula/jigdo.rb
@@ -14,7 +14,7 @@ class Jigdo < Formula
 
   depends_on "pkg-config" => :build
   depends_on "wget" => :recommended
-  depends_on "berkeley-db4"
+  depends_on "berkeley-db"
   depends_on "gtk+"
 
   # Use MacPorts patch for compilation on 10.9; this software is no longer developed.
@@ -33,6 +33,6 @@ class Jigdo < Formula
   end
 
   test do
-    system "#{bin}/jigdo-file", "-h"
+    assert_match "version #{version}", shell_output("#{bin}/jigdo-file -v")
   end
 end

--- a/Library/Formula/nvi.rb
+++ b/Library/Formula/nvi.rb
@@ -4,7 +4,7 @@ class Nvi < Formula
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   sha256 "8bc348889159a34cf268f80720b26f459dbd723b5616107d36739d007e4c978d"
 
-  depends_on "berkeley-db4"
+  depends_on "berkeley-db"
 
   # Patches per MacPorts
   # The first corrects usage of BDB flags.
@@ -21,6 +21,13 @@ class Nvi < Formula
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/patches/8ef45e8b/nvi/patch-ex_script.c.diff"
     sha256 "742c4578319ddc07b0b86482b4f2b86125026f200749e07c6d2ac67976204728"
+  end
+
+  # support berkeley > 4, patch extracted from debian package
+  # http://http.debian.net/debian/pool/main/n/nvi/nvi_1.81.6-11.debian.tar.gz
+  patch do
+    url "https://gist.githubusercontent.com/nijikon/c77bd170ff76dfe6cea4/raw/76369bda9d345c8d027766c4f892a5c82de0f493/nvi-db4.patch"
+    sha256 "33f707366757cc83dddf39251f64b45d6549a07ad21bc0fcc66ed6fc5d2b3964"
   end
 
   def install


### PR DESCRIPTION
This is an attempt to remove ```berkeley-db4```. I already switch ```exim``` to ```berkeley-db``` in this #42905. The only package left is ```nvi```, I was able to build it with this dependency, but I do get ```BDB0635 DB_CREATE must be specified to create databases.```, this does not happen with ```berkeley-db4```. Please share what you think about this idea.