### PR TITLE
llvm: add option to run regression tests

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -88,6 +88,7 @@ class Llvm < Formula
   option "with-lldb", "Build LLDB debugger"
   option "with-rtti", "Build with C++ RTTI"
   option "with-python", "Build Python bindings against Homebrew Python"
+  option "with-tests", "Run regression tests after build"
   option "without-assertions", "Speeds up LLVM, but provides less debug information"
 
   deprecated_option "rtti" => "with-rtti"
@@ -148,6 +149,7 @@ class Llvm < Formula
     mktemp do
       system "cmake", "-G", "Unix Makefiles", buildpath, *(std_cmake_args + args)
       system "make"
+      system "make", "check-all" if build.with?("tests")
       system "make", "install"
     end
 


### PR DESCRIPTION
  For reference:
    http://llvm.org/docs/TestingGuide.html

There is a larger test suite available, but that's going in a different
commit because it requires the installation of a separate tool (lnt).