### PR TITLE
always use opt_prefix in install_name

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -137,13 +137,7 @@ class Keg
     # the basename of the file itself.
     basename = File.basename(file.dylib_id)
     relative_dirname = file.dirname.relative_path_from(path)
-    shortpath = HOMEBREW_PREFIX.join(relative_dirname, basename)
-
-    if shortpath.exist? && !options[:keg_only]
-      shortpath.to_s
-    else
-      opt_record.join(relative_dirname, basename).to_s
-    end
+    opt_record.join(relative_dirname, basename).to_s
   end
 
   def find_dylib(name)


### PR DESCRIPTION
Opening this for feedback; are there downsides?

dylib install_names are presently rewritten relative to HOMEBREW_PREFIX,
except for keg-only formulas, which are rewritten relative to
opt_prefix.

If we make a formula keg_only, all of its dependents need to be bumped,
since it will no longer exist in HOMEBREW_PREFIX and all of the links
will be written incorrectly.

If we always use opt_prefix, we avoid that dilemma, and make installed
packages more robust if a dependency is `brew unlink`ed. (Is that a feature or a bug?)