### PR TITLE
CurlApacheMirrorDownloadStrategy: ignore HOMEBREW_CURL_VERBOSE

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -359,6 +359,7 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
     buf = ""
 
     pid = fork do
+      ENV.delete "HOMEBREW_CURL_VERBOSE"
       rd.close
       $stdout.reopen(wr)
       $stderr.reopen(wr)


### PR DESCRIPTION
Fixes #43002