### PR TITLE
Gpgme and dependencies

### DIFF
--- a/Library/Formula/gpgme.rb
+++ b/Library/Formula/gpgme.rb
@@ -1,9 +1,9 @@
 class Gpgme < Formula
   desc "Library access to GnuPG"
   homepage "https://www.gnupg.org/related_software/gpgme/"
-  url "ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-1.5.5.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-1.5.5.tar.bz2"
-  sha256 "0b3d3d5107680c594777aae65882a1ff6dd1ba629a83432e719c8b82a743c207"
+  url "ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
+  sha256 "b09de4197ac280b102080e09eaec6211d081efff1963bf7821cf8f4f9916099d"
 
   bottle do
     cellar :any

--- a/Library/Formula/gpgme.rb
+++ b/Library/Formula/gpgme.rb
@@ -3,6 +3,7 @@ class Gpgme < Formula
   homepage "https://www.gnupg.org/related_software/gpgme/"
   url "ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
+  mirror "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
   sha256 "b09de4197ac280b102080e09eaec6211d081efff1963bf7821cf8f4f9916099d"
 
   bottle do

--- a/Library/Formula/libassuan.rb
+++ b/Library/Formula/libassuan.rb
@@ -18,7 +18,8 @@ class Libassuan < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--enable-static"
     system "make", "install"
   end
 

--- a/Library/Formula/libassuan.rb
+++ b/Library/Formula/libassuan.rb
@@ -5,6 +5,7 @@ class Libassuan < Formula
   mirror "ftp://ftp.gnupg.org/gcrypt/libassuan/libassuan-2.3.0.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-2.3.0.tar.bz2"
   sha256 "87c999f572047fa22a79ab5de4c8a1a5a91f292561b69573965cac7751320452"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libgpg-error.rb
+++ b/Library/Formula/libgpg-error.rb
@@ -5,6 +5,7 @@ class LibgpgError < Formula
   mirror "ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
   sha256 "3266895ce3419a7fb093e63e95e2ee3056c481a9bc0d6df694cfd26f74e72522"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libgpg-error.rb
+++ b/Library/Formula/libgpg-error.rb
@@ -18,7 +18,8 @@ class LibgpgError < Formula
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
-                          "--disable-silent-rules"
+                          "--disable-silent-rules",
+                          "--enable-static"
     system "make", "install"
   end
 


### PR DESCRIPTION
 - Update libgpgme to the latest version. 
 - Enable static libraries for the dependencies of libgpgme, so that we can actually use the libgpgme static library.