### PR TITLE
git-flow-avh: source repo and artifact SHA have changed

### DIFF
--- a/Library/Formula/git-flow-avh.rb
+++ b/Library/Formula/git-flow-avh.rb
@@ -1,11 +1,11 @@
 class GitFlowAvh < Formula
   desc "AVH edition of git-flow"
-  homepage "https://github.com/petervanderdoes/gitflow"
-  url "https://github.com/petervanderdoes/gitflow/archive/1.8.0.tar.gz"
-  sha256 "8239131b8dac160d7e929eab376fa14de44a55cbd5c5545e0ad4464d3a57adef"
+  homepage "https://github.com/petervanderdoes/gitflow-avh"
+  url "https://github.com/petervanderdoes/gitflow-avh/archive/1.8.0.tar.gz"
+  sha256 "350665a9de7a9fe58ab82df5ef70c4e6c4f95bf844e30c23e2f3486396727511"
 
   head do
-    url "https://github.com/petervanderdoes/gitflow.git", :branch => "develop"
+    url "https://github.com/petervanderdoes/gitflow-avh.git", :branch => "develop"
 
     resource "completion" do
       url "https://github.com/petervanderdoes/git-flow-completion.git", :branch => "develop"


### PR DESCRIPTION
Started recieving a sha256 mismatch against this formula today:

```
Already downloaded: /Library/Caches/Homebrew/git-flow-avh-1.8.0.tar.gz
Error: SHA256 mismatch
Expected: 8239131b8dac160d7e929eab376fa14de44a55cbd5c5545e0ad4464d3a57adef
Actual: 350665a9de7a9fe58ab82df5ef70c4e6c4f95bf844e30c23e2f3486396727511
Archive: /Library/Caches/Homebrew/git-flow-avh-1.8.0.tar.gz
To retry an incomplete download, remove the file above.
```

After investigating, we discovered that the source repo was renamed to `petervanderdoes/gitflow-avh` per https://github.com/petervanderdoes/gitflow-avh/issues/204 

Presumably this is also the cause of the artifact SHA changing, but I'm not really certain what Github's mechanism is for repo renames.