### PR TITLE
update: fix test for non-master update support

### DIFF
--- a/Library/Homebrew/test/test_updater.rb
+++ b/Library/Homebrew/test/test_updater.rb
@@ -58,6 +58,7 @@ class UpdaterTests < Homebrew::TestCase
     FormulaVersions.stubs(:new).returns(stub(:formula_at_revision => "2.0"))
     @updater.diff = fixture(fixture_name)
     @updater.in_repo_expect("git diff --quiet", true)
+    @updater.in_repo_expect("git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null", "refs/remotes/origin/master")
     @updater.in_repo_expect("git symbolic-ref --short HEAD 2>/dev/null", "master")
     @updater.in_repo_expect("git rev-parse -q --verify HEAD", "1234abcd")
     @updater.in_repo_expect("git config core.autocrlf false")


### PR DESCRIPTION
Commit a71d4a9b (PR #44058) brought support for updating repositories with a default branch different from master. This fixes the tests broken by that commit. Unfortunately, without this fix `brew tests` continues to be broken and consequently all bot builds fail.