### PR TITLE
tlsdate: add openssl dependency

### DIFF
--- a/Library/Formula/tlsdate.rb
+++ b/Library/Formula/tlsdate.rb
@@ -4,11 +4,13 @@ class Tlsdate < Formula
   head "https://github.com/ioerror/tlsdate.git"
   url "https://github.com/ioerror/tlsdate/archive/tlsdate-0.0.8.tar.gz"
   sha256 "65b2f8bd36556c7685916f7a783f3bec7b0712a012a6f34247a2fd5e8b410d17"
+  revision 1
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "openssl"
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
Fixes build failure on 10.11