### PR TITLE
osxutils: Remove conflict line referencing non-existant googlecl

### DIFF
--- a/Library/Formula/osxutils.rb
+++ b/Library/Formula/osxutils.rb
@@ -1,9 +1,9 @@
 class Osxutils < Formula
-  desc "Command-line access of Mac-specific information, settings, and metadata"
+  desc "CLI access of Mac-specific information, settings, and metadata"
   homepage "https://github.com/vasi/osxutils"
-  head "https://github.com/vasi/osxutils.git"
   url "https://github.com/vasi/osxutils/archive/v1.8.1.tar.gz"
   sha256 "26c49f00435d2b58a3768f0712d25afc09139e91994ba2bdaa21915004214186"
+  head "https://github.com/vasi/osxutils.git"
 
   bottle do
     cellar :any
@@ -15,7 +15,6 @@ class Osxutils < Formula
   conflicts_with "trash", :because => "both install a trash binary"
   conflicts_with "leptonica",
     :because => "both leptonica and osxutils ship a `fileinfo` executable."
-  conflicts_with "googlecl", :because => "both install a google binary"
 
   def install
     system "make"


### PR DESCRIPTION
This formula doesn't install because brew looks for the now-removed `googlecl` formula. This PR removes the reference to it, and cleans up the formula to pass audit.