### PR TITLE
More failure logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - export TRAVIS_BUILD_DIR="/usr/local"
   - sudo chown -R $USER /usr/local
   - cd /usr/local
-  - if [ -f ".git/shallow" ]; then git fetch --unshallow; fi
+  - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow; fi
   - git reset --hard $TRAVIS_COMMIT
   - git clean -qxdff
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
 before_install:
   - sudo rsync -az "$TRAVIS_BUILD_DIR/" /usr/local/
   - export TRAVIS_BUILD_DIR="/usr/local"
+  - sudo chown -R $USER /usr/local
   - cd /usr/local
   - if [ -f ".git/shallow" ]; then git fetch --unshallow; fi
   - git reset --hard $TRAVIS_COMMIT

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -18,7 +18,6 @@
 # --dry-run:       Just print commands, don't run them.
 # --fail-fast:     Immediately exit on a failing step.
 # --verbose:       Print out all logs in realtime
-# --no-verbose-install: Don't run `brew install` with `--verbose`.
 #
 # --ci-master:           Shortcut for Homebrew master branch CI options.
 # --ci-pr:               Shortcut for Homebrew pull request CI options.
@@ -532,7 +531,6 @@ module Homebrew
       test "brew", "fetch", "--retry", *formula_fetch_options
       test "brew", "uninstall", "--force", canonical_formula_name if formula.installed?
       install_args = []
-      install_args << "--verbose" unless ARGV.include? "--no-verbose-install"
       install_args << "--build-bottle" unless ARGV.include? "--no-bottle"
       install_args << "--HEAD" if ARGV.include? "--HEAD"
 
@@ -849,6 +847,7 @@ module Homebrew
     ENV["HOMEBREW_DEVELOPER"] = "1"
     ENV["HOMEBREW_SANDBOX"] = "1"
     ENV["HOMEBREW_NO_EMOJI"] = "1"
+    ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
     ARGV << "--verbose" if ENV["TRAVIS"]
 
     if ARGV.include?("--ci-master") || ARGV.include?("--ci-pr") \

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1304,8 +1304,14 @@ class Formula
       $stdout.flush
 
       unless $?.success?
+        log_lines = ENV["HOMEBREW_FAIL_LOG_LINES"]
+        log_lines ||= "15"
+
         log.flush
-        Kernel.system "/usr/bin/tail", "-n", "5", logfn unless verbose
+        unless verbose
+          puts "Last #{log_lines} lines from #{logfn}:"
+          Kernel.system "/usr/bin/tail", "-n", log_lines, logfn
+        end
         log.puts
 
         require "cmd/config"


### PR DESCRIPTION
- formula: increase fail log lines, allow config. The default is almost never useful. 15 seems like a good medium as it'll not fill a 80x24 default but provides a bit more context. Also allow it to be overriden for developers and `test-bot`.
- test-bot: configure log lines instead of verbose. The `--verbose` seems to cause some issues with compiling software like `boost` under Xcode 7.

CC @xu-cheng @tdsmith 