### PR TITLE
Update ImageMagick head URL to official git repo

### DIFF
--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -5,8 +5,7 @@ class Imagemagick < Formula
   mirror "http://ftp.nluug.nl/ImageMagick/ImageMagick-6.9.1-10.tar.xz"
   sha256 "22565464059376513869b6626982e0726a33788ccc7e19a08e55ff1683d4ff92"
 
-  head "https://subversion.imagemagick.org/subversion/ImageMagick/trunk",
-       :using => :svn
+  head "http://git.imagemagick.org/repos/ImageMagick.git"
 
   bottle do
     sha256 "efc853c530ddce73bf7abfcd1dfc9e571ca2d8207e655892cf75a2902b8050bd" => :yosemite


### PR DESCRIPTION
The svn url no longer seems to work, failing with an HTTP 500 internal
server error and/or HTTP 403 forbidden. Cannot check out the latest
revision both by hand and through brew.

Site says that https://git.imagemagick.org/repos/ImageMagick is the
official source repo, so this points brew thataway.

http://www.imagemagick.org/script/install-source.php