### PR TITLE
gst-plugins-bad: can optionally use srtp

### DIFF
--- a/Library/Formula/gst-plugins-bad.rb
+++ b/Library/Formula/gst-plugins-bad.rb
@@ -37,6 +37,7 @@ class GstPluginsBad < Formula
   depends_on "rtmpdump" => :optional
   depends_on "schroedinger" => :optional
   depends_on "sound-touch" => :optional
+  depends_on "srtp" => :optional
 
   option "with-applemedia", "Build with applemedia support"
 


### PR DESCRIPTION
provides srtpenc and srtpdec gstreamer elements

```
$ gst-inspect-1.0 srtp
Plugin Details:
  Name                     srtp
  Description              GStreamer SRTP
  Filename                 /usr/local/lib/gstreamer-1.0/libgstsrtp.so
  Version                  1.4.5
  License                  LGPL
  Source module            gst-plugins-bad
  Source release date      2014-12-18
  Binary package           GStreamer
  Origin URL               http://gstreamer.net/

  srtpenc: SRTP encoder
  srtpdec: SRTP decoder

  2 features:
  +-- 2 elements
```