### PR TITLE
Don't set PYTHONPATH for :python3

### DIFF
--- a/Library/Formula/treeline.rb
+++ b/Library/Formula/treeline.rb
@@ -4,19 +4,20 @@ class Treeline < Formula
   url "https://downloads.sourceforge.net/project/treeline/2.0.0/treeline-2.0.0.tar.gz"
   sha256 "71af995fca9e0eaf4e6205d72eb4ee6a979a45ea2a1f6600ed8a39bb1861d118"
 
-  bottle do
-    cellar :any
-    sha256 "271f5380e8ab3bf777a20f8dd077462ac1768baf749c7625100a7aeddb067190" => :yosemite
-    sha256 "f46d47da8720bd8cfbf54c14f5e0c2d6116be8d362d3eaebb5039f4996fb9800" => :mavericks
-    sha256 "f37b950321dca64236f8844eee5f62ec9e6bca115dde0d17160e519b0dbf95fe" => :mountain_lion
-  end
-
   depends_on :python3
   depends_on "sip" => "with-python3"
   depends_on "pyqt" => "with-python3"
 
   def install
-    system "./install.py", "-p#{prefix}"
+    pyver = Language::Python.major_minor_version "python3"
+    ENV.delete "PYTHONPATH"
+    %w[sip pyqt].each do |f|
+      ENV.append_path "PYTHONPATH", "#{Formula[f].opt_lib}/python#{pyver}/site-packages"
+    end
+
+    system "./install.py", "-p#{libexec}"
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
   test do

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -24,9 +24,7 @@ class PythonRequirement < Requirement
       ENV.prepend_path "PATH", Formula["python"].opt_bin
     end
 
-    if python_binary == "python"
-      ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"
-    end
+    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"
   end
 
   def python_short_version

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -24,7 +24,9 @@ class PythonRequirement < Requirement
       ENV.prepend_path "PATH", Formula["python"].opt_bin
     end
 
-    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"
+    if python_binary == "python"
+      ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"
+    end
   end
 
   def python_short_version
@@ -59,10 +61,6 @@ class Python3Requirement < PythonRequirement
   cask "python3"
 
   satisfy(:build_env => false) { which_python }
-
-  env do
-    ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{python_short_version}/site-packages"
-  end
 
   def python_binary
     "python3"


### PR DESCRIPTION
Reduces the impact of #43724 by not changing anything in the python2 case.