### PR TITLE
Use system tar for bottle TOC inspection

### DIFF
--- a/Library/Homebrew/bottles.rb
+++ b/Library/Homebrew/bottles.rb
@@ -39,7 +39,7 @@ def bottle_tag
 end
 
 def bottle_receipt_path(bottle_file)
-  Utils.popen_read("tar", "-tzf", bottle_file, "*/*/INSTALL_RECEIPT.json").chomp
+  Utils.popen_read("/usr/bin/tar", "-tzf", bottle_file, "*/*/INSTALL_RECEIPT.json").chomp
 end
 
 def bottle_resolve_formula_names(bottle_file)


### PR DESCRIPTION
If the user has gnu-tar named as 'tar' in $PATH, then the command for inspecting the table-of-contents of a homemade bottle fails.  This is because gnu-tar won't accept wildcards for the `-t` option unless a special additional option is passed, one which system tar doesn't accept.

Enforce use of `/usr/bin/tar` for this task, so that everyone can pour homemade bottles.

Fixes #43701 
