### PR TITLE
Upgrade davix to last upstream version 0.5.0

### DIFF
--- a/Library/Formula/davix.rb
+++ b/Library/Formula/davix.rb
@@ -2,9 +2,9 @@ class Davix < Formula
   desc "Library and tools for advanced file I/O with HTTP-based protocols"
   homepage "https://dmc.web.cern.ch/projects/davix/home"
   url "https://github.com/cern-it-sdc-id/davix.git",
-    :revision => "9d8f400ec1882602fc18312f35d617fe94ebbd67",
-    :tag => "R_0_4_0-1"
-  version "0.4.0-1"
+    :revision => "c53eb1472537da1694a5adc4c8fef5611eae7ab8",
+    :tag => "R_0_5_0"
+  version "0.5.0"
 
   head "https://github.com/cern-it-sdc-id/davix.git"
 


### PR DESCRIPTION
Upgrade the davix tool to the last upstream version 0.5.0