### PR TITLE
Update gnu-apl.rb

### DIFF
--- a/Library/Formula/gnu-apl.rb
+++ b/Library/Formula/gnu-apl.rb
@@ -1,9 +1,9 @@
 class GnuApl < Formula
+  version "1.5"
   desc "GNU implementation of the programming language APL"
   homepage "https://www.gnu.org/software/apl/"
-  url "http://ftpmirror.gnu.org/apl/apl-1.4.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/apl/apl-1.4.tar.gz"
-  sha256 "69da31db180e6ae17116122758c266e19f62e256f04e3c4959f6f2b224a1893a"
+  url "svn://svn.sv.gnu.org/apl/trunk", :revision => "662"
+  head "svn://svn.sv.gnu.org/apl/trunk"
 
   bottle do
     revision 1
@@ -14,12 +14,11 @@ class GnuApl < Formula
   # GNU Readline is required; libedit won't work.
   depends_on "readline"
   depends_on :macos => :mavericks
+  depends_on "postgresql" => :recommended
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
This [issue](http://lists.gnu.org/archive/html/bug-apl/2015-03/msg00059.html) and `clang` support have been fixed in gnu svn rev 662 or earlier, but not in `apl-1.5.tar.gz`. So this `gnu-apl-1.5` will work with svn.

It is the first time that I make such pull request, and I have gone through [this tutorial](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-%28and-get-it-merged%29.md#how-to-open-a-homebrew-pull-request-and-get-it-merged).

I hope it is fine. Please help me fix the mistakes.