### PR TITLE
handle old opt_link for brew switch/(un)link/upgrade

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -18,14 +18,8 @@ module Homebrew
           # Remove every symlink that links to keg, because it can
           # be left by migrator
           links.each do |link|
-            old_opt = HOMEBREW_PREFIX/"opt/#{link.basename}"
             if link.exist? && link.realpath == keg.rack.realpath
               old_cellars << link
-            end
-
-            if old_opt.symlink? && old_opt.realpath.to_s == keg.to_s
-              old_opt.unlink
-              old_opt.parent.rmdir_if_possible
             end
           end
 
@@ -52,13 +46,6 @@ module Homebrew
         name = rack.basename
 
         links.each do |link|
-          old_opt = HOMEBREW_PREFIX/"opt/#{link.basename}"
-          if old_opt.symlink? && old_opt.exist? \
-              && old_opt.realpath.parent == rack.realpath
-            old_opt.unlink
-            old_opt.parent.rmdir_if_possible
-          end
-
           link.unlink if link.exist? && link.realpath == rack.realpath
         end
 

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -183,6 +183,7 @@ class Keg
     path.rmtree
     path.parent.rmdir_if_possible
     remove_opt_record if optlinked?
+    remove_oldname_opt_record
   end
 
   def unlink
@@ -254,6 +255,14 @@ class Keg
 
   def find(*args, &block)
     path.find(*args, &block)
+  end
+
+  def oldname_opt_record
+    @oldname_opt_record ||= if (opt_dir = HOMEBREW_PREFIX/"opt").directory?
+      opt_dir.subdirs.detect do |dir|
+        dir.symlink? && dir != opt_record && path.parent == dir.resolved_path.parent
+      end
+    end
   end
 
   def link(mode = OpenStruct.new)
@@ -330,9 +339,22 @@ class Keg
     ObserverPathnameExtension.total
   end
 
+  def remove_oldname_opt_record
+    return unless oldname_opt_record
+    return unless oldname_opt_record.resolved_path == path
+    @oldname_opt_record.unlink
+    @oldname_opt_record.parent.rmdir_if_possible
+    @oldname_opt_record = nil
+  end
+
   def optlink(mode = OpenStruct.new)
     opt_record.delete if opt_record.symlink? || opt_record.exist?
     make_relative_symlink(opt_record, path, mode)
+
+    if oldname_opt_record
+      oldname_opt_record.delete
+      make_relative_symlink(oldname_opt_record, path, mode)
+    end
   end
 
   def delete_pyc_files!

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -48,6 +48,36 @@ class LinkTests < Homebrew::TestCase
     refute_predicate @dst, :symlink?
   end
 
+  def test_oldname_opt_record
+    assert_nil @keg.oldname_opt_record
+    oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
+    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
+    assert_equal oldname_opt_record, @keg.oldname_opt_record
+  end
+
+  def test_optlink_relink
+    oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
+    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
+    keg_record = HOMEBREW_CELLAR.join("foo", "2.0")
+    keg_record.join("bin").mkpath
+    keg = Keg.new(keg_record)
+    keg.optlink
+    assert_equal keg_record, oldname_opt_record.resolved_path
+    keg.uninstall
+    refute_predicate oldname_opt_record, :symlink?
+  end
+
+  def test_remove_oldname_opt_record
+    oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
+    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0")
+    @keg.remove_oldname_opt_record
+    assert_predicate oldname_opt_record, :symlink?
+    oldname_opt_record.unlink
+    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
+    @keg.remove_oldname_opt_record
+    refute_predicate oldname_opt_record, :symlink?
+  end
+
   def test_link_dry_run
     @mode.dry_run = true
 


### PR DESCRIPTION
Fix opl opt link from https://github.com/Homebrew/homebrew/issues/42965

* brew upgrade/switch relinks old name opt to new keg