### PR TITLE
migrator: link Cellar and opt before the keg.

### DIFF
--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -163,9 +163,9 @@ class Migrator
       unlink_oldname
       move_to_new_directory
       repin
-      link_newname unless old_linked_keg.nil?
-      link_oldname_opt
       link_oldname_cellar
+      link_oldname_opt
+      link_newname unless old_linked_keg.nil?
       update_tabs
     rescue Interrupt
       ignore_interrupts { backup_oldname }


### PR DESCRIPTION
When there's absolute symlinks in a linked directory in the `keg`
(e.g. `bin`)that point to the `Cellar` or `opt` then linking the `keg`
will fail before the `Cellar` or `opt` has been linked.

CC @vladshablinsky @tdsmith @xucheng

Closes #44306.