### PR TITLE
quiet_system: don't print cmd even when verbose mode

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -123,7 +123,7 @@ module Homebrew
   def describe_java
     if which("java").nil?
       "N/A"
-    elsif !(`/usr/libexec/java_home --failfast &>/dev/null` && $?.success?)
+    elsif !quiet_system "/usr/libexec/java_home", "--failfast"
       "N/A"
     else
       java = `java -version 2>&1`.lines.first.chomp

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -133,8 +133,7 @@ def interactive_shell(f = nil)
 end
 
 module Homebrew
-  def self.system(cmd, *args)
-    puts "#{cmd} #{args*" "}" if ARGV.verbose?
+  def self._system(cmd, *args)
     pid = fork do
       yield if block_given?
       args.collect!(&:to_s)
@@ -143,6 +142,11 @@ module Homebrew
     end
     Process.wait(pid)
     $?.success?
+  end
+
+  def self.system(cmd, *args)
+    puts "#{cmd} #{args*" "}" if ARGV.verbose?
+    _system(cmd, *args)
   end
 
   def self.git_head
@@ -213,7 +217,7 @@ end
 
 # prints no output
 def quiet_system(cmd, *args)
-  Homebrew.system(cmd, *args) do
+  Homebrew._system(cmd, *args) do
     # Redirect output streams to `/dev/null` instead of closing as some programs
     # will fail to execute if they can't write to an open stream.
     $stdout.reopen("/dev/null")


### PR DESCRIPTION
It's kinda annoying that quiet_system wasn't really quiet. 