### PR TITLE
update Apache formulas to new mirror selector

### DIFF
--- a/Library/Formula/activemq-cpp.rb
+++ b/Library/Formula/activemq-cpp.rb
@@ -1,7 +1,7 @@
 class ActivemqCpp < Formula
   desc "C++ API for message brokers such as Apache ActiveMQ"
   homepage "https://activemq.apache.org/cms/index.html"
-  url "https://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.8.4/activemq-cpp-library-3.8.4-src.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=activemq/activemq-cpp/3.8.4/activemq-cpp-library-3.8.4-src.tar.bz2"
   sha256 "9fba18d57f7512ae4f17008d7745d1b4c957b858b585860deadbf9208cb733e3"
 
   bottle do

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -1,7 +1,7 @@
 class Activemq < Formula
   desc "Apache ActiveMQ: powerful open source messaging server"
   homepage "https://activemq.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/activemq/5.11.1/apache-activemq-5.11.1-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/activemq/5.11.1/apache-activemq-5.11.1-bin.tar.gz"
   sha256 "5ae90f4ea6caa3af7d9f79d1cc55b575dd44170b1451f096494e1a356828d35f"
 
   depends_on :java => "1.6+"

--- a/Library/Formula/ant.rb
+++ b/Library/Formula/ant.rb
@@ -1,7 +1,7 @@
 class Ant < Formula
   desc "Java build tool"
   homepage "https://ant.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.9.6-bin.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=ant/binaries/apache-ant-1.9.6-bin.tar.bz2"
   sha256 "a43b0928960d63d6b1e2bed37e1ce4fd8fa1788ba84e08388bfe9513f02e8db3"
   head "https://git-wip-us.apache.org/repos/asf/ant.git"
 
@@ -18,7 +18,7 @@ class Ant < Formula
   option "with-bcel", "Install Byte Code Engineering Library"
 
   resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
     sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
   end
 

--- a/Library/Formula/apache-archiva.rb
+++ b/Library/Formula/apache-archiva.rb
@@ -1,7 +1,7 @@
 class ApacheArchiva < Formula
   desc "The Build Artifact Repository Manager"
   homepage "https://archiva.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz"
   sha256 "6af7c3c47c35584f729a9c139675a01f9a9819d0cdde292552fc783284a34cfa"
 
   depends_on :java => "1.7+"

--- a/Library/Formula/apache-drill.rb
+++ b/Library/Formula/apache-drill.rb
@@ -1,7 +1,7 @@
 class ApacheDrill < Formula
   desc "Schema-free SQL query engine for Hadoop and NoSQL"
   homepage "https://drill.apache.org/download/"
-  url "https://www.apache.org/dyn/closer.cgi?path=drill/drill-1.1.0/apache-drill-1.1.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=drill/drill-1.1.0/apache-drill-1.1.0.tar.gz"
   mirror "http://getdrill.org/drill/download/apache-drill-1.1.0.tar.gz"
   sha256 "04b6b21eb526f0491050a432f7d2bbea77d0bf231ac404843840c604310a41d2"
 

--- a/Library/Formula/apache-forrest.rb
+++ b/Library/Formula/apache-forrest.rb
@@ -1,11 +1,11 @@
 class ApacheForrest < Formula
   desc "Publishing framework providing multiple output formats"
   homepage "https://forrest.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-sources.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=forrest/apache-forrest-0.9-sources.tar.gz"
   sha256 "c6ac758db2eb0d4d91bd1733bbbc2dec4fdb33603895c464bcb47a34490fb64d"
 
   resource "deps" do
-    url "https://www.apache.org/dyn/closer.cgi?path=forrest/apache-forrest-0.9-dependencies.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=forrest/apache-forrest-0.9-dependencies.tar.gz"
     sha256 "33146b4e64933691d3b779421b35da08062a704618518d561281d3b43917ccf1"
   end
 

