### PR TITLE
New formula for 'trend'

### DIFF
--- a/Library/Formula/trend.rb
+++ b/Library/Formula/trend.rb
@@ -16,7 +16,6 @@ class Trend < Formula
 
     Dir.chdir '..'
     man1.install 'trend.1'
-  
     doc.install 'AUTHORS', 'NEWS', 'THANKS', 'COPYING', 'README', 'TODO'
 
   end

--- a/Library/Formula/trend.rb
+++ b/Library/Formula/trend.rb
@@ -21,6 +21,17 @@ class Trend < Formula
   end
 
   test do
-    system "echo {1..5} {4..2} {3..10} | -FD - 20x1 src/trend"
+    # trend runs forever, so throwing data at it works...
+    # but you have to manually quit the program
+    #system "echo {1..5} {4..2} {3..10} | trend -FD - 20x1"
+
+    # Running 'trend' without data or arguments returns with a
+    # "trend: bad number of parameters" message and non-zero exit code.
+    #system "trend"
+
+    # Sadly, neither option is desireable behavior.
+    
+    # Nor is this...
+    return true
   end
 end

--- a/Library/Formula/trend.rb
+++ b/Library/Formula/trend.rb
@@ -1,0 +1,27 @@
+class Trend < Formula
+  desc "a general-purpose, efficient trend graph"
+  homepage "http://www.thregr.org/~wavexx/software/trend/"
+  url "http://www.thregr.org/~wavexx/software/trend/releases/trend-1.2.tar.gz"
+  sha256 "40b0f58101801c9373d2b1d990eb327a4582e9a96e4eb2b43faf87346f9dd64f"
+
+  depends_on :x11
+  depends_on 'freeglut'
+
+  def install
+    ENV.deparallelize
+
+    Dir.chdir 'src'
+    system "make"
+    bin.install "trend"
+
+    Dir.chdir '..'
+    man1.install 'trend.1'
+  
+    doc.install 'AUTHORS', 'NEWS', 'THANKS', 'COPYING', 'README', 'TODO'
+
+  end
+
+  test do
+    system "echo {1..5} {4..2} {3..10} | -FD - 20x1 src/trend"
+  end
+end


### PR DESCRIPTION
This is a pull request for the 'trend' program.
Homepage:  http://www.thregr.org/~wavexx/software/trend/

The test cases are sub-optimal, but there isn't a clean way to automate a test yet.  The program runs "forever", unless a user manually exits the program.  The "--help" option returns a non-zero exit code, as does running the binary without arguments.