### PR TITLE
gnome 3.18.0 packages

### DIFF
--- a/Library/Formula/at-spi2-atk.rb
+++ b/Library/Formula/at-spi2-atk.rb
@@ -1,8 +1,8 @@
 class AtSpi2Atk < Formula
   desc "Accessibility Toolkit GTK+ module"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-atk/2.14/at-spi2-atk-2.14.1.tar.xz"
-  sha256 "058f34ea60edf0a5f831c9f2bdd280fe95c1bcafb76e466e44aa0fb356d17bcb"
+  url "https://download.gnome.org/sources/at-spi2-atk/2.18/at-spi2-atk-2.18.0.tar.xz"
+  sha256 "4a6db33453b6efd15fa7d84ef2a3421262a053f57f1df6e7a2536d02bacdf375"
 
   bottle do
     cellar :any

--- a/Library/Formula/at-spi2-core.rb
+++ b/Library/Formula/at-spi2-core.rb
@@ -1,8 +1,8 @@
 class AtSpi2Core < Formula
   desc "Protocol definitions and daemon for D-Bus at-spi"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-core/2.14/at-spi2-core-2.14.1.tar.xz"
-  sha256 "eef9660b14fdf0fb1f30d1be7c72d591fa7cbb87b00ca3a444425712f46ce657"
+  url "https://download.gnome.org/sources/at-spi2-core/2.18/at-spi2-core-2.18.0.tar.xz"
+  sha256 "1aeec77db6eb8087049af39a07f55756c55319f739d2998030fe6f4ced03ca76"
 
   bottle do
     sha256 "b15229c8b3d6d349c44038d0da14817f96bbbc68e8b263c986891ca75bd575fd" => :el_capitan
@@ -17,11 +17,12 @@ class AtSpi2Core < Formula
   depends_on "glib"
   depends_on "d-bus"
   depends_on :x11
+  depends_on "gobject-introspection"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-introspection=no"
+                          "--enable-introspection=yes"
     system "make", "install"
   end
 end

--- a/Library/Formula/atkmm.rb
+++ b/Library/Formula/atkmm.rb
@@ -1,8 +1,8 @@
 class Atkmm < Formula
   desc "Official C++ interface for the ATK accessibility toolkit library"
   homepage "http://www.gtkmm.org"
-  url "https://download.gnome.org/sources/atkmm/2.22/atkmm-2.22.7.tar.xz"
-  sha256 "bfbf846b409b4c5eb3a52fa32a13d86936021969406b3dcafd4dd05abd70f91b"
+  url "https://download.gnome.org/sources/atkmm/2.24/atkmm-2.24.1.tar.xz"
+  sha256 "26c41d8da37d04eef9f219c6ce87d94852e1cacaad823050e520e1c08a36ed23"
 
   bottle do
     sha1 "6c47047d111b4b950e1cb15425365b13b11f6a1b" => :mavericks
@@ -14,8 +14,55 @@ class Atkmm < Formula
   depends_on "atk"
   depends_on "glibmm"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <atkmm/init.h>
