### PR TITLE
bulk_extractor: add openssl dependency

### DIFF
--- a/Library/Formula/bulk_extractor.rb
+++ b/Library/Formula/bulk_extractor.rb
@@ -3,6 +3,7 @@ class BulkExtractor < Formula
   homepage "https://github.com/simsong/bulk_extractor/wiki"
   url "http://digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz"
   sha256 "297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,6 +16,7 @@ class BulkExtractor < Formula
   depends_on "boost"
   depends_on "exiv2" => :optional
   depends_on "libewf" => :optional
+  depends_on "openssl"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -41,7 +43,7 @@ class BulkExtractor < Formula
     output_dir = testpath/"output"
     system "#{bin}/bulk_extractor", "-o", output_dir, input_file
 
-    assert (output_dir/"url.txt").read.include?("http://brew.sh")
-    assert (output_dir/"telephone.txt").read.include?("(201)555-1212")
+    assert_match "http://brew.sh", (output_dir/"url.txt").read
+    assert_match "(201)555-1212", (output_dir/"telephone.txt").read
   end
 end


### PR DESCRIPTION
Fixes #43912
Also switches to `assert_match` in test to satisfy `brew audit`.