### PR TITLE
ace: 6.3.2 and El Capitan support

### DIFF
--- a/Library/Formula/ace.rb
+++ b/Library/Formula/ace.rb
@@ -1,13 +1,20 @@
 class Ace < Formula
   desc "ADAPTIVE Communication Environment: OO network programming in C++"
   homepage "http://www.cse.wustl.edu/~schmidt/ACE.html"
-  url "http://download.dre.vanderbilt.edu/previous_versions/ACE-6.3.0.tar.bz2"
-  sha256 "e22b6adb1fdd0af45e1c78087d8fd24555b7dcbf0cd6a22b4b131a737602b561"
+  url "http://download.dre.vanderbilt.edu/previous_versions/ACE-6.3.2.tar.bz2"
+  sha256 "d8e5ad92eab743936fb8921301e7df09a4d331270be2b7b3dec7f47b8ba2ce5f"
 
   bottle do
     sha1 "90cb518c4554949453de2eb406a7d1ef8fda3880" => :yosemite
     sha1 "2a58aa9a687ed6b8d3eef8f982b0c96554d85de7" => :mavericks
     sha1 "faa49b7abaf6661f0e4cff46715755985a4a980a" => :mountain_lion
+  end
+
+  # Add config/platform support for El Capitan
+  # https://github.com/DOCGroup/ATCD/pull/141
+  patch :p2 do
+    url "https://github.com/DOCGroup/ATCD/pull/141.diff"
+    sha256 "4a9584c2eb876245ee1f8442886663a83937380ed5d2ceb70e3594b702f544bb"
   end
 
   def install


### PR DESCRIPTION
Update to 6.3.2 and add El Capitan support patch from upstream PR DOCGroup/ATCD#141.
This fixes issue #42255.