### PR TITLE
Add a description to sbtenv

### DIFF
--- a/Library/Formula/sbtenv.rb
+++ b/Library/Formula/sbtenv.rb
@@ -1,4 +1,5 @@
 class Sbtenv < Formula
+  desc "Command-line tool for managing sbt environments"
   homepage "https://github.com/mazgi/sbtenv"
   url "https://github.com/mazgi/sbtenv/archive/version/0.0.9.tar.gz"
   sha256 "0c5809eda41a0041d073bb22e92e8de00a8f17b91af2b78c32f0cf5ebea2cd54"


### PR DESCRIPTION
This just provides the missing field, phrased in line with the scalaenv description.