### PR TITLE
gjstest 1.0.1 (new formula)

### DIFF
--- a/Library/Formula/gjstest.rb
+++ b/Library/Formula/gjstest.rb
@@ -1,0 +1,34 @@
+class Gjstest < Formula
+  desc "Fast javascript unit testing framework that runs on the V8 engine."
+  homepage "https://github.com/google/gjstest"
+  url "https://github.com/google/gjstest/archive/v1.0.1.tar.gz"
+  sha256 "c64d1b8d153b9afaa17ce521d9a7d07acbf13838dab7b2e57822f0bf046f80e5"
+  head "https://github.com/google/gjstest.git"
+
+  depends_on :macos => :mavericks
+
+  depends_on "gflags"
+  depends_on "glog"
+  depends_on "libxml2"
+  depends_on "protobuf"
+  depends_on "re2"
+  depends_on "v8"
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  test do
+    (testpath/"sample_test.js").write <<-EOF
+      function SampleTest() {
+      }
+      registerTestSuite(SampleTest);
+
+      addTest(SampleTest, function twoPlusTwoEqualsFour() {
+        expectEq(4, 2+2);
+      });
+    EOF
+
+    system "#{bin}/gjstest", "--js_files", "#{testpath}/sample_test.js"
+  end
+end


### PR DESCRIPTION
There was a gjstest formula in the past, but it stopped building due to
v8 issues and was removed. As of the v8 upgrade in 9dae089, this can
work again.

For google/gjstest#3.