### PR TITLE
Git Town 0.7.3 (new formula)

### DIFF
--- a/Library/Formula/git-town.rb
+++ b/Library/Formula/git-town.rb
@@ -1,0 +1,40 @@
+class GitTown < Formula
+  desc "High-level command-line interface for Git"
+  homepage "http://www.git-town.com"
+  url "https://github.com/Originate/git-town/archive/v0.7.3.tar.gz"
+  sha256 "947fd6dac603dcb02467cc2969ef26db1ccdc72312b6b0d70fb8d11179eb09ba"
+
+  depends_on "dialog" => :recommended
+
+  def install
+    # Install the source
+    libexec.install Dir["src/*"]
+
+    # Symlink the executables
+    bin.install_symlink Dir["#{libexec}/git-*"]
+    bin.install_symlink "#{libexec}/helpers"
+    bin.install_symlink "#{libexec}/drivers"
+
+    # Install the man pages
+    man1.install Dir["man/man1/*"]
+  end
+
+  def caveats
+    <<-EOS.undent
+      To install the Fish shell autocompletions,
+      run "git town install-fish-autocompletion"
+      in the terminal.
+
+      To install the completions manually, make
+      #{libexec}/autocomplete/git.fish
+      available as ~/.config/fish/completions/git.fish.
+      In a standard setup, this looks like:
+      mkdir -p ~/.config/fish/completions
+      ln -s #{libexec}/autocomplete/git.fish ~/.config/fish/completions/git.fish
+    EOS
+  end
+
+  test do
+    system "#{bin}/git-town", "version"
+  end
+end

--- a/Library/Formula/git-town.rb
+++ b/Library/Formula/git-town.rb
@@ -7,15 +7,8 @@ class GitTown < Formula
   depends_on "dialog" => :recommended
 
   def install
-    # Install the source
     libexec.install Dir["src/*"]
-
-    # Symlink the executables
-    bin.install_symlink Dir["#{libexec}/git-*"]
-    bin.install_symlink "#{libexec}/helpers"
-    bin.install_symlink "#{libexec}/drivers"
-
-    # Install the man pages
+    bin.write_exec_script Dir["#{libexec}/git-*"]
     man1.install Dir["man/man1/*"]
   end
 
@@ -24,17 +17,12 @@ class GitTown < Formula
       To install the Fish shell autocompletions,
       run "git town install-fish-autocompletion"
       in the terminal.
-
-      To install the completions manually, make
-      #{libexec}/autocomplete/git.fish
-      available as ~/.config/fish/completions/git.fish.
-      In a standard setup, this looks like:
-      mkdir -p ~/.config/fish/completions
-      ln -s #{libexec}/autocomplete/git.fish ~/.config/fish/completions/git.fish
     EOS
   end
 
   test do
-    system "#{bin}/git-town", "version"
+    cd HOMEBREW_PREFIX do
+      system "#{bin}/git-town", "config"
+    end
   end
 end


### PR DESCRIPTION
We have been running on [our own tap](https://github.com/Originate/homebrew-gittown) for a while. Git Town is now stable and in widespread use, with external contributors, so we wanted to make this available on the main tap for easier installation.

Any guidance on improving the formula is appreciated! Right now the audit fails with 

```
git-town:
 * Non-executables were installed to "/usr/local/Cellar/git-town/0.7.3/bin"
The offending files are:
  /usr/local/Cellar/git-town/0.7.3/bin/helpers
```

Git Town is a Bash script that loads additional code from `src/helpers` and `src/drivers`. Is there a better way to do this?

Thanks for all the amazing work on HomeBrew, we are honored to contribute Git Town!