### PR TITLE
unnecessary calls to .select simplified

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -18,7 +18,7 @@ class Cleaner
     # and will conflict if more than one formula provides it
     observe_file_removal @f.lib/"charset.alias"
 
-    [@f.bin, @f.sbin, @f.lib].select(&:exist?).each { |d| clean_dir d }
+    [@f.bin, @f.sbin, @f.lib].each { |d| clean_dir(d) if d.exist? }
 
     # Get rid of any info 'dir' files, so they don't conflict at the link stage
     info_dir_file = @f.info + "dir"

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -501,7 +501,7 @@ class FormulaAuditor
         }
       end
 
-      spec.patches.select(&:external?).each { |p| audit_patch(p) }
+      spec.patches.each { |p| audit_patch(p) if p.external? }
     end
 
     %w[Stable Devel].each do |name|
@@ -1135,12 +1135,14 @@ class ResourceAuditor
     end
 
     # Use new-style archive downloads
-    urls.select { |u| u =~ %r{https://.*github.*/(?:tar|zip)ball/} && u !~ /\.git$/ }.each do |u|
+    urls.each do |u|
+      next unless u =~ %r{https://.*github.*/(?:tar|zip)ball/} && u !~ /\.git$/
       problem "Use /archive/ URLs for GitHub tarballs (url is #{u})."
     end
 
     # Don't use GitHub .zip files
-    urls.select { |u| u =~ %r{https://.*github.*/(archive|releases)/.*\.zip$} && u !~ %r{releases/download} }.each do |u|
+    urls.each do |u|
+      next unless u =~ %r{https://.*github.*/(archive|releases)/.*\.zip$} && u !~ %r{releases/download}
       problem "Use GitHub tarballs rather than zipballs (url is #{u})."
     end
   end

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -110,7 +110,8 @@ module Homebrew
     return unless HOMEBREW_CACHE_FORMULA.directory?
     candidates = HOMEBREW_CACHE_FORMULA.children
     lockfiles  = candidates.select { |f| f.file? && f.extname == ".brewing" }
-    lockfiles.select(&:readable?).each do |file|
+    lockfiles.each do |file|
+      next unless file.readable?
       file.open.flock(File::LOCK_EX | File::LOCK_NB) && file.unlink
     end
   end
@@ -118,7 +119,7 @@ module Homebrew
   def rm_DS_Store
     paths = Queue.new
     %w[Cellar Frameworks Library bin etc include lib opt sbin share var].
-      map { |p| HOMEBREW_PREFIX/p }.select(&:exist?).each { |p| paths << p }
+      map { |p| HOMEBREW_PREFIX/p }.each { |p| paths << p if p.exist? }
     workers = (0...Hardware::CPU.cores).map do
       Thread.new do
         begin

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -234,7 +234,8 @@ class Checks
   def check_for_broken_symlinks
     broken_symlinks = []
 
-    Keg::PRUNEABLE_DIRECTORIES.select(&:directory?).each do |d|
+    Keg::PRUNEABLE_DIRECTORIES.each do |d|
+      next unless d.directory?
       d.find do |path|
         if path.symlink? && !path.resolved_path_exists?
           broken_symlinks << path

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -24,7 +24,7 @@ module Homebrew
       else
         fetch_formula(f)
         f.resources.each { |r| fetch_resource(r) }
-        f.patchlist.select(&:external?).each { |p| fetch_patch(p) }
+        f.patchlist.each { |p| fetch_patch(p) if p.external? }
       end
     end
   end

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -2,7 +2,7 @@ require "sandbox"
 
 module Homebrew
   def postinstall
-    ARGV.resolved_formulae.select(&:post_install_defined?).each { |f| run_post_install(f) }
+    ARGV.resolved_formulae.each { |f| run_post_install(f) if f.post_install_defined? }
   end
 
   def run_post_install(formula)

--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -7,7 +7,8 @@ module Homebrew
 
     dirs = []
 
-    Keg::PRUNEABLE_DIRECTORIES.select(&:directory?).each do |dir|
+    Keg::PRUNEABLE_DIRECTORIES.each do |dir|
+      next unless dir.directory?
       dir.find do |path|
         path.extend(ObserverPathnameExtension)
         if path.symlink?

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -46,7 +46,7 @@ module Homebrew
   def migrate_taps(options = {})
     ignore = HOMEBREW_LIBRARY/"Formula/.gitignore"
     return unless ignore.exist? || options.fetch(:force, false)
-    (HOMEBREW_LIBRARY/"Formula").children.select(&:symlink?).each(&:unlink)
+    (HOMEBREW_LIBRARY/"Formula").children.each { |c| c.unlink if c.symlink? }
     ignore.unlink if ignore.exist?
   end
 

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -30,7 +30,9 @@ module Homebrew
     # this procedure will be removed in the future if it seems unnecessasry
     rename_taps_dir_if_necessary
 
-    Tap.select(&:git?).each do |tap|
+    Tap.each do |tap|
+      next unless tap.git?
+
       tap.path.cd do
         updater = Updater.new(tap.path)
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1105,8 +1105,8 @@ class Formula
 
     patchlist.grep(DATAPatch) { |p| p.path = path }
 
-    patchlist.select(&:external?).each do |patch|
-      patch.verify_download_integrity(patch.fetch)
+    patchlist.each do |patch|
+      patch.verify_download_integrity(patch.fetch) if patch.external?
     end
   end
 

--- a/Library/Homebrew/test/test_patching.rb
+++ b/Library/Homebrew/test/test_patching.rb
@@ -17,7 +17,7 @@ class PatchingTests < Homebrew::TestCase
 
   def teardown
     @_f.clear_cache
-    @_f.patchlist.select(&:external?).each(&:clear_cache)
+    @_f.patchlist.each { |p| p.clear_cache if p.external? }
   end
 
   def assert_patched(formula)


### PR DESCRIPTION
These are minor perf optimizations.

* `.select(…).each` = “create a new array by looping over the original one then loop over the new one”
* `.each` with a condition in the block = “loop over the original array without creating a new one”