### PR TITLE
Make openal-soft keg only

### DIFF
--- a/Library/Formula/openal-soft.rb
+++ b/Library/Formula/openal-soft.rb
@@ -3,6 +3,7 @@ class OpenalSoft < Formula
   homepage "http://kcat.strangesoft.net/openal.html"
   url "http://kcat.strangesoft.net/openal-releases/openal-soft-1.16.0.tar.bz2"
   sha256 "2f3dcd313fe26391284fbf8596863723f99c65d6c6846dccb48e79cadaf40d5f"
+  revision 1
 
   bottle do
     cellar :any
@@ -25,6 +26,8 @@ class OpenalSoft < Formula
   # clang 4.2's support for alignas is incomplete
   fails_with :llvm
   fails_with(:clang) { build 425 }
+
+  keg_only :provided_by_osx, "OS X provides OpenAL.framework."
 
   def install
     ENV.universal_binary if build.universal?
@@ -53,6 +56,6 @@ class OpenalSoft < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-lopenal"
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lopenal"
   end
 end

--- a/Library/Formula/sfml.rb
+++ b/Library/Formula/sfml.rb
@@ -4,6 +4,7 @@ class Sfml < Formula
   homepage "http://www.sfml-dev.org/"
   url "http://www.sfml-dev.org/files/SFML-2.3-sources.zip"
   sha256 "a1dc8b00958000628c5394bc8438ba1aa5971fbeeef91a2cf3fa3fff443de7c1"
+  revision 1
 
   head "https://github.com/SFML/SFML.git"
 
@@ -22,7 +23,7 @@ class Sfml < Formula
   depends_on "jpeg"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "openal-soft"
+  depends_on "openal-soft" => :optional
 
   # https://github.com/Homebrew/homebrew/issues/40301
   depends_on :macos => :lion


### PR DESCRIPTION
OS X already provides `OpenAL.framework` and many existing packages pick that up without much problem. But `openal-soft` has same (with some extensions?) header and library signatures that precede the framework. For example, `sfml` can be successfully built without `openal-soft`, using native `OpenAL.framework`.

I suggest make `openal-soft` keg only and any dependency on that optional.