### PR TITLE
commands: sort external commands by name

### DIFF
--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -39,6 +39,7 @@ module Homebrew
   def external_commands
     paths.flat_map { |p| Dir["#{p}/brew-*"] }.
       map { |f| File.basename(f, ".rb")[5..-1] }.
-      reject { |f| f =~ /\./ }
+      reject { |f| f =~ /\./ }.
+      sort
   end
 end


### PR DESCRIPTION
Because external commands are found in different directories on the search path, they are initially sorted by origin (in search path order) and then by name. Sorting them by name only gives a nicer output for `brew commands`.