### PR TITLE
poppler 0.36.0

### DIFF
--- a/Library/Formula/diff-pdf.rb
+++ b/Library/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha256 "cb90f2e0fd4bc3fe235111f982bc20455a1d6bc13f4219babcba6bd60c1fe466"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Library/Formula/pdf2htmlex.rb
+++ b/Library/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.13.6.tar.gz"
   sha256 "fc133a5791bfd76a4425af16c6a6a2460f672501b490cbda558213cb2b03d5d7"
-  revision 2
+  revision 3
 
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 

--- a/Library/Formula/poppler.rb
+++ b/Library/Formula/poppler.rb
@@ -1,8 +1,8 @@
 class Poppler < Formula
   desc "PDF rendering library (based on the xpdf-3.0 code base)"
   homepage "http://poppler.freedesktop.org"
-  url "http://poppler.freedesktop.org/poppler-0.35.0.tar.xz"
-  sha256 "e86755b1a4df6efe39d84f581c11bcb0e34976166a671a7b700c28ebaa3e2189"
+  url "http://poppler.freedesktop.org/poppler-0.36.0.tar.xz"
+  sha256 "93cc067b23c4ef7421380d3e8bd7c940b2027668446750787d7c1cb42720248e"
 
   bottle do
     sha256 "67d25bdcc05d0491fb91771a7dabd2a1977b1ffb0e522920220b7c7718cb0b8d" => :el_capitan


### PR DESCRIPTION
Checked dependencies, all using `--build-from-source`:

- [x] diff-pdf (updated formula revision included in commit)
- [x] pdf2htmlex (updated formula revision included in commit)
- [x] pdf2svg
- [x] pdfgrep
- [x] pdftoipe (using `--HEAD homebrew/head-only/pdftoipe`)
- [x] xournal (using `--with-poppler` option)
- [x] inkscape
- [x] pdf-tools