### PR TITLE
lnav: add re2c as build time dependency.

### DIFF
--- a/Library/Formula/lnav.rb
+++ b/Library/Formula/lnav.rb
@@ -15,6 +15,7 @@ class Lnav < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
+    depends_on "re2c" => :build
   end
 
   depends_on "readline"


### PR DESCRIPTION
Recent changes in lnav have added re2c as a build time dependency.
Fix the homebrew formula to reflect the same.