### PR TITLE
physfs 2.0.3: add HEAD and test

### DIFF
--- a/Library/Formula/physfs.rb
+++ b/Library/Formula/physfs.rb
@@ -2,21 +2,28 @@ class Physfs < Formula
   desc "Library to provide abstract access to various archives"
   homepage "https://icculus.org/physfs/"
   url "https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
-  # Upstream not responding:
-  # https://github.com/Homebrew/homebrew/issues/17203
-  mirror "https://dl.dropbox.com/u/3252883/Games/physfs-2.0.3.tar.bz2"
   sha256 "ca862097c0fb451f2cacd286194d071289342c107b6fe69079c079883ff66b69"
+  head "https://hg.icculus.org/icculus/physfs/", :using => :hg
 
   depends_on "cmake" => :build
 
   def install
     mkdir "macbuild" do
-      system "cmake", "..",
-                      "-DPHYSFS_BUILD_WX_TEST=FALSE",
-                      "-DPHYSFS_BUILD_TEST=TRUE",
-                      *std_cmake_args
-      system "make"
+      args = std_cmake_args
+      args << "-DPHYSFS_BUILD_TEST=TRUE"
+      args << "-DPHYSFS_BUILD_WX_TEST=FALSE" unless build.head?
+      system "cmake", "..", *args
       system "make", "install"
     end
+  end
+
+  test do
+    (testpath/"test.txt").write "homebrew"
+    system "zip", "test.zip", "test.txt"
+    (testpath/"test").write <<-EOS.undent
+      addarchive test.zip 1
+      cat test.txt
+      EOS
+    assert_match /Successful\.\nhomebrew/, shell_output("#{bin}/test_physfs < test 2>&1")
   end
 end


### PR DESCRIPTION
- `HEAD` repo added
- `mirror` (#17203) removed as official URL works
- `test` block added