### PR TITLE
par2: remove obsolete par2tbb conflict

### DIFF
--- a/Library/Formula/par2.rb
+++ b/Library/Formula/par2.rb
@@ -4,9 +4,6 @@ class Par2 < Formula
   url "https://downloads.sourceforge.net/project/parchive/par2cmdline/0.4/par2cmdline-0.4.tar.gz"
   sha256 "9e32b7dbcf7bca8249f98824757d4868714156fe2276516504cd26f736e9f677"
 
-  conflicts_with "par2tbb",
-    :because => "par2 and par2tbb install the same binaries."
-
   # Clang doesn't like variable length arrays of non-POD types.
   patch :DATA
 


### PR DESCRIPTION
par2tbb formula was moved to boneyard in #43360. This caused `Error: No
available formula for par2tbb` to show.