### PR TITLE
nuttcp: remove mirror with incompatible file type

### DIFF
--- a/Library/Formula/nuttcp.rb
+++ b/Library/Formula/nuttcp.rb
@@ -2,8 +2,7 @@ class Nuttcp < Formula
   desc "Network performance measurement tool"
   homepage "http://www.nuttcp.net/nuttcp"
   url "http://www.nuttcp.net/nuttcp/nuttcp-6.1.2.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/nuttcp/nuttcp_6.1.2.orig.tar.gz"
-  sha256 "4edfa66a6d03fbd8a5c030a8aad33786945d83455b395486dba592e8a2312a87"
+  sha256 "054e96d9d68fe917df6f25fab15c7755bdd480f6420d7d48d9194a1a52378169"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Reverts 46e8c91bc8a2a789772b1a940d7b1c90ade0d575, which added the mirror, but with a .gz instead of a .bz2 file, so the SHAs differ.

Now that the main site is up, `brew install` fails because the SHA is for the mirrored .gz instead of the primary .bz2. (Mirror only has .gz, main only has .bz2.) I downloaded both tarballs and verified that their contents are in fact the same.