### PR TITLE
remove Requirement#pour_bottle?

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -55,12 +55,6 @@ class Requirement
     !!result
   end
 
-  # Can overridden to optionally prevent a formula with this requirement from
-  # pouring a bottle.
-  def pour_bottle?
-    true
-  end
-
   # Overriding #fatal? is deprecated.
   # Pass a boolean to the fatal DSL method instead.
   def fatal?

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -14,10 +14,6 @@ class PythonRequirement < Requirement
     version == Version.new("2.7")
   end
 
-  def pour_bottle?
-    build? || system_python?
-  end
-
   env do
     short_version = python_short_version
 


### PR DESCRIPTION
It's never used since a0a93f1b3b7b2be9b8a319be91086ffe220f8e32.