### PR TITLE
Bump scw 1.4.0

### DIFF
--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Scw < Formula
   desc "Manage BareMetal Servers from Command Line (as easily as with Docker)"
   homepage "https://github.com/scaleway/scaleway-cli"
-  url "https://github.com/scaleway/scaleway-cli/archive/v1.3.0.tar.gz"
-  sha256 "b02ed007f831b9ffd79be0b670c6c1bfa59a87ba87ac54dea48005cfb305f5c7"
+  url "https://github.com/scaleway/scaleway-cli/archive/v1.4.0.tar.gz"
+  sha256 "ab7ee002be9557eb2b8075e3b0df340f5e379545152049f2512f1dc2b47b7b8a"
 
   head "https://github.com/scaleway/scaleway-cli.git"
 
@@ -26,7 +26,11 @@ class Scw < Formula
     ln_s buildpath, buildpath/"src/github.com/scaleway/scaleway-cli"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    system "go", "build", "-o", "scw", "."
+    inreplace "pkg/scwversion/placeholder.go" do |s|
+      s.gsub! /VERSION = "master"/, "VERSION = \"v#{version}\""
+      s.gsub! /GITCOMMIT = "master"/, "GITCOMMIT = \"v#{version}\""
+    end
+    system "go", "build", "-o", "scw", "./cmd/scw"
     bin.install "scw"
 
     bash_completion.install "contrib/completion/bash/scw"


### PR DESCRIPTION
Bump to latest version of scw

---

Updated the displayed version (usually done from the Makefile but needs to be in a git clone):

Before:

```console
$  scw version
Client version: master
Go version (client): go1.5
Git commit (client): master
OS/Arch (client): darwin/amd64
```

Now:

```console
$  scw version
Client version: v1.4.0
Go version (client): go1.5
Git commit (client): v1.4.0
OS/Arch (client): darwin/amd64
```