### PR TITLE
nanomsg: upgrade to 0.6-beta

### DIFF
--- a/Library/Formula/nanomsg.rb
+++ b/Library/Formula/nanomsg.rb
@@ -1,8 +1,8 @@
 class Nanomsg < Formula
   desc "Socket library in C"
   homepage "http://nanomsg.org"
-  url "http://download.nanomsg.org/nanomsg-0.5-beta.tar.gz"
-  sha256 "13bff7ae8f31957722ee62d50504ce1a0c590da908f8566f997e3e521abb089f"
+  url "https://github.com/nanomsg/nanomsg/releases/download/0.6-beta/nanomsg-0.6-beta.tar.gz"
+  sha256 "69e2098446c9cd2c067b5ba38567c9ba30bf861a515b3d0a9302cb21c1167a69"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This pull request updates the nanomsg library URL to version 0.6-beta and its SHA256 sum