### PR TITLE
gdal: switch PDF driver linking to libpodofo

### DIFF
--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -3,7 +3,7 @@ class Gdal < Formula
   homepage "http://www.gdal.org/"
   url "http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz"
   sha256 "66bc8192d24e314a66ed69285186d46e6999beb44fc97eeb9c76d82a117c0845"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "4f09a9aeb578a5c6039aa4d96c6d41c1640c02564f5c8ab70d5ccc5f8909936c" => :yosemite
@@ -75,6 +75,7 @@ class Gdal < Formula
     # Other libraries
     depends_on "xz" # get liblzma compression algorithm library from XZutils
     depends_on "poppler"
+    depends_on "podofo"
     depends_on "json-c"
   end
 
@@ -160,7 +161,7 @@ class Gdal < Formula
       dods-root
       epsilon
       webp
-      poppler
+      podofo
     ]
     if build.with? "complete"
       supported_backends.delete "liblzma"


### PR DESCRIPTION
Addresses #42031, where `gdal` fails to build against latest `poppler`.

As per the [Geospatial PDF](http://www.gdal.org/frmt_pdf.html) driver page...

>Starting with GDAL 1.9.0, as an alternative, the PDF driver can be compiled against libpodofo (LGPL-licensed) to avoid the libpoppler dependency. This is sufficient to get the georeferencing and vector information. However, for getting the imagery, the pdftoppm utility that comes with the poppler distribution must be available in the system PATH. ...

So this PR adds `podofo` and sets it to be linked against, while still requiring `poppler` for its command line utility. I looked into setting up a patch from the v2.0 branch, but IMO too much has changed for it to be worth maintaining a patch for 1.11 branch.

I did not do extensive testing, but it compiles on 10.9 and `gdalinfo` reads a geospatial PDF using that driver.