### PR TITLE
(WIP) ddar: installation fixed

### DIFF
--- a/Library/Formula/ddar.rb
+++ b/Library/Formula/ddar.rb
@@ -1,6 +1,6 @@
 class Ddar < Formula
   desc "De-duplicating archiver"
-  homepage "http://www.synctus.com/ddar/"
+  homepage "https://github.com/basak/ddar/wiki"
   url "https://github.com/basak/ddar/archive/v1.0.tar.gz"
   sha256 "b95a11f73aa872a75a6c2cb29d91b542233afa73a8eb00e8826633b8323c9b22"
   revision 1
@@ -9,16 +9,22 @@ class Ddar < Formula
 
   depends_on "xmltoman" => :build
   depends_on :python if MacOS.version <= :snow_leopard
-  depends_on "protobuf" => "with-python"
+  depends_on "protobuf"
 
   def install
-    system "make", "-f", "Makefile.prep", "pydist"
-    system "python", "setup.py", "install",
-                     "--prefix=#{prefix}",
-                     "--single-version-externally-managed",
-                     "--record=installed.txt"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    ENV.prepend_path "PYTHONPATH", Language::Python.homebrew_site_packages
 
-    bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    system "make", "-f", "Makefile.prep", "pydist"
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
     man1.install Dir["*.1"]
+  end
+
+  test do
+    # WIP don't merge this
+    system "ddar", "-h"
   end
 end


### PR DESCRIPTION
The installed script wasn’t finding its own library. This fixes it, but it still fails to find `protobuf`:

```
$ ddar -h
Traceback (most recent call last):
  File "/usr/local/Cellar/ddar/1.0_1/libexec/bin/ddar", line 20, in <module>
    import synctus.ddar_pb2, synctus.dds
  File "/usr/local/lib/python2.7/site-packages/synctus/ddar_pb2.py", line 6, in <module>
ImportError: No module named google.protobuf
```

I don’t know how to fix that. cc @tdsmith

TODO:
- [ ] Fix the installation
- [ ] Add a test