### PR TITLE
procmail 14: autonomous mail processor

### DIFF
--- a/Library/Formula/procmail.rb
+++ b/Library/Formula/procmail.rb
@@ -1,0 +1,29 @@
+class Procmail < Formula
+  desc "Autonomous mail processor"
+  homepage "http://www.procmail.org"
+  # Note the use of the patched version from Apple
+  url "http://www.opensource.apple.com/tarballs/procmail/procmail-14.tar.gz"
+  sha256 "f3bd815d82bb70625f2ae135df65769c31dd94b320377f0067cd3c2eab968e81"
+
+  keg_only :provided_pre_el_capitan
+
+  def install
+    system "make", "-C", "procmail", "BASENAME=#{prefix}", "MANDIR=#{man}",
+           "LOCKINGTEST=1", "install"
+  end
+
+  test do
+    path = testpath/"test.mail"
+    path.write <<-EOS.undent
+      From alice@example.net Tue Sep 15 15:33:41 2015
+      Date: Tue, 15 Sep 2015 15:33:41 +0200
+      From: Alice <alice@example.net>
+      To: Bob <bob@example.net>
+      Subject: Test
+
+      please ignore
+    EOS
+    assert_match /Subject: Test/, shell_output("#{bin}/formail -X 'Subject' < #{path}")
+    assert_match /please ignore/, shell_output("#{bin}/formail -I '' < #{path}")
+  end
+end


### PR DESCRIPTION
It seems the venerable procmail was removed from Mac OS X 10.11 El Capitan :unamused: 