### PR TITLE
Revert "mercurial: vendor pyopenssl"

### DIFF
--- a/Library/Formula/mercurial.rb
+++ b/Library/Formula/mercurial.rb
@@ -14,68 +14,10 @@ class Mercurial < Formula
     sha256 "43e273e2a20d66d05e25505578949b042257df64bfe731d4a5e7d1b37b3c4c0c" => :mountain_lion
   end
 
-  depends_on "openssl"
-
-  resource "six" do
-    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
-    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
-  end
-
-  resource "enum34" do
-    url "https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz"
-    sha256 "d3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447"
-  end
-
-  resource "pyasn1" do
-    url "https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.8.tar.gz"
-    sha256 "5d33be7ca0ec5997d76d29ea4c33b65c00c0231407fff975199d7f40530b8347"
-  end
-
-  resource "idna" do
-    url "https://pypi.python.org/packages/source/i/idna/idna-2.0.tar.gz"
-    sha256 "16199aad938b290f5be1057c0e1efc6546229391c23cea61ca940c115f7d3d3b"
-  end
-
-  resource "ipaddress" do
-    url "https://pypi.python.org/packages/source/i/ipaddress/ipaddress-1.0.14.tar.gz"
-    sha256 "226f4be44c6cb64055e23060848266f51f329813baae28b53dc50e93488b3b3e"
-  end
-
-  resource "pycparser" do
-    url "https://pypi.python.org/packages/source/p/pycparser/pycparser-2.14.tar.gz"
-    sha256 "7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73"
-  end
-
-  resource "cffi" do
-    url "https://pypi.python.org/packages/source/c/cffi/cffi-1.1.2.tar.gz"
-    sha256 "390970b602708c91ddc73953bb6929e56291c18a4d80f360afa00fad8b6f3339"
-  end
-
-  resource "cryptography" do
-    url "https://pypi.python.org/packages/source/c/cryptography/cryptography-0.9.3.tar.gz"
-    sha256 "aed022f738dd9adb840d92960b0464ea1fbb222ba118938858eb93fe25151c2d"
-  end
-
-  resource "pyopenssl" do
-    url "https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.15.1.tar.gz"
-    sha256 "f0a26070d6db0881de8bcc7846934b7c3c930d8f9c79d45883ee48984bc0d672"
-  end
-
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     ENV.minimal_optimization if MacOS.version <= :snow_leopard
 
-    resources.each do |r|
-      r.stage do
-        system "python", *Language::Python.setup_install_args(libexec/"vendor")
-      end
-    end
-
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    system "make", "PREFIX=#{libexec}", "install-bin"
-    bin.install Dir["#{libexec}/bin/*"]
-    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
-
+    system "make", "PREFIX=#{prefix}", "install-bin"
     # Install man pages, which come pre-built in source releases
     man1.install "doc/hg.1"
     man5.install "doc/hgignore.5", "doc/hgrc.5"


### PR DESCRIPTION
These modules are optionally used by some third-party Mercurial commands
but not by Mercurial core and the InsecurePlatformWarning people were
complaining about no longer appears on current OS versions.

This reverts commit 57873691a76cbe54be7bd981292871dfa5e229a9.

cc @DomT4; what do you think?