### PR TITLE
commonmark: disable make test during build

### DIFF
--- a/Library/Formula/commonmark.rb
+++ b/Library/Formula/commonmark.rb
@@ -18,7 +18,6 @@ class Commonmark < Formula
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make"
-      system "make", "test"
       system "make", "install"
     end
   end


### PR DESCRIPTION
`make test` fails due to incompatibility with CPython 3.5 (https://github.com/jgm/cmark/issues/83). Disable it per discussion in https://github.com/Homebrew/homebrew/issues/44197.