### PR TITLE
gst-plugins-bad: add optional sound-touch dependency

### DIFF
--- a/Library/Formula/gst-plugins-bad.rb
+++ b/Library/Formula/gst-plugins-bad.rb
@@ -35,6 +35,7 @@ class GstPluginsBad < Formula
   depends_on "opus" => :optional
   depends_on "rtmpdump" => :optional
   depends_on "schroedinger" => :optional
+  depends_on "sound-touch" => :optional
 
   option "with-applemedia", "Build with applemedia support"
 


### PR DESCRIPTION
Allows use of the bpmdetect plugin, among other things.