### PR TITLE
Allow building libepoxy as universal.

### DIFF
--- a/Library/Formula/libepoxy.rb
+++ b/Library/Formula/libepoxy.rb
@@ -11,6 +11,8 @@ class Libepoxy < Formula
     sha256 "495b9da3d417b836eaf1cdd1aba41782d975d0b3d007e1f9c91fab7e57c2a197" => :mountain_lion
   end
 
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "automake" => :build
   depends_on "autoconf" => :build
@@ -23,6 +25,8 @@ class Libepoxy < Formula
   end
 
   def install
+    ENV.universal_binary if build.universal?
+
     resource("xorg-macros").stage do
       system "./configure", "--prefix=#{buildpath}/xorg-macros"
       system "make", "install"


### PR DESCRIPTION
This allows building libepoxy as a universal binary. This is useful when trying to build other things as universal that depend upon this.