### PR TITLE
dovecot: Fix deprecated keys in plist

### DIFF
--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -45,7 +45,7 @@ class Dovecot < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-        <key>OnDemand</key>
+        <key>KeepAlive</key>
         <false/>
         <key>RunAtLoad</key>
         <true/>
@@ -54,8 +54,6 @@ class Dovecot < Formula
           <string>#{opt_sbin}/dovecot</string>
           <string>-F</string>
         </array>
-        <key>ServiceDescription</key>
-        <string>Dovecot mail server</string>
         <key>StandardErrorPath</key>
         <string>#{var}/log/dovecot/dovecot.log</string>
         <key>StandardOutPath</key>


### PR DESCRIPTION
The "OnDemand" and "ServiceDescription" keys were deprecated in OS X 10.5. Replace "OnDemand" with "KeepAlive" and delete the "ServiceDescription" key. The old keys were generating warnings. See https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/launchd.plist.5.html