### PR TITLE
Remove references to bin/examples

### DIFF
--- a/Library/Formula/flow.rb
+++ b/Library/Formula/flow.rb
@@ -12,20 +12,23 @@ class Flow < Formula
     sha256 "5cf57fcca47de49144872145c9bb8b004c649f0ff12b1927573ddf821710275a" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     system "make"
     bin.install "bin/flow"
-    (share/"flow").install "bin/examples"
 
     bash_completion.install "resources/shell/bash-completion" => "flow-completion.bash"
     zsh_completion.install_symlink bash_completion/"flow-completion.bash" => "_flow"
   end
 
   test do
-    output = `#{bin}/flow single #{share}/flow/examples/01_HelloWorld`
-    assert_match(/This type is incompatible with/, output)
-    assert_match(/Found 1 error/, output)
+    system "#{bin}/flow init #{testpath}"
+    (testpath/"test.js").write <<-EOS.undent
+      /* @flow */
+      var x: string = 123;
+    EOS
+    expected = /number\nThis type is incompatible with\n.*string\n\nFound 1 error/
+    assert_match expected, shell_output("#{bin}/flow check #{testpath}", 2)
   end
 end


### PR DESCRIPTION
Flow used to stick some examples in the bin directory, but we stopped doing that as of v0.14.0 (https://github.com/facebook/flow/commit/b904adf1aaefa5b58990819bc03b01e7b618cb32). However the homebrew formula was still referencing it and that would cause errors.

Fixes facebook/flow#765