### PR TITLE
awscli 1.8.2

### DIFF
--- a/Library/Formula/awscli.rb
+++ b/Library/Formula/awscli.rb
@@ -1,9 +1,9 @@
 class Awscli < Formula
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
-  url "https://pypi.python.org/packages/source/a/awscli/awscli-1.8.1.tar.gz"
-  mirror "https://github.com/aws/aws-cli/archive/1.8.1.tar.gz"
-  sha256 "7f487e7d488787140c09de057b5117e3388a3b2d6ae609fa6e9c35f3201b685c"
+  url "https://pypi.python.org/packages/source/a/awscli/awscli-1.8.2.tar.gz"
+  mirror "https://github.com/aws/aws-cli/archive/1.8.2.tar.gz"
+  sha256 "764d5baf7e8bfe62c19630b32f8568abac644149ea23ad83d6252d9418a966dc"
 
   bottle do
     cellar :any
@@ -50,8 +50,8 @@ class Awscli < Formula
   end
 
   resource "botocore" do
-    url "https://pypi.python.org/packages/source/b/botocore/botocore-1.1.12.tar.gz"
-    sha256 "29bab9a006b45676ec1a559f337415e5a7d8a690d29578d116d5d73d01b9bde5"
+    url "https://pypi.python.org/packages/source/b/botocore/botocore-1.2.0.tar.gz"
+    sha256 "59f2b9109d2cef499679b1676622e653b6a74be8ce20f84104fe631eb5434972"
   end
 
   resource "docutils" do


### PR DESCRIPTION
I wanted to ask, cause now, when I change the version in order to build, it always wants to download bootle and fails.

```
balrog:local n$ brew fetch awscli
/usr/local/Library/brew.rb (Formulary::FormulaLoader): loading /usr/local/Library/Formula/awscli.rb
==> Downloading https://homebrew.bintray.com/bottles/awscli-1.8.2.yosemite.bottle.tar.gz
/usr/bin/curl -fLA Homebrew 0.9.5 (Ruby 2.0.0-481; OS X 10.10.5) https://homebrew.bintray.com/bottles/awscli-1.8.2.yosemite.bottle.tar.gz -C 0 -o /Library/Caches/Homebrew/awscli-1.8.2.yosemite.bottle.tar.gz.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "awscli"
Download failed: https://homebrew.bintray.com/bottles/awscli-1.8.2.yosemite.bottle.tar.gz
/usr/local/Library/Homebrew/download_strategy.rb:297:in `rescue in fetch'
/usr/local/Library/Homebrew/download_strategy.rb:286:in `fetch'
/usr/local/Library/Homebrew/resource.rb:109:in `fetch'
/usr/local/Library/Homebrew/cmd/fetch.rb:82:in `fetch_fetchable'
/usr/local/Library/Homebrew/cmd/fetch.rb:49:in `fetch_formula'
/usr/local/Library/Homebrew/cmd/fetch.rb:23:in `block in fetch'
/usr/local/Library/Homebrew/cmd/fetch.rb:19:in `each'
/usr/local/Library/Homebrew/cmd/fetch.rb:19:in `fetch'
/usr/local/Library/brew.rb:127:in `<main>'
```

I need to pass ```--build-from-source``` in order to rebuild the new version. Is this the new desired behaviour or what?