### PR TITLE
md5sha1sum: explicitly set openssl paths

### DIFF
--- a/Library/Formula/md5sha1sum.rb
+++ b/Library/Formula/md5sha1sum.rb
@@ -16,6 +16,10 @@ class Md5sha1sum < Formula
   depends_on "openssl"
 
   def install
+    openssl = Formula["openssl"]
+    ENV["SSLINCPATH"] = openssl.opt_include
+    ENV["SSLLIBPATH"] = openssl.opt_lib
+
     system "./configure", "--prefix=#{prefix}"
     system "make"
 


### PR DESCRIPTION
configure has a hardcoded set of include and library paths, and fails if it can't find openssl in any of them. This causes it to pick up the wrong openssl on older OS Xs, and to fail to pick up any on 10.11.

It actually links against the correct openssl on older OS Xs, so the revision isn't being bumped and bottles aren't being rebuilt.