### PR TITLE
duplicity: add 'par2' recommended dependency

### DIFF
--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -23,6 +23,7 @@ class Duplicity < Formula
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "librsync"
   depends_on :gpg => :run
+  depends_on "par2" => :optional
 
   # generated with homebrew-pypi-poet from
   # for i in boto pyrax dropbox mega.py paramiko pycrypto


### PR DESCRIPTION
This PR:

- adds `par2` dependency to `duplicity` formula
- improves tests so they are actually doing some work

`par2` is an optional feature for `duplicity` tool. If used it adds data
recovery capability to backup.

Please let me know if further input or clarification is needed! I will be
responsive.