### PR TITLE
ode: Remove "--disable-demos" from default install and add the "--with-dem…

### DIFF
--- a/Library/Formula/ode.rb
+++ b/Library/Formula/ode.rb
@@ -23,6 +23,7 @@ class Ode < Formula
   option "with-double-precision", "Compile ODE with double precision"
   option "with-shared", "Compile ODE with shared library support"
   option "with-libccd", "Enable all libccd colliders (except box-cylinder)"
+  option "with-drawstuff", "Include the drawstuff library and demos. Requires X11."
 
   deprecated_option "enable-double-precision" => "with-double-precision"
   deprecated_option "enable-shared" => "with-shared"
@@ -31,11 +32,11 @@ class Ode < Formula
   depends_on "pkg-config" => :build
 
   def install
-    args = ["--prefix=#{prefix}",
-            "--disable-demos"]
+    args = ["--prefix=#{prefix}"]
     args << "--enable-double-precision" if build.with? "double-precision"
     args << "--enable-shared" if build.with? "shared"
     args << "--enable-libccd" if build.with? "libccd"
+    args << "--with-demos" if build.with? "drawstuff"
 
     if build.head?
       ENV["LIBTOOLIZE"] = "glibtoolize"

--- a/Library/Formula/ode.rb
+++ b/Library/Formula/ode.rb
@@ -18,6 +18,7 @@ class Ode < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    depends_on :x11 if build.with? "drawstuff"
   end
 
   option "with-double-precision", "Compile ODE with double precision"


### PR DESCRIPTION
Requesting help for debugging, reference #43312.
Trying to build ode with the drawstuff library and demos.  
Building manually works, resulting in an additional `ode-0.13.1/drawstuff` library, as well as a `ode-0.13.1/ode/demo` folder with several demos.