### PR TITLE
docbook: sandbox related modifications

### DIFF
--- a/Library/Formula/docbook-xsl.rb
+++ b/Library/Formula/docbook-xsl.rb
@@ -3,6 +3,7 @@ class DocbookXsl < Formula
   homepage "http://docbook.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/docbook/docbook-xsl/1.78.1/docbook-xsl-1.78.1.tar.bz2"
   sha256 "c98f7296ab5c8ccd2e0bc07634976a37f50847df2d8a59bdb1e157664700b467"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -21,6 +22,7 @@ class DocbookXsl < Formula
   end
 
   def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     doc_files = %w[AUTHORS BUGS COPYING NEWS README RELEASE-NOTES.txt TODO VERSION VERSION.xsl]
     xsl_files = %w[assembly catalog.xml common docsrc eclipse epub epub3 extensions
                    fo highlighting html htmlhelp images javahelp lib log manpages
@@ -35,6 +37,7 @@ class DocbookXsl < Formula
   end
 
   def post_install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     [prefix/"docbook-xsl/catalog.xml", prefix/"docbook-xsl-ns/catalog.xml"].each do |catalog|
       system "xmlcatalog", "--noout", "--del", "file://#{catalog}", "#{etc}/xml/catalog"
       system "xmlcatalog", "--noout", "--add", "nextCatalog", "", "file://#{catalog}", "#{etc}/xml/catalog"

--- a/Library/Formula/docbook.rb
+++ b/Library/Formula/docbook.rb
@@ -12,8 +12,6 @@ class Docbook < Formula
     sha256 "5d563a04a11cee14fd7c52a6b4a85d397b019bf2f5cc96005e2d17dac4ad7231" => :mavericks
   end
 
-  depends_on "libxml2"
-
   resource "xml412" do
     url "http://www.docbook.org/xml/4.1.2/docbkx412.zip"
     sha256 "30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772"
@@ -52,7 +50,7 @@ class Docbook < Formula
     # by other formulas to be removed
     unless File.file?("#{etc}/xml/catalog")
       ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-      system "#{Formula["libxml2"].opt_bin}/xmlcatalog", "--noout", "--create", "catalog"
+      system "xmlcatalog", "--noout", "--create", "catalog"
       (etc/"xml").install "catalog"
     end
 
@@ -78,9 +76,9 @@ class Docbook < Formula
     %w[4.2 4.1.2 4.3 4.4 4.5 5.0].each do |version|
       catalog = prefix/"docbook/xml/#{version}/catalog.xml"
 
-      system "#{Formula["libxml2"].opt_bin}/xmlcatalog", "--noout", "--del",
+      system "xmlcatalog", "--noout", "--del",
              "file://#{catalog}", "#{etc}/xml/catalog"
-      system "#{Formula["libxml2"].opt_bin}/xmlcatalog", "--noout", "--add", "nextCatalog",
+      system "xmlcatalog", "--noout", "--add", "nextCatalog",
              "", "file://#{catalog}", "#{etc}/xml/catalog"
     end
   end

--- a/Library/Formula/docbook.rb
+++ b/Library/Formula/docbook.rb
@@ -46,14 +46,6 @@ class Docbook < Formula
   def install
     (etc/"xml").mkpath
 
-    # only create catalog file if it doesn't exist already to avoid content added
-    # by other formulas to be removed
-    unless File.file?("#{etc}/xml/catalog")
-      ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-      system "xmlcatalog", "--noout", "--create", "catalog"
-      (etc/"xml").install "catalog"
-    end
-
     %w[42 412 43 44 45 50].each do |version|
       resource("xml#{version}").stage do |r|
         if version == "412"
@@ -73,6 +65,13 @@ class Docbook < Formula
 
   def post_install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    # only create catalog file if it doesn't exist already to avoid content added
+    # by other formulas to be removed
+    unless File.file?("#{etc}/xml/catalog")
+      system "xmlcatalog", "--noout", "--create", "#{etc}/xml/catalog"
+    end
+
     %w[4.2 4.1.2 4.3 4.4 4.5 5.0].each do |version|
       catalog = prefix/"docbook/xml/#{version}/catalog.xml"
 

--- a/Library/Formula/scrollkeeper.rb
+++ b/Library/Formula/scrollkeeper.rb
@@ -3,6 +3,7 @@ class Scrollkeeper < Formula
   homepage "http://scrollkeeper.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/scrollkeeper/scrollkeeper/0.3.14/scrollkeeper-0.3.14.tar.gz"
   sha256 "4a0bd3c3a2c5eca6caf2133a504036665485d3d729a16fc60e013e1b58e7ddad"
+  revision 1
 
   depends_on "gettext"
   depends_on "docbook"
@@ -11,6 +12,7 @@ class Scrollkeeper < Formula
     :because => "scrollkeeper and rarian install the same binaries."
 
   def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--with-xml-catalog=#{etc}/xml/catalog"


### PR DESCRIPTION
per our observations in Homebrew/homebrew-x11#129
the install block contained a lot of operations that were dealing
with #{etc}/xml/catalog, outside the keg. These operations have now
been moved into a post_install block.