### PR TITLE
proxytunnel: add openssl dependency

### DIFF
--- a/Library/Formula/proxytunnel.rb
+++ b/Library/Formula/proxytunnel.rb
@@ -3,6 +3,9 @@ class Proxytunnel < Formula
   homepage "http://proxytunnel.sourceforge.net/"
   url "https://downloads.sourceforge.net/proxytunnel/proxytunnel-1.9.0.tgz"
   sha256 "2ef5bbf8d81ddf291d71f865c5dab89affcc07c4cb4b3c3f23e1e9462721a6b9"
+  revision 1
+
+  depends_on "openssl"
 
   # Remove conflicting strlcpy/strlcat declarations
   patch :DATA


### PR DESCRIPTION
Fixes build failure on OS X 10.11.