### PR TITLE
launchdns 1.0.3

### DIFF
--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -1,9 +1,9 @@
 class Launchdns < Formula
   desc "Mini DNS server designed soely to route queries to localhost"
   homepage "https://github.com/josh/launchdns"
-  url "https://github.com/josh/launchdns/archive/v1.0.1.tar.gz"
+  url "https://github.com/josh/launchdns/archive/v1.0.2.tar.gz"
   head "https://github.com/josh/launchdns.git"
-  sha256 "e96d1b92819a294f1e325df629ae4bf202fd137b8504cf4ddd00cda7e47f7099"
+  sha256 "a67d54096055532af25f6dc9319c0dad6da87658d4d4a2d636ab015b393f011f"
 
   bottle do
     cellar :any
@@ -21,6 +21,7 @@ class Launchdns < Formula
   end
 
   test do
+    system "#{bin}/launchdns --version | grep -vq 'without socket activation'"
     system "#{bin}/launchdns", "-p0", "-t1"
   end
 

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -21,7 +21,7 @@ class Launchdns < Formula
   end
 
   test do
-    system "#{bin}/launchdns --version | grep -vq 'without socket activation'"
+    assert_not_match /without socket activation/, shell_output("#{bin}/launchdns --version")
     system "#{bin}/launchdns", "-p0", "-t1"
   end
 

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -5,6 +5,8 @@ class Launchdns < Formula
   head "https://github.com/josh/launchdns.git"
   sha256 "c34bab9b4f5c0441d76fefb1ee16cb0279ab435e92986021c7d1d18ee408a5dd"
 
+  depends_on :macos => :yosemite
+
   bottle do
     cellar :any
     revision 1

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -1,9 +1,9 @@
 class Launchdns < Formula
   desc "Mini DNS server designed soely to route queries to localhost"
   homepage "https://github.com/josh/launchdns"
-  url "https://github.com/josh/launchdns/archive/v1.0.2.tar.gz"
+  url "https://github.com/josh/launchdns/archive/v1.0.3.tar.gz"
   head "https://github.com/josh/launchdns.git"
-  sha256 "a67d54096055532af25f6dc9319c0dad6da87658d4d4a2d636ab015b393f011f"
+  sha256 "c34bab9b4f5c0441d76fefb1ee16cb0279ab435e92986021c7d1d18ee408a5dd"
 
   bottle do
     cellar :any

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -22,7 +22,7 @@ class Launchdns < Formula
   end
 
   test do
-    assert_not_match /without socket activation/, shell_output("#{bin}/launchdns --version")
+    assert_no_match /without socket activation/, shell_output("#{bin}/launchdns --version")
     system "#{bin}/launchdns", "-p0", "-t1"
   end
 

--- a/Library/Formula/launchdns.rb
+++ b/Library/Formula/launchdns.rb
@@ -15,6 +15,7 @@ class Launchdns < Formula
 
   def install
     ENV["PREFIX"] = prefix
+    system "./configure", "--with-launch-h", "--with-launch-h-activate-socket"
     system "make", "install"
 
     (prefix+"etc/resolver/dev").write("nameserver 127.0.0.1\nport 55353\n")


### PR DESCRIPTION
Updates launchdns formula with a smoke test to ensure `launch.h` support was compiled correctly. Should be a good test to ensure any automated binaries work.

-
To: @mikemcquaid  