### PR TITLE
FORD 4.2.3

### DIFF
--- a/Library/Formula/ford.rb
+++ b/Library/Formula/ford.rb
@@ -1,8 +1,8 @@
 class Ford < Formula
   desc "Automatic documentation generator for modern Fortran programs"
   homepage "https://github.com/cmacmackin/ford/"
-  url "https://pypi.python.org/packages/source/F/FORD/FORD-4.1.0.tar.gz"
-  sha256 "ec04b08468f75ac0acbda4fd6a15a432eb267e9c28098b5937125a95d2c6fdff"
+  url "https://pypi.python.org/packages/source/F/FORD/FORD-4.2.3.tar.gz"
+  sha256 "8dac3abec4ea88ff68218738bbd0407c2a0b1714c644e28883b1e36611c609b4"
 
   head "https://github.com/cmacmackin/ford.git"
 
@@ -12,22 +12,27 @@ class Ford < Formula
     sha256 "9b16cc8ab21faa866d70a954f8b54d9824f6cc09fcfa9a99659d38d4e3824eea" => :mavericks
     sha256 "c149f7b6422be7355dac922c4ed691716e8c5eb0258af294777fefff308af615" => :mountain_lion
   end
-
+  depends_on "graphviz"
   depends_on :python if MacOS.version <= :snow_leopard
 
-  resource "toposort" do
-    url "https://pypi.python.org/packages/source/t/toposort/toposort-1.4.tar.gz"
-    sha256 "c190b9d9a9e53ae2835f4d524130147af601fbd63677d19381c65067a80fa903"
+  resource "beautifulsoup4" do
+    url "https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.4.0.tar.gz"
+    sha256 "fad91da88f69438b9ba939ab1b2cabaa31b1d914f1cccb4bb157a993ed2917f6"
+  end
+
+  resource "graphviz" do
+    url "https://pypi.python.org/packages/source/g/graphviz/graphviz-0.4.6.zip"
+    sha256 "f12da6fd8318d909ef13bb269bf6b96dd09d3b908a8e2b373b9ba5dbe3d3ec69"
+  end
+
+  resource "Jinja2" do
+    url "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz"
+    sha256 "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4"
   end
 
   resource "Markdown" do
     url "https://pypi.python.org/packages/source/M/Markdown/Markdown-2.6.2.tar.gz"
     sha256 "ee17d0d7dc091e645dd48302a2e21301cc68f188505c2069d8635f94554170bf"
-  end
-
-  resource "beautifulsoup4" do
-    url "https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.4.0.tar.gz"
-    sha256 "fad91da88f69438b9ba939ab1b2cabaa31b1d914f1cccb4bb157a993ed2917f6"
   end
 
   resource "markdown-include" do
@@ -40,19 +45,19 @@ class Ford < Formula
     sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
   end
 
-  resource "Jinja2" do
-    url "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz"
-    sha256 "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4"
-  end
-
   resource "Pygments" do
     url "https://pypi.python.org/packages/source/P/Pygments/Pygments-2.0.2.tar.gz"
     sha256 "7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51"
   end
 
+  resource "toposort" do
+    url "https://pypi.python.org/packages/source/t/toposort/toposort-1.4.tar.gz"
+    sha256 "c190b9d9a9e53ae2835f4d524130147af601fbd63677d19381c65067a80fa903"
+  end
+
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    %w[toposort Markdown beautifulsoup4 markdown-include MarkupSafe Jinja2 Pygments].each do |r|
+    %w[beautifulsoup4 graphviz Jinja2 Markdown markdown-include MarkupSafe Pygments toposort].each do |r|
       resource(r).stage do
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end


### PR DESCRIPTION
FORD 4.2.3

Major enhancement:
 - Call graphs
 - Module dependency graphs
 - Type/class graph/diagram

Also, I have reordered the python package dependencies/resources now that [Homebrew PyPi Poet](https://github.com/tdsmith/homebrew-pypi-poet) sorts them in alphabetical order. This will ease maintenance in the future. When the formula for FORD was first authored, `poet -f ford` produced resource stanzas that were neither sorted, nor in a deterministic order. This made inspecting the stanzas for changed versions more time consuming.