### PR TITLE
Portaudio to install with C++ bindings as default.

### DIFF
--- a/Library/Formula/portaudio.rb
+++ b/Library/Formula/portaudio.rb
@@ -15,13 +15,16 @@ class Portaudio < Formula
   depends_on "pkg-config" => :build
 
   option :universal
+  option "with-cxx", "Build C++ bindings"
 
   def install
     ENV.universal_binary if build.universal?
+
     system "./configure", "--prefix=#{prefix}",
                           "--disable-debug",
                           "--disable-dependency-tracking",
-                          "--enable-mac-universal=#{build.universal? ? "yes" : "no"}"
+                          "--enable-mac-universal=#{build.universal? ? "yes" : "no"}",
+                          "--enable-cxx=#{(build.with? "cxx") ? "yes": "no"}"
     system "make", "install"
 
     # Need 'pa_mac_core.h' to compile PyAudio

--- a/Library/Formula/portaudio.rb
+++ b/Library/Formula/portaudio.rb
@@ -15,7 +15,7 @@ class Portaudio < Formula
   depends_on "pkg-config" => :build
 
   option :universal
-  option "with-cxx", "Build C++ bindings"
+  option "without-cxx", "Build C++ bindings"
 
   def install
     ENV.universal_binary if build.universal?
@@ -24,7 +24,7 @@ class Portaudio < Formula
                           "--disable-debug",
                           "--disable-dependency-tracking",
                           "--enable-mac-universal=#{build.universal? ? "yes" : "no"}",
-                          "--enable-cxx=#{(build.with? "cxx") ? "yes": "no"}"
+                          "--enable-cxx=#{(build.without? "cxx") ? "no": "yes"}"
     system "make", "install"
 
     # Need 'pa_mac_core.h' to compile PyAudio


### PR DESCRIPTION
The same as #42995 but with opposite default.