### PR TITLE
allowing rescue https redirect error

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -276,7 +276,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         ohai "Downloading from #{urls.last}"
         if !ENV["HOMEBREW_NO_INSECURE_REDIRECT"].nil? && @url.start_with?("https://") &&
            urls.any? { |u| !u.start_with? "https://" }
-          raise "HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set."
+          puts "HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set."
+          raise CurlDownloadStrategyError.new(@url)
         end
         @url = urls.last
       end


### PR DESCRIPTION
It can be useful when implementing custom https mirror strategy such as #42955.