### PR TITLE
Suggest 'brew uninstall' everywhere for consistency

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -63,7 +63,7 @@ module Homebrew
     end
   rescue MultipleVersionsInstalledError => e
     ofail e
-    puts "Use `brew remove --force #{e.name}` to remove all versions."
+    puts "Use `brew uninstall --force #{e.name}` to remove all versions."
   end
 
   def rm_pin(rack)


### PR DESCRIPTION
Mixing 'brew remove' with 'brew uninstall' can confuse users. See #43023.