### PR TITLE
dylibbundler: add HEAD

### DIFF
--- a/Library/Formula/dylibbundler.rb
+++ b/Library/Formula/dylibbundler.rb
@@ -1,8 +1,9 @@
 class Dylibbundler < Formula
   desc "Utility to bundle libraries into executables for OS X"
-  homepage "http://macdylibbundler.sourceforge.net"
+  homepage "https://github.com/auriamg/macdylibbundler"
   url "https://downloads.sourceforge.net/project/macdylibbundler/macdylibbundler/0.4.4/dylibbundler-0.4.4.zip"
   sha256 "65d050327df99d12d96ae31a693bace447f4115e6874648f1b3960a014362200"
+  head "https://github.com/auriamg/macdylibbundler.git"
 
   bottle do
     cellar :any
@@ -19,11 +20,5 @@ class Dylibbundler < Formula
 
   test do
     system "#{bin}/dylibbundler", "-h"
-  end
-
-  def caveats; <<-EOS.undent
-    Usage example:
-      dylibbundler -od -b -x ./HelloWorld.app/Contents/MacOS/helloworld  -d ./HelloWorld.app/Contents/libs/
-    EOS
   end
 end


### PR DESCRIPTION
Development has moved to GH, but a new release is not
imminent (https://github.com/auriamg/macdylibbundler/issues/8#issuecomment-107240755).