### PR TITLE
Warn when migration is needed

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -71,7 +71,13 @@ module Homebrew
 
         if f.installed?
           msg = "#{f.full_name}-#{f.installed_version} already installed"
-          msg << ", it's just not linked" unless f.linked_keg.symlink? || f.keg_only?
+          unless f.linked_keg.symlink?
+            if Pathname.new("#{HOMEBREW_CELLAR}/#{f.oldname}").exist?
+              msg << ", it's just not migrated"
+            elsif !f.keg_only?
+              msg << ", it's just not linked"
+            end
+          end
           opoo msg
         else
           formulae << f

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -1,5 +1,6 @@
 require "formula"
 require "keg"
+require "migrator"
 
 module Homebrew
   def outdated
@@ -16,6 +17,13 @@ module Homebrew
     formulae.map do |f|
       all_versions = []
       older_or_same_tap_versions = []
+
+      if f.oldname && !f.rack.exist?
+        if Pathname.new("#{HOMEBREW_CELLAR}/#{f.oldname}").exist?
+          raise Migrator::MigrationNeededError.new(f)
+        end
+      end
+
       f.rack.subdirs.each do |dir|
         keg = Keg.new dir
         version = keg.version

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -4,6 +4,15 @@ require "tab"
 require "tap_migrations"
 
 class Migrator
+  class MigrationNeededError < RuntimeError
+    def initialize(formula)
+      super <<-EOS.undent
+        #{formula.oldname} was renamed to #{formula.name} and needs to be migrated.
+        Please run `brew migrate #{formula.oldname}`
+      EOS
+    end
+  end
+
   class MigratorNoOldnameError < RuntimeError
     def initialize(formula)
       super "#{formula.name} doesn't replace any formula."


### PR DESCRIPTION
If someone uses e.g. `git pull` instead of `brew update` then they can see errors from `outdated` (which bubbles to `upgrade`) when a formula hasn't been migrated yet. Instead of erroring out throw a more helpful exception telling them to manually run `migrate`.

Also, on `brew install` in the same situation: be a bit clearer if a formula hasn't been migrated rather than just saying it isn't linked.

CC @xu-cheng @vladshablinsky 