+
+      int main(int argc, char *argv[])
+      {
+         Atk::init();
+         return 0;
+      }
+    EOS
+    atk = Formula["atk"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    libsigcxx = Formula["libsigc++"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{atk.opt_include}/atk-1.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{include}/atkmm-1.6
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -L#{atk.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -latk-1.0
+      -latkmm-1.6
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lintl
+      -lsigc-2.0
+    ]
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/baobab.rb
+++ b/Library/Formula/baobab.rb
@@ -1,8 +1,8 @@
 class Baobab < Formula
   desc "Gnome disk usage analyzer"
   homepage "https://wiki.gnome.org/Apps/Baobab"
-  url "https://download.gnome.org/sources/baobab/3.16/baobab-3.16.1.tar.xz"
-  sha256 "1fe40433df3adda0bcc4d0a6edc2bc2501888798d7e8336ad51d443c9a1fcef2"
+  url "https://download.gnome.org/sources/baobab/3.18/baobab-3.18.0.tar.xz"
+  sha256 "75924c53dd0e94d97c2f0ec30270fa3ffc59adfab7e21aac3ed9c6c088760b5a"
 
   bottle do
     sha256 "3c1abb546e17fa589ba508bd1ce8756c26324ab6eca51f6adaa8a660d67bda02" => :yosemite

--- a/Library/Formula/cairomm.rb
+++ b/Library/Formula/cairomm.rb
@@ -1,9 +1,8 @@
 class Cairomm < Formula
   desc "Vector graphics library with cross-device output support"
   homepage "http://cairographics.org/cairomm/"
-  url "http://cairographics.org/releases/cairomm-1.11.2.tar.gz"
-  sha256 "ccf677098c1e08e189add0bd146f78498109f202575491a82f1815b6bc28008d"
-  revision 1
+  url "https://download.gnome.org/sources/cairomm/1.12/cairomm-1.12.0.tar.xz"
+  sha256 "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
 
   bottle do
     cellar :any
@@ -13,20 +12,16 @@ class Cairomm < Formula
     sha256 "7ecc1bc6775f3286561b178012109d249935ad8d56fb5996d43071ac897ffb2b" => :mavericks
   end
 
-  option :cxx11
+  needs :cxx11
 
   depends_on "pkg-config" => :build
-  if build.cxx11?
-    depends_on "libsigc++" => "c++11"
-  else
-    depends_on "libsigc++"
-  end
+  depends_on "libsigc++"
 
   depends_on "libpng"
   depends_on "cairo"
 
   def install
-    ENV.cxx11 if build.cxx11?
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
@@ -72,7 +67,7 @@ class Cairomm < Formula
       -lcairomm-1.0
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/gedit.rb
+++ b/Library/Formula/gedit.rb
@@ -1,8 +1,8 @@
 class Gedit < Formula
   desc "The GNOME text editor"
   homepage "https://wiki.gnome.org/Apps/Gedit"
-  url "https://download.gnome.org/sources/gedit/3.16/gedit-3.16.3.tar.xz"
-  sha256 "c28df44a29ee5707441f89e94b513079d709111afec4bd4b079a1dff0242cdb2"
+  url "https://download.gnome.org/sources/gedit/3.18/gedit-3.18.0.tar.xz"
+  sha256 "9abd4f1478385f8b6c983298206f4ab1a25c682b9c87fb00d759b7db5b949533"
 
   bottle do
     sha256 "a181e2b41c720e0022adfe06a4125fac8e02f4dc096c180d82f65de6049b4ec1" => :el_capitan
@@ -24,10 +24,6 @@ class Gedit < Formula
   depends_on "gtksourceview3"
   depends_on "gsettings-desktop-schemas"
   depends_on "gnome-icon-theme"
-
-  # ensures that gtk-mac-integration has been linked against gtk+3
-  # filed upstream as https://bugzilla.gnome.org/show_bug.cgi?id=751431
-  patch :DATA
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -129,58 +125,3 @@ class Gedit < Formula
     system "./test"
   end
 end
-
-__END__
-diff --git a/configure b/configure
-index 2a16d57..9ad2e56 100755
---- a/configure
-+++ b/configure
-@@ -13107,12 +13107,12 @@ if test -n "$GTK_MAC_CFLAGS"; then
-     pkg_cv_GTK_MAC_CFLAGS="$GTK_MAC_CFLAGS"
-  elif test -n "$PKG_CONFIG"; then
-     if test -n "$PKG_CONFIG" && \
--    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integration\""; } >&5
--  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration") 2>&5
-+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integration-gtk3\""; } >&5
-+  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration-gtk3") 2>&5
-   ac_status=$?
-   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-   test $ac_status = 0; }; then
--  pkg_cv_GTK_MAC_CFLAGS=`$PKG_CONFIG --cflags "gtk-mac-integration" 2>/dev/null`
-+  pkg_cv_GTK_MAC_CFLAGS=`$PKG_CONFIG --cflags "gtk-mac-integration-gtk3" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
- else
-   pkg_failed=yes
-@@ -13124,12 +13124,12 @@ if test -n "$GTK_MAC_LIBS"; then
-     pkg_cv_GTK_MAC_LIBS="$GTK_MAC_LIBS"
-  elif test -n "$PKG_CONFIG"; then
-     if test -n "$PKG_CONFIG" && \
--    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integration\""; } >&5
--  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration") 2>&5
-+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtk-mac-integrationi-gtk3\""; } >&5
-+  ($PKG_CONFIG --exists --print-errors "gtk-mac-integration-gtk3") 2>&5
-   ac_status=$?
-   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-   test $ac_status = 0; }; then
--  pkg_cv_GTK_MAC_LIBS=`$PKG_CONFIG --libs "gtk-mac-integration" 2>/dev/null`
-+  pkg_cv_GTK_MAC_LIBS=`$PKG_CONFIG --libs "gtk-mac-integration-gtk3" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
- else
-   pkg_failed=yes
-@@ -13150,14 +13150,14 @@ else
-         _pkg_short_errors_supported=no
- fi
-         if test $_pkg_short_errors_supported = yes; then
--	        GTK_MAC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "gtk-mac-integration" 2>&1`
-+	        GTK_MAC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "gtk-mac-integration-gtk3" 2>&1`
-         else
--	        GTK_MAC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "gtk-mac-integration" 2>&1`
-+	        GTK_MAC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "gtk-mac-integration-gtk3" 2>&1`
-         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$GTK_MAC_PKG_ERRORS" >&5
-
--	as_fn_error $? "Package requirements (gtk-mac-integration) were not met:
-+	as_fn_error $? "Package requirements (gtk-mac-integration-gtk3) were not met:
-
- $GTK_MAC_PKG_ERRORS

--- a/Library/Formula/ghex.rb
+++ b/Library/Formula/ghex.rb
@@ -1,8 +1,8 @@
 class Ghex < Formula
   desc "GNOME hex editor"
   homepage "https://wiki.gnome.org/Apps/Ghex"
-  url "https://download.gnome.org/sources/ghex/3.10/ghex-3.10.1.tar.xz"
-  sha256 "34b66cb5c84410c420df72f229d25aee5979e58048a246ed719b046f0c241132"
+  url "https://download.gnome.org/sources/ghex/3.18/ghex-3.18.0.tar.xz"
+  sha256 "c5b1eb50a8dd1334880b37617871498b778ea137f79bb43894ec68e4f63dc925"
 
   bottle do
     sha256 "e52e0de4433e01d625f49a5bb871b132b395fb57b8dfbcddaf01e97adc9f08e6" => :yosemite
@@ -17,13 +17,8 @@ class Ghex < Formula
   depends_on :python => :build if MacOS.version <= :snow_leopard
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-themes-standard" => :optional
 
   def install
-    # forces use of gtk3-update-icon-cache instead of gtk-update-icon-cache. No bugreport should
-    # be filed for this since it only occurs because Homebrew renames gtk+3's gtk-update-icon-cache
-    # to gtk3-update-icon-cache in order to avoid a collision between gtk+ and gtk+3.
-    inreplace "icons/Makefile.in", "gtk-update-icon-cache", "gtk3-update-icon-cache"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -36,10 +31,6 @@ class Ghex < Formula
   def post_install
     system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
     system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
-    # HighContrast is provided by gnome-themes-standard
-    if File.file?("#{HOMEBREW_PREFIX}/share/icons/HighContrast/.icon-theme.cache")
-      system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/HighContrast"
-    end
   end
 
   test do

