### PR TITLE
Set GDK_PIXBUF_MODULE_FILE for gdk-pixbuf

### DIFF
--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -52,12 +52,14 @@ class GdkPixbuf < Formula
   def post_install
     # Change the version directory below with any future update
     ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+    ENV["GDK_PIXBUF_MODULE_FILE"]="#{lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
   end
 
   def caveats; <<-EOS.undent
-    Programs that require this module need to set the environment variable
+    Programs that require this module need to set the environment variables:
       export GDK_PIXBUF_MODULEDIR="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+      export GDK_PIXBUF_MODULE_FILE="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     If you need to manually update the query loader cache, set GDK_PIXBUF_MODULEDIR then run
       #{bin}/gdk-pixbuf-query-loaders --update-cache
     EOS

--- a/Library/Formula/librsvg.rb
+++ b/Library/Formula/librsvg.rb
@@ -45,6 +45,7 @@ class Librsvg < Formula
     # librsvg is not aware GDK_PIXBUF_MODULEDIR must be set
     # set GDK_PIXBUF_MODULEDIR and update loader cache
     ENV["GDK_PIXBUF_MODULEDIR"] = "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+    ENV["GDK_PIXBUF_MODULE_FILE"]="#{Formula["gdk-pixbuf"].lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     system "#{Formula["gdk-pixbuf"].opt_bin}/gdk-pixbuf-query-loaders", "--update-cache"
   end
 

--- a/Library/Formula/xplanetfx.rb
+++ b/Library/Formula/xplanetfx.rb
@@ -39,14 +39,16 @@ class Xplanetfx < Formula
     if build.with?("gui")
       ENV.prepend_create_path "PYTHONPATH", "#{HOMEBREW_PREFIX}/lib/python2.7/site-packages/gtk-2.0"
       ENV.prepend_create_path "GDK_PIXBUF_MODULEDIR", "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+      ENV.prepend_create_path "GDK_PIXBUF_MODULE_FILE", "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     end
-    bin.env_script_all_files(libexec+"bin", :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"])
+    bin.env_script_all_files(libexec+"bin", :PATH => "#{path}:$PATH", :PYTHONPATH => ENV["PYTHONPATH"], :GDK_PIXBUF_MODULEDIR => ENV["GDK_PIXBUF_MODULEDIR"], :GDK_PIXBUF_MODULE_FILE => ENV["GDK_PIXBUF_MODULE_FILE"])
   end
 
   def post_install
     if build.with?("gui")
       # Change the version directory below with any future update
       ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+      ENV["GDK_PIXBUF_MODULE_FILE"]="#{Formula["gdk-pixbuf"].lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
       system "#{HOMEBREW_PREFIX}/bin/gdk-pixbuf-query-loaders", "--update-cache"
     end
   end


### PR DESCRIPTION
Without this variable set in addition to GDK_PIXBUF_MODULEDIR, the proper cache file does not get updated in the event of Homebrew installations in places other than `/usr/local/`