### PR TITLE
gst-plugins-bad: can optionally use opus, opencv

### DIFF
--- a/Library/Formula/gst-plugins-bad.rb
+++ b/Library/Formula/gst-plugins-bad.rb
@@ -31,6 +31,8 @@ class GstPluginsBad < Formula
   depends_on "libdvdread" => :optional
   depends_on "libexif" => :optional
   depends_on "libmms" => :optional
+  depends_on "homebrew/science/opencv" => :optional
+  depends_on "opus" => :optional
   depends_on "rtmpdump" => :optional
   depends_on "schroedinger" => :optional
 


### PR DESCRIPTION
gst-plugins-bad finds the pkgconfig files and works.

```
[pierce@plo-pro local]$ gst-inspect-1.0 opus
Plugin Details:
  Name                     opus
  Description              OPUS plugin library
  Filename                 /usr/local/lib/gstreamer-1.0/libgstopus.so
  Version                  1.4.5
  License                  LGPL
  Source module            gst-plugins-bad
  Source release date      2014-12-18
  Binary package           GStreamer Bad Plug-ins source release
  Origin URL               Unknown package origin

  opusenc: Opus audio encoder
  opusdec: Opus audio decoder
  opusparse: Opus audio parser
  rtpopusdepay: RTP Opus packet depayloader
  rtpopuspay: RTP Opus payloader

  5 features:
  +-- 5 elements

[pierce@plo-pro local]$ gst-inspect-1.0 opencv
Plugin Details:
  Name                     opencv
  Description              GStreamer OpenCV Plugins
  Filename                 /usr/local/lib/gstreamer-1.0/libgstopencv.so
  Version                  1.4.5
  License                  LGPL
  Source module            gst-plugins-bad
  Source release date      2014-12-18
  Binary package           GStreamer Bad Plug-ins source release
  Origin URL               Unknown package origin

  cvdilate: cvdilate
  cvequalizehist: cvequalizehist
  cverode: cverode
  cvlaplace: cvlaplace
  cvsmooth: cvsmooth
  cvsobel: cvsobel
  edgedetect: edgedetect
  faceblur: faceblur
  facedetect: facedetect
  motioncells: motioncells
  pyramidsegment: pyramidsegment
  templatematch: templatematch
  opencvtextoverlay: opencvtextoverlay
  handdetect: handdetect
  skindetect: skindetect
  retinex: Retinex image colour enhacement
  segmentation: Foreground/background video sequence segmentation
  grabcut: Grabcut-based image FG/BG segmentation
  disparity: Stereo image disparity (depth) map calculation

  19 features:
  +-- 19 elements

```