### PR TITLE
xlslib: fix download url

### DIFF
--- a/Library/Formula/xlslib.rb
+++ b/Library/Formula/xlslib.rb
@@ -3,7 +3,7 @@ require "formula"
 class Xlslib < Formula
   desc "C++/C library to construct Excel .xls files in code"
   homepage "http://sourceforge.net/projects/xlslib"
-  url "https://downloads.sourceforge.net/project/xlslib/xlslib-package-2.4.0.zip"
+  url "https://downloads.sourceforge.net/project/xlslib/xlslib-old/xlslib-package-2.4.0.zip"
   sha1 "73447c5c632c0e92c1852bd2a2cada7dd25f5492"
 
   bottle do


### PR DESCRIPTION
URL moved to "xlslib-old" since 2.5.0 is out.

I'm just fixing the URL for 2.4.0 instead of bumping to 2.5.0 because I can't get 2.5.0 to build. It's giving me autoconf/automake grief.