### PR TITLE
Convince cpythons to recognize .tbd stubs

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -63,6 +63,14 @@ class Python < Formula
   # a plain unix build. Remove `-lX11`, too because our Tk is "AquaTk".
   patch :DATA if build.with? "tcl-tk"
 
+  # Fix extension module builds against Xcode 7 SDKs
+  # https://github.com/Homebrew/homebrew/issues/41085
+  # https://bugs.python.org/issue25136
+  patch do
+    url "https://bugs.python.org/file40479/xcode-stubs-2.7.patch"
+    sha256 "86714b750c887065952cd556f4d23246edf3124384f579356c8e377bc6ff2f83"
+  end
+
   def lib_cellar
     prefix/"Frameworks/Python.framework/Versions/2.7/lib/python2.7"
   end

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -53,6 +53,14 @@ class Python3 < Formula
   # X11.
   patch :DATA if build.with? "tcl-tk"
 
+  # Fix extension module builds against Xcode 7 SDKs
+  # https://github.com/Homebrew/homebrew/issues/41085
+  # https://bugs.python.org/issue25136
+  patch do
+    url "https://bugs.python.org/file40478/xcode-stubs.diff"
+    sha256 "029cc0dc72b1bcf4ddc5f913cc4a3fd970378073c6355921891f041aca2f8b12"
+  end
+
   def lib_cellar
     prefix/"Frameworks/Python.framework/Versions/#{xy}/lib/python#{xy}"
   end


### PR DESCRIPTION
Applies the patches I sent upstream. Allows building Python stdlib (and other) extension modules on Xcode 7-only systems.

Ref #41085.