### PR TITLE
legit: fix wrong version specification

### DIFF
--- a/Library/Formula/legit.rb
+++ b/Library/Formula/legit.rb
@@ -2,7 +2,6 @@ class Legit < Formula
   desc "Command-line interface for Git, optimized for workflow simplicity"
   homepage "http://www.git-legit.org/"
   url "https://github.com/kennethreitz/legit/archive/v0.2.0.tar.gz"
-  version "0.1.0"
   sha256 "dce86a16d9c95e2a7d93be75f1fc17c67d3cd2a137819fa498e179bf21daf39e"
 
   bottle do


### PR DESCRIPTION
I don't know why this had passed the test, but anyway the correct version is 0.2.0 for legit.