### PR TITLE
gstreamer 1.5.90

### DIFF
--- a/Library/Formula/gstreamer.rb
+++ b/Library/Formula/gstreamer.rb
@@ -1,9 +1,8 @@
 class Gstreamer < Formula
   desc "GStreamer is a development framework for multimedia applications"
   homepage "http://gstreamer.freedesktop.org/"
-  url "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.4.5.tar.xz"
-  mirror "http://ftp.osuosl.org/pub/blfs/svn/g/gstreamer-1.4.5.tar.xz"
-  sha256 "40801aa7f979024526258a0e94707ba42b8ab6f7d2206e56adbc4433155cb0ae"
+  url "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.5.90.tar.xz"
+  sha256 "7cd8094880b5dc4b7f457a9288b611c15aaf1b9cf4a63da49c821ab687eb56ed"
 
   bottle do
     revision 2


### PR DESCRIPTION
The test currently fails if `gst-python` is installed (#43420) but it was like this before this PR:

```
Testing gstreamer
==> /usr/local/Cellar/gstreamer/1.5.90/bin/gst-inspect-1.0

ERROR: Caught a segmentation fault while loading plugin file:
/usr/local/lib/gstreamer-1.0/libgstpythonplugin.dylib

Please either:
- remove it and restart.
- run with --gst-disable-segtrap --gst-disable-registry-fork and debug.
```

Stuff to check:

- [ ] `clutter-gst`
- [ ] `efl`
- [ ] `gst-plugins-base`
- [ ] `gst-validate`
- [ ] `libcanberra`
- [ ] `libnice`
- [ ] `homebrew/science/opencv`
- [ ] `homebrew/science/opencv3`
- [ ] `gst-python` (doesn’t currently have a dependency on `gstreamer`, but appears to depend on it)