### PR TITLE
iojs 3.2.0

### DIFF
--- a/Library/Formula/iojs.rb
+++ b/Library/Formula/iojs.rb
@@ -1,8 +1,8 @@
 class Iojs < Formula
   desc "npm-compatible platform based on Node.js"
   homepage "https://iojs.org/"
-  url "https://iojs.org/dist/v3.1.0/iojs-v3.1.0.tar.xz"
-  sha256 "8d0e11833dd86517868ac95ea87732c0f9614bc3c10150abf1d133ce378dfe48"
+  url "https://iojs.org/dist/v3.2.0/iojs-v3.2.0.tar.xz"
+  sha256 "52bf6b872ae97f4152acf8387657a23280e83ddee8f0d2ea620c5d36d067358c"
 
   bottle do
     sha256 "c18ede09560539014d6ea794c01ba9f1e4fc057f06f4040a90c7d6b95283f7cd" => :yosemite


### PR DESCRIPTION
The repository is now called Node, and the description reads "Future Node.js releases will be from this repo."  What's the plan on our end?