### PR TITLE
Warn re OS X curl on <10.7

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -653,13 +653,23 @@ class Checks
     end
   end
 
+  def check_for_bad_curl
+    if MacOS.version <= "10.6" && !Formula["curl"].installed? then <<-EOS.undent
+      The system curl on 10.6 and below is often incapable of supporting
+      modern secure connections & will fail on fetching formulae.
+      We recommend you:
+        brew install curl
+      EOS
+    end
+  end
+
   def check_user_curlrc
     if %w[CURL_HOME HOME].any? { |key| ENV[key] && File.exist?("#{ENV[key]}/.curlrc") } then <<-EOS.undent
     You have a curlrc file
     If you have trouble downloading packages with Homebrew, then maybe this
     is the problem? If the following command doesn't work, then try removing
     your curlrc:
-      curl http://github.com
+      curl https://github.com
     EOS
     end
   end


### PR DESCRIPTION
The `curl` on <10.7 is more or less incapable of fetching any recently-changed GNOME project (i.e. the ones we've moved across to `https`) and various other places. We've been softly using our curl on 10.6 and below for a while, but never communicating that en-mass to users.

Closes #43283.