--- a/Library/Formula/glibmm.rb
+++ b/Library/Formula/glibmm.rb
@@ -1,8 +1,8 @@
 class Glibmm < Formula
   desc "C++ interface to glib"
   homepage "http://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/glibmm/2.46/glibmm-2.46.0.tar.xz"
-  sha256 "1772e3ec45a572ed820beabaf546a37e8f78f45ec718c52d773e4c8939ffb7d0"
+  url "https://download.gnome.org/sources/glibmm/2.46/glibmm-2.46.1.tar.xz"
+  sha256 "9647e596c1081d2ea202bd3da2824ec2ea359498fa86eb59a55b1b307dd8c4aa"
 
   bottle do
     cellar :any

--- a/Library/Formula/glibmm.rb
+++ b/Library/Formula/glibmm.rb
@@ -1,8 +1,8 @@
 class Glibmm < Formula
   desc "C++ interface to glib"
   homepage "http://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/glibmm/2.44/glibmm-2.44.0.tar.xz"
-  sha256 "1b0ac0425d24895507c0e0e8088a464c7ae2d289c47afa1c11f63278fc672ea8"
+  url "https://download.gnome.org/sources/glibmm/2.46/glibmm-2.46.0.tar.xz"
+  sha256 "1772e3ec45a572ed820beabaf546a37e8f78f45ec718c52d773e4c8939ffb7d0"
 
   bottle do
     cellar :any
@@ -16,7 +16,10 @@ class Glibmm < Formula
   depends_on "libsigc++"
   depends_on "glib"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -53,7 +56,7 @@ class Glibmm < Formula
       -lintl
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/gnome-common.rb
+++ b/Library/Formula/gnome-common.rb
@@ -1,8 +1,8 @@
 class GnomeCommon < Formula
   desc "Core files for GNOME"
   homepage "https://git.gnome.org/browse/gnome-common/"
-  url "https://download.gnome.org/sources/gnome-common/3.14/gnome-common-3.14.0.tar.xz"
-  sha256 "4c00242f781bb441289f49dd80ed1d895d84de0c94bfc2c6818a104c9e39262c"
+  url "https://download.gnome.org/sources/gnome-common/3.18/gnome-common-3.18.0.tar.xz"
+  sha256 "22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -1,8 +1,8 @@
 class GnomeIconTheme < Formula
   desc "Icons for the GNOME project"
   homepage "https://developer.gnome.org"
-  url "https://download.gnome.org/sources/adwaita-icon-theme/3.16/adwaita-icon-theme-3.16.2.1.tar.xz"
-  sha256 "b4556dfbf555d4fac12d4d5c12f7519de0d43ec42a1b649611439a50bf7acb96"
+  url "https://download.gnome.org/sources/adwaita-icon-theme/3.18/adwaita-icon-theme-3.18.0.tar.xz"
+  sha256 "5e9ce726001fdd8ee93c394fdc3cdb9e1603bbed5b7c62df453ccf521ec50e58"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/gnome-themes-standard.rb
+++ b/Library/Formula/gnome-themes-standard.rb
@@ -1,8 +1,8 @@
 class GnomeThemesStandard < Formula
   desc "Default themes for the GNOME desktop environment"
   homepage "https://git.gnome.org/browse/gnome-themes-standard/"
-  url "https://download.gnome.org/sources/gnome-themes-standard/3.16/gnome-themes-standard-3.16.2.tar.xz"
-  sha256 "59eb79a59d44b5cd8daa8de1e7559fb5186503dcd78e47d0b72cb896d8654b9f"
+  url "https://download.gnome.org/sources/gnome-themes-standard/3.18/gnome-themes-standard-3.18.0.tar.xz"
+  sha256 "e646eb04c225282b7df7fff65741adaad4cf9ed2c12616b7310e7edd27d2bacb"
 
   bottle do
     cellar :any

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -18,7 +18,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
-  depends_on "python" => :build if MacOS.version == :mavericks
+  depends_on "python" if MacOS.version == :mavericks
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -18,6 +18,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
+  depends_on :python
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -18,7 +18,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
-  depends_on :python
+  depends_on "python" => :build if MacOS.version == :mavericks
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -1,8 +1,8 @@
 class GobjectIntrospection < Formula
-  desc "Generate interface introspection data for GObject libraries"
+  desc "Generate introspection data for GObject libraries"
   homepage "https://live.gnome.org/GObjectIntrospection"
-  url "https://download.gnome.org/sources/gobject-introspection/1.44/gobject-introspection-1.44.0.tar.xz"
-  sha256 "6f0c2c28aeaa37b5037acbf21558098c4f95029b666db755d3a12c2f1e1627ad"
+  url "https://download.gnome.org/sources/gobject-introspection/1.46/gobject-introspection-1.46.0.tar.xz"
+  sha256 "6658bd3c2b8813eb3e2511ee153238d09ace9d309e4574af27443d87423e4233"
 
   bottle do
     revision 2
@@ -16,6 +16,7 @@ class GobjectIntrospection < Formula
 
   depends_on "pkg-config" => :run
   depends_on "glib"
+  depends_on "cairo"
   depends_on "libffi"
 
   resource "tutorial" do

--- a/Library/Formula/gstreamermm.rb
+++ b/Library/Formula/gstreamermm.rb
@@ -3,6 +3,7 @@ class Gstreamermm < Formula
   homepage "http://gstreamer.freedesktop.org/bindings/cplusplus.html"
   url "https://download.gnome.org/sources/gstreamermm/1.4/gstreamermm-1.4.3.tar.xz"
   sha256 "f1c11ee1cf7537d77de7f8d486e09c5140cc4bb78882849718cd88959a55462e"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,13 +17,10 @@ class Gstreamermm < Formula
   depends_on "glibmm"
   depends_on "gst-plugins-base"
 
