### PR TITLE
fix update-test

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -2,26 +2,33 @@ require "extend/ENV"
 
 module Homebrew
   def update_test
-    homebrew_repository_git = HOMEBREW_REPOSITORY/".git"
-
     mktemp do
       curdir = Pathname.new(Dir.pwd)
 
-      ohai "Setup test environment..."
+      oh1 "Setup test environment..."
       # copy Homebrew installation
-      cp_r homebrew_repository_git, curdir/".git"
-      safe_system "git", "checkout", "--force", "master"
-      safe_system "git", "reset", "--hard", "origin/master"
+      cp_r HOMEBREW_REPOSITORY/".git", curdir/".git"
+      start_sha1 = Utils.popen_read("git", "rev-parse", "origin/master").chomp
+      end_sha1 = Utils.popen_read("git", "rev-parse", "HEAD").chomp
 
-      # set git origin
-      safe_system "git", "config", "remote.origin.url", "file://#{homebrew_repository_git}"
+      # set git origin to another copy
+      cp_r HOMEBREW_REPOSITORY/".git", curdir/"remote.git"
+      safe_system "git", "config", "remote.origin.url", "file://#{curdir}/remote.git"
+
+      # force push origin to end_sha1
+      safe_system "git", "checkout", "--force", "master"
+      safe_system "git", "reset", "--hard", end_sha1
+      safe_system "git", "push", "--force", "origin", "master"
+
+      # set test copy to start_sha1
+      safe_system "git", "reset", "--hard", start_sha1
 
       # update ENV["PATH"]
       ENV.extend(Stdenv)
       ENV.prepend_path "PATH", "#{curdir}/bin"
 
       # run brew update
-      ohai "Running brew update..."
+      oh1 "Running brew update..."
       safe_system "brew", "update", "--verbose"
     end
   end


### PR DESCRIPTION
Previously, `brew update-test` is run against master branch of local
repo. However, we test PR using a detached branch in `brew test-bot`.
The result is `brew update-test` will always be up-to-date in `test-bot`.

To fix it, we create two local copies of git repo, and set master branch
to start and end sha1 correspondingly. After that, `brew update` will be
run to simulate the change between start and end sha1.

cc @mikemcquaid 