--- a/Library/Formula/apache-opennlp.rb
+++ b/Library/Formula/apache-opennlp.rb
@@ -1,7 +1,7 @@
 class ApacheOpennlp < Formula
   desc "Machine learning toolkit for processing natural language text"
   homepage "https://opennlp.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=opennlp/opennlp-1.6.0/apache-opennlp-1.6.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=opennlp/opennlp-1.6.0/apache-opennlp-1.6.0-bin.tar.gz"
   mirror "https://www.us.apache.org/dist/opennlp/opennlp-1.6.0/apache-opennlp-1.6.0-bin.tar.gz"
   sha256 "417ca3d4e535fa69238ab0eb657a0b471da821218d078de959967b31748d99e6"
 

--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -2,7 +2,7 @@ class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
   head "https://github.com/apache/spark.git"
-  url "https://www.apache.org/dyn/closer.cgi?path=spark/spark-1.4.1/spark-1.4.1-bin-hadoop2.6.tgz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=spark/spark-1.4.1/spark-1.4.1-bin-hadoop2.6.tgz"
   version "1.4.1"
   sha256 "9cde95349cccfeb99643d2dadb63f8e88ac355e0038aae7d5029142ce94ae370"
 

--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -1,7 +1,7 @@
 class AprUtil < Formula
   desc "Companion library to apr, the Apache Portable Runtime library"
   homepage "https://apr.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=apr/apr-util-1.5.4.tar.bz2"
   sha256 "a6cf327189ca0df2fb9d5633d7326c460fe2b61684745fd7963e79a6dd0dc82e"
   revision 1
 

--- a/Library/Formula/apr.rb
+++ b/Library/Formula/apr.rb
@@ -1,7 +1,7 @@
 class Apr < Formula
   desc "Apache Portable Runtime library"
   homepage "https://apr.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.2.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=apr/apr-1.5.2.tar.bz2"
   sha256 "7d03ed29c22a7152be45b8e50431063736df9e1daa1ddf93f6a547ba7a28f67a"
 
   bottle do

--- a/Library/Formula/avro-c.rb
+++ b/Library/Formula/avro-c.rb
@@ -1,7 +1,7 @@
 class AvroC < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz"
   sha256 "69b56580f4cc63acbc49825153664ead44abdf1ff8f6f3511d5877533a745a66"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/avro-cpp.rb
+++ b/Library/Formula/avro-cpp.rb
@@ -1,7 +1,7 @@
 class AvroCpp < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/cpp/avro-cpp-1.7.7.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=avro/avro-1.7.7/cpp/avro-cpp-1.7.7.tar.gz"
   sha256 "f9bdfad58f513014940fcda372840e36f4f3787a20a00bc0666d254973a1ec1d"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/avro-tools.rb
+++ b/Library/Formula/avro-tools.rb
@@ -1,7 +1,7 @@
 class AvroTools < Formula
   desc "Avro command-line tools and utilities"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/java/avro-tools-1.7.7.jar"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=avro/avro-1.7.7/java/avro-tools-1.7.7.jar"
   sha256 "ca1658c64d3609e9b7fe62039b3a95993fa18ed3244121c1f71d677ec51ab092"
 
   def install

--- a/Library/Formula/cassandra.rb
+++ b/Library/Formula/cassandra.rb
@@ -1,7 +1,7 @@
 class Cassandra < Formula
   desc "Eventually consistent, distributed key-value store"
   homepage "https://cassandra.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=/cassandra/2.2.0/apache-cassandra-2.2.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/cassandra/2.2.0/apache-cassandra-2.2.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/cassandra/2.2.0/apache-cassandra-2.2.0-bin.tar.gz"
   sha256 "6405eb063e7c8a44a485ac12b305c00ad62c526cc021bcce145c29423ae7b0a2"
 

--- a/Library/Formula/couchdb.rb
+++ b/Library/Formula/couchdb.rb
@@ -1,7 +1,7 @@
 class Couchdb < Formula
   desc "CouchDB is a document database server"
   homepage "https://couchdb.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"
   sha256 "5a601b173733ce3ed31b654805c793aa907131cd70b06d03825f169aa48c8627"
   revision 3
 

