### PR TITLE
Improved nesting behavior for `String#undent`

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -273,25 +273,25 @@ class BuildToolsError < RuntimeError
     if MacOS.version >= "10.10"
       xcode_text = <<-EOS.undent
         To continue, you must install Xcode from the App Store,
-              or the CLT by running:
-                xcode-select --install
+        or the CLT by running:
+          xcode-select --install
       EOS
     elsif MacOS.version == "10.9"
       xcode_text = <<-EOS.undent
         To continue, you must install Xcode from:
-                https://developer.apple.com/downloads/
-              or the CLT by running:
-                xcode-select --install
+          https://developer.apple.com/downloads/
+        or the CLT by running:
+          xcode-select --install
       EOS
     elsif MacOS.version >= "10.7"
       xcode_text = <<-EOS.undent
         To continue, you must install Xcode or the CLT from:
-                https://developer.apple.com/downloads/
+          https://developer.apple.com/downloads/
       EOS
     else
       xcode_text = <<-EOS.undent
         To continue, you must install Xcode from:
-                https://developer.apple.com/xcode/downloads/
+          https://developer.apple.com/xcode/downloads/
       EOS
     end
 
@@ -320,24 +320,24 @@ class BuildFlagsError < RuntimeError
     if MacOS.version >= "10.10"
       xcode_text = <<-EOS.undent
         or install Xcode from the App Store, or the CLT by running:
-                xcode-select --install
+          xcode-select --install
       EOS
     elsif MacOS.version == "10.9"
       xcode_text = <<-EOS.undent
         or install Xcode from:
-                https://developer.apple.com/downloads/
-              or the CLT by running:
-                xcode-select --install
+          https://developer.apple.com/downloads/
+        or the CLT by running:
+          xcode-select --install
       EOS
     elsif MacOS.version >= "10.7"
       xcode_text = <<-EOS.undent
         or install Xcode or the CLT from:
-                https://developer.apple.com/downloads/
+          https://developer.apple.com/downloads/
       EOS
     else
       xcode_text = <<-EOS.undent
         or install Xcode from:
-                https://developer.apple.com/xcode/downloads/
+          https://developer.apple.com/xcode/downloads/
       EOS
     end
 

--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -1,6 +1,6 @@
 class String
   def undent
-    gsub(/^.{#{(slice(/^ +/) || '').length}}/, "")
+    gsub(/^[ \t]{#{(slice(/^[ \t]+/) || '').length}}/, "")
   end
 
   # eg:

--- a/Library/Homebrew/test/test_string.rb
+++ b/Library/Homebrew/test/test_string.rb
@@ -8,7 +8,7 @@ class StringTest < Homebrew::TestCase
 ....my friend over
     there
     EOS
-    assert_equal "hi\nmy friend over\nthere\n", undented
+    assert_equal "hi\n....my friend over\nthere\n", undented
   end
 
   def test_undent_not_indented
@@ -17,5 +17,18 @@ hi
 I'm not indented
     EOS
     assert_equal "hi\nI'm not indented\n", undented
+  end
+
+  def test_undent_nested
+    nest = <<-EOS.undent
+      goodbye
+    EOS
+
+    undented = <<-EOS.undent
+      hello
+      #{nest}
+    EOS
+
+    assert_equal "hello\ngoodbye\n\n", undented
   end
 end


### PR DESCRIPTION
In #41021 I realized that Homebrew's current `String#undent` implementation does not play nicely
with nested heredocs. In particular, `String#undent` chops off the first <number of spaces> characters from a nested heredoc.

This commit changes this behavior by only `gsub`ing for whitespace characters (`\s`) instead of matching **all** characters (`.`). I've updated `test_undent` in `test_string.rb` to reflect this behavior, and added `test_undent_nested` to reflect the new expected behavior.

As far as I know, no heredocs in Homebrew rely on the **current** behavior of `String#undent` w/r/t `gsub`ing anything up to the indentation level. `BuildToolsError` and `BuildFlagsError` do have to be changed to remove workarounds for the old behavior, which I'll do presently.

\- William