### PR TITLE
jq: segregate build dependencies

### DIFF
--- a/Library/Formula/jq.rb
+++ b/Library/Formula/jq.rb
@@ -13,16 +13,17 @@ class Jq < Formula
 
   head do
     url "https://github.com/stedolan/jq.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   depends_on "oniguruma"  # jq depends > 1.5
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "bison" => :build # jq depends on bison > 2.5
 
   def install
-    system "autoreconf", "-iv"
+    system "autoreconf", "-iv" unless build.stable?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Execute `autoreconf`only when built with options, HEAD or devel. 
This has been changed in PR [#42988] (https://github.com/Homebrew/homebrew/pull/42988). Reverting to original behavior.
