### PR TITLE
sofia-sip: add openssl dependency

### DIFF
--- a/Library/Formula/sofia-sip.rb
+++ b/Library/Formula/sofia-sip.rb
@@ -3,10 +3,12 @@ class SofiaSip < Formula
   homepage "http://sofia-sip.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
   sha256 "2b01bc2e1826e00d1f7f57d29a2854b15fd5fe24695e47a14a735d195dd37c81"
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gettext"
+  depends_on "openssl"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Fixes build failure on 10.11.