### PR TITLE
sqoop 1.4.6

### DIFF
--- a/Library/Formula/sqoop.rb
+++ b/Library/Formula/sqoop.rb
@@ -1,14 +1,15 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.5/sqoop-1.4.5.bin__hadoop-2.0.4-alpha.tar.gz"
-  version "1.4.5"
-  sha256 "2f36ba52ae64f2f674780984aa4ed53d43565098f208a4fcbd800af664b1def9"
+  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz"
+  version "1.4.6"
+  sha256 "d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496"
 
   depends_on "hadoop"
   depends_on "hbase"
   depends_on "hive"
   depends_on "zookeeper"
+  depends_on "coreutils"
 
   def spoop_envs
     <<-EOS.undent
@@ -22,6 +23,15 @@ class Sqoop < Formula
   def install
     libexec.install %w[bin conf lib]
     libexec.install Dir["*.jar"]
+
+    # use coreutils' readlink instead of the OS X one to get the '-f' option
+    scripts = %w[
+      sqoop sqoop-codegen sqoop-create-hive-table sqoop-eval
+      sqoop-export sqoop-help sqoop-import sqoop-import-all-tables
+      sqoop-import-mainframe sqoop-job sqoop-list-databases sqoop-list-tables
+      sqoop-merge sqoop-metastore sqoop-version]
+    inreplace scripts.map { |s| "#{libexec}/bin/#{s}" }, /\breadlink\b/, "greadlink"
+
     bin.write_exec_script Dir["#{libexec}/bin/*"]
 
     # Install a sqoop-env.sh file
@@ -33,5 +43,10 @@ class Sqoop < Formula
     Hadoop, Hive, HBase and ZooKeeper must be installed and configured
     for Sqoop to work.
     EOS
+  end
+
+  test do
+    ENV["JAVA_HOME"] = `/usr/libexec/java_home`.chomp
+    assert_match(/Sqoop #{version}/, shell_output("#{bin}/sqoop-version"))
   end
 end


### PR DESCRIPTION
I added a `coreutils` dependency because scripts use `readlink`’s `-f` option, not available on OS X. This issue was already present with the previous version but we didn’t see it because of the lack of a test.