### PR TITLE
xlslib: use https homepage

### DIFF
--- a/Library/Formula/xlslib.rb
+++ b/Library/Formula/xlslib.rb
@@ -1,6 +1,6 @@
 class Xlslib < Formula
   desc "C++/C library to construct Excel .xls files in code"
-  homepage "http://sourceforge.net/projects/xlslib"
+  homepage "https://sourceforge.net/projects/xlslib"
   url "https://downloads.sourceforge.net/project/xlslib/xlslib-old/xlslib-package-2.4.0.zip"
   mirror "https://dl.bintray.com/homebrew/mirror/xlslib-package-2.4.0.zip"
   sha256 "acc92e31294f91d8ac8adbbfc84f7a8917f7ad649a6c97b71c9f95c25887f840"


### PR DESCRIPTION
It's redirected to http if not logged it, but https is used already in 12 other formulae in same scenario.