### PR TITLE
thefuck.rb: fix deprecated syntax in caveat

### DIFF
--- a/Library/Formula/thefuck.rb
+++ b/Library/Formula/thefuck.rb
@@ -59,7 +59,7 @@ class Thefuck < Formula
   def caveats; <<-EOS.undent
     Add the following to your .bash_profile, .bashrc or .zshrc:
 
-      eval "$(thefuck-alias)"
+      eval "$(thefuck --alias)"
 
     For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases
     EOS


### PR DESCRIPTION
The syntax previously in the caveat,
    Add the following to your .bash_profile, .bashrc or .zshrc:

      eval "$(thefuck-alias)"

    For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases

Now gives a warning:
```console
% thefuck-alias
/usr/local/Cellar/thefuck/2.7/libexec/lib/python2.7/site-packages/thefuck/main.py:102: UserWarning: `thefuck-alias` is deprecated, us `thefuck --alias` instead.
  warn('`thefuck-alias` is deprecated, us `thefuck --alias` instead.')
TF_ALIAS=fuck alias fuck='eval $(thefuck $(fc -ln -1 | tail -n 1)); fc -R'
```
Fixed.