### PR TITLE
thefuck: tweak outdated alias

### DIFF
--- a/Library/Formula/thefuck.rb
+++ b/Library/Formula/thefuck.rb
@@ -59,7 +59,7 @@ class Thefuck < Formula
   def caveats; <<-EOS.undent
     Add the following to your .bash_profile, .bashrc or .zshrc:
 
-      eval "$(thefuck-alias)"
+      eval "$(thefuck --alias)"
 
     For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases
     EOS


### PR DESCRIPTION
Corrects `UserWarning: `thefuck-alias` is deprecated, us `thefuck --alias` instead.`

