### PR TITLE
tig: install system tigrc as sample

### DIFF
--- a/Library/Formula/tig.rb
+++ b/Library/Formula/tig.rb
@@ -43,10 +43,21 @@ class Tig < Formula
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
-    system "make", "install"
+    system "make"
+    # Ensure the configured `sysconfdir` is used during runtime by
+    # installing in a separate step.
+    system "make", "install", "sysconfdir=#{prefix/"share/tig/examples"}"
     system "make install-doc-man" if build.with? "docs"
     bash_completion.install "contrib/tig-completion.bash"
     zsh_completion.install "contrib/tig-completion.zsh" => "_tig"
     cp "#{bash_completion}/tig-completion.bash", zsh_completion
+  end
+
+  def caveats; <<-EOS.undent
+    A sample of the default configuration has been installed to:
+      #{prefix/"share/tig/examples/tigrc"}
+    to override the system-wide default configuration, copy the sample to:
+      #{etc/"tigrc"}
+    EOS
   end
 end


### PR DESCRIPTION
Package tig without installing the default system-wide tigrc to
/usr/local/etc so that it falls back to use the internal (and always
updated) tigrc copy. This avoids problems when new options are added as
seen in jonas/tig#407.

As a caveat, users are offered the option to install the system-wide
tigrc from a tigrc sample.

Fixes #43958
Fixes jonas/tig#407