### PR TITLE
duplicity: Swift backup not working because of oslo.utils

### DIFF
--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -3,6 +3,7 @@ class Duplicity < Formula
   homepage "http://www.nongnu.org/duplicity/"
   url "https://code.launchpad.net/duplicity/0.6-series/0.6.26/+download/duplicity-0.6.26.tar.gz"
   sha256 "8bef8a5d805b79ae177e54d42152238bce1b2aaf9ad32e03a2c3a20cbd4e074a"
+  revision 1
 
   bottle do
     sha256 "9fa603fc7c3d6045ec7c6cea234deb9856bf68466bf78d298fac7790fb96ab25" => :yosemite

--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -42,8 +42,13 @@ class Duplicity < Formula
   end
 
   resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.6.0.tar.gz"
-    sha256 "1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75"
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz"
+    sha256 "398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
+    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
   end
 
   resource "iso8601" do
@@ -51,19 +56,34 @@ class Duplicity < Formula
     sha256 "e712ff3a18604833f5073e836aad795b21170b19bbef70947c441ed89d0ac0e1"
   end
 
+  resource "monotonic" do
+    url "https://pypi.python.org/packages/source/m/monotonic/monotonic-0.3.tar.gz"
+    sha256 "2825ba5ded67b1a70d44529634d3f4ddfad67a5ed7fdcf026022a3ce175be07b"
+  end
+
+  resource "msgpack-python" do
+    url "https://pypi.python.org/packages/source/m/msgpack-python/msgpack-python-0.4.6.tar.gz"
+    sha256 "bfcc581c9dbbf07cc2f951baf30c3249a57e20dcbd60f7e6ffc43ab3cc614794"
+  end
+
   resource "pytz" do
-    url "https://pypi.python.org/packages/source/p/pytz/pytz-2014.10.tar.bz2"
-    sha256 "387f968fde793b142865802916561839f5591d8b4b14c941125eb0fca7e4e58d"
+    url "https://pypi.python.org/packages/source/p/pytz/pytz-2015.4.tar.bz2"
+    sha256 "a78b484d5472dd8c688f8b3eee18646a25c66ce45b2c26652850f6af9ce52b17"
   end
 
   resource "Babel" do
-    url "https://pypi.python.org/packages/source/B/Babel/Babel-1.3.tar.gz"
-    sha256 "9f02d0357184de1f093c10012b52e7454a1008be6a5c185ab7a3307aceb1d12e"
+    url "https://pypi.python.org/packages/source/B/Babel/Babel-2.0.tar.gz"
+    sha256 "44988df191123065af9857eca68e9151526a931c12659ca29904e4f11de7ec1b"
+  end
+
+  resource "debtcollector" do
+    url "https://pypi.python.org/packages/source/d/debtcollector/debtcollector-0.7.0.tar.gz"
+    sha256 "03ef06604e666a9f4a1506ffcfa887068bdb9f16e33657f9211a7b4e8bc753ea"
   end
 
   resource "pbr" do
-    url "https://pypi.python.org/packages/source/p/pbr/pbr-0.10.7.tar.gz"
-    sha256 "3219912992192c68d21885409ff853ab97b19559c6b5f9f76fd84f06b00f7a27"
+    url "https://pypi.python.org/packages/source/p/pbr/pbr-1.5.0.tar.gz"
+    sha256 "bd6db6ecddf5d8ab40d7d554508c29cfe0d150a1789f07d4dd32abe896068e7e"
   end
 
   resource "simplejson" do
@@ -82,33 +102,38 @@ class Duplicity < Formula
   end
 
   resource "oslo.i18n" do
-    url "https://pypi.python.org/packages/source/o/oslo.i18n/oslo.i18n-1.3.1.tar.gz"
-    sha256 "8e1b9b3f87cea9e43a2414bb02d8c79b0a688c916afa1f1453f6a0a65ffd85f6"
+    url "https://pypi.python.org/packages/source/o/oslo.i18n/oslo.i18n-2.4.0.tar.gz"
+    sha256 "b788a543416483196015177daf77c2d2a8ba84ea72b4372a7afa54707333308c"
   end
 
   resource "oslo.utils" do
