### PR TITLE
subversion: remove universal python fail

### DIFF
--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -226,11 +226,6 @@ class Subversion < Formula
     end
   end
 
-  test do
-    system "#{bin}/svnadmin", "create", "test"
-    system "#{bin}/svnadmin", "verify", "test"
-  end
-
   def caveats
     s = <<-EOS.undent
       svntools have been installed to:
@@ -263,6 +258,11 @@ class Subversion < Formula
     end
 
     s
+  end
+
+  test do
+    system "#{bin}/svnadmin", "create", "test"
+    system "#{bin}/svnadmin", "verify", "test"
   end
 end
 


### PR DESCRIPTION
Remove `--universal` requirement when using `--with-python` and a universal Python.

The previous fix's pull request: #40437

Using `ARCHFLAGS` is [the documented way to handle building a Python extension for a single architecture](https://developer.apple.com/library/mac/releasenotes/OpenSource/PerlExtensionsRelNotes/#//apple_ref/doc/uid/TP40006659-CH1-DontLinkElementID_3).