### PR TITLE
Yafc fix url plus chmod bug

### DIFF
--- a/Library/Formula/yafc.rb
+++ b/Library/Formula/yafc.rb
@@ -1,7 +1,7 @@
 class Yafc < Formula
   desc "Command-line FTP client"
   homepage "http://www.yafc-ftp.com/"
-  url "http://www.yafc-ftp.com/upload/yafc-1.3.6.tar.xz"
+  url "http://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz"
   sha256 "63a32556ed16a589634a5aca3f03134b8d488e06ecb36f9df6ef450aa3a47973"
 
   bottle do

--- a/Library/Formula/yafc.rb
+++ b/Library/Formula/yafc.rb
@@ -20,6 +20,12 @@ class Yafc < Formula
     sha256 "55b361e7ff87f85776a0cd4560b3c39a7f7db132a232c71265e567d734f11f25"
   end
 
+  # Upstream commit to fix the parsing of mode when using chmod on ssh
+  patch do
+    url "https://github.com/sebastinas/yafc/commit/a16c1c985f3d4e2b676231f4773358927041d8e9.diff"
+    sha256 "ca6c6f81e71dec4090bd29395599075d24374a818bc822910bb14e0f144a8cdd"
+  end
+
   def install
     readline = Formula["readline"].opt_prefix
 


### PR DESCRIPTION
This PR includes 2 fixes : 
===================

Seems like the url to download the tar.gz has changed from http://www.yafc-ftp.com/upload/yafc-1.3.6.tar.xz to http://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz

----

There is a bug in the yafc project (v1.3.6) that happens when using the chmod command on a ssh connection .
This bug is fixed by this commit : sebastinas/yafc@a16c1c9 , but not realeased yet .

This PR added the patch to the yafc formula so people don't have to wait for the next yafc release .