### PR TITLE
rkflashtool: Fix encoding issue in the test for mavericks

### DIFF
--- a/Library/Formula/rkflashtool.rb
+++ b/Library/Formula/rkflashtool.rb
@@ -33,6 +33,8 @@ class Rkflashtool < Formula
   test do
     (testpath/"input.file").write "ABCD"
     system bin/"rkcrc", "input.file", "output.file"
-    assert_equal "ABCD\264\366\a\t", `cat output.file`
+    result = shell_output("cat output.file")
+    result.force_encoding("UTF-8") if result.respond_to?(:force_encoding)
+    assert_equal "ABCD\264\366\a\t", result
   end
 end


### PR DESCRIPTION
For some reason the encoding of cat is not the same in Maverkics => https://github.com/Homebrew/homebrew/pull/44038