### PR TITLE
Alter patch to make http-parser bottle relocatable

### DIFF
--- a/Library/Formula/http-parser.rb
+++ b/Library/Formula/http-parser.rb
@@ -13,8 +13,8 @@ class HttpParser < Formula
   depends_on "coreutils" => :build
 
   patch do
-    url "https://patch-diff.githubusercontent.com/raw/joyent/http-parser/pull/247.diff"
-    sha256 "0f081d0cbf44575b2db2889b318245e692706b756725ba64d1277f571c8b921f"
+    url "https://gist.githubusercontent.com/staticfloat/6b51c399ace589e97b14/raw/9bd86c435e2fc001030649fc2623f048329c694b/rel_symlink.diff"
+    sha256 "278e3745b0c7d419b5bde0e18bc64ceb07a7ddeea1ae12bfdcfa482b888fe957"
   end
 
   def install


### PR DESCRIPTION
I'm not sure if you guys would prefer this patch rolled into the current one (as I have it right now) or as a separate one on top of the current patch.  The only reason I rolled it into the current one is that it touches some of the same lines.

This patch changes the `ln` command to create a relative symlink rather than an absolute one.