### PR TITLE
duplicity: gnupg dependency

### DIFF
--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -20,7 +20,7 @@ class Duplicity < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "librsync"
-  depends_on "gnupg"
+  depends_on :gpg => :run
 
   # generated with homebrew-pypi-poet from
   # for i in boto pyrax dropbox mega.py paramiko pycrypto


### PR DESCRIPTION
This PR "relaxes" the `duplicity` formula dependency on `gnupg` if `gnupg2` is installed.

`duplicity` formula works just fine with `gnupg2`.