### PR TITLE
clamav: avoid freshclam database load error

### DIFF
--- a/Library/Formula/clamav.rb
+++ b/Library/Formula/clamav.rb
@@ -3,6 +3,7 @@ class Clamav < Formula
   homepage "http://www.clamav.net/"
   url "https://downloads.sourceforge.net/clamav/clamav-0.98.7.tar.gz"
   sha256 "282417b707740de13cd8f18d4cbca9ddd181cf96b444db2cad98913a5153e272"
+  revision 1
 
   bottle do
     sha256 "3c8049f743c8968556ff116b22dfaa23e328210d66f2d53a4623ddc9d03c3b9e" => :yosemite
@@ -32,7 +33,8 @@ class Clamav < Formula
       "--sysconfdir=#{etc}/clamav",
       "--disable-zlib-vcheck",
       "--with-zlib=#{MacOS.sdk_path}/usr",
-      "--with-openssl=#{Formula["openssl"].opt_prefix}"
+      "--with-openssl=#{Formula["openssl"].opt_prefix}",
+      "--enable-llvm=no"
     ]
 
     args << "--with-libjson=#{Formula["json-c"].opt_prefix}" if build.with? "json-c"


### PR DESCRIPTION
Mend updating of bytecode database in clamav-0.98.7 by disabling compilation with llvm. Needs review once a fix is in place upstream.
https://bugzilla.clamav.net/show_bug.cgi?id=11309

Closes #41152