### PR TITLE
open-scene-graph 3.4.0

### DIFF
--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -1,9 +1,8 @@
 class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "http://www.openscenegraph.org/projects/osg"
-  url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.3.3.zip"
-  sha256 "b81cda123ffb3bd108e0fe4be4fff1351d6636e6fb0a1475b2c4fb9618d3ae2b"
-  revision 1
+  url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
+  sha256 "5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e"
 
   head "http://www.openscenegraph.org/svn/osg/OpenSceneGraph/trunk/"
 


### PR DESCRIPTION
Updates OpenSceneGraph to the [latest stable release](http://www.openscenegraph.org/index.php/download-section/stable-releases)