### PR TITLE
Update osm2pgsql to 0.88.1

### DIFF
--- a/Library/Formula/osm2pgsql.rb
+++ b/Library/Formula/osm2pgsql.rb
@@ -1,8 +1,8 @@
 class Osm2pgsql < Formula
   desc "OpenStreetMap data to PostgreSQL converter"
   homepage "https://wiki.openstreetmap.org/wiki/Osm2pgsql"
-  url "https://github.com/openstreetmap/osm2pgsql/archive/0.88.0.tar.gz"
-  sha256 "45a6768e680a50c416fdae72cf4b26091644947a7ead44c8b7484f2276b2f119"
+  url "https://github.com/openstreetmap/osm2pgsql/archive/0.88.1.tar.gz"
+  sha256 "08ec33c833768dec9856f537bbf4416ad45837ee0851eeeab0081c7bbed3449e"
 
   bottle do
     sha256 "ca63b113b0b300a3bb6c0f8b1426185906806a6ba44ef13a68b01642824f6c0b" => :yosemite
@@ -20,13 +20,6 @@ class Osm2pgsql < Formula
   depends_on "protobuf-c" => :recommended
   depends_on "lua" => :recommended
 
-  # Apply a fix from the 0.88.x branch.
-  # This will be in 0.88.1, so won't be needed when that's tagged
-  patch do
-    url "https://github.com/openstreetmap/osm2pgsql/commit/cb449abc73e5ef076f1f8b6535b7d9641a1237f7.diff"
-    sha256 "e0175a3b1de82b67d45adbd50b8194c16673e147401f25dcc22c1c0c8d44aec6"
-  end
-
   def install
     args = [
       "--prefix=#{prefix}",
@@ -41,8 +34,8 @@ class Osm2pgsql < Formula
       args << "--with-protobuf-c=#{Formula["protobuf-c"].opt_prefix}"
     end
     # Mountain Lion has some problems with C++11.
-    # This is probably going to be a fatal issue for 0.89 and 0.90 on it, but
-    # for now it can be worked around
+    # This is probably going to be a fatal issue for 0.89 and 0.90, but
+    # for now it can be worked around.
     args << "--without-cxx11" if MacOS.version < :mavericks
     system "./autogen.sh"
     system "./configure", *args


### PR DESCRIPTION
0.88.1 includes the patch which was being cherry-picked, so the the build is simpler.