### PR TITLE
Update csvprintf formula to use GitHub version

### DIFF
--- a/Library/Formula/csvprintf.rb
+++ b/Library/Formula/csvprintf.rb
@@ -1,11 +1,15 @@
 class Csvprintf < Formula
   desc "Command-line utility for parsing CSV files"
-  homepage "https://code.google.com/p/csvprintf/"
-  url "https://csvprintf.googlecode.com/files/csvprintf-1.0.3.tar.gz"
-  sha256 "6bc848141447e11af61d0e3fc900b35f13d9d779ddcdfd77d1070d523c708014"
+  homepage "https://github.com/archiecobbs/csvprintf"
+  url "https://github.com/archiecobbs/csvprintf/archive/1.0.3.tar.gz"
+  sha256 "484db6a5f0cdb1a09b375274b30fbbde3c886d5da974d3f247c83b0bf853ef83"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
 
   def install
     ENV.append "LDFLAGS", "-liconv"
+    system "./autogen.sh"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
The official version of csvprintf has moved from Google Code to GitHub.
The GitHub version of the release tarball currently omits some files
pre-generated by autoconf/automake, which both changes the checksum and
requires an additional build step.