### PR TITLE
Add librados and rados utility from Ceph

### DIFF
--- a/Library/Formula/rados.rb
+++ b/Library/Formula/rados.rb
@@ -3,20 +3,19 @@ class Rados < Formula
   homepage "http://ceph.com/"
   head "https://github.com/ceph/ceph.git"
 
+  depends_on "libtool" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "snappy"
   depends_on "cryptopp"
   depends_on "boost"
   depends_on "leveldb"
-  depends_on "libtool"
-  depends_on "automake"
-  depends_on "pkgconfig"
   depends_on "python"
-
 
   def install
     system "./autogen.sh"
-    
+
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     system "./configure", "--without-fuse",
                           "--without-tcmalloc",

--- a/Library/Formula/rados.rb
+++ b/Library/Formula/rados.rb
@@ -1,0 +1,53 @@
+class Rados < Formula
+  desc "RADOS is a library for connecting and utilizing Ceph"
+  homepage "http://ceph.com/"
+  head "https://github.com/ceph/ceph.git"
+
+  depends_on "openssl"
+  depends_on "snappy"
+  depends_on "cryptopp"
+  depends_on "boost"
+  depends_on "leveldb"
+  depends_on "libtool"
+  depends_on "automake"
+  depends_on "pkgconfig"
+  depends_on "python"
+
+
+  def install
+    system "./autogen.sh"
+    
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    system "./configure", "--without-fuse",
+                          "--without-tcmalloc",
+                          "--without-libaio",
+                          "--without-libxfs",
+                          "--with-rados",
+                          "--without-rbd",
+                          "--without-cephfs",
+                          "--without-radosgw",
+                          "--without-selinux",
+                          "--without-radosstriper",
+                          "--without-mon",
+                          "--without-mds",
+                          "--without-debug",
+                          "--without-libatomic-ops",
+                          "--disable-client",
+                          "--disable-server",
+                          "--disable-coverage",
+                          "--disable-pgrefdebugging",
+                          "--disable-cephfs-java",
+                          "--disable-xio",
+                          "--disable-valgrind",
+                          "--without-libzfs",
+                          "--without-lttng",
+                          "--without-babeltrace",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/rados"
+  end
+end


### PR DESCRIPTION
This adds a new formula that builds from head (there is no stable version that supports OS X yet) the librados library as well as the rados utility. This allows development of Ceph applications using OS X.

Unfortunately it installs a python package unconditionally (ceph-detect-init), and there is no way to disable it, so I am forcing it to depend on the Homebrew python because otherwise it will attempt to install it in the wrong location (specifically, the OS site-packages).