### PR TITLE
dshb v0.1.0 (new formula)

### DIFF
--- a/Library/Formula/dshb.rb
+++ b/Library/Formula/dshb.rb
@@ -1,0 +1,19 @@
+class Dshb < Formula
+  desc "OS X system monitor in Swift"
+  homepage "https://github.com/beltex/dshb"
+  url "https://github.com/beltex/dshb/releases/download/v0.1.0/dshb-0.1.0-source.zip"
+  sha256 "efed42a2be0dbc6de3b22b314b582b1d6517922b72e08e063f3d1d3810a782f9"
+
+  depends_on :xcode => ["7.0", :build]
+
+  def install
+    system "make", "release"
+    bin.install "bin/dshb"
+    man1.install "doc/dshb.1"
+  end
+
+  test do
+    ENV["TERM"] = "xterm"
+    pipe_output("#{bin}/dshb", "q", 0)
+  end
+end


### PR DESCRIPTION
Hello Homebrew! :beers: 

This is a self-submission of a new formula, [dshb](https://github.com/beltex/dshb), my sincerest apologies for breaking the rules! :) Being a Swift based tool I thought I’d go ahead and write the initial formula to kick things off incase any difficulties were to come up in the process. I hope this is alright, if not, by all means close this.

### What

An OS X system monitor in Swift, inspired by <a href="https://en.wikipedia.org/wiki/Top_(software)">top</a> & [htop](https://github.com/hishamhm/htop)

### Notes

* Passes `brew audit dshb --online --strict`

* Used [SourceKitten](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/sourcekitten.rb), [Carthage](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/carthage.rb), (both Swift based tools) and [htop-osx](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/htop-osx.rb) formulae as reference

* `depends_on :xcode => ["6.3", :build]` is used because Xcode 6.3 (up to 6.4) comes with the Swift 1.2 compiler. See https://github.com/Homebrew/homebrew/issues/42864#issuecomment-133078788 for more

* Since `dshb` uses multiple Git submodules, I thought it be best to point to the source code archive such that the checksum holds more value. This is a custom source code archive, as the ones generated from GitHub do not include submodules (see https://github.com/beltex/dshb/issues/29 for more detail)

### Questions

* Can `depends_on` specify a version range? Xcode 6.3 to 6.4 (but not higher) have the Swift 1.2 compiler that is required

* Can `depends_on` also warn that the Xcode version in question is active or not? As in `xcode-select -s`. Currently, if a user has Xcode 6.3 and 7 installed (with 7 being active) for example, the `depends_on` check will pass, but the build will fail since when `swiftc` (the Swift compiler) is called it will link to version 2.0 of the compiler that has breaking changes.

* I'm not sure how to express the fact that `dshb` supports OS X 10.9, yet Mavericks can't officially build it because Xcode 6.3 (and above) doesn't support it (really it's Xcode.app that doesn't, the Swift compiler that comes bundled should work fine). The `dshb` binary we get is _“universal”_ in that it works on 10.9 to 10.11. Two options I can see for this. One is when Swift goes open source later this year, folks can get there hands on Swift independent of Xcode and thus the formula could instead depend on the Swift compiler version instead of Xcode (see https://github.com/Homebrew/homebrew/issues/42864#issuecomment-133078788 for more). Alternatively, could have the bottle be used in that case, with no option to build from source.

* Not much we can do for the test requirement, did the same thing that `htop-osx` formula does, booting and passing `q` as input to quit and asserting success. Beyond that, all I can think of is running `-v` or `-h` and checking the output. Is there something better that can be done?

Reference issue: https://github.com/beltex/dshb/issues/1