### PR TITLE
Update Node.js to 4.0.0 (Alt)

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -1,11 +1,9 @@
-# Note that x.even are stable releases, x.odd are devel releases
 class Node < Formula
-  desc "Platform built on Chrome's JavaScript runtime to build network applications"
+  desc "Platform built on the V8 JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz"
-  sha256 "b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d"
-  head "https://github.com/nodejs/node.git", :branch => "v0.12"
-  revision 1
+  url "https://nodejs.org/dist/v4.1.0/node-v4.1.0.tar.gz"
+  sha256 "453005f64ee529f7dcf1237eb27ee2fa2415c49f5c9e7463e8b71fba61c5b408"
+  head "https://github.com/nodejs/node.git"
 
   bottle do
     sha256 "7d58243777c4133034254d1756de907efaf5e12bcf5eb94c11119f4f0306a815" => :el_capitan
@@ -33,20 +31,15 @@ class Node < Formula
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-2.14.2.tgz"
-    sha256 "592029e3406cbbaf249135e18212fab91db1601f991f61b4b2a03580311a066e"
+    url "https://registry.npmjs.org/npm/-/npm-2.14.4.tgz"
+    sha256 "c8b602de5d51f956aa8f9c34d89be38b2df3b7c25ff6588030eb8224b070db27"
   end
 
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
     args << "--with-intl=system-icu" if build.with? "icu4c"
-
-    if build.with? "openssl"
-      args << "--shared-openssl"
-    else
-      args << "--without-ssl2" << "--without-ssl3"
-    end
+    args << "--shared-openssl" if build.with? "openssl"
 
     system "./configure", *args
     system "make", "install"
@@ -143,6 +136,7 @@ class Node < Formula
       assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
       assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
       system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "bignum"
     end
   end
 end


### PR DESCRIPTION
The [other PR](https://github.com/Homebrew/homebrew/pull/43714) still needed lots of work, and even went so far as to remove the entire npm staging routine.  

This, I believe, is a minimal subset of changes to the existing formula to make node.js 4+ work later this week once npm 2.14.3 is shipping without any floating patches.  

Please let me know if this PR is undesired or making too much noise.

This should also provide a good testing ground for figuring out which pieces of the formula can be simplified or removed.