### PR TITLE
audit: cache formula names during audit_formula_name

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -211,11 +211,6 @@ class FormulaAuditor
   end
 
   @@aliases ||= Formula.aliases
-  @@remote_official_taps ||= if (homebrew_tapd = HOMEBREW_LIBRARY/"Taps/homebrew").directory?
-    OFFICIAL_TAPS - homebrew_tapd.subdirs.map(&:basename).map { |tap| tap.to_s.sub(/^homebrew-/, "") }
-  else
-    OFFICIAL_TAPS
-  end
 
   def audit_formula_name
     return unless @strict
@@ -246,6 +241,8 @@ class FormulaAuditor
     end
 
     if @online
+      @@remote_official_taps ||= OFFICIAL_TAPS - Tap.select(&:official?).map(&:repo)
+
       same_name_tap_formulae += @@remote_official_taps.map do |tap|
         Thread.new { Homebrew.search_tap "homebrew", tap, name }
       end.flat_map(&:value)


### PR DESCRIPTION
It speeds up the process when auditing multiple formulae. For example, audit all of formulae:
* Before `audit_formula_name: 15.094845999999986`
* After `audit_formula_name: 0.5617120000000043`