### PR TITLE
cairo: enable xcb when xquartz is installed

### DIFF
--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -18,6 +18,7 @@ class Cairo < Formula
   option :universal
 
   depends_on "pkg-config" => :build
+  depends_on :x11 => :optional if MacOS.version > :leopard
   depends_on "freetype"
   depends_on "fontconfig"
   depends_on "libpng"
@@ -38,7 +39,7 @@ class Cairo < Formula
       --enable-quartz-image
     ]
 
-    args << "--enable-xcb=no" if MacOS.version <= :leopard
+    args << (build.with?("x11") ? "--enable-xcb=yes" : "--enable-xcb=no")
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Certain formula like [i3](https://github.com/Homebrew/homebrew-x11/blob/master/i3.rb) require cairo to be built with xcb, only when the cairo formula `depends_on :x11` does `./configure` find the necessary files to build cairo with xcb support.

Without this change `find $(brew --prefix cairo) -name cairo-xcb.h` finds nothing; with this change the header file is found and the appropriate code available in the cairo library.