-    url "https://pypi.python.org/packages/source/o/oslo.utils/oslo.utils-1.2.1.tar.gz"
-    sha256 "9cd8bcde345554582fd12c6daab81a7327a90c72861aa644e8b7b3fbfed5deba"
+    url "https://pypi.python.org/packages/source/o/oslo.utils/oslo.utils-2.3.0.tar.gz"
+    sha256 "c0ee7075a04a4c432d74d7b578fdc3478a5e831c9bd26fdff13b9bcc1e745ed4"
   end
 
   resource "oslo.serialization" do
-    url "https://pypi.python.org/packages/source/o/oslo.serialization/oslo.serialization-1.2.0.tar.gz"
-    sha256 "073f25ef4b7138e28ecb75bab413582c4dc1a54ab63b540a1702edee7c0a0557"
+    url "https://pypi.python.org/packages/source/o/oslo.serialization/oslo.serialization-1.8.0.tar.gz"
+    sha256 "89156873f2dfa4aed0265ca9c27d7e66c9aff6cfd5b01cafd2eb4e6bd462579b"
   end
 
   resource "stevedore" do
-    url "https://pypi.python.org/packages/source/s/stevedore/stevedore-1.2.0.tar.gz"
-    sha256 "3f70db9052c26e66dac61cb73d8c6f5211373983d39872addab617c759db4b45"
+    url "https://pypi.python.org/packages/source/s/stevedore/stevedore-1.7.0.tar.gz"
+    sha256 "68cf8691407cfd9c11e32381ef14ff566292dca0d113aba384d3fcc100933791"
+  end
+
+  resource "wrapt" do
+    url "https://pypi.python.org/packages/source/w/wrapt/wrapt-1.10.5.tar.gz"
+    sha256 "99cbb4e3a3ea964df0cb1437261fc1198616ec872e7b501622f3f7f92fcd0833"
   end
 
   resource "oslo.config" do
-    url "https://pypi.python.org/packages/source/o/oslo.config/oslo.config-1.6.0.tar.gz"
-    sha256 "a88cf1af696b4d9cae783a4c8c6898e6fb4abd176f9c9906ba388e7eac5eab17"
+    url "https://pypi.python.org/packages/source/o/oslo.config/oslo.config-2.2.0.tar.gz"
+    sha256 "8ecb41d524a5c09e9a06513936177c2b8df3494d065f6999df7c533370693e3d"
   end
 
   resource "python-keystoneclient" do
-    url "https://pypi.python.org/packages/source/p/python-keystoneclient/python-keystoneclient-1.0.0.tar.gz"
-    sha256 "6d960d2196efc7a181519a77f757a27ceeeac71f41f624318ae7f1088d2e6db4"
+    url "https://pypi.python.org/packages/source/p/python-keystoneclient/python-keystoneclient-1.6.0.tar.gz"
+    sha256 "45ac3b13b8b63ab62cb3fbfcaf46a2241d8053dfe17961db911c45c1f23d06ff"
   end
 
   resource "python-novaclient" do
@@ -197,13 +222,13 @@ class Duplicity < Formula
   end
 
   resource "futures" do
-    url "https://pypi.python.org/packages/source/f/futures/futures-2.2.0.tar.gz"
-    sha256 "151c057173474a3a40f897165951c0e33ad04f37de65b6de547ddef107fd0ed3"
+    url "https://pypi.python.org/packages/source/f/futures/futures-3.0.3.tar.gz"
+    sha256 "2fe2342bb4fe8b8e217f0d21b5921cbe5408bf966d9f92025e707e881b198bed"
   end
 
   resource "python-swiftclient" do
-    url "https://pypi.python.org/packages/source/p/python-swiftclient/python-swiftclient-2.3.1.tar.gz"
-    sha256 "20a9d81dc0d948740a188a0c42e7f7fcc9c81a185bfbdf180f68580ea49309a6"
+    url "https://pypi.python.org/packages/source/p/python-swiftclient/python-swiftclient-2.5.0.tar.gz"
+    sha256 "6efcbff0bf60521ef682068c10c2d8959d887f70ed84ccd2def9945e8e94560e"
   end
 
   def install


### PR DESCRIPTION
Fixes Homebrew/homebrew#43027: oslo.utils could not be imported by python-keystoneclient and prevents Swift-Backups with duplicity

 - updated python-keystoneclient and dependencies
 - updated python-swiftclient and dependencies