### PR TITLE
bitrise 0.9.10

### DIFF
--- a/Library/Formula/bitrise.rb
+++ b/Library/Formula/bitrise.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Bitrise < Formula
   desc "Command-line automation tool"
   homepage "https://github.com/bitrise-io/bitrise"
-  url "https://github.com/bitrise-io/bitrise/archive/0.9.7.tar.gz"
-  sha256 "cecd0cd112941c6b6f9d6cd334ea6a31aef1123af89e17c3950fbc8e8dbe5de2"
+  url "https://github.com/bitrise-io/bitrise/archive/0.9.10.tar.gz"
+  sha256 "4e76667c6992331f38da4e662cf54cc9375c3bf069af373b2183b7ef16ec7be7"
 
   bottle do
     cellar :any
@@ -16,13 +16,13 @@ class Bitrise < Formula
   depends_on "go" => :build
 
   resource "envman" do
-    url "https://github.com/bitrise-io/envman/archive/0.9.3.tar.gz"
-    sha256 "ff9cb03f978332499bad52f4930f736ded2f8573e8b713b5082f65432e618b8f"
+    url "https://github.com/bitrise-io/envman/archive/0.9.5.tar.gz"
+    sha256 "94017e7b5840452e32264e20c9b5e3c268db074bbceb813bc2f4a50dc7fee5e0"
   end
 
   resource "stepman" do
-    url "https://github.com/bitrise-io/stepman/archive/0.9.7.tar.gz"
-    sha256 "1eae33616e9c1c952f7c3cfc677fecc0cf0f0781a4aa2e686969e74485284c89"
+    url "https://github.com/bitrise-io/stepman/archive/0.9.10.tar.gz"
+    sha256 "1a11485dd809176baa20b7efa28debf21b9538afa8eda0cbc01f34cc1921eec1"
   end
 
   def go_install_package(basepth, pkgname)
@@ -48,25 +48,20 @@ class Bitrise < Formula
 
   test do
     (testpath/"bitrise.yml").write <<-EOS.undent
-      format_version: 0.9.8
+      format_version: 0.9.10
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib
-      app:
-        envs: []
       workflows:
         test_wf:
-          title: Workflow for master branch
-          envs: []
           steps:
           - script:
-              title: Test
+              title: Write a test string to a file, for compare
               inputs:
-              - content: |-
-                  #!/bin/bash
-                  set -e
-                  pwd
-                  printf 'Test - OK' > brew.test.file
+              - content: printf 'Test - OK' > brew.test.file
     EOS
 
+    # setup with --minimal flag, to skip the included `brew doctor` check
+    system "#{bin}/bitrise", "setup", "--minimal"
+    # run the defined test_wf workflow
     system "#{bin}/bitrise", "run", "test_wf"
     assert_equal "Test - OK", (testpath/"brew.test.file").read.chomp
   end


### PR DESCRIPTION
test was modified to make it smaller (the test bitrise.yml file was a bit too verbose), and to use the new --minimal flag for setup, to skip calling `brew doctor`