### PR TITLE
update: secure formula loading in rename

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -78,7 +78,14 @@ module Homebrew
       next unless (dir = HOMEBREW_CELLAR/oldname).directory? && !dir.subdirs.empty?
 
       begin
-        migrator = Migrator.new(Formulary.factory("#{user}/#{repo}/#{newname}"))
+        f = Formulary.factory("#{user}/#{repo}/#{newname}")
+      rescue FormulaUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
+      end
+
+      next unless f
+
+      begin
+        migrator = Migrator.new(f)
         migrator.migrate
       rescue Migrator::MigratorDifferentTapsError
       end


### PR DESCRIPTION
For update, all formula loading need to be secured by `rescue`.
Otherwise it's easy to crash `brew update` for vasty reasons, e.g.
new Formula DSL.

cc @mikemcquaid @vladshablinsky 