### PR TITLE
gdal: treat numpy as a build dependency

### DIFF
--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -1,9 +1,8 @@
 class Gdal < Formula
   desc "GDAL: Geospatial Data Abstraction Library"
   homepage "http://www.gdal.org/"
-  url "http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz"
-  sha256 "66bc8192d24e314a66ed69285186d46e6999beb44fc97eeb9c76d82a117c0845"
-  revision 3
+  url "http://download.osgeo.org/gdal/1.11.3/gdal-1.11.3.tar.gz"
+  sha256 "561588bdfd9ca91919d4679a77a2b44214b158934ee8b425295ca5be33a1014d"
 
   bottle do
     revision 1

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -291,16 +291,8 @@ class Gdal < Formula
     system "make"
     system "make", "install"
 
-    # `python-config` may try to talk us into building bindings for more
-    # architectures than we really should.
-    if MacOS.prefer_64_bit?
-      ENV.append_to_cflags "-arch #{Hardware::CPU.arch_64_bit}"
-    else
-      ENV.append_to_cflags "-arch #{Hardware::CPU.arch_32_bit}"
-    end
-
     cd "swig/python" do
-      system "python", "setup.py", "install", "--prefix=#{prefix}", "--record=installed.txt", "--single-version-externally-managed"
+      system "python", *Language::Python.setup_install_args(prefix)
       bin.install Dir["scripts/*"]
     end
 

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -87,6 +87,10 @@ class Gdal < Formula
     depends_on "swig" => :build
   end
 
+  option "without-python", "Build without python2 support"
+  depends_on :python => :optional if MacOS.version <= :snow_leopard
+  depends_on :python3 => :optional
+
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455
   # including prefix lib dir added by Homebrew:
@@ -290,9 +294,11 @@ class Gdal < Formula
     system "make"
     system "make", "install"
 
-    cd "swig/python" do
-      system "python", *Language::Python.setup_install_args(prefix)
-      bin.install Dir["scripts/*"]
+    Language::Python.each_python(build) do |python, python_version|
+      cd "swig/python" do
+        system python, *Language::Python.setup_install_args(prefix)
+        bin.install Dir["scripts/*"] if python == "python"
+      end
     end
 
     if build.with? "swig-java"


### PR DESCRIPTION
Don't bother installing numpy. Addresses issues in #44117.