### PR TITLE
qt5: fix various build and runtime errors

### DIFF
--- a/Library/Formula/qt5.rb
+++ b/Library/Formula/qt5.rb
@@ -30,14 +30,35 @@ class Qt5 < Formula
     # when this formula is updated to 5.5.1
     patch :DATA
 
-    # Upstream commit to fix the fatal build error on OS X El Capitan.
+    # Build error: Fix build with clang 3.7.
     # https://codereview.qt-project.org/#/c/121545/
     # Should land in the 5.5.1 release.
-    if MacOS.version >= :el_capitan
-      patch do
-        url "https://raw.githubusercontent.com/DomT4/scripts/2107043e8/Homebrew_Resources/Qt5/qt5_el_capitan.diff"
-        sha256 "bd8fd054247ec730f60778e210d58cba613265e5df04ec93f4110421fb03b14a"
-      end
+    patch do
+      url "https://raw.githubusercontent.com/DomT4/scripts/2107043e8/Homebrew_Resources/Qt5/qt5_el_capitan.diff"
+      sha256 "bd8fd054247ec730f60778e210d58cba613265e5df04ec93f4110421fb03b14a"
+    end
+
+    # Build error: Fix library paths with Xcode 7 for QtWebEngine.
+    # https://codereview.qt-project.org/#/c/122729/
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/2fcc1f8ec1df1c90785f4fa6632cebac68772fa9/qt5/el-capitan-2.diff"
+      sha256 "b8f04efd047eeed7cfd15b029ece20b5fe3c0960b74f7a5cb98bd36475463227"
+    end
+
+    # Build error: Fix CGEventCreateMouseEvent use with 10.11 SDK.
+    # https://codereview.qt-project.org/#/c/115138/
+    # Should land in the 5.5.1 release.
+    patch do
+      url "https://gist.githubusercontent.com/UniqMartin/baf089e326f572150971/raw/1de52d53929bc3472cc7f345c16f068c37c75263/qtbug-47641.patch"
+      sha256 "c74c73b2d540788f0be2f1f137d0844feca8f5022a044851366380bf2972ead0"
+    end
+
+    # Runtime error: Make tooltips transparent for mouse events.
+    # https://codereview.qt-project.org/#/c/124274/
+    # Should land in the 5.5.1 release.
+    patch do
+      url "https://gist.githubusercontent.com/swallat/6b7d10fd929a0087fea4/raw/9b201a2848f8b8e16067855f30588a7b6dc607ec/qt5.5-qnsview-tooltip-cocoa.patch"
+      sha256 "5fa4511ee0c91491358d569f884dad9e4088eafa329e7dbe2b38a62afeef899d"
     end
   end
 


### PR DESCRIPTION
As discussed in #42452. All addressed build errors are somehow related to Xcode 7 (Clang version, OS X SDK, …), so these fixes are needed for both Yosemite and El Capitan. Fortunately, most of this stuff will be in Qt 5.5.1 as far as I can tell.

Thanks to @DomT4, @mikemcquaid, and @swallat for preparing the patches used here.