### PR TITLE
don't set PYTHONPATH in PythonRequirement env

### DIFF
--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -23,8 +23,6 @@ class PythonRequirement < Requirement
     elsif short_version != Version.new("2.7")
       ENV.prepend_path "PATH", Formula["python"].opt_bin
     end
-
-    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"
   end
 
   def python_short_version
@@ -60,9 +58,7 @@ class Python3Requirement < PythonRequirement
 
   satisfy(:build_env => false) { which_python }
 
-  env do
-    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{python_short_version}/site-packages"
-  end
+  env {}
 
   def python_binary
     "python3"


### PR DESCRIPTION
Alex noticed that setting PYTHONPATH causes weirdness if we depend_on something which
may be optionally built --with-python3; PYTHONPATH unexpectedly contains
python3 modules in the depending formula if the formula upon which it
depends was built --with-python3 even though the depending formula may
only use python2.

The consequence of this is if something needs to use a Python module
installed by a Homebrew formula, the depending formula will need to
configure PYTHONPATH manually.