### PR TITLE
test-bot: don't consider optional deps for compiler selection

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -410,7 +410,7 @@ module Homebrew
       end
 
       begin
-        formula.recursive_dependencies
+        deps.each { |d| d.to_formula.recursive_dependencies }
       rescue TapFormulaUnavailableError => e
         raise if e.tap.installed?
         safe_system "brew", "tap", e.tap.name

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -398,15 +398,15 @@ module Homebrew
       if formula.stable
         return unless satisfied_requirements?(formula, :stable)
 
-        deps |= formula.stable.deps.to_a
-        reqs |= formula.stable.requirements.to_a
+        deps |= formula.stable.deps.to_a.select { |d| !d.optional? }
+        reqs |= formula.stable.requirements.to_a.select { |r| !r.optional? }
       elsif formula.devel
         return unless satisfied_requirements?(formula, :devel)
       end
 
       if formula.devel && !ARGV.include?("--HEAD")
-        deps |= formula.devel.deps.to_a
-        reqs |= formula.devel.requirements.to_a
+        deps |= formula.devel.deps.to_a.select { |d| !d.optional? }
+        reqs |= formula.devel.requirements.to_a.select { |r| !r.optional? }
       end
 
       begin

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -398,15 +398,15 @@ module Homebrew
       if formula.stable
         return unless satisfied_requirements?(formula, :stable)
 
-        deps |= formula.stable.deps.to_a.select { |d| !d.optional? }
-        reqs |= formula.stable.requirements.to_a.select { |r| !r.optional? }
+        deps |= formula.stable.deps.to_a.reject(&:optional?)
+        reqs |= formula.stable.requirements.to_a.reject(&:optional?)
       elsif formula.devel
         return unless satisfied_requirements?(formula, :devel)
       end
 
       if formula.devel && !ARGV.include?("--HEAD")
-        deps |= formula.devel.deps.to_a.select { |d| !d.optional? }
-        reqs |= formula.devel.requirements.to_a.select { |r| !r.optional? }
+        deps |= formula.devel.deps.to_a.reject(&:optional?)
+        reqs |= formula.devel.requirements.to_a.reject(&:optional?)
       end
 
       begin


### PR DESCRIPTION
Fixes test-bot mishandling of optional cross-tap dependencies. Without
this change, since formula.stable.deps includes the optional dependencies but
formula.recursive_dependencies does not, test-bot was trying to select a
compiler for an untapped formula, which raised an error.

Our suspect handling of optional dependencies was exposed by #43145 /
7184348e822d6745d8a103de104ff9626536bf1e.