### PR TITLE
libtommath, libtomcrypt: new website for libtom project

### DIFF
--- a/Library/Formula/libtomcrypt.rb
+++ b/Library/Formula/libtomcrypt.rb
@@ -1,7 +1,7 @@
 class Libtomcrypt < Formula
   desc "Modular and portable cryptographic toolkit"
-  homepage "http://www.libtom.net/?page=features&whatfile=crypt"
-  url "http://www.libtom.net/files/crypt-1.17.tar.bz2"
+  homepage "http://www.libtom.net/LibTomCrypt/"
+  url "https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.tar.bz2"
   mirror "https://distfiles.macports.org/libtomcrypt/crypt-1.17.tar.bz2"
   sha256 "e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116"
   head "https://github.com/libtom/libtomcrypt.git"

--- a/Library/Formula/libtommath.rb
+++ b/Library/Formula/libtommath.rb
@@ -1,10 +1,10 @@
 class Libtommath < Formula
   desc "C library for number theoretic multiple-precision integers"
-  # homepage/url down since ~May 2015
-  homepage "http://libtom.org/?page=features&newsitems=5&whatfile=ltm"
-  url "http://libtom.org/files/ltm-0.42.0.tar.bz2"
+  homepage "http://www.libtom.net/LibTomMath/"
+  url "https://github.com/libtom/libtommath/releases/download/v0.42.0/ltm-0.42.0.tar.bz2"
   mirror "https://distfiles.macports.org/libtommath/ltm-0.42.0.tar.bz2"
   sha256 "7b5c258304c34ac5901cfddb9f809b9b3b8ac7d04f700cf006ac766a923eb217"
+  head "https://github.com/libtom/libtommath.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
STATUS: Don't merge yet; status of upstream sites is unclear.

Per their website, now at www.libtom.net:

> This website is back, and libtom has found new maintainers.