### PR TITLE
added customsshd daemon

### DIFF
--- a/Library/Formula/customsshd.rb
+++ b/Library/Formula/customsshd.rb
@@ -1,0 +1,15 @@
+class Customsshd < Formula
+  desc "Passwordless launchd SSHD daemon for OSX UI user session"
+  homepage "https://github.com/xfreebird/customsshd"
+  url "https://github.com/xfreebird/customsshd/archive/1.0.0.tar.gz"
+  sha256 "e473c6855f50e232080360bd520c76bc900d4754692dca482bb38286432df721"
+  version "1.0.0"
+
+  def install
+    bin.install "customsshd"
+  end
+
+  test do
+    system "customsshd", "--version"
+  end
+end


### PR DESCRIPTION
It was created to allow running commands through ssh in user UI session.
It is started by launchd when user logs in.
Useful for running iOS simulator tests when connected through ssh.
The default SSHD daemon does not have access the user UI session, hence failing the tests.