--- a/Library/Formula/fop.rb
+++ b/Library/Formula/fop.rb
@@ -1,7 +1,7 @@
 class Fop < Formula
   desc "XSL-FO print formatter for making PDF or PS documents"
   homepage "https://xmlgraphics.apache.org/fop/index.html"
-  url "https://www.apache.org/dyn/closer.cgi?path=/xmlgraphics/fop/binaries/fop-2.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/xmlgraphics/fop/binaries/fop-2.0-bin.tar.gz"
   sha256 "1e90cfc9e07c2da088592860fa4651a7640c9e1e3500b71a613a5dea03eb3665"
 
   bottle do

--- a/Library/Formula/hadoop.rb
+++ b/Library/Formula/hadoop.rb
@@ -1,7 +1,7 @@
 class Hadoop < Formula
   desc "Framework for distributed processing of large data sets"
   homepage "https://hadoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
   mirror "https://archive.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
   sha256 "991dc34ea42a80b236ca46ff5d207107bcc844174df0441777248fdb6d8c9aa0"
 

--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -1,7 +1,7 @@
 class Hbase < Formula
   desc "Hadoop database: a distributed, scalable, big data store"
   homepage "https://hbase.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=hbase/1.0.1.1/hbase-1.0.1.1-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=hbase/1.0.1.1/hbase-1.0.1.1-bin.tar.gz"
   sha256 "fd20fd98e9c11d96d0281077e3040c81f45bafcc1e4f14318cede31e45819fdf"
 
   depends_on :java => "1.6+"

--- a/Library/Formula/hive.rb
+++ b/Library/Formula/hive.rb
@@ -1,7 +1,7 @@
 class Hive < Formula
   desc "Hadoop-based data summarization, query, and analysis"
   homepage "https://hive.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=hive/hive-1.2.1/apache-hive-1.2.1-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=hive/hive-1.2.1/apache-hive-1.2.1-bin.tar.gz"
   sha256 "29d9780c4af887ef623bafe6a73ec6f1bea9759bbe31fb4aeeb5b0f68c4c9979"
 
   depends_on "hadoop"

--- a/Library/Formula/ivy.rb
+++ b/Library/Formula/ivy.rb
@@ -1,7 +1,7 @@
 class Ivy < Formula
   desc "Agile dependency manager"
   homepage "https://ant.apache.org/ivy/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
   sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
 
   def install

--- a/Library/Formula/jmeter.rb
+++ b/Library/Formula/jmeter.rb
@@ -1,7 +1,7 @@
 class Jmeter < Formula
   desc "Load testing and performance measurement application"
   homepage "https://jmeter.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=jmeter/binaries/apache-jmeter-2.13.tgz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=jmeter/binaries/apache-jmeter-2.13.tgz"
   sha256 "9fe33d3d6e381103d3ced2962cdef5c164a06fc58c55e247eadf5a5dbcd4d8fe"
 
   resource "jmeterplugins-standard" do

--- a/Library/Formula/log4cxx.rb
+++ b/Library/Formula/log4cxx.rb
@@ -1,7 +1,7 @@
 class Log4cxx < Formula
   desc "Library of C++ classes for flexible logging"
   homepage "https://logging.apache.org/log4cxx/index.html"
-  url "https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
   sha256 "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
 
   bottle do

--- a/Library/Formula/mahout.rb
+++ b/Library/Formula/mahout.rb
@@ -1,7 +1,7 @@
 class Mahout < Formula
   desc "Library to help build scalable machine learning libraries"
   homepage "https://mahout.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=mahout/0.11.0/apache-mahout-distribution-0.11.0.zip"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=mahout/0.11.0/apache-mahout-distribution-0.11.0.zip"
   sha256 "3b4a68c69cff2ce41b9ddd789469eaa85ea3d7bab980717182bf94ea71c22904"
 
   head do

--- a/Library/Formula/maven.rb
+++ b/Library/Formula/maven.rb
@@ -1,7 +1,7 @@
 class Maven < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
   mirror "https://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
   sha256 "3a8dc4a12ab9f3607a1a2097bbab0150c947ad6719d8f1bb6d5b47d0fb0c4779"
 

