### PR TITLE
elixir: add --devel option for 1.1.0-beta

### DIFF
--- a/Library/Formula/elixir.rb
+++ b/Library/Formula/elixir.rb
@@ -30,6 +30,11 @@ class Elixir < Formula
 
   head "https://github.com/elixir-lang/elixir.git"
 
+  devel do
+    url "https://github.com/elixir-lang/elixir/archive/v1.1.0-beta.tar.gz"
+    sha256 "a506907137dc2432bf40f3c6a86ca807af5bf9d7f3a3efd05fed14e5267beb79"
+  end
+
   bottle do
     sha256 "e25c7d985147de85b0e8d0adfc12f92c34af748af2c58557ad4f34aa7f96e63b" => :yosemite
     sha256 "2c5931b0eea75db2e22c6a20cb17c632c5052d03254bd355c0db5b9dbd90ba51" => :mavericks

--- a/Library/Formula/elixir.rb
+++ b/Library/Formula/elixir.rb
@@ -31,6 +31,7 @@ class Elixir < Formula
   head "https://github.com/elixir-lang/elixir.git"
 
   devel do
+    version "1.1.0"
     url "https://github.com/elixir-lang/elixir/archive/v1.1.0-beta.tar.gz"
     sha256 "a506907137dc2432bf40f3c6a86ca807af5bf9d7f3a3efd05fed14e5267beb79"
   end


### PR DESCRIPTION
It would be nice to install the Elixir v1.1.0 beta with the `--devel` option instead of grabbing the latest changes from `HEAD`.

Release notes:
https://github.com/elixir-lang/elixir/releases/tag/v1.1.0-beta