### PR TITLE
pull --bottle: delete cached bottles on failure

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -221,6 +221,7 @@ module Homebrew
         raise e if retry_count >= max_retries
         sleep_seconds = 2**retry_count
         ohai "That didn't work; sleeping #{sleep_seconds} seconds and trying again..."
+        f.bottle.cached_download.delete if f.bottle.cached_download.file?
         sleep sleep_seconds
         retry
       end


### PR DESCRIPTION
This would prevent the failure I just got:

```
…snip…
curl: (22) The requested URL returned error: 401 Unauthorized
Error: Failed to download resource "idris"
Download failed: https://homebrew.bintray.com/bottles/idris-0.9.19.yosemite.bottle.tar.gz

==> That didn't work; sleeping 8 seconds and trying again...
==> Downloading https://homebrew.bintray.com/bottles/idris-0.9.19.yosemite.bottle.tar.gz
######################################################################## 100,0%
Downloaded to: /Library/Caches/Homebrew/idris-0.9.19.yosemite.bottle.tar.gz
SHA1: 7fc1beb84db1690aa7c8cf465901b38e5a93e4a7
SHA256: 69488c077522fc820f9d3fd32ae8fef6f28439104f62caf109365a2488b051fe
Warning: Formula reports different SHA256: 3715762d595681a647c0694a285695f4b4a1358954a4be56cf669f61da625965

==> That didn't work; sleeping 16 seconds and trying again...
==> Downloading https://homebrew.bintray.com/bottles/idris-0.9.19.yosemite.bottle.tar.gz
Already downloaded: /Library/Caches/Homebrew/idris-0.9.19.yosemite.bottle.tar.gz
SHA1: 7fc1beb84db1690aa7c8cf465901b38e5a93e4a7
SHA256: 69488c077522fc820f9d3fd32ae8fef6f28439104f62caf109365a2488b051fe
Warning: Formula reports different SHA256: 3715762d595681a647c0694a285695f4b4a1358954a4be56cf669f61da625965
Error: Failed to download idris bottle!
```

The command slept 16 seconds but didn’t retry the download since the bottle was already cached.