### PR TITLE
quantlib 1.6.1

### DIFF
--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -34,7 +34,8 @@ class Quantlib < Formula
       system "./autogen.sh"
     end
     system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-lispdir=#{share}/emacs/site-lisp/quantlib"
     system "make", "install"
   end
 

--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -1,9 +1,9 @@
 class Quantlib < Formula
   desc "Library for quantitative finance"
   homepage "http://quantlib.org/"
-  url "https://downloads.sourceforge.net/project/quantlib/QuantLib/1.6/QuantLib-1.6.tar.gz"
-  mirror "https://distfiles.macports.org/QuantLib/QuantLib-1.6.tar.gz"
-  sha256 "a135d424a59cbb00a75d7f7ac3a181d49e804abae1776b555ec0183e309f81ce"
+  url "https://downloads.sourceforge.net/project/quantlib/QuantLib/1.6.1/QuantLib-1.6.1.tar.gz"
+  mirror "https://distfiles.macports.org/QuantLib/QuantLib-1.6.1.tar.gz"
+  sha256 "4f90994671173ef20d2bfd34cefc79f753370d79eccafaec926db8c4b6c37870"
 
   head do
     url "https://github.com/lballabio/quantlib.git"


### PR DESCRIPTION
Provides Boost 1.59 compatibility (#42960)