### PR TITLE
minidlna: fix broken sample conf

### DIFF
--- a/Library/Formula/minidlna.rb
+++ b/Library/Formula/minidlna.rb
@@ -33,32 +33,47 @@ class Minidlna < Formula
     system "./autogen.sh" if build.head?
     system "./configure", "--exec-prefix=#{prefix}"
     system "make", "install"
-    sample_config_path.write sample_config
+  end
+
+  def post_install
+    (pkgshare/"minidlna.conf").write <<-EOS.undent
+      friendly_name=Mac DLNA Server
+      media_dir=#{ENV["HOME"]}/.config/minidlna/media
+      db_dir=#{ENV["HOME"]}/.config/minidlna/cache
+      log_dir=#{ENV["HOME"]}/.config/minidlna
+    EOS
   end
 
   def caveats; <<-EOS.undent
       Simple single-user configuration:
 
       mkdir -p ~/.config/minidlna
-      cp #{sample_config_path} ~/.config/minidlna/minidlna.conf
+      cp #{opt_pkgshare}/minidlna.conf ~/.config/minidlna/minidlna.conf
       ln -s YOUR_MEDIA_DIR ~/.config/minidlna/media
       minidlnad -f ~/.config/minidlna/minidlna.conf -P ~/.config/minidlna/minidlna.pid
     EOS
   end
 
-  def sample_config_path
-    share + "minidlna/minidlna.conf"
-  end
-
-  def sample_config; <<-EOS.undent
-    friendly_name=Mac DLNA Server
-    media_dir=#{ENV["HOME"]}/.config/minidlna/media
-    db_dir=#{ENV["HOME"]}/.config/minidlna/cache
-    log_dir=#{ENV["HOME"]}/.config/minidlna
-    EOS
-  end
-
   test do
-    system "#{sbin}/minidlnad", "-V"
+    (testpath/".config/minidlna/media").mkpath
+    (testpath/".config/minidlna/cache").mkpath
+    (testpath/"minidlna.conf").write <<-EOS.undent
+      friendly_name=Mac DLNA Server
+      media_dir=#{testpath}/.config/minidlna/media
+      db_dir=#{testpath}/.config/minidlna/cache
+      log_dir=#{testpath}/.config/minidlna
+    EOS
+
+    pid = fork do
+      exec "#{sbin}/minidlnad -f minidlna.conf -p 8081 -P #{testpath}/minidlna.pid"
+    end
+    sleep 2
+
+    begin
+      assert_match /MiniDLNA #{version}/, shell_output("curl localhost:8081")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
   end
 end


### PR DESCRIPTION
It seems unlikely users actually want their config which we instruct them to use to read:
```
friendly_name=Mac DLNA Server
media_dir=/private/tmp/minidlna20150920-86661-1e1sfik/minidlna-1.1.5/.brew_home/.config/minidlna/media
db_dir=/private/tmp/minidlna20150920-86661-1e1sfik/minidlna-1.1.5/.brew_home/.config/minidlna/cache
log_dir=/private/tmp/minidlna20150920-86661-1e1sfik/minidlna-1.1.5/.brew_home/.config/minidlna
```
:smile_cat: 