### PR TITLE
allegro: Switch head to point to github.

### DIFF
--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -22,7 +22,7 @@ class Allegro < Formula
   end
 
   head do
-    url "git://git.code.sf.net/p/alleg/allegro", :branch => "5.1"
+    url "https://github.com/liballeg/allegro5.git", :branch => "5.1"
 
     depends_on "theora" => :recommended
   end


### PR DESCRIPTION
Upstream moved git hosting from sourceforge to github: [News link](http://liballeg.org/#allegros-git-repository-is-now-hosted-at-github.)