### PR TITLE
logstash 1.5.4

### DIFF
--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -1,11 +1,13 @@
 class Logstash < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://download.elasticsearch.org/logstash/logstash/logstash-1.5.2.tar.gz"
-  sha256 "1d1805d388392a69f5049b35c176186389a7f8bf7347c4528c255edc1f9b0d6a"
+  url "https://download.elastic.co/logstash/logstash/logstash-1.5.4.tar.gz"
+  sha256 "f03075ee534ce6e7667679447f56543ce05cebbdb7b65a9396a5e538bf3e9fa8"
+
+  depends_on :java => "1.7+"
 
   def install
-    inreplace %w[bin/logstash], /^\. "\$\(cd `dirname \$0`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"/, ". #{libexec}/bin/logstash.lib.sh"
+    inreplace %w[bin/logstash], %r{^\. "\$\(cd `dirname \$0`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
     inreplace %w[bin/logstash.lib.sh], /^LOGSTASH_HOME=.*$/, "LOGSTASH_HOME=#{libexec}"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/logstash"
@@ -14,12 +16,17 @@ class Logstash < Formula
   def caveats; <<-EOS.undent
     Logstash 1.5 emits an unhelpful error if you try to start it without config.
     Please read the getting started guide located at:
-    https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html
+      https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html
     EOS
   end
 
   test do
-    system "#{bin}/logstash", "--version"
-    system "/bin/echo 'hello world' | #{bin}/logstash agent -e 'input { stdin { type => stdin } } output { stdout { codec => rubydebug } }'"
+    (testpath/"simple.conf").write <<-EOS.undent
+      input { stdin { type => stdin } }
+      output { stdout { codec => rubydebug } }
+    EOS
+
+    output = pipe_output("/bin/echo 'hello world' | #{bin}/logstash agent -f simple.conf")
+    assert_match /hello world/, output
   end
 end


### PR DESCRIPTION
Fixes the CVE-2015-5619 potential vulnerability.

Closes #42288.