### PR TITLE
apache-spark 1.5.0

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -2,9 +2,9 @@ class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
   head "https://github.com/apache/spark.git"
-  url "https://www.apache.org/dyn/closer.cgi?path=spark/spark-1.4.1/spark-1.4.1-bin-hadoop2.6.tgz"
-  version "1.4.1"
-  sha256 "9cde95349cccfeb99643d2dadb63f8e88ac355e0038aae7d5029142ce94ae370"
+  url "https://www.apache.org/dyn/closer.cgi?path=spark/spark-1.5.0/spark-1.5.0-bin-hadoop2.6.tgz"
+  version "1.5.0"
+  sha256 "d8d8ac357b9e4198dad33042f46b1bc09865105051ffbd7854ba272af726dffc"
 
   def install
     # Rename beeline to distinguish it from hive's beeline


### PR DESCRIPTION
Apache Spark has a new point release, 1.5.0: [release blog post](https://spark.apache.org/news/spark-1-5-0-released.html)