### PR TITLE
kitchen-sync: use brewed libyaml-cpp

### DIFF
--- a/Library/Formula/kitchen-sync.rb
+++ b/Library/Formula/kitchen-sync.rb
@@ -29,8 +29,6 @@ class KitchenSync < Formula
   end
 
   test do
-    assert File.exist?("#{bin}/ks")
-    assert File.exist?("#{bin}/ks_mysql") if build.with? "mysql"
-    assert File.exist?("#{bin}/ks_postgresql") if build.with? "postgresql"
+    shell_output "#{bin}/ks 2>&1", 1
   end
 end

--- a/Library/Formula/kitchen-sync.rb
+++ b/Library/Formula/kitchen-sync.rb
@@ -13,7 +13,10 @@ class KitchenSync < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "boost"
+  depends_on "yaml-cpp" => (MacOS.version <= :mountain_lion ? "c++11" : [])
+
   depends_on :mysql => :recommended
   depends_on :postgresql => :optional
 


### PR DESCRIPTION
Otherwise kitchen-sync vendors and installs libyaml-cpp, which causes
conflicts.