### PR TITLE
duck 4.8.18026

### DIFF
--- a/Library/Formula/duck.rb
+++ b/Library/Formula/duck.rb
@@ -1,8 +1,8 @@
 class Duck < Formula
   desc "Command-line interface for Cyberduck (a multi-protocol file transfer tool)"
   homepage "https://duck.sh/"
-  url "https://dist.duck.sh/duck-src-4.7.2.18007.tar.gz"
-  sha256 "2b30071ef58aed42805724f318b1e3f013749cc534e54265ee305dfc2ec86d69"
+  url "https://dist.duck.sh/duck-src-4.8.18026.tar.gz"
+  sha256 "ff75b2b0a4df30aef4f6cd2ba20fb3fa1198760fb7d8216abc62e032df4aa1e4"
   head "https://svn.cyberduck.io/trunk/"
 
   bottle do
@@ -24,8 +24,7 @@ class Duck < Formula
   end
 
   test do
-    filename = (testpath/"test")
-    system "#{bin}/duck", "--download", stable.url, filename
-    filename.verify_checksum stable.checksum
+    system "#{bin}/duck", "--download", Formula["when"].stable.url, testpath/"test"
+    (testpath/"test").verify_checksum Formula["when"].stable.checksum
   end
 end


### PR DESCRIPTION
The duck tarball is ~275MB so it's silly to use it for the test.