### PR TITLE
Remove incomplete files in cache on `brew cleanup` (Issue 44182)

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -57,6 +57,10 @@ module Homebrew
   def cleanup_cache
     return unless HOMEBREW_CACHE.directory?
     HOMEBREW_CACHE.children.each do |path|
+      if path.to_s.end_with? ".incomplete"
+        cleanup_path(path) { path.unlink }
+        next
+      end
       if prune?(path)
         if path.file?
           cleanup_path(path) { path.unlink }


### PR DESCRIPTION
This simply deletes all files whose names end in '.incomplete' whenever `brew cleanup` is run.

Fixes [Issue 44182](https://github.com/Homebrew/homebrew/issues/44182)
Test output:
```
Run options: --seed 13091

Finished in 8.006936s, 77.5578 runs/s, 173.9742 assertions/s.

621 runs, 1393 assertions, 0 failures, 0 errors, 0 skips
```