### PR TITLE
Upgrade Node.js to v4.0.0

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -1,130 +1,23 @@
-# Note that x.even are stable releases, x.odd are devel releases
 class Node < Formula
   desc "Platform built on Chrome's JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz"
-  sha256 "b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d"
-  head "https://github.com/nodejs/node.git", :branch => "v0.12"
-  revision 1
-
-  bottle do
-    sha256 "15689cc474a79975eaa6d791b24e6fa021494839c9b691ac307d74acefc5f834" => :yosemite
-    sha256 "a7a7d37c6e5088ed3f58b867d4d246851715d3a4f2f3b4b3c40cc7452ff6728c" => :mavericks
-    sha256 "374f3c5b576e4173590b8413e9941df121a84f46bd48161fc758e1f7d42e0402" => :mountain_lion
-  end
+  url "https://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
+  sha256 "e110e5a066f3a6fe565ede7dd66f3727384b9b5c5fbf46f8db723d726e2f5900"
 
   option "with-debug", "Build with debugger hooks"
-  option "without-npm", "npm will not be installed"
-  option "without-completion", "npm bash completion will not be installed"
+  option "with-icu4c", "Build with Intl (icu4c) support"
 
-  deprecated_option "enable-debug" => "with-debug"
-
-  depends_on :python => :build if MacOS.version <= :snow_leopard
   depends_on "pkg-config" => :build
-  depends_on "openssl" => :optional
-
-  # https://github.com/nodejs/node-v0.x-archive/issues/7919
-  # https://github.com/Homebrew/homebrew/issues/36681
   depends_on "icu4c" => :optional
-
-  fails_with :llvm do
-    build 2326
-  end
-
-  resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.14.2.tgz"
-    sha256 "592029e3406cbbaf249135e18212fab91db1601f991f61b4b2a03580311a066e"
-  end
+  depends_on :python => :build if MacOS.version <= :snow_leopard
 
   def install
-    args = %W[--prefix=#{prefix} --without-npm]
+    args = %W[--prefix=#{prefix}]
     args << "--debug" if build.with? "debug"
     args << "--with-intl=system-icu" if build.with? "icu4c"
 
-    if build.with? "openssl"
-      args << "--shared-openssl"
-    else
-      args << "--without-ssl2" << "--without-ssl3"
-    end
-
     system "./configure", *args
     system "make", "install"
-
-    if build.with? "npm"
-      resource("npm").stage buildpath/"npm_install"
-
-      # make sure npm can find node
-      ENV.prepend_path "PATH", bin
-      # set log level temporarily for npm's `make install`
-      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
-
-      cd buildpath/"npm_install" do
-        system "./configure", "--prefix=#{libexec}/npm"
-        system "make", "install"
-      end
-
-      if build.with? "completion"
-        bash_completion.install \
-          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
-      end
-    end
-  end
-
-  def post_install
-    return if build.without? "npm"
-
-    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
-    node_modules.mkpath
-    npm_exec = node_modules/"npm/bin/npm-cli.js"
-    # Kill npm but preserve all other modules across node updates/upgrades.
-    rm_rf node_modules/"npm"
-
-    cp_r libexec/"npm/lib/node_modules/npm", node_modules
-    # This symlink doesn't hop into homebrew_prefix/bin automatically so
-    # remove it and make our own. This is a small consequence of our bottle
-    # npm make install workaround. All other installs **do** symlink to
-    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
-    # so mimics npm's normal install.
-    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
-
-    # Let's do the manpage dance. It's just a jump to the left.
-    # And then a step to the right, with your hand on rm_f.
-    ["man1", "man3", "man5", "man7"].each do |man|
-      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
-      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
-      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
-    end
-
-    npm_root = node_modules/"npm"
-    npmrc = npm_root/"npmrc"
-    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
-  end
-
-  def caveats
-    s = ""
-
-    if build.without? "npm"
-      s += <<-EOS.undent
-        Homebrew has NOT installed npm. If you later install it, you should supplement
-        your NODE_PATH with the npm module folder:
-          #{HOMEBREW_PREFIX}/lib/node_modules
-      EOS
-    end
-
-    if build.with? "icu4c"
-      s += <<-EOS.undent
-
-        Please note `icu4c` is built with a newer deployment target than Node and
-        this may cause issues in certain usage. Node itself is built against the
-        outdated `libstdc++` target, which is the root cause. For more information see:
-          https://github.com/nodejs/node-v0.x-archive/issues/7919
-
-        If this is an issue for you, do `brew install node --without-icu4c`.
-      EOS
-    end
-
-    s
   end
 
   test do
@@ -134,14 +27,5 @@ class Node < Formula
     output = `#{bin}/node #{path}`.strip
     assert_equal "hello", output
     assert_equal 0, $?.exitstatus
-
-    if build.with? "npm"
-      # make sure npm can find node
-      ENV.prepend_path "PATH", opt_bin
-      assert_equal which("node"), opt_bin/"node"
-      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
-      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
-    end
   end
 end


### PR DESCRIPTION
Today the Node.js team has released `v4.0.0` so this formula takes from the `io.js` formula since `v4.0.0` is coming from the `io.js` codebase.

https://nodejs.org/en/blog/release/v4.0.0/