### PR TITLE
duplicity: pexpect python package resource

### DIFF
--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -232,6 +232,11 @@ class Duplicity < Formula
     sha256 "6efcbff0bf60521ef682068c10c2d8959d887f70ed84ccd2def9945e8e94560e"
   end
 
+  resource "pexpect" do
+    url "https://pypi.python.org/packages/source/p/pexpect/pexpect-2.4.tar.gz"
+    sha256 "43c788f59dcf4bed677fd0b16891787dbf747e210ffedb6e90156fbbbd4d3b7b"
+  end
+
   def install
     ENV["PYTHONPATH"] = libexec/"lib/python2.7/site-packages"
 


### PR DESCRIPTION
This PR adds a `pexpect 2.4` python package to `duplicity` formula.

`pexpect` package is required for a couple `duplicity` features, including the `par2` integration I was trying to run.

Please let me know if I can be of any assistance related to this, I'll be responsive.