### PR TITLE
unar 1.9.1

### DIFF
--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -1,11 +1,10 @@
 class Unar < Formula
   desc "RAR archive command-line tools"
   homepage "http://unarchiver.c3.cx/commandline"
-  url "https://theunarchiver.googlecode.com/files/unar1.8.1_src.zip"
-  version "1.8.1"
-  sha256 "67ccb1c780150840f38de63b8e7047717ef4c71b7574d9ef57bd9d9c93255709"
+  url "http://unarchiver.c3.cx/downloads/unar1.9.1_src.zip"
+  sha256 "28045fb688563c002b7c2807e80575d3f9af8eb024739f9ab836f681bb8e822c"
 
-  head "https://code.google.com/p/theunarchiver/", :using => :hg
+  head "https://bitbucket.org/WAHa_06x36/theunarchiver", :using => :hg
 
   depends_on :xcode => :build
 
@@ -19,20 +18,23 @@ class Unar < Formula
   end
 
   def install
-    # Build XADMaster.framework, unar and lsar
-    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "XADMaster", "SYMROOT=../", "-configuration", "Release"
-    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "unar", "SYMROOT=../", "-configuration", "Release"
-    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "lsar", "SYMROOT=../", "-configuration", "Release"
+    # Files in unar1.9.1_src.zip have 'The Unarchiver' path prefix, but HEAD checkout does not.
+    cd build.head? ? "." : "./The Unarchiver" do
+      # Build XADMaster.framework, unar and lsar
+      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "XADMaster", "SYMROOT=../", "-configuration", "Release"
+      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "unar", "SYMROOT=../", "-configuration", "Release"
+      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "lsar", "SYMROOT=../", "-configuration", "Release"
 
-    bin.install "./Release/unar", "./Release/lsar"
+      bin.install "./Release/unar", "./Release/lsar"
 
-    lib.install "./Release/libXADMaster.a"
-    frameworks.install "./Release/XADMaster.framework"
-    (include/"libXADMaster").install_symlink Dir["#{frameworks}/XADMaster.framework/Headers/*"]
+      lib.install "./Release/libXADMaster.a"
+      frameworks.install "./Release/XADMaster.framework"
+      (include/"libXADMaster").install_symlink Dir["#{frameworks}/XADMaster.framework/Headers/*"]
 
-    cd "./Extra" do
-      man1.install "lsar.1", "unar.1"
-      bash_completion.install "unar.bash_completion", "lsar.bash_completion"
+      cd "./Extra" do
+        man1.install "lsar.1", "unar.1"
+        bash_completion.install "unar.bash_completion", "lsar.bash_completion"
+      end
     end
   end
 

--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -19,11 +19,13 @@ class Unar < Formula
   end
 
   def install
-    # Files in unar1.9.1_src.zip have 'The Unarchiver' path prefix, but HEAD checkout does not.
+    # Files in unar1.9.1_src.zip have "The Unarchiver" path prefix, but HEAD checkout does not.
+    # Build on some versions of Xcode will fail if there's whitespace in path, so workaround
+    # by moving things out of "The Unarchiver" folder.
     unless build.head?
-      # Build on some versions of Xcode will fail when there's whitespace in path, so workaround it with a symlink.
-      ln_s "./The Unarchiver", "./The-Unarchiver"
-      cd "./The-Unarchiver"
+      mv "./The Unarchiver/Extra", "."
+      mv "./The Unarchiver/UniversalDetector", "."
+      mv "./The Unarchiver/XADMaster", "."
     end
 
     # Build XADMaster.framework, unar and lsar

--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -20,7 +20,11 @@ class Unar < Formula
 
   def install
     # Files in unar1.9.1_src.zip have 'The Unarchiver' path prefix, but HEAD checkout does not.
-    cd "./The Unarchiver" unless build.head?
+    unless build.head?
+      # Build on some versions of Xcode will fail when there's whitespace in path, so workaround it with a symlink.
+      ln_s "./The Unarchiver", "./The-Unarchiver"
+      cd "./The-Unarchiver"
+    end
 
     # Build XADMaster.framework, unar and lsar
     xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "XADMaster", "SYMROOT=../", "-configuration", "Release"

--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -3,6 +3,7 @@ class Unar < Formula
   homepage "http://unarchiver.c3.cx/commandline"
   url "http://unarchiver.c3.cx/downloads/unar1.9.1_src.zip"
   sha256 "28045fb688563c002b7c2807e80575d3f9af8eb024739f9ab836f681bb8e822c"
+  version "1.9.1"
 
   head "https://bitbucket.org/WAHa_06x36/theunarchiver", :using => :hg
 

--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -20,22 +20,22 @@ class Unar < Formula
 
   def install
     # Files in unar1.9.1_src.zip have 'The Unarchiver' path prefix, but HEAD checkout does not.
-    cd build.head? ? "." : "./The Unarchiver" do
-      # Build XADMaster.framework, unar and lsar
-      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "XADMaster", "SYMROOT=../", "-configuration", "Release"
-      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "unar", "SYMROOT=../", "-configuration", "Release"
-      xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "lsar", "SYMROOT=../", "-configuration", "Release"
+    cd "./The Unarchiver" unless build.head?
 
-      bin.install "./Release/unar", "./Release/lsar"
+    # Build XADMaster.framework, unar and lsar
+    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "XADMaster", "SYMROOT=../", "-configuration", "Release"
+    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "unar", "SYMROOT=../", "-configuration", "Release"
+    xcodebuild "-project", "./XADMaster/XADMaster.xcodeproj", "-target", "lsar", "SYMROOT=../", "-configuration", "Release"
 
-      lib.install "./Release/libXADMaster.a"
-      frameworks.install "./Release/XADMaster.framework"
-      (include/"libXADMaster").install_symlink Dir["#{frameworks}/XADMaster.framework/Headers/*"]
+    bin.install "./Release/unar", "./Release/lsar"
 
-      cd "./Extra" do
-        man1.install "lsar.1", "unar.1"
-        bash_completion.install "unar.bash_completion", "lsar.bash_completion"
-      end
+    lib.install "./Release/libXADMaster.a"
+    frameworks.install "./Release/XADMaster.framework"
+    (include/"libXADMaster").install_symlink Dir["#{frameworks}/XADMaster.framework/Headers/*"]
+
+    cd "./Extra" do
+      man1.install "lsar.1", "unar.1"
+      bash_completion.install "unar.bash_completion", "lsar.bash_completion"
     end
   end
 


### PR DESCRIPTION
Update `unar` to 1.9.1

Problem is, the source code archive `unar1.9.1_src.zip` has a path prefix "The Unarchiver" in it, while HEAD checkout does not. I have to add

```ruby
cd build.head? ? "." : "./The Unarchiver" do
```

to deal with it.