### PR TITLE
libvoikko 3.8

### DIFF
--- a/Library/Formula/libvoikko.rb
+++ b/Library/Formula/libvoikko.rb
@@ -1,8 +1,8 @@
 class Libvoikko < Formula
   desc "Linguistic software for Finnish"
   homepage "http://voikko.puimula.org/"
-  url "http://www.puimula.org/voikko-sources/libvoikko/libvoikko-3.7.1.tar.gz"
-  sha256 "83c7620595e82fa065fffff306cbe4cbedfa56b8d0203a5424997c18305ca43c"
+  url "http://www.puimula.org/voikko-sources/libvoikko/libvoikko-3.8.tar.gz"
+  sha256 "1df2f4a47217d1de5978e1586c1bbf61a1454cef6aadadbda6aec45738e69cff"
 
   bottle do
     cellar :any

--- a/Library/Formula/malaga.rb
+++ b/Library/Formula/malaga.rb
@@ -1,7 +1,7 @@
 class Malaga < Formula
   desc "Grammar development environment for natural languages"
   homepage "http://home.arcor.de/bjoern-beutel/malaga/"
-  url "http://home.arcor.de/bjoern-beutel/malaga/malaga-7.12.tgz"
+  url "https://launchpad.net/ubuntu/+archive/primary/+files/malaga_7.12.orig.tar.gz"
   sha256 "8811e5feaae03e1b6e3008116fdc7471a53b6c0c5036751c637b15058f855ace"
 
   bottle do


### PR DESCRIPTION
Updated to release 3.8

The homepage of libmalaga seems to be gone since last Voikko update, so I switched to copy from Ubuntu.