### PR TITLE
fig: deprecated boot2docker dep -> docker-machine

### DIFF
--- a/Library/Formula/fig.rb
+++ b/Library/Formula/fig.rb
@@ -13,10 +13,10 @@ class Fig < Formula
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "libyaml"
 
-  # It's possible that the user wants to manually install Docker and Boot2Docker,
+  # It's possible that the user wants to manually install Docker and Machine,
   # for example, they want to compile Docker manually
   depends_on "docker" => :recommended
-  depends_on "boot2docker" => :recommended
+  depends_on "docker-machine" => :recommended
 
   resource "docker-py" do
     url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.3.1.tar.gz"


### PR DESCRIPTION
As boot2docker-cli has been deprecated:

> This project is officially deprecated in favor of Docker Machine. The
code and documentation here only exist as a reference for users who
have not yet switched over (but please do soon)

https://github.com/boot2docker/boot2docker-cli/blob/master/README.md