### PR TITLE
cdrtools 3.01 (stable)

### DIFF
--- a/Library/Formula/cdrtools.rb
+++ b/Library/Formula/cdrtools.rb
@@ -3,13 +3,8 @@ class Cdrtools < Formula
   homepage "http://cdrecord.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.00.tar.bz2"
-    sha256 "7f9cb64820055573b880f77b2f16662a512518336ba95ab49228a1617973423d"
-
-    patch :p0 do
-      url "https://trac.macports.org/export/104091/trunk/dports/sysutils/cdrtools/files/patch-include_schily_sha2.h"
-      sha256 "59a62420138c54fbea6eaa10a11f69488bb3fecf4f954fda47a3b1e424671d61"
-    end
+    url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.01.tar.bz2"
+    sha256 "ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f"
   end
 
   bottle do
@@ -17,11 +12,6 @@ class Cdrtools < Formula
     sha256 "c5961aaef116ae0dd425197550ae59c91f16da2552992de6c44331685dea58b6" => :yosemite
     sha256 "6dad15e2cfc911cda652271f764b830fe913affc85c1e92407006141594ac267" => :mavericks
     sha256 "ab6ca1d2649635c76c83343eba34fe89b3720613cdeee5cf2ee82789c6fa0687" => :mountain_lion
-  end
-
-  devel do
-    url "https://downloads.sourceforge.net/project/cdrtools/alpha/cdrtools-3.01a31.tar.bz2"
-    sha256 "183b5c12777779e78d8b69461aae52401f863768e7e7391d60730006f8cadc5a"
   end
 
   depends_on "smake" => :build
@@ -44,7 +34,8 @@ class Cdrtools < Formula
   test do
     system "#{bin}/cdrecord", "-version"
     system "#{bin}/cdda2wav", "-version"
-    (testpath/"testfile.txt").write("testing mkisofs")
+    date = shell_output("date")
+    (testpath/"testfile.txt").write(date)
     system "#{bin}/mkisofs", "-r", "-o", "test.iso", "testfile.txt"
     assert (testpath/"test.iso").exist?
   end


### PR DESCRIPTION
Update cdrtools (stable) to 3.01.
Drop devel until a version newer than 3.01 (stable) is released. This seems to be required to pass "brew audit cdrtools".