### PR TITLE
advancecomp 1.20

### DIFF
--- a/Library/Formula/advancecomp.rb
+++ b/Library/Formula/advancecomp.rb
@@ -1,11 +1,12 @@
 class Advancecomp < Formula
   desc "Recompression utilities for .PNG, .MNG, .ZIP, and .GZ files"
   homepage "http://advancemame.sourceforge.net/comp-readme.html"
-  url "https://downloads.sourceforge.net/project/advancemame/advancecomp/1.19/advancecomp-1.19.tar.gz"
-  sha256 "d594c50c3da356aa961f75b00e958a4ed1e142c6530b42926092e46419af3047"
+  url "https://github.com/amadvance/advancecomp/releases/download/v1.20/advancecomp-1.20.tar.gz"
+  sha256 "590a447cfc7ab3a37ec707e13967a0046a81a888c561ebaff5415b1e946da67b"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--enable-bzip2",
                           "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"
   end


### PR DESCRIPTION
- Version bump.
- `bzip2` enabled by default (already provided by OS X)