### PR TITLE
whirr: fix download URL

### DIFF
--- a/Library/Formula/whirr.rb
+++ b/Library/Formula/whirr.rb
@@ -1,7 +1,7 @@
 class Whirr < Formula
   desc "Set of libraries for running cloud services"
   homepage "https://whirr.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=whirr/whirr-0.8.2/whirr-0.8.2.tar.gz"
+  url "https://archive.apache.org/dist/whirr/whirr-0.8.2/whirr-0.8.2.tar.gz"
   sha256 "d5ec36c4a6928079118065e3d918679870a42c844e47924b1cd4d7be00a4aca5"
 
   def install


### PR DESCRIPTION
The old URL is downloading an interactive HTML page instead of the tarball and `brew install` is getting an SHA mismatch.