### PR TITLE
gdal 1.11.2_3 (gdal.jar)

### DIFF
--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -80,7 +80,11 @@ class Gdal < Formula
   end
 
   depends_on :java => ["1.7+", :optional, :build]
-  depends_on "swig" if build.with? "swig-java"
+
+  if build.with? "swig-java"
+    depends_on "ant" => :build
+    depends_on "swig" => :build
+  end
 
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455
@@ -304,6 +308,10 @@ class Gdal < Formula
         inreplace "java.opt", "#JAVA_HOME = /usr/lib/jvm/java-6-openjdk/", "JAVA_HOME=$(shell echo $$JAVA_HOME)"
         system "make"
         system "make", "install"
+
+        # Install the jar that complements the native JNI bindings
+        system "ant"
+        lib.install "gdal.jar"
       end
     end
 


### PR DESCRIPTION
Install dal.jar along with the native JNI bindings.

Native JNI bindings are typically very specific to the java wrapper.  This installs the associated
jar file to be used with the native JNI shared objects.