### PR TITLE
cleanup: speed up rm_DS_Store by multithread

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -123,10 +123,20 @@ module Homebrew
   end
 
   def rm_DS_Store
-    paths = %w[Cellar Frameworks Library bin etc include lib opt sbin share var].
-            map { |p| HOMEBREW_PREFIX/p }.select(&:exist?)
-    args = paths.map(&:to_s) + %w[-name .DS_Store -delete]
-    quiet_system "find", *args
+    paths = Queue.new
+    %w[Cellar Frameworks Library bin etc include lib opt sbin share var].
+      map { |p| HOMEBREW_PREFIX/p }.select(&:exist?).each { |p| paths << p }
+    workers = (0...Hardware::CPU.cores).map do
+      Thread.new do
+        begin
+          while p = paths.pop(true)
+            quiet_system "find", p, "-name", ".DS_Store", "-delete"
+          end
+        rescue ThreadError # ignore empty queue error
+        end
+      end
+    end
+    workers.map(&:join)
   end
 
   def eligible_for_cleanup?(formula)


### PR DESCRIPTION
Before

```
$ time brew cleanup -s
brew cleanup -s  0.73s user 3.52s system 58% cpu 7.297 total
```

After

```
$ time brew cleanup -s
brew cleanup -s  0.69s user 2.57s system 139% cpu 2.341 total
```