### PR TITLE
tidy-html5 5.0.0

### DIFF
--- a/Library/Formula/tidy-html5.rb
+++ b/Library/Formula/tidy-html5.rb
@@ -1,8 +1,8 @@
 class TidyHtml5 < Formula
   desc "Granddaddy of HTML tools, with support for modern standards"
   homepage "http://www.html-tidy.org/"
-  url "https://github.com/htacg/tidy-html5/archive/4.9.35.tar.gz"
-  sha256 "d4309a094627efdb184772df0b4ea22e8cd01c4704b56721300951d6f04d94b3"
+  url "https://github.com/htacg/tidy-html5/archive/5.0.0.tar.gz"
+  sha256 "44b1ab3d4aa1c4c4185bdc8b9cc4cddd4f2cc9cf2fdd679f32890844e683e7e3"
 
   bottle do
     cellar :any
@@ -21,7 +21,7 @@ class TidyHtml5 < Formula
   end
 
   test do
-    output = pipe_output(bin/"tidy5 -q", "<!doctype html><title></title>")
+    output = pipe_output(bin/"tidy -q", "<!doctype html><title></title>")
     assert_match /^<!DOCTYPE html>/, output
     assert_match /HTML Tidy for HTML5/, output
   end


### PR DESCRIPTION
Also updated test because 5.0.0 introduced a breaking change: `tidy5` has been renamed to `tidy`.

By the way, after the rename, the executable and libraries now override system `tidy`, which is the old HTML 4 `tidy` from 2006 (see `/usr/bin/tidy --version`). Still, `tidy-html5` should be mostly (if not entirely) backwards compatible, per https://github.com/htacg/tidy-html5/issues/221. So, do we need to do anything about this? Like making it keg-only or moving it to homebrew/dupes?