### PR TITLE
id3lib: update patch links

### DIFF
--- a/Library/Formula/id3lib.rb
+++ b/Library/Formula/id3lib.rb
@@ -7,12 +7,14 @@ class Id3lib < Formula
     sha256 "2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d079"
 
     patch do
-      url "https://trac.macports.org/export/112431/trunk/dports/audio/id3lib/files/id3lib-vbr-overflow.patch"
+      url "https://raw.githubusercontent.com/DomT4/scripts/c24f2952/Homebrew_Resources/MacPorts_Import/id3lib/id3lib-vbr-overflow.patch"
+      mirror "https://trac.macports.org/export/112431/trunk/dports/audio/id3lib/files/id3lib-vbr-overflow.patch"
       sha256 "0ec91c9d89d80f40983c04147211ced8b4a4d8a5be207fbe631f5eefbbd185c2"
     end
 
     patch do
-      url "https://trac.macports.org/export/90780/trunk/dports/audio/id3lib/files/id3lib-main.patch"
+      url "https://raw.githubusercontent.com/DomT4/scripts/c24f2952/Homebrew_Resources/MacPorts_Import/id3lib/id3lib-main.patch"
+      mirror "https://trac.macports.org/export/90780/trunk/dports/audio/id3lib/files/id3lib-main.patch"
       sha256 "83c8d2fa54e8f88b682402b2a8730dcbcc8a7578681301a6c034fd53e1275463"
     end
   end
@@ -32,17 +34,20 @@ class Id3lib < Formula
   depends_on "libtool" => :build
 
   patch do
-    url "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/no-iomanip.h.patch"
+    url "https://raw.githubusercontent.com/DomT4/scripts/c24f2952/Homebrew_Resources/MacPorts_Import/id3lib/r112430/no-iomanip.h.patch"
+    mirror "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/no-iomanip.h.patch"
     sha256 "da0bd9f3d17f1dd054720c17dfd15062eabdfc4d38126bb1b2ef5e8f39904925"
   end
 
   patch do
-    url "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/automake.patch"
+    url "https://raw.githubusercontent.com/DomT4/scripts/c24f2952/Homebrew_Resources/MacPorts_Import/id3lib/r112430/automake.patch"
+    mirror "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/automake.patch"
     sha256 "c1ae2aa04baee7f92301cbed120340682e62e1f839bb61f8f6d3c459a7faf097"
   end
 
   patch do
-    url "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/boolcheck.patch"
+    url "https://raw.githubusercontent.com/DomT4/scripts/c24f2952/Homebrew_Resources/MacPorts_Import/id3lib/r112430/boolcheck.patch"
+    mirror "https://trac.macports.org/export/112430/trunk/dports/audio/id3lib/files/boolcheck.patch"
     sha256 "a7881dc25665f284798934ba19092d1eb45ca515a34e5c473accd144aa1a215a"
   end
 
@@ -52,7 +57,7 @@ class Id3lib < Formula
   end
 
   def install
-    system "autoreconf -fi"
+    system "autoreconf", "-fvi"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Should fix the failure in https://github.com/Homebrew/homebrew-x11/pull/123.