### PR TITLE
Update rethinkdb to 2.1.3

### DIFF
--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -1,8 +1,8 @@
 class Rethinkdb < Formula
   desc "The open-source database for the realtime web"
   homepage "http://www.rethinkdb.com/"
-  url "http://download.rethinkdb.com/dist/rethinkdb-2.1.2.tgz"
-  sha256 "e46495ccd95e8b2bd855211f48ecd6964a64b520b951115d46b9b9e55cb48322"
+  url "http://download.rethinkdb.com/dist/rethinkdb-2.1.3.tgz"
+  sha256 "8dbfbd89e1053eda7acde7e0bb9c4ceb64c5371ceb9b3e16019e6fc60776890f"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This updates the `rethinkdb` formula to our latest 2.1.3 release.

(release notes: https://github.com/rethinkdb/rethinkdb/releases/tag/v2.1.3 )

Thank you!