### PR TITLE
node 4.0.0

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -2,10 +2,9 @@
 class Node < Formula
   desc "Platform built on Chrome's JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz"
-  sha256 "b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d"
-  head "https://github.com/nodejs/node.git", :branch => "v0.12"
-  revision 1
+  url "https://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
+  sha256 "e110e5a066f3a6fe565ede7dd66f3727384b9b5c5fbf46f8db723d726e2f5900"
+  head "https://github.com/nodejs/node.git"
 
   bottle do
     sha256 "15689cc474a79975eaa6d791b24e6fa021494839c9b691ac307d74acefc5f834" => :yosemite
@@ -31,11 +30,6 @@ class Node < Formula
     build 2326
   end
 
-  resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.14.2.tgz"
-    sha256 "592029e3406cbbaf249135e18212fab91db1601f991f61b4b2a03580311a066e"
-  end
-
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
@@ -43,29 +37,25 @@ class Node < Formula
 
     if build.with? "openssl"
       args << "--shared-openssl"
-    else
-      args << "--without-ssl2" << "--without-ssl3"
     end
 
     system "./configure", *args
     system "make", "install"
 
     if build.with? "npm"
-      resource("npm").stage buildpath/"npm_install"
-
       # make sure npm can find node
       ENV.prepend_path "PATH", bin
       # set log level temporarily for npm's `make install`
       ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
 
-      cd buildpath/"npm_install" do
+      cd "deps/npm" do
         system "./configure", "--prefix=#{libexec}/npm"
         system "make", "install"
       end
 
       if build.with? "completion"
         bash_completion.install \
-          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+          "deps/npm/lib/utils/completion.sh" => "npm"
       end
     end
   end
@@ -110,6 +100,12 @@ class Node < Formula
         your NODE_PATH with the npm module folder:
           #{HOMEBREW_PREFIX}/lib/node_modules
       EOS
+    else
+      s += <<-EOS.undent
+        Node.js v4 was installed with a patched version of npm (with node-gyp v3) which
+        is required to build native modules with Node.js v4. It is not recommended to
+        upgrade npm to a version that still ships with node-gyp v2.
+      EOS
     end
 
     if build.with? "icu4c"
@@ -141,7 +137,7 @@ class Node < Formula
       assert_equal which("node"), opt_bin/"node"
       assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
       assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
-      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "bignum"
     end
   end
 end


### PR DESCRIPTION
Node.js v4.0.0 was released with new features and performance/memory improvements (see [this blog post](https://nodejs.org/en/blog/release/v4.0.0/)).
This version of node requires node-gyp v3 to work (install native modules). Sadly it will take ~2 more weeks until a official stable version of npm with node-gyp will be released. Thats why a floating patch to upgrade node-gyp is needed until then. I can think of two possibilities how we can handle this patch in the formula:
* download npm as before as a resource and apply the floating patch manually (as there is no patch support for resources yet)
* use the already patched version of npm which ships with node v4 but install it in a separate step to libexec/npm as before

I've used the second approve fore this PR because I see no advantage in manually patching a resource to only get an exact copy of what is already stored on disk in the node sources.
I've updated the test to install a native addon to test node-gyp, removed the npm update test because it would install a broken npm atm and removed the without-ssl arguments because ssl support was dropped in v4. 