### PR TITLE
net-snmp: add support for 10.11

### DIFF
--- a/Library/Formula/net-snmp.rb
+++ b/Library/Formula/net-snmp.rb
@@ -38,6 +38,7 @@ class NetSnmp < Formula
 
     # https://sourceforge.net/p/net-snmp/bugs/2504/
     ln_s "darwin13.h", "include/net-snmp/system/darwin14.h"
+    ln_s "darwin13.h", "include/net-snmp/system/darwin15.h"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Fixes #43930