### PR TITLE
boot2docker 1.8.0

### DIFF
--- a/Library/Formula/boot2docker.rb
+++ b/Library/Formula/boot2docker.rb
@@ -4,7 +4,7 @@ class Boot2docker < Formula
   # Boot2docker and docker are generally updated at the same time.
   # Please update the version of docker too
   url "https://github.com/boot2docker/boot2docker-cli.git",
-    :tag => "v1.7.1", :revision => "8fdc6f573bf08149b6311681800d55fda6e19e71"
+    :tag => "v1.8.0", :revision => "9a2606673efcfa282fb64a5a5c9e1b2f89d86fb4"
   head "https://github.com/boot2docker/boot2docker-cli.git"
 
   bottle do


### PR DESCRIPTION
This will be the last update to `boot2docker` as the project is now deprecated in favor of [Docker Machine](https://docs.docker.com/machine/).