### PR TITLE
python3 3.5.0rc4 (devel)

### DIFF
--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -15,8 +15,8 @@ class Python3 < Formula
   head "https://hg.python.org/cpython", :using => :hg
 
   devel do
-    url "https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc3.tgz"
-    sha256 "d82ad71248846a740e4bc6834df7e43d046723058c30025ed02a2ebf2fbdf6c5"
+    url "https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc4.tgz"
+    sha256 "d2576bcff852a8818842da2496782576413bd32ce3dd835192f86eeec4384379"
   end
 
   option :universal


### PR DESCRIPTION
rc4 came out on the 9th of September. [Changelog](https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-0-release-candidate-4)