### PR TITLE
gpg-agent 2.0.29

### DIFF
--- a/Library/Formula/gpg-agent.rb
+++ b/Library/Formula/gpg-agent.rb
@@ -1,9 +1,9 @@
 class GpgAgent < Formula
   desc "GPG key agent"
   homepage "https://www.gnupg.org/"
-  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.28.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.28.tar.bz2"
-  sha256 "ce092ee4ab58fd19b9fb34a460c07b06c348f4360dd5dd4886d041eb521a534c"
+  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
+  sha256 "68ed6b386ba78425b05a60e8ee22785ff0fef190bdc6f1c612f19a58819d4ac9"
 
   bottle do
     sha256 "8400aa29d4a700d35cb23cda2bf5b3d36fe12860d0f969a9e7e62c76bed61c56" => :el_capitan
@@ -59,6 +59,6 @@ index c022805..96ea7ed 100755
 -PACKAGE_TARNAME='gnupg'
 +PACKAGE_NAME='gpg-agent'
 +PACKAGE_TARNAME='gpg-agent'
- PACKAGE_VERSION='2.0.28'
- PACKAGE_STRING='gnupg 2.0.28'
+ PACKAGE_VERSION='2.0.29'
+ PACKAGE_STRING='gnupg 2.0.29'
  PACKAGE_BUGREPORT='http://bugs.gnupg.org'


### PR DESCRIPTION
Looks like we forgot to bump this when we bumped `gnupg2`.  I think this means that anyone who's brewed the latest `gnupg2` has an outdated agent.  But I don't *think* this means we should make a revision bump, because I don't *think* anything significant about the 2.0.29 release had to do with the agent.

I could however be totally wrong.  Paging doctor @DomT4!