### PR TITLE
Recommend setuid for mtr

### DIFF
--- a/Library/Formula/mtr.rb
+++ b/Library/Formula/mtr.rb
@@ -36,14 +36,15 @@ class Mtr < Formula
   end
 
   def caveats; <<-EOS.undent
-    mtr requires superuser privileges. You can either run the program
-    via `sudo`, or change its ownership to root and set the setuid bit:
+    mtr requires superuser privileges for raw sockets access. You can either
+    run the program via `sudo`, or change its ownership to root and set the
+    setuid bit:
 
       sudo chown root:wheel #{sbin}/mtr
       sudo chmod u+s #{sbin}/mtr
 
-    In any case, you should be certain that you trust the software you
-    are executing with elevated privileges.
+    mtr drops privileges immediately after starting up and should be fairly
+    safe to setuid.
     EOS
   end
 end

--- a/Library/Formula/mtr.rb
+++ b/Library/Formula/mtr.rb
@@ -36,8 +36,14 @@ class Mtr < Formula
   end
 
   def caveats; <<-EOS.undent
-    mtr requires root privileges so you will need to run `sudo mtr`.
-    You should be certain that you trust any software you grant root privileges.
+    mtr requires superuser privileges. You can either run the program
+    via `sudo`, or change its ownership to root and set the setuid bit:
+
+      sudo chown root:wheel #{sbin}/mtr
+      sudo chmod u+s #{sbin}/mtr
+
+    In any case, you should be certain that you trust the software you
+    are executing with elevated privileges.
     EOS
   end
 end


### PR DESCRIPTION
mtr drops privileges immediately after starting up and opening raw sockets:

https://github.com/traviscross/mtr/blob/7dbc602cd558d8a0835a323511e4997b8d5d34c1/mtr.c#L562-L579

It should be fairly safe to setuid.

cc @mikemcquaid 