### PR TITLE
daemon: Fix hosting for strlcpy patch.

### DIFF
--- a/Library/Formula/daemon.rb
+++ b/Library/Formula/daemon.rb
@@ -6,7 +6,7 @@ class Daemon < Formula
 
   # fixes for mavericks strlcpy/strlcat: https://trac.macports.org/ticket/42845
   patch do
-    url "https://trac.macports.org/raw-attachment/ticket/42845/daemon-0.6.4-ignore-strlcpy-strlcat.patch"
+    url "https://gist.githubusercontent.com/jacobsa/b86cf524156ca10c54e1/raw/91dae330611c96ecb55b26e07e905ab2279258f0/daemon-0.6.4-ignore-strlcpy-strlcat.patch"
     sha256 "a56e16b0801a13045d388ce7e755b2b4e40288c3731ce0f92ea879d0871782c0"
   end if MacOS.version >= :mavericks
 


### PR DESCRIPTION
I've tried all day and haven't been able to get trac.macports.org to respond a single time, which means this formula won't install. Host it on GitHub instead.

I couldn't find a pristine copy of this patch, so I reconstructed it by hand from an HTML view in Google's [cache][] of the macports page. I guess I got it right byte for byte because the SHA-256 hash checks
out.

[cache]: http://webcache.googleusercontent.com/search?q=cache:V75bzw8DTMAJ:trac.macports.org/attachment/ticket/42845/daemon-0.6.4-ignore-strlcpy-strlcat.patch&hl=en&gl=au&strip=0&vwsrc=1