### PR TITLE
sandbox: permit /var/tmp & DerivedData

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -31,6 +31,7 @@ module Homebrew
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_cellar(formula)
+        sandbox.allow_write_xcode
         sandbox.allow_write_path HOMEBREW_PREFIX
         sandbox.deny_write_homebrew_library
         sandbox.exec(*args)

--- a/Library/Homebrew/cmd/test.rb
+++ b/Library/Homebrew/cmd/test.rb
@@ -49,6 +49,7 @@ module Homebrew
             sandbox.record_log(f.logs/"sandbox.test.log")
             sandbox.allow_write_temp_and_cache
             sandbox.allow_write_log(f)
+            sandbox.allow_write_xcode
             sandbox.exec(*args)
           else
             exec(*args)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -553,6 +553,7 @@ class FormulaInstaller
         sandbox.record_log(formula.logs/"sandbox.build.log")
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
+        sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
         sandbox.exec(*args)
       else

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -57,6 +57,7 @@ class Sandbox
 
   def allow_write_temp_and_cache
     allow_write_path "/private/tmp"
+    allow_write_path "/private/var/tmp"
     allow_write "^/private/var/folders/[^/]+/[^/]+/[C,T]/", :type => :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE
@@ -66,6 +67,11 @@ class Sandbox
     allow_write_path formula.rack
     allow_write_path formula.etc
     allow_write_path formula.var
+  end
+
+  # Xcode projects expect access to certain cache/archive dirs.
+  def allow_write_xcode
+    allow_write_path "/Users/#{ENV["USER"]}/Library/Developer/Xcode/DerivedData/"
   end
 
   def allow_write_log(formula)


### PR DESCRIPTION
Long term it would be nice to sandbox everything that writes to DerivedData but it is essentially a cache directory of sorts.

The downside of allowing stuff to write there particularly is that DerivedData is notoriously bad at getting cleaned up, so if you do a lot of Xcode-using installations very quickly, you can chew your disk space up.