### PR TITLE
fontforge: remove app

### DIFF
--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -93,6 +93,10 @@ class Fontforge < Formula
     system "make"
     system "make", "install"
 
+    # The app here is not functional. You should install Fontforge
+    # via the Cask if you want GUI/App support.
+    (share/"fontforge/osx/FontForge.app").rmtree
+
     if build.with? "extra-tools"
       cd "contrib/fonttools" do
         system "make"


### PR DESCRIPTION
The App hasn't actually been fully supported for a long long time. Launching the GUI from the command-line worked until recently but that support passed with Cairo/Pango's mandatory X11 support.

If you want the App/GUI, I recommend checking out the Cask.

Closes #43321.