-  # though the library does not require a C++11 compliant compiler, the examples do,
-  # causing a build-time error on Mountain Lion
-  # no need to report this upstream, since the upcoming new release has the C++11 requirement
-  # already in configure.ac
-  patch :DATA
+  needs :cxx11
 
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
@@ -91,48 +89,7 @@ class Gstreamermm < Formula
       -lintl
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end
-
-__END__
-diff --git a/examples/dynamic_changing_element/main.cc b/examples/dynamic_changing_element/main.cc
-index 6192f45..e3ca128 100644
---- a/examples/dynamic_changing_element/main.cc
-+++ b/examples/dynamic_changing_element/main.cc
-@@ -20,13 +20,24 @@ RefPtr<Element> conv_before,
- conv_after,
- curr_effect;
- RefPtr<Pipeline> pipeline;
--std::vector<Glib::ustring> effects = {"identity", "exclusion",
--		"navigationtest", "agingtv", "videoflip", "vertigotv",
--		"gaussianblur", "shagadelictv", "edgetv"};
-+std::vector<Glib::ustring> effects;
- int curr_position = 0;
-
- RefPtr<Glib::MainLoop> main_loop;
-
-+void effects_init()
-+{
-+	effects.push_back("identity");
-+	effects.push_back("exclusion");
-+	effects.push_back("navigationtest");
-+	effects.push_back("agingtv");
-+	effects.push_back("videoflip");
-+	effects.push_back("vertigotv");
-+	effects.push_back("gaussianblur");
-+	effects.push_back("shagadelictv");
-+	effects.push_back("edgetv");
-+}
-+
- PadProbeReturn event_probe_cb (const RefPtr<Pad>& pad, const PadProbeInfo& info)
- {
-	RefPtr<Event> event = info.get_event();
-@@ -79,6 +90,7 @@ bool on_timeout()
-
- int main(int argc, char** argv)
- {
-+	effects_init();
-	init(argc, argv);
-	main_loop = Glib::MainLoop::create();

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,8 +1,8 @@
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "http://gtk.org/"
-  url "https://download.gnome.org/sources/gtk+/3.16/gtk+-3.16.7.tar.xz"
-  sha256 "19689d14de54d182fad538153dbff6d41f53841f940aa871585fdea0306c7fba"
+  url "https://download.gnome.org/sources/gtk+/3.18/gtk+-3.18.0.tar.xz"
+  sha256 "7fb8ae257403317d3852bad28d064d35f67e978b1fed8b71d5997e87204271b9"
 
   bottle do
     sha256 "0688f5f68465a8abe79833403bf30e2a223f07d260ae53817b66991b89274923" => :el_capitan
@@ -23,6 +23,9 @@ class Gtkx3 < Formula
   depends_on "pango"
   depends_on "glib"
   depends_on "hicolor-icon-theme"
+
+  # filed upstream in https://bugzilla.gnome.org/show_bug.cgi?id=755401
+  patch :DATA
 
   def install
     ENV.universal_binary if build.universal?
@@ -115,3 +118,59 @@ class Gtkx3 < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/testsuite/gtk/Makefile.in b/testsuite/gtk/Makefile.in
+index 87cffd6..7de122b 100644
+--- a/testsuite/gtk/Makefile.in
++++ b/testsuite/gtk/Makefile.in
+@@ -118,7 +118,7 @@ am__EXEEXT_2 = accel$(EXEEXT) accessible$(EXEEXT) action$(EXEEXT) \
+ 	firefox-stylecontext$(EXEEXT) floating$(EXEEXT) focus$(EXEEXT) \
+ 	gestures$(EXEEXT) grid$(EXEEXT) gtkmenu$(EXEEXT) \
+ 	icontheme$(EXEEXT) keyhash$(EXEEXT) listbox$(EXEEXT) \
+-	notify$(EXEEXT) no-gtk-init$(EXEEXT) object$(EXEEXT) \
++	no-gtk-init$(EXEEXT) object$(EXEEXT) \
+ 	objects-finalize$(EXEEXT) papersize$(EXEEXT) rbtree$(EXEEXT) \
+ 	recentmanager$(EXEEXT) regression-tests$(EXEEXT) \
+ 	spinbutton$(EXEEXT) stylecontext$(EXEEXT) templates$(EXEEXT) \
+@@ -264,11 +264,6 @@ no_gtk_init_OBJECTS = no-gtk-init.$(OBJEXT)
+ no_gtk_init_LDADD = $(LDADD)
+ no_gtk_init_DEPENDENCIES = $(top_builddir)/gtk/libgtk-3.la \
+ 	$(top_builddir)/gdk/libgdk-3.la $(am__DEPENDENCIES_1)
+-notify_SOURCES = notify.c
+-notify_OBJECTS = notify.$(OBJEXT)
+-notify_LDADD = $(LDADD)
+-notify_DEPENDENCIES = $(top_builddir)/gtk/libgtk-3.la \
+-	$(top_builddir)/gdk/libgdk-3.la $(am__DEPENDENCIES_1)
+ object_SOURCES = object.c
+ object_OBJECTS = object.$(OBJEXT)
+ object_LDADD = $(LDADD)
+@@ -738,7 +733,7 @@ EXTRA_DIST = file-chooser-test-dir/empty \
+ TEST_PROGS = accel accessible action adjustment bitmask builder \
+ 	builderparser cellarea check-icon-names clipboard defaultvalue \
+ 	entry expander firefox-stylecontext floating focus gestures \
+-	grid gtkmenu icontheme keyhash listbox notify no-gtk-init \
++	grid gtkmenu icontheme keyhash listbox no-gtk-init \
+ 	object objects-finalize papersize rbtree recentmanager \
+ 	regression-tests spinbutton stylecontext templates textbuffer \
+ 	textiter treemodel treepath treeview typename window \
+@@ -1145,10 +1140,6 @@ no-gtk-init$(EXEEXT): $(no_gtk_init_OBJECTS) $(no_gtk_init_DEPENDENCIES) $(EXTRA
+ 	@rm -f no-gtk-init$(EXEEXT)
+ 	$(AM_V_CCLD)$(LINK) $(no_gtk_init_OBJECTS) $(no_gtk_init_LDADD) $(LIBS)
+ 
+-notify$(EXEEXT): $(notify_OBJECTS) $(notify_DEPENDENCIES) $(EXTRA_notify_DEPENDENCIES) 
+-	@rm -f notify$(EXEEXT)
+-	$(AM_V_CCLD)$(LINK) $(notify_OBJECTS) $(notify_LDADD) $(LIBS)
+-
+ object$(EXEEXT): $(object_OBJECTS) $(object_DEPENDENCIES) $(EXTRA_object_DEPENDENCIES) 
+ 	@rm -f object$(EXEEXT)
+ 	$(AM_V_CCLD)$(LINK) $(object_OBJECTS) $(object_LDADD) $(LIBS)
+@@ -1251,7 +1242,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/liststore.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/modelrefcount.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/no-gtk-init.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/notify.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/object.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/objects-finalize.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/papersize.Po@am__quote@
+

--- a/Library/Formula/gtkmm.rb
+++ b/Library/Formula/gtkmm.rb
@@ -3,7 +3,7 @@ class Gtkmm < Formula
   homepage "http://www.gtkmm.org/"
   url "https://download.gnome.org/sources/gtkmm/2.24/gtkmm-2.24.4.tar.xz"
   sha256 "443a2ff3fcb42a915609f1779000390c640a6d7fd19ad8816e6161053696f5ee"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -21,7 +21,10 @@ class Gtkmm < Formula
   depends_on "atkmm"
   depends_on "cairomm"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -116,7 +119,7 @@ class Gtkmm < Formula
       -lpangomm-1.4
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/gtkmm3.rb
+++ b/Library/Formula/gtkmm3.rb
@@ -1,8 +1,8 @@
 class Gtkmm3 < Formula
   desc "C++ interfaces for GTK+ and GNOME"
   homepage "http://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/gtkmm/3.16/gtkmm-3.16.0.tar.xz"
-  sha256 "9b8d4af5e1bb64e52b53bc8ef471ef43e1b9d11a829f16ef54c3a92985b0dd0c"
+  url "https://download.gnome.org/sources/gtkmm/3.18/gtkmm-3.18.0.tar.xz"
+  sha256 "829fa113daed74398c49c3f2b7672807f58ba85d0fa463f5bc726e1b0138b86b"
 
   bottle do
     sha256 "a07b50d5f0475e3b785400c90ab17912fb036f6c5e04a07f4c63bfb7791bef34" => :yosemite
@@ -15,7 +15,10 @@ class Gtkmm3 < Formula
   depends_on "pangomm"
   depends_on "atkmm"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -115,7 +118,7 @@ class Gtkmm3 < Formula
       -lpangomm-1.4
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/libglademm.rb
+++ b/Library/Formula/libglademm.rb
@@ -3,7 +3,7 @@ class Libglademm < Formula
   homepage "https://gnome.org"
   url "https://download.gnome.org/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2"
   sha256 "38543c15acf727434341cc08c2b003d24f36abc22380937707fc2c5c687a2bc3"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -17,7 +17,10 @@ class Libglademm < Formula
   depends_on "gtkmm"
   depends_on "libglade"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
@@ -128,7 +131,7 @@ class Libglademm < Formula
       -lsigc-2.0
       -lxml2
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/libgnomecanvasmm.rb
+++ b/Library/Formula/libgnomecanvasmm.rb
@@ -3,7 +3,7 @@ class Libgnomecanvasmm < Formula
   homepage "https://launchpad.net/libgnomecanvasmm"
   url "https://download.gnome.org/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2"
   sha256 "996577f97f459a574919e15ba7fee6af8cda38a87a98289e9a4f54752d83e918"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,7 +16,10 @@ class Libgnomecanvasmm < Formula
   depends_on "libgnomecanvas"
   depends_on "gtkmm"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
@@ -127,7 +130,7 @@ class Libgnomecanvasmm < Formula
       -lpangomm-1.4
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/libpeas.rb
+++ b/Library/Formula/libpeas.rb
@@ -1,8 +1,8 @@
 class Libpeas < Formula
   desc "GObject plugin library"
   homepage "https://developer.gnome.org/libpeas/stable/"
-  url "https://download.gnome.org/sources/libpeas/1.14/libpeas-1.14.0.tar.xz"
-  sha256 "5e4b3a8968b71497ab26a7a528c414c4c640c5724328fa3507854f04788e2d76"
+  url "https://download.gnome.org/sources/libpeas/1.16/libpeas-1.16.0.tar.xz"
+  sha256 "b093008ecd65f7d55c80517589509698ff15ad41f664b11a3eb88ff461b1454e"
 
   bottle do
     sha256 "6959622982b81ce241a372f6911563987b3b5169c27afb46539e18460b4591fd" => :el_capitan
@@ -28,8 +28,7 @@ class Libpeas < Formula
 
   def install
     system "autoreconf", "-i"
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--enable-gtk"

--- a/Library/Formula/libsigc++.rb
+++ b/Library/Formula/libsigc++.rb
@@ -1,8 +1,8 @@
 class Libsigcxx < Formula
   desc "Callback framework for C++"
   homepage "http://libsigc.sourceforge.net"
-  url "https://download.gnome.org/sources/libsigc++/2.4/libsigc++-2.4.1.tar.xz"
-  sha256 "540443492a68e77e30db8d425f3c0b1299c825bf974d9bfc31ae7efafedc19ec"
+  url "https://download.gnome.org/sources/libsigc++/2.6/libsigc++-2.6.0.tar.xz"
+  sha256 "67c07771bf6313022883055efb0fad7cc9875168a4c0d01879d1846747e4ce3d"
 
   bottle do
     cellar :any
@@ -12,13 +12,12 @@ class Libsigcxx < Formula
     sha256 "258748c43eb3d2d530b382cbee57b42ad6f1cea7eab162791f113bd30f07ebd0" => :mavericks
   end
 
-  option :cxx11
+  needs :cxx11
 
   def install
-    ENV.cxx11 if build.cxx11?
+    ENV.cxx11
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
   test do
@@ -33,7 +32,7 @@ class Libsigcxx < Formula
          return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp",
+    system ENV.cxx, "-std=c++11", "test.cpp",
                    "-L#{lib}", "-lsigc-2.0", "-I#{include}/sigc++-2.0", "-I#{lib}/sigc++-2.0/include", "-o", "test"
     system "./test"
   end

--- a/Library/Formula/libsigc++.rb
+++ b/Library/Formula/libsigc++.rb
@@ -1,8 +1,8 @@
 class Libsigcxx < Formula
   desc "Callback framework for C++"
   homepage "http://libsigc.sourceforge.net"
-  url "https://download.gnome.org/sources/libsigc++/2.6/libsigc++-2.6.0.tar.xz"
-  sha256 "67c07771bf6313022883055efb0fad7cc9875168a4c0d01879d1846747e4ce3d"
+  url "https://download.gnome.org/sources/libsigc++/2.6/libsigc++-2.6.1.tar.xz"
+  sha256 "186f2167c1b3d90529ce8e715246bf160bc67ec1ec19f4e45d76c0ae54dfbe1b"
 
   bottle do
     cellar :any
@@ -18,9 +18,7 @@ class Libsigcxx < Formula
     ENV.cxx11
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make"
-    # make check currently fails
-    # reported upstream as https://bugzilla.gnome.org/show_bug.cgi?id=755393
-    # system "make", "check"
+    system "make", "check"
     system "make", "install"
   end
   test do

--- a/Library/Formula/libsigc++.rb
+++ b/Library/Formula/libsigc++.rb
@@ -18,6 +18,9 @@ class Libsigcxx < Formula
     ENV.cxx11
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make"
+    # make check currently fails
+    # reported upstream as https://bugzilla.gnome.org/show_bug.cgi?id=755393
+    # system "make", "check"
     system "make", "install"
   end
   test do

--- a/Library/Formula/net6.rb
+++ b/Library/Formula/net6.rb
@@ -3,13 +3,16 @@ class Net6 < Formula
   homepage "http://gobby.0x539.de"
   url "http://releases.0x539.de/net6/net6-1.3.14.tar.gz"
   sha256 "155dd82cbe1f8354205c79ab2bb54af4957047422250482596a34b0e0cc61e21"
-  revision 1
+  revision 2
 
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libsigc++"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Library/Formula/nordugrid-arc.rb
+++ b/Library/Formula/nordugrid-arc.rb
@@ -19,6 +19,11 @@ class NordugridArc < Formula
 
   needs :cxx11
 
+  # build fails on Mavericks due to a clang compiler bug
+  # and bottling also fails if gcc is being used due to conflicts between
+  # libc++ and libstdc++
+  depends_on MinimumMacOSRequirement => :yosemite
+
   # bug filed upstream at http://bugzilla.nordugrid.org/show_bug.cgi?id=3514
   patch do
     url "https://gist.githubusercontent.com/tschoonj/065dabc33be5ec636058/raw/beee466cdf5fe56f93af0b07022532b1945e9d2e/nordugrid-arc.diff"

--- a/Library/Formula/nordugrid-arc.rb
+++ b/Library/Formula/nordugrid-arc.rb
@@ -1,10 +1,8 @@
 class NordugridArc < Formula
   desc "Grid computing middleware"
   homepage "http://www.nordugrid.org"
-  url "http://download.nordugrid.org/packages/nordugrid-arc/releases/5.0.0/src/nordugrid-arc_5.0.0.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/nordugrid-arc/nordugrid-arc_5.0.0.orig.tar.gz"
-  sha256 "59132ce88f0d88d9a08a56eb879fe9bd07b2eedfce1506508e71457b7f4add1b"
-  revision 1
+  url "http://download.nordugrid.org/packages/nordugrid-arc/releases/5.0.2/src/nordugrid-arc-5.0.2.tar.gz"
+  sha256 "d7306d91b544eeba571ede341e43760997c46d4ccdacc8b785c64f594780a9d1"
 
   bottle do
     sha256 "db44e56921dda90426b9bb78ac996bcc261e6e169584636bae3ed7acd31aa229" => :yosemite
@@ -20,6 +18,12 @@ class NordugridArc < Formula
   depends_on "globus-toolkit"
 
   needs :cxx11
+
+  # bug filed upstream at http://bugzilla.nordugrid.org/show_bug.cgi?id=3514
+  patch do
+    url "https://gist.githubusercontent.com/tschoonj/065dabc33be5ec636058/raw/beee466cdf5fe56f93af0b07022532b1945e9d2e/nordugrid-arc.diff"
+    sha256 "5561ea013ddd03ee4f72437f2e01f22b2c0cac2806bf837402724be281ac2b6d"
+  end
 
   fails_with :clang do
     build 500

--- a/Library/Formula/nordugrid-arc.rb
+++ b/Library/Formula/nordugrid-arc.rb
@@ -4,6 +4,7 @@ class NordugridArc < Formula
   url "http://download.nordugrid.org/packages/nordugrid-arc/releases/5.0.0/src/nordugrid-arc_5.0.0.orig.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/n/nordugrid-arc/nordugrid-arc_5.0.0.orig.tar.gz"
   sha256 "59132ce88f0d88d9a08a56eb879fe9bd07b2eedfce1506508e71457b7f4add1b"
+  revision 1
 
   bottle do
     sha256 "db44e56921dda90426b9bb78ac996bcc261e6e169584636bae3ed7acd31aa229" => :yosemite
@@ -18,12 +19,15 @@ class NordugridArc < Formula
   depends_on "libxml2"
   depends_on "globus-toolkit"
 
+  needs :cxx11
+
   fails_with :clang do
     build 500
     cause "Fails with 'template specialization requires \"template<>\"'"
   end
 
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--disable-swig",
                           "--prefix=#{prefix}"

--- a/Library/Formula/nzbget.rb
+++ b/Library/Formula/nzbget.rb
@@ -3,6 +3,7 @@ class Nzbget < Formula
   homepage "http://nzbget.net/"
   url "https://github.com/nzbget/nzbget/releases/download/v15.0/nzbget-15.0-src.tar.gz"
   sha256 "3ef13f3e5917e4cda19c4fc0cd37e79967a19b4e3448c239ff24e37712a6cc0a"
+  revision 1
 
   head "https://github.com/nzbget/nzbget.git"
 
@@ -15,6 +16,8 @@ class Nzbget < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "libsigc++"
+
+  needs :cxx11
 
   fails_with :clang do
     build 500
@@ -30,6 +33,7 @@ class Nzbget < Formula
   end
 
   def install
+    ENV.cxx11
     resource("libpar2").stage do
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{libexec}/lp2"

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -1,8 +1,8 @@
 class Pangomm < Formula
   desc "C++ interface to Pango"
   homepage "http://www.pango.org/"
-  url "https://download.gnome.org/sources/pangomm/2.36/pangomm-2.36.0.tar.xz"
-  sha256 "a8d96952c708d7726bed260d693cece554f8f00e48b97cccfbf4f5690b6821f0"
+  url "https://download.gnome.org/sources/pangomm/2.38/pangomm-2.38.1.tar.xz"
+  sha256 "effb18505b36d81fc32989a39ead8b7858940d0533107336a30bc3eef096bc8b"
 
   bottle do
     cellar :any
@@ -17,7 +17,10 @@ class Pangomm < Formula
   depends_on "cairomm"
   depends_on "pango"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -30,5 +33,58 @@ class Pangomm < Formula
         return 0;
       }
     EOS
+    cairo = Formula["cairo"]
+    cairomm = Formula["cairomm"]
+    fontconfig = Formula["fontconfig"]
+    freetype = Formula["freetype"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    harfbuzz = Formula["harfbuzz"]
+    libpng = Formula["libpng"]
+    libsigcxx = Formula["libsigc++"]
+    pango = Formula["pango"]
+    pixman = Formula["pixman"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{cairo.opt_include}/cairo
+      -I#{cairomm.opt_include}/cairomm-1.0
+      -I#{cairomm.opt_lib}/cairomm-1.0/include
+      -I#{fontconfig.opt_include}
+      -I#{freetype.opt_include}/freetype2
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{harfbuzz.opt_include}/harfbuzz
+      -I#{include}/pangomm-1.4
+      -I#{libpng.opt_include}/libpng16
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{lib}/pangomm-1.4/include
+      -I#{pango.opt_include}/pango-1.0
+      -I#{pixman.opt_include}/pixman-1
+      -L#{cairo.opt_lib}
+      -L#{cairomm.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -L#{pango.opt_lib}
+      -lcairo
+      -lcairomm-1.0
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lintl
+      -lpango-1.0
+      -lpangocairo-1.0
+      -lpangomm-1.4
+      -lsigc-2.0
+    ]
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
+    system "./test"
   end
 end

--- a/Library/Formula/pixman.rb
+++ b/Library/Formula/pixman.rb
@@ -1,8 +1,8 @@
 class Pixman < Formula
   desc "Low-level library for pixel manipulation"
   homepage "http://cairographics.org/"
-  url "http://cairographics.org/releases/pixman-0.32.6.tar.gz"
-  sha256 "3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904"
+  url "http://cairographics.org/releases/pixman-0.32.8.tar.gz"
+  sha256 "575ade17c40b47d391b02b4c0c63531c897b31e70046c96749514b7d8800d65d"
 
   bottle do
     cellar :any

--- a/Library/Formula/pygobject3.rb
+++ b/Library/Formula/pygobject3.rb
@@ -1,8 +1,8 @@
 class Pygobject3 < Formula
   desc "GLib/GObject/GIO Python bindings for Python 3"
   homepage "https://live.gnome.org/PyGObject"
-  url "https://download.gnome.org/sources/pygobject/3.16/pygobject-3.16.2.tar.xz"
-  sha256 "de620e00fe7ecb788aa2dc0d664e41f71b8e718e728168e8d982cf193a9e7e64"
+  url "https://download.gnome.org/sources/pygobject/3.18/pygobject-3.18.0.tar.xz"
+  sha256 "1c3ba1112d3713cd5c86260312bfeb0de1f84f18808e51072c50b29d46156dc9"
 
   bottle do
     sha256 "94b5cacf8c2a265e8086c9037d376ff7008f50de2d68b346cc08750ffda94f1d" => :el_capitan

--- a/Library/Formula/synfig.rb
+++ b/Library/Formula/synfig.rb
@@ -3,6 +3,7 @@ class Synfig < Formula
   homepage "http://synfig.org"
   url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/synfig-1.0.tar.gz"
   sha256 "1f2f9b209d49dff838049e9817b0458ac6987e912a56c061aa2f9c2faeb40720"
+  revision 1
 
   head "git://synfig.git.sourceforge.net/gitroot/synfig/synfig"
 
@@ -28,7 +29,10 @@ class Synfig < Formula
   depends_on "mlt"
   depends_on "libtool" => :run
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     boost = Formula["boost"]
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -111,7 +115,7 @@ class Synfig < Formula
       -lxml++-2.6
       -lxml2
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Library/Formula/synfig.rb
+++ b/Library/Formula/synfig.rb
@@ -31,6 +31,12 @@ class Synfig < Formula
 
   needs :cxx11
 
+  # bug filed upstream as http://www.synfig.org/issues/thebuggenie/synfig/issues/904
+  patch do
+    url "https://gist.githubusercontent.com/tschoonj/06d5de3cdc5d063f8612/raw/26fe46b6eedeecdc686b9fd5aac01de9f2756424/synfig.diff"
+    sha256 "0ac5b757ba3dda6a863a79e717fc239648c490eac1e643ff275b8ac232a466a3"
+  end
+
   def install
     ENV.cxx11
     boost = Formula["boost"]

--- a/Library/Formula/synfigstudio.rb
+++ b/Library/Formula/synfigstudio.rb
@@ -3,6 +3,7 @@ class Synfigstudio < Formula
   homepage "http://synfig.org"
   url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/synfigstudio-1.0.tar.gz"
   sha256 "2b23916ca0be4073edad9b0cb92fd30311dd3b8f73372c836ba735100251ee28"
+  revision 1
 
   bottle do
     revision 1
@@ -19,7 +20,10 @@ class Synfigstudio < Formula
   depends_on "etl"
   depends_on "synfig"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Library/Formula/synfigstudio.rb
+++ b/Library/Formula/synfigstudio.rb
@@ -22,6 +22,12 @@ class Synfigstudio < Formula
 
   needs :cxx11
 
+  # bug filed upstream as http://www.synfig.org/issues/thebuggenie/synfig/issues/904
+  patch do
+    url "https://gist.githubusercontent.com/tschoonj/91fd64c528c7b971f185/raw/85dca7ef41f118007676bb0ca58b978693ee3d4e/synfigstudio.diff"
+    sha256 "ae16c0086256f266ffdef7ea758b5385b869833e04562b7d9194da6101b24f2f"
+  end
+
   def install
     ENV.cxx11
     system "./configure", "--disable-debug",

--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -1,8 +1,8 @@
 class Vte3 < Formula
   desc "Terminal emulator widget used by GNOME terminal"
   homepage "https://developer.gnome.org/vte/"
-  url "https://download.gnome.org/sources/vte/0.40/vte-0.40.2.tar.xz"
-  sha256 "9b68fbc16b27f2d79e6271f2b0708808594ac5acf979d0fccea118608199fd2d"
+  url "https://download.gnome.org/sources/vte/0.42/vte-0.42.0.tar.xz"
+  sha256 "2168f79d2043cbbe6d4375d01e54cebda71bb6f5d9dc8ad658b9a1dc1052de04"
 
   bottle do
     sha256 "a80a1136edc91d2572a5164cffefb5069ae3dea9fc646a588d8c6f241efb95a2" => :yosemite
@@ -16,6 +16,7 @@ class Vte3 < Formula
   depends_on "gtk+3"
   depends_on "gnutls"
   depends_on "vala"
+  depends_on "gobject-introspection"
 
   def install
     args = [
@@ -23,7 +24,7 @@ class Vte3 < Formula
       "--prefix=#{prefix}",
       "--disable-Bsymbolic",
       "--enable-introspection=yes",
-      "--enable-gnome-pty-helper"
+      "--enable-gnome-pty-helper",
     ]
 
     system "./configure", *args


### PR DESCRIPTION
This branch represents my efforts to pull in the latest gnome 3.18.0 packages.
These are (not all of them in this PR):

- [x] glib (#44221)
- [x] pango (#44218)
- [x] atk (#44222)
- [x] libgweather (#44205)
- [x] libgit2-glib (#44229) 
- [x] zenity (Homebrew/homebrew-x11#129)
- [x] gdl (#44167) 
- [x] geocode-glib (#44184) 
- [x] gtksourceview3 (#44187)
- [x] yelp-tools and yelp-xsl (#44232)
- [x] gdk-pixbuf )#44231)
- [x] libgtop (#44228)
- [x] evince (#44227)
- [x] libsoup (#44226)
- [x] glib-networking (#44225)
- [x] gsettings-desktop-schemas (#44224)
- [x] gucharmap (#44223)
- [x] anjuta (#44169)
- [x] libxml++ (#44204)
- [x] libsigc++ (make check fails -> needs a closer look)
- [x] glibmm (depends on glib 2.46.0 in #44221), already updated to 2.46.1!
- [x] pangomm
- [x] gtkmm3
- [x] gtksourceviewmm3 (Homebrew/homebrew-x11#130)
- [x] gnome-common
- [x] at-spi2-atk
- [x] at-spi2-core
- [x] gtk+3
- [x] libpeas
- [x] pygobject3
- [x] gedit
- [x] atkmm
- [x] cairomm
- [x] gobject-introspection
- [x] gnome-icon-theme
- [x] gnome-themes-standard
- [x] vte
- [x] ghex
- [x] baobab
- [x] pixman

and probably others I am forgetting now...

Please don't accept any other gnome PRs in the meantime in order not to create any unresolved dependencies. Thanks!