### PR TITLE
node: add support for statically linking icu4c

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -14,16 +14,14 @@ class Node < Formula
   option "with-debug", "Build with debugger hooks"
   option "without-npm", "npm will not be installed"
   option "without-completion", "npm bash completion will not be installed"
+  option "with-full-icu", "Build with full-icu (all locales) instead of small-icu (English only)"
 
   deprecated_option "enable-debug" => "with-debug"
+  deprecated_option "with-icu4c" => "with-full-icu"
 
   depends_on :python => :build if MacOS.version <= :snow_leopard
   depends_on "pkg-config" => :build
   depends_on "openssl" => :optional
-
-  # https://github.com/nodejs/node-v0.x-archive/issues/7919
-  # https://github.com/Homebrew/homebrew/issues/36681
-  depends_on "icu4c" => :optional
 
   fails_with :llvm do
     build 2326
@@ -34,11 +32,24 @@ class Node < Formula
     sha256 "c8b602de5d51f956aa8f9c34d89be38b2df3b7c25ff6588030eb8224b070db27"
   end
 
+  resource "icu4c" do
+    url "https://ssl.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.tgz"
+    mirror "https://fossies.org/linux/misc/icu4c-55_1-src.tgz"
+    version "55.1"
+    sha256 "e16b22cbefdd354bec114541f7849a12f8fc2015320ca5282ee4fd787571457b"
+  end
+
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"
-    args << "--with-intl=system-icu" if build.with? "icu4c"
     args << "--shared-openssl" if build.with? "openssl"
+    if build.with? "full-icu"
+      args << "--with-intl=full-icu"
+    else
+      args << "--with-intl=small-icu"
+    end
+
+    resource("icu4c").stage buildpath/"deps/icu"
 
     system "./configure", *args
     system "make", "install"
@@ -105,18 +116,6 @@ class Node < Formula
       EOS
     end
 
-    if build.with? "icu4c"
-      s += <<-EOS.undent
-
-        Please note `icu4c` is built with a newer deployment target than Node and
-        this may cause issues in certain usage. Node itself is built against the
-        outdated `libstdc++` target, which is the root cause. For more information see:
-          https://github.com/nodejs/node-v0.x-archive/issues/7919
-
-        If this is an issue for you, do `brew install node --without-icu4c`.
-      EOS
-    end
-
     s
   end
 
@@ -126,6 +125,9 @@ class Node < Formula
 
     output = `#{bin}/node #{path}`.strip
     assert_equal "hello", output
+    assert_equal 0, $?.exitstatus
+    output = `#{bin}/node -e "console.log(new Date('2015-09-15').toLocaleDateString('en'))"`.strip
+    assert_match /9\/1[45]\/2015/u, output # depends on system timezone
     assert_equal 0, $?.exitstatus
 
     if build.with? "npm"


### PR DESCRIPTION
This PR changes the Node.js formula's behavior from optionally dynamically linking against a brewed `icu4c` to statically linking to a `resource` staged `icu4c` by default to avoid issues with different c++ standard libraries, see #36681. A `resource` is needed, because otherwise the configure script would download `icu4c` itself (after passing an additional configure argument), which is against the formula guidelines.

For previous discussion see #44110 and https://github.com/Homebrew/homebrew/pull/43973#issuecomment-140591176 (and the following comments).

By default Node.js will now be build with 'small-icu' support, which matches the current distributed Node.js binaries. This means the full `Intl` API is supported, but only the English locale is bundled to reduce file size (see also [nodes Intl/icu docs](https://github.com/nodejs/node#intl-ecma-402-support)). For getting support other locales you can either build `--with-full-icu` or load additional locales at runtime as [described here](https://github.com/nodejs/node-v0.x-archive/wiki/Intl#using-and-customizing-the-small-icu-build).

A test for testing `Intl` support was added too.