### PR TITLE
Improve launchdns linking example

### DIFF
--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -24,7 +24,7 @@ class Launchdns < Formula
 
   def caveats; <<-EOS.undent
       To have *.dev resolved to 127.0.0.1:
-          sudo ln -s #{HOMEBREW_PREFIX}/etc/resolver /etc/resolver
+          sudo ln -s #{HOMEBREW_PREFIX}/etc/resolver /etc
     EOS
   end
 


### PR DESCRIPTION
With the old instructions, if /etc/resolver link does not exist the link will be created as expected. However, if the link or directory already exists this will result in a nested directory like /etc/resolver/resolver.

-
To: @mikemcquaid 