### PR TITLE
libelf: bump revision

### DIFF
--- a/Library/Formula/libelf.rb
+++ b/Library/Formula/libelf.rb
@@ -3,6 +3,7 @@ class Libelf < Formula
   homepage "http://www.mr511.de/software/"
   url "http://www.mr511.de/software/libelf-0.8.13.tar.gz"
   sha256 "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
It took us a while to catch this in terms of how rapidly Homebrew moves, so rather than leaving people with a decade old `libelf` I think it's worthwhile bumping the revision a touch to fix it. The bottle is `cellar :any`.

Roughly ~430 bottle downloads in the last 24 hours.

Ref: https://github.com/Homebrew/homebrew/commit/7063c65967015ed8d01ac4cc23dcffc1616b51cb