### PR TITLE
Fix Magit’s version reporting.

### DIFF
--- a/Library/Formula/magit.rb
+++ b/Library/Formula/magit.rb
@@ -39,7 +39,7 @@ class Magit < Formula
     ]
     # Can't run `make install` alone without ENV.j1:
     # https://github.com/magit/magit/issues/1670
-    system "make"
+    system "make", "VERSION=#{version}"
     system "make", "install", *args
   end
 


### PR DESCRIPTION
Without this change, the “version” is an empty string.