### PR TITLE
Allow Riemann to do its own argument parsing

### DIFF
--- a/Library/Formula/riemann.rb
+++ b/Library/Formula/riemann.rb
@@ -13,7 +13,7 @@ class Riemann < Formula
       else
         config=$@
       fi
-      exec "#{libexec}/bin/riemann" "$config"
+      exec "#{libexec}/bin/riemann" $config
     EOS
   end
 


### PR DESCRIPTION
Riemann accepts command arguments, of the form
```
riemann test riemann.config
```

Currently we get this error from Homebrew's riemann:
```
mac:riemann-config jfoy$ riemann test riemann.config
INFO [2015-09-04 10:52:02,817] main - riemann.bin - PID 47193
ERROR [2015-09-04 10:52:02,820] main - riemann.bin - Couldn't start
java.io.FileNotFoundException: /Users/jfoy/src/riemann-config/test riemann.config (No such file or directory)
    at java.io.FileInputStream.open(Native Method)
    at java.io.FileInputStream.<init>(FileInputStream.java:138)
    at java.io.FileInputStream.<init>(FileInputStream.java:93)
    at clojure.lang.Compiler.loadFile(Compiler.java:7083)
    at clojure.lang.RT$3.invoke(RT.java:318)
    at riemann.config$include.invoke(config.clj:408)
    at riemann.bin$_main.invoke(bin.clj:68)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.AFn.applyTo(AFn.java:144)
    at riemann.bin.main(Unknown Source)
```

Removing the quotes around `$@` allows success:
```
mac:riemann-config jfoy$ riemann test riemann.config
INFO [2015-09-04 11:05:58,112] main - riemann.repl - REPL server {:port 5557, :host 0.0.0.0} online


Testing clojure.core

Ran 0 tests containing 0 assertions.
0 failures, 0 errors.
```