### PR TITLE
h2o 1.4.5

### DIFF
--- a/Library/Formula/h2o.rb
+++ b/Library/Formula/h2o.rb
@@ -1,8 +1,8 @@
 class H2o < Formula
   desc "HTTP server with support for HTTP/1.x and HTTP/2"
   homepage "https://github.com/h2o/h2o/"
-  url "https://github.com/h2o/h2o/archive/v1.4.4.tar.gz"
-  sha256 "0297ca73dba460653c6edb14dab17095f60616baf7c51e45ac9f8a6d54b9ba55"
+  url "https://github.com/h2o/h2o/archive/v1.4.5.tar.gz"
+  sha256 "0f60e8d35afad61afc284a7abfa9c9a3b976e8f9faed3f0966fb34056e2e138d"
   head "https://github.com/h2o/h2o.git"
 
   bottle do


### PR DESCRIPTION
A security fix has been released for H2O.  This pull request follows the fix.

ref: https://h2o.examp1e.net/vulnerabilities.html#CVE-2015-5638