--- a/Library/Formula/mesos.rb
+++ b/Library/Formula/mesos.rb
@@ -1,7 +1,7 @@
 class Mesos < Formula
   desc "Apache cluster manager"
   homepage "https://mesos.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=mesos/0.23.0/mesos-0.23.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=mesos/0.23.0/mesos-0.23.0.tar.gz"
   mirror "https://archive.apache.org/dist/mesos/0.23.0/mesos-0.23.0.tar.gz"
   sha256 "b967355ec1f7cf9ffcef76b58939ed48dd4975ea90d1c976669b50c589bdbdec"
 

--- a/Library/Formula/nifi.rb
+++ b/Library/Formula/nifi.rb
@@ -1,7 +1,7 @@
 class Nifi < Formula
   desc "Easy to use, powerful, and reliable system to process and distribute data."
   homepage "https://nifi.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=/nifi/0.2.1/nifi-0.2.1-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/nifi/0.2.1/nifi-0.2.1-bin.tar.gz"
   sha256 "e151dab553a8ea466f7462d75145e2aa08ced938499aef184850aa4d3209c605"
 
   depends_on :java => "1.7+"

--- a/Library/Formula/pig.rb
+++ b/Library/Formula/pig.rb
@@ -1,7 +1,7 @@
 class Pig < Formula
   desc "Platform for analyzing large data sets"
   homepage "https://pig.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=pig/pig-0.15.0/pig-0.15.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=pig/pig-0.15.0/pig-0.15.0.tar.gz"
   mirror "https://archive.apache.org/dist/pig/pig-0.15.0/pig-0.15.0.tar.gz"
   sha256 "c52112ca618daaca298cf068e6451449fe946e8dccd812d56f8f537aa275234b"
 

--- a/Library/Formula/pylucene.rb
+++ b/Library/Formula/pylucene.rb
@@ -1,7 +1,7 @@
 class Pylucene < Formula
   desc "Python extension for accessing Java Lucene"
   homepage "https://lucene.apache.org/pylucene/index.html"
-  url "https://www.apache.org/dyn/closer.cgi?path=lucene/pylucene/pylucene-4.10.1-1-src.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=lucene/pylucene/pylucene-4.10.1-1-src.tar.gz"
   sha256 "63c946d3470ffc2e1a5025b93282235991c46f02c01034de482d7ecada073286"
 
   option "with-shared", "build jcc as a shared library"

--- a/Library/Formula/solr.rb
+++ b/Library/Formula/solr.rb
@@ -1,7 +1,7 @@
 class Solr < Formula
   desc "Enterprise search platform from the Apache Lucene project"
   homepage "https://lucene.apache.org/solr/"
-  url "https://www.apache.org/dyn/closer.cgi?path=lucene/solr/5.3.0/solr-5.3.0.tgz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=lucene/solr/5.3.0/solr-5.3.0.tgz"
   mirror "https://archive.apache.org/dist/lucene/solr/5.3.0/solr-5.3.0.tgz"
   sha256 "26aec63d81239a65f182f17bbf009b1070f7db0bb83657ac2a67a08b57227f7c"
 

--- a/Library/Formula/sqoop.rb
+++ b/Library/Formula/sqoop.rb
@@ -1,7 +1,7 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.5/sqoop-1.4.5.bin__hadoop-2.0.4-alpha.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=sqoop/1.4.5/sqoop-1.4.5.bin__hadoop-2.0.4-alpha.tar.gz"
   version "1.4.5"
   sha256 "2f36ba52ae64f2f674780984aa4ed53d43565098f208a4fcbd800af664b1def9"
 

--- a/Library/Formula/storm.rb
+++ b/Library/Formula/storm.rb
@@ -1,7 +1,7 @@
 class Storm < Formula
   desc "Distributed realtime computation system to process data streams"
   homepage "https://storm.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz"
   sha256 "2e8337126de8d1e180abe77fb81af7c971f8c4b2dad94e446ac86c0f02ba3fb2"
 
   def install

--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -1,7 +1,7 @@
 class Subversion < Formula
   desc "Version control system designed to be a better CVS"
   homepage "https://subversion.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=subversion/subversion-1.8.13.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=subversion/subversion-1.8.13.tar.bz2"
   mirror "https://archive.apache.org/dist/subversion/subversion-1.8.13.tar.bz2"
   sha256 "1099cc68840753b48aedb3a27ebd1e2afbcc84ddb871412e5d500e843d607579"
 
@@ -13,7 +13,7 @@ class Subversion < Formula
   end
 
   devel do
-    url "https://www.apache.org/dyn/closer.cgi?path=subversion/subversion-1.9.0-rc3.tar.bz2"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=subversion/subversion-1.9.0-rc3.tar.bz2"
     mirror "https://archive.apache.org/dist/subversion/subversion-1.9.0-rc3.tar.bz2"
     sha256 "c49432a1a2e83fa3babd7a0602d207c8c11feb1d0660828609710f101737fa6d"
   end

--- a/Library/Formula/thrift.rb
+++ b/Library/Formula/thrift.rb
@@ -3,7 +3,7 @@ class Thrift < Formula
   homepage "https://thrift.apache.org/"
 
   stable do
-    url "https://www.apache.org/dyn/closer.cgi?path=thrift/0.9.2/thrift-0.9.2.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=thrift/0.9.2/thrift-0.9.2.tar.gz"
     sha256 "cef50d3934c41db5fa7724440cc6f10a732e7a77fe979b98c23ce45725349570"
 
     # Apply any necessary patches (none currently required)

--- a/Library/Formula/tika.rb
+++ b/Library/Formula/tika.rb
@@ -1,7 +1,7 @@
 class Tika < Formula
   desc "Content analysis toolkit"
   homepage "https://tika.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.10.jar"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tika/tika-app-1.10.jar"
   sha256 "21ac3c156c2b53c451599f1b2c441c7898fce8efb7e912f6894e5e543d7cd48c"
 
   depends_on :java => "1.7+"

--- a/Library/Formula/tomcat-native.rb
+++ b/Library/Formula/tomcat-native.rb
@@ -1,7 +1,7 @@
 class TomcatNative < Formula
   desc "Lets Tomcat use some native resources for performance"
   homepage "https://tomcat.apache.org/native-doc/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz"
   mirror "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/1.1.33/source/tomcat-native-1.1.33-src.tar.gz"
   sha256 "523dde7393c57307eedf4972ebbe19a9e9af6f7699e3b1ef6dabd7a11677866e"
 

--- a/Library/Formula/tomcat.rb
+++ b/Library/Formula/tomcat.rb
@@ -1,7 +1,7 @@
 class Tomcat < Formula
   desc "Implementation of Java Servlet and JavaServer Pages"
   homepage "https://tomcat.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.tar.gz"
   mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.tar.gz"
   sha256 "9f11588f0ff767adde63cd6919462c0c2742897560f4b367a0ffffdd8b1ed382"
 
@@ -15,7 +15,7 @@ class Tomcat < Formula
   option "with-fulldocs", "Install full documentation locally"
 
   resource "fulldocs" do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-fulldocs.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-fulldocs.tar.gz"
     mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-fulldocs.tar.gz"
     version "8.0.26"
     sha256 "813513d61e6def5ccf01adc95bf9d28594fce71ff32f5e23dc1482c7ec2f129b"

--- a/Library/Formula/tomee-jax-rs.rb
+++ b/Library/Formula/tomee-jax-rs.rb
@@ -1,7 +1,7 @@
 class TomeeJaxRs < Formula
   desc "TomeEE Web Profile plus JAX-RS"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz"
   version "1.7.2"
   sha256 "561ef98f69b312a03b305f37fd492ed59f9802137e2995ea57db98d438b0b9c8"
 

--- a/Library/Formula/tomee-plume.rb
+++ b/Library/Formula/tomee-plume.rb
@@ -1,7 +1,7 @@
 class TomeePlume < Formula
   desc "Apache TomEE Plume"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz"
   version "1.7.2"
   sha256 "7e6c67a19c6f0cc352e6a107fdf7ee1908eda6e4bfbdcc6d43dcf984de360508"
 

--- a/Library/Formula/tomee-plus.rb
+++ b/Library/Formula/tomee-plus.rb
@@ -1,7 +1,7 @@
 class TomeePlus < Formula
   desc "Everything in TomEE Web Profile and JAX-RS, plus more"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz"
   version "1.7.2"
   sha256 "deb551788f56e5051e4f9cd6a642b9543c7635819a58015b72d8506de08c693a"
 

--- a/Library/Formula/tomee-webprofile.rb
+++ b/Library/Formula/tomee-webprofile.rb
@@ -1,7 +1,7 @@
 class TomeeWebprofile < Formula
   desc "All-Apache Java EE 6 Web Profile stack"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz"
   version "1.7.2"
   sha256 "9802fef834a3d2944fc325440e1aadbd3b00956e5ef43f5ef9eea8b91a12d230"
 

--- a/Library/Formula/trafficserver.rb
+++ b/Library/Formula/trafficserver.rb
@@ -1,7 +1,7 @@
 class Trafficserver < Formula
   desc "HTTP/1.1 compliant caching proxy server"
   homepage "https://trafficserver.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-5.3.1.tar.bz2"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=trafficserver/trafficserver-5.3.1.tar.bz2"
   mirror "https://archive.apache.org/dist/trafficserver/trafficserver-5.3.1.tar.bz2"
   sha256 "e6c33c7cfb629406a320a61217e08db3123cfe4b77c2eaef0eaa520065dbeb43"
   revision 1

--- a/Library/Formula/whirr.rb
+++ b/Library/Formula/whirr.rb
@@ -1,7 +1,7 @@
 class Whirr < Formula
   desc "Set of libraries for running cloud services"
   homepage "https://whirr.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=whirr/whirr-0.8.2/whirr-0.8.2.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=whirr/whirr-0.8.2/whirr-0.8.2.tar.gz"
   sha256 "d5ec36c4a6928079118065e3d918679870a42c844e47924b1cd4d7be00a4aca5"
 
   def install

--- a/Library/Formula/xerces-c.rb
+++ b/Library/Formula/xerces-c.rb
@@ -1,7 +1,7 @@
 class XercesC < Formula
   desc "Validating XML parser"
   homepage "https://xerces.apache.org/xerces-c/"
-  url "https://www.apache.org/dyn/closer.cgi?path=xerces/c/3/sources/xerces-c-3.1.2.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=xerces/c/3/sources/xerces-c-3.1.2.tar.gz"
   sha256 "743bd0a029bf8de56a587c270d97031e0099fe2b7142cef03e0da16e282655a0"
 
   bottle do

--- a/Library/Formula/xml-security-c.rb
+++ b/Library/Formula/xml-security-c.rb
@@ -1,7 +1,7 @@
 class XmlSecurityC < Formula
   desc "Implementation of primary security standards for XML"
   homepage "https://santuario.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.3.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?action=download&filename=/santuario/c-library/xml-security-c-1.7.3.tar.gz"
   sha256 "e5226e7319d44f6fd9147a13fb853f5c711b9e75bf60ec273a0ef8a190592583"
 
   bottle do

--- a/Library/Formula/zookeeper.rb
+++ b/Library/Formula/zookeeper.rb
@@ -4,7 +4,7 @@ class Zookeeper < Formula
   revision 1
 
   stable do
-    url "https://www.apache.org/dyn/closer.cgi?path=zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?action=download&filename=zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz"
     sha256 "01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994"
 
     # To resolve Yosemite build errors.


### PR DESCRIPTION
Apache updated their mirror selector[1] and removed the asjson parameter, breaking all Apache formulas. They re-added as_json, but not asjson. But they also added a download option, making the Apache download strategy useless. This commit removes this download strategy and updates all Apache formulas to use the download option.

Fixes #43476.

[1] See recent commits in their SVN repo: https://svn.apache.org/repos/asf/infrastructure/site