### PR TITLE
pincaster: add openssl dependency

### DIFF
--- a/Library/Formula/pincaster.rb
+++ b/Library/Formula/pincaster.rb
@@ -3,6 +3,9 @@ class Pincaster < Formula
   homepage "https://github.com/jedisct1/Pincaster"
   url "http://download.pureftpd.org/pincaster/releases/pincaster-0.6.tar.bz2"
   sha256 "c88be055ecf357b50b965afe70b5fc15dff295fbe2b6f0c473cf7e4a795a9f97"
+  revision 1
+
+  depends_on "openssl"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Fixes a build failure on 10.11 where `pincaster` fails to find OpenSSL, like several other formula.

When I first made this fix and tested it, it would then fail due to not being able to find the YAJL library. Though when I tested it today (on a machine without YAJL installed), it succeeded. Something about my other test box, which I had previously used to do the "try installing everything", may have had some residue that caused it to spuriously detect YAJL's presence.