### PR TITLE
yafc: Updates url of yafc-1.3.6.tar.xz

### DIFF
--- a/Library/Formula/yafc.rb
+++ b/Library/Formula/yafc.rb
@@ -1,7 +1,7 @@
 class Yafc < Formula
   desc "Command-line FTP client"
   homepage "http://www.yafc-ftp.com/"
-  url "http://www.yafc-ftp.com/upload/yafc-1.3.6.tar.xz"
+  url "http://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz"
   sha256 "63a32556ed16a589634a5aca3f03134b8d488e06ecb36f9df6ef450aa3a47973"
 
   bottle do


### PR DESCRIPTION
Seems like the url to download the tar.gz has changed from http://www.yafc-ftp.com/upload/yafc-1.3.6.tar.xz to http://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz 