### PR TITLE
llvm: add support for building with polly

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -80,6 +80,10 @@ class Llvm < Formula
     resource "clang-tools-extra" do
       url "http://llvm.org/git/clang-tools-extra.git"
     end
+
+    resource "polly" do
+      url "http://llvm.org/git/polly.git"
+    end
   end
 
   option :universal
@@ -87,6 +91,7 @@ class Llvm < Formula
   option "with-lld", "Build LLD linker"
   option "with-lldb", "Build LLDB debugger"
   option "with-rtti", "Build with C++ RTTI"
+  option "with-polly", "Build with the experimental Polly optimizer"
   option "with-python", "Build Python bindings against Homebrew Python"
   option "without-assertions", "Speeds up LLVM, but provides less debug information"
 
@@ -127,6 +132,7 @@ class Llvm < Formula
 
     (buildpath/"tools/lld").install resource("lld") if build.with? "lld"
     (buildpath/"tools/lldb").install resource("lldb") if build.with? "lldb"
+    (buildpath/"tools/polly").install resource("polly") if build.with? "polly"
 
     args = %w[
       -DLLVM_OPTIMIZED_TABLEGEN=On


### PR DESCRIPTION
For reference:
    http://polly.llvm.org/get_started.html
    http://polly.llvm.org/example_load_Polly_into_clang.html

Polly is an optimization infrastructure for llvm that performs memory
access optimizations.

Currently set up to support --HEAD-only builds (I think), because
according to the website Polly is not really that stable.