### PR TITLE
tn5250: add openssl dependency

### DIFF
--- a/Library/Formula/tn5250.rb
+++ b/Library/Formula/tn5250.rb
@@ -3,6 +3,9 @@ class Tn5250 < Formula
   homepage "http://tn5250.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/tn5250/tn5250/0.17.4/tn5250-0.17.4.tar.gz"
   sha256 "354237d400dc46af887cb3ffa4ed1f2c371f5b8bee8be046a683a4ac9db4f9c5"
+  revision 1
+
+  depends_on "openssl"
 
   # Fix segfault; reported here:
   # http://archive.midrange.com/linux5250/201207/msg00000.html


### PR DESCRIPTION
Fixes build failure on 10.11