### PR TITLE
CoreLocationCLI 2.0.0 (new formula)

### DIFF
--- a/Library/Formula/corelocationcli.rb
+++ b/Library/Formula/corelocationcli.rb
@@ -1,0 +1,17 @@
+class Corelocationcli < Formula
+  desc "Prints location information from CoreLocation"
+  homepage "https://github.com/fulldecent/corelocationcli"
+  url "https://github.com/fulldecent/corelocationcli/archive/2.0.0.tar.gz"
+  sha256 "d256ae0a534ef15f4b9a77704ef3bd52935c310a4f6a687657d79945c5544515"
+
+  depends_on :xcode => :build
+
+  def install
+    xcodebuild "-project", "CoreLocationCLI.xcodeproj", "SYMROOT=build", "-sdk", "macosx#{MacOS.version}"
+    bin.install "build/Release/CoreLocationCLI"
+  end
+
+  test do
+    system "#{bin}/CoreLocationCLI", "-h"
+  end
+end

--- a/Library/Formula/corelocationcli.rb
+++ b/Library/Formula/corelocationcli.rb
@@ -12,6 +12,6 @@ class Corelocationcli < Formula
   end
 
   test do
-    system "#{bin}/CoreLocationCLI", "-h"
+    system "(#{bin}/CoreLocationCLI -h; true)"
   end
 end

--- a/Library/Formula/corelocationcli.rb
+++ b/Library/Formula/corelocationcli.rb
@@ -12,6 +12,6 @@ class Corelocationcli < Formula
   end
 
   test do
-    system "(#{bin}/CoreLocationCLI -h; true)"
+    shell_output("#{bin}/CoreLocationCLI -h", 1)
   end
 end


### PR DESCRIPTION
Command line program to print location information from CoreLocation.
More info: https://github.com/fulldecent/corelocationcli

Notice: We can only test that CoreLocationCLI is installed. CoreLocation framework needs user's interaction to allow its access to the client (CoreLocationCLI). 

![CoreLocationCLI_UserInteration](https://cloud.githubusercontent.com/assets/1571265/9741301/adae76f8-5651-11e5-8c95-136477732e4c.png)