### PR TITLE
mobile-shell: use official repository URL

### DIFF
--- a/Library/Formula/mobile-shell.rb
+++ b/Library/Formula/mobile-shell.rb
@@ -12,7 +12,7 @@ class MobileShell < Formula
   end
 
   head do
-    url "https://github.com/keithw/mosh.git", :shallow => false
+    url "https://github.com/mobile-shell/mosh.git", :shallow => false
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
https://mosh.mit.edu/ refers to https://github.com/mobile-shell/mosh as the official repository, and while https://github.com/keithw/mosh redirects to https://github.com/mobile-shell/mosh using it here can cause some confusion.