### PR TITLE
rubocop: re-enable whitespace-related cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -106,15 +106,6 @@ Style/WordArray:
 Style/UnneededCapitalW:
     Enabled: false
 
-# TODO: rubocop bug regarding __END__
-# see https://github.com/bbatsov/rubocop/issues/1541
-Style/TrailingWhitespace:
-    Enabled: false
-Style/Tab:
-    Enabled: false
-Style/TrailingBlankLines:
-    Enabled: false
-
 # we use raise, not fail
 Style/SignalException:
   EnforcedStyle: only_raise


### PR DESCRIPTION
The issue referenced in the removed lines was fixed in Rubocop 0.30.0 (Homebrew already uses 0.33.0).

After this change, `brew style` will list additional offences, all of which are superfluous trailing blank lines. Most affected files are formulae. A few core files are listed, too.