### PR TITLE
boost{,-bcp,-python} 1.59.0

### DIFF
--- a/Library/Formula/boost-bcp.rb
+++ b/Library/Formula/boost-bcp.rb
@@ -3,8 +3,17 @@ class BoostBcp < Formula
   homepage "http://www.boost.org/doc/tools/bcp/"
   url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
   sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
-
   head "https://github.com/boostorg/boost.git"
+
+  stable do
+    # Fixed compilation of operator<< into a record ostream, when
+    # the operator right hand argument is not directly supported by
+    # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549
+    patch do
+      url "https://github.com/boostorg/log/commit/7da193fde1a9c1bc925ee980339f4df2e1a66fa7.patch"
+      sha256 "c0513daec3fe65a45dd40bf54c6e6b4526f265b63405e7d94ee8c40630c01bf3"
+    end
+  end
 
   bottle do
     cellar :any

--- a/Library/Formula/boost-bcp.rb
+++ b/Library/Formula/boost-bcp.rb
@@ -1,8 +1,8 @@
 class BoostBcp < Formula
   desc "Utility for extracting subsets of the Boost library"
   homepage "http://www.boost.org/doc/tools/bcp/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
-  sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
+  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
 
   head "https://github.com/boostorg/boost.git"
 

--- a/Library/Formula/boost-python.rb
+++ b/Library/Formula/boost-python.rb
@@ -1,18 +1,9 @@
 class BoostPython < Formula
   desc "C++ library for C++/Python interoperability"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
-  sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
+  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
   head "https://github.com/boostorg/boost.git"
-
-  stable do
-    # don't explicitly link a Python framework
-    # https://github.com/boostorg/build/pull/78
-    patch do
-      url "https://gist.githubusercontent.com/tdsmith/9026da299ac1bfd3f419/raw/b73a919c38af08941487ca37d46e711864104c4d/boost-python.diff"
-      sha256 "9f374761ada11eecd082e7f9d5b80efeb387039d3a290f45b61f0730bce3801a"
-    end
-  end
 
   bottle do
     cellar :any

--- a/Library/Formula/boost-python.rb
+++ b/Library/Formula/boost-python.rb
@@ -5,6 +5,16 @@ class BoostPython < Formula
   sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
   head "https://github.com/boostorg/boost.git"
 
+  stable do
+    # Fixed compilation of operator<< into a record ostream, when
+    # the operator right hand argument is not directly supported by
+    # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549
+    patch do
+      url "https://github.com/boostorg/log/commit/7da193fde1a9c1bc925ee980339f4df2e1a66fa7.patch"
+      sha256 "c0513daec3fe65a45dd40bf54c6e6b4526f265b63405e7d94ee8c40630c01bf3"
+    end
+  end
+
   bottle do
     cellar :any
     sha256 "7f627fb1887ecaaea4b6b363d300a21c5274a1607c7dc64f2114d3794b5fec11" => :yosemite

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -1,8 +1,8 @@
 class Boost < Formula
   desc "Collection of portable C++ source libraries"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
-  sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
+  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
 
   head "https://github.com/boostorg/boost.git"
 

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -3,8 +3,17 @@ class Boost < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
   sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
-
   head "https://github.com/boostorg/boost.git"
+
+  stable do
+    # Fixed compilation of operator<< into a record ostream, when
+    # the operator right hand argument is not directly supported by
+    # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549
+    patch do
+      url "https://github.com/boostorg/log/commit/7da193fde1a9c1bc925ee980339f4df2e1a66fa7.patch"
+      sha256 "c0513daec3fe65a45dd40bf54c6e6b4526f265b63405e7d94ee8c40630c01bf3"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
http://www.boost.org/users/history/version_1_59_0.html

- Boost.Log contains has a regression that prevents some of the logging statements from compiling ([#11549](https://svn.boost.org/trac/boost/ticket/11549)). This is fixed in [git](https://github.com/boostorg/log/commit/7da193fde1a9c1bc925ee980339f4df2e1a66fa7).
- Explicitly link a Python framework fixed boostorg/build#78