### PR TITLE
superenv: Only strip sysroot flags for OS X SDKs

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -160,8 +160,9 @@ class Cmd
     when "-undefineddynamic_lookup"
       args << "-Wl,-undefined,dynamic_lookup"
     when /^-isysroot/, /^--sysroot/
-      # We set the sysroot
-      enum.next
+      sdk = enum.next
+      # We set the sysroot for OS X SDKs
+      args << "-isysroot" << sdk unless sdk.downcase.include? "osx"
     when "-dylib"
       args << "-Wl,#{arg}"
     when /^-I(.+)?/


### PR DESCRIPTION
Removing all sysroot flags is ok until a non-OS X SDK is needed. In that case,
builds can fail due to the non-OS X SDK being overwritten or overridden by
the OS X SDK.

Sysroot flags are now only stripped if they are an OS X SDK. This is reliant on
only OS X SDKs containing the string "macosx", so this will break if if the
wrong SDK shows up. However, the chances of that happening seem low, as Apple
probably doesn't want to introduce something OS X that doesn't work with OS X,
so it should be robust for the near future.

This could break in an environment without the command line tools. The fix for
that is a bit more involved, though, so that will have to go later.