### PR TITLE
ENV#userpaths!: ensure Superenv.bin and opt path come at first

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -190,10 +190,16 @@ module SharedEnvExtension
 
   # @private
   def userpaths!
-    paths = ORIGINAL_PATHS.map { |p| p.realpath.to_s rescue nil } - %w[/usr/X11/bin /opt/X11/bin]
-    self["PATH"] = paths.unshift(*self["PATH"].split(File::PATH_SEPARATOR)).uniq.join(File::PATH_SEPARATOR)
+    paths = self["PATH"].split(File::PATH_SEPARATOR)
+    # put Superenv.bin and opt path at the first
+    new_paths = paths.select { |p| p.start_with?("#{HOMEBREW_REPOSITORY}/Library/ENV") || p.start_with?("#{HOMEBREW_PREFIX}/opt") }
     # XXX hot fix to prefer brewed stuff (e.g. python) over /usr/bin.
-    prepend_path "PATH", HOMEBREW_PREFIX/"bin"
+    new_paths << "#{HOMEBREW_PREFIX}/bin"
+    # reset of self["PATH"]
+    new_paths += paths
+    # user paths
+    new_paths += ORIGINAL_PATHS.map { |p| p.realpath.to_s rescue nil } - %w[/usr/X11/bin /opt/X11/bin]
+    self["PATH"] = new_paths.uniq.join(File::PATH_SEPARATOR)
   end
 
   def fortran


### PR DESCRIPTION
This ensures that binaries in /usr/local/bin would not overwrite
superenv.