### PR TITLE
let tests pass on Xcode-only systems

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -65,7 +65,7 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_env
-    assert_match "CMAKE_PREFIX_PATH=\"#{HOMEBREW_PREFIX}\"",
+    assert_match /CMAKE_PREFIX_PATH="#{HOMEBREW_PREFIX}[:"]/,
                  cmd("--env")
   end
 


### PR DESCRIPTION
The test failed with this output on an Xcode-only system because the test didn't expect the possibility that CMAKE_PREFIX_PATH could contain additional prefixes.

http://pastebin.com/raw.php?i=QdCma4NX