### PR TITLE
Change all "objective-caml" to "ocaml"

### DIFF
--- a/Library/Formula/bibtex2html.rb
+++ b/Library/Formula/bibtex2html.rb
@@ -11,7 +11,7 @@ class Bibtex2html < Formula
     sha1 "32377bea1f584fedf5d2abb604a1d46e5e92ac5c" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "hevea"
   depends_on :tex => :optional
 

--- a/Library/Formula/camlp5.rb
+++ b/Library/Formula/camlp5.rb
@@ -10,7 +10,7 @@ class Camlp5 < Formula
     sha256 "60312c75054d1db597c8afaf2d0563d41e192480531b74b2ad40908e36bbfb8b" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   option "strict", "Compile in strict mode"
 

--- a/Library/Formula/coccinelle.rb
+++ b/Library/Formula/coccinelle.rb
@@ -11,7 +11,7 @@ class Coccinelle < Formula
     sha256 "8a91d91164c21682355d050b84752a672d725027df95a32654a53aea02ff394f" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4"
 
   def install

--- a/Library/Formula/compcert.rb
+++ b/Library/Formula/compcert.rb
@@ -11,7 +11,7 @@ class Compcert < Formula
     sha256 "7ce52bcd1e488829d71481741f49abd3489b9b86e2f400825de439a730d3ba2b" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "coq" => :build
   depends_on "menhir" => :build
 

--- a/Library/Formula/coq.rb
+++ b/Library/Formula/coq.rb
@@ -28,7 +28,7 @@ class Coq < Formula
 
   depends_on Camlp5TransitionalModeRequirement
   depends_on "camlp5"
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     camlp5_lib = Formula["camlp5"].opt_lib+"ocaml/camlp5"

--- a/Library/Formula/flow.rb
+++ b/Library/Formula/flow.rb
@@ -12,7 +12,7 @@ class Flow < Formula
     sha256 "5cf57fcca47de49144872145c9bb8b004c649f0ff12b1927573ddf821710275a" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     system "make"

--- a/Library/Formula/hevea.rb
+++ b/Library/Formula/hevea.rb
@@ -10,7 +10,7 @@ class Hevea < Formula
     sha256 "1777a109ad7bf3693bd3cb0c09ec99846fbb73611e705eba4a7a48cf195c7ce4" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "ghostscript" => :optional
 
   def install

--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -13,7 +13,7 @@ class Lablgtk < Formula
 
   depends_on "pkg-config" => :build
   depends_on "camlp4" => :build
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "gtk+"
   depends_on "librsvg"
 

--- a/Library/Formula/ledit.rb
+++ b/Library/Formula/ledit.rb
@@ -11,7 +11,7 @@ class Ledit < Formula
     sha256 "338e160cde4ece1c167ec07e8b202f599ba0267ac5c3b6ca896b569067cb2e20" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp5"
 
   def install

--- a/Library/Formula/menhir.rb
+++ b/Library/Formula/menhir.rb
@@ -10,7 +10,7 @@ class Menhir < Formula
     sha1 "7ab625d14199153fac46742c684e623e68590469" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     ENV.deparallelize

--- a/Library/Formula/mldonkey.rb
+++ b/Library/Formula/mldonkey.rb
@@ -18,7 +18,7 @@ class Mldonkey < Formula
   end
 
   depends_on "camlp4" => :build
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "pkg-config" => :build
   depends_on "gd"
   depends_on "libpng"

--- a/Library/Formula/ocamlsdl.rb
+++ b/Library/Formula/ocamlsdl.rb
@@ -17,7 +17,7 @@ class Ocamlsdl < Formula
   depends_on "sdl_image" => :recommended
   depends_on "sdl_gfx" => :recommended
   depends_on "sdl_ttf" => :recommended
-  depends_on "objective-caml"
+  depends_on "ocaml"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Library/Formula/one-ml.rb
+++ b/Library/Formula/one-ml.rb
@@ -12,7 +12,7 @@ class OneMl < Formula
     sha256 "d9cc9f66611ddf1d255a3090886d84f76ecd90c82fc1b6833a9c736f372dc484" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     system "make"

--- a/Library/Formula/opam.rb
+++ b/Library/Formula/opam.rb
@@ -13,7 +13,7 @@ class Opam < Formula
     sha256 "fab436947193e2e0b402320e520daa2826af8c80d0ddb4f9cf37d11ebd009ddf" => :mountain_lion
   end
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4" => :recommended
 
   # aspcud has a fairly large buildtime dep tree, and uses gringo,

--- a/Library/Formula/orpie.rb
+++ b/Library/Formula/orpie.rb
@@ -11,7 +11,7 @@ class Orpie < Formula
   end
 
   depends_on "gsl"
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "camlp4" => :build
 
   def install

--- a/Library/Formula/polygen.rb
+++ b/Library/Formula/polygen.rb
@@ -4,7 +4,7 @@ class Polygen < Formula
   url "http://www.polygen.org/dist/polygen-1.0.6-20040628-src.zip"
   sha256 "703c483820b33a5d695e884e58e2723a660930180fde845f38d6135d247c64a5"
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     cd "src" do

--- a/Library/Formula/ssreflect.rb
+++ b/Library/Formula/ssreflect.rb
@@ -4,7 +4,7 @@ class Ssreflect < Formula
   url "http://ssr.msr-inria.inria.fr/FTP/ssreflect-1.5.tar.gz"
   sha256 "bad978693d1bfd0a89586a34678bcc244e3b7efba6431e0f83d8e1ae8f82a142"
 
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "coq"
 
   option "with-doc", "Install HTML documents"

--- a/Library/Formula/unison.rb
+++ b/Library/Formula/unison.rb
@@ -12,7 +12,7 @@ class Unison < Formula
     sha256 "dc4dcbeb2e2f224f9fffede14f8d3c7c220f032023b83626b75409707e93df35" => :mountain_lion
   end
 
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
 
   def install
     ENV.j1

--- a/Library/Formula/why3.rb
+++ b/Library/Formula/why3.rb
@@ -11,7 +11,7 @@ class Why3 < Formula
   end
 
   depends_on "menhir"
-  depends_on "objective-caml"
+  depends_on "ocaml"
   depends_on "coq" => :optional
   depends_on "lablgtk" => :optional
   depends_on "hevea" => [:build, :optional]

--- a/Library/Formula/wyrd.rb
+++ b/Library/Formula/wyrd.rb
@@ -11,7 +11,7 @@ class Wyrd < Formula
   end
 
   depends_on "remind"
-  depends_on "objective-caml" => :build
+  depends_on "ocaml" => :build
   depends_on "camlp4" => :build
 
   def install


### PR DESCRIPTION
Follow-up to  https://github.com/Homebrew/homebrew/pull/42851 (rename
objective-caml formula to ocaml).
Renames formulas using/depending on ocaml in the main homebrew library