### PR TITLE
fossil: don't pass --with-tcl unless CLT available

### DIFF
--- a/Library/Formula/fossil.rb
+++ b/Library/Formula/fossil.rb
@@ -1,9 +1,10 @@
 class Fossil < Formula
   desc "Distributed software configuration management"
   homepage "https://www.fossil-scm.org/"
-  head "https://www.fossil-scm.org/", :using => :fossil
   url "https://www.fossil-scm.org/download/fossil-src-1.33.tar.gz"
   sha256 "6295c48289456f09e86099988058a12148dbe0051b72d413b4dff7216d6a7f3e"
+
+  head "https://www.fossil-scm.org/", :using => :fossil
 
   bottle do
     cellar :any
@@ -16,11 +17,23 @@ class Fossil < Formula
   option "without-tcl", "Build without the tcl-th1 command bridge"
 
   depends_on "openssl"
+  depends_on :osxfuse => :optional
 
   def install
     args = []
     args << "--json" if build.with? "json"
-    args << "--with-tcl" if build.with? "tcl"
+
+    if MacOS::CLT.installed? && build.with?("tcl")
+      args << "--with-tcl"
+    else
+      args << "--with-tcl-stubs"
+    end
+
+    if build.with? "osxfuse"
+      ENV.prepend "CFLAGS", "-I#{HOMEBREW_PREFIX}/include/osxfuse"
+    else
+      args << "--disable-fusefs"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
This seems to resolve the problem in #42493, but since there's no explicit `--without-tcl` option, not 110% sure.

Closes #42493.