### PR TITLE
guile: Remove glibtoolize replacement for HEAD build

### DIFF
--- a/Library/Formula/guile.rb
+++ b/Library/Formula/guile.rb
@@ -41,7 +41,6 @@ class Guile < Formula
 
   def install
     if build.head?
-      inreplace "autogen.sh", "libtoolize", "glibtoolize"
       system "./autogen.sh"
     end
 


### PR DESCRIPTION
This removes the replacement of libtoolize with glibtoolize when building guile --HEAD.

The workaround was introduced as a fix for #34769, but since then upstream itself added glibtoolize detection in `autogen.sh`.

Excerpt from upstream [`autogen.sh`](http://git.savannah.gnu.org/gitweb/?p=guile.git;a=blob;f=autogen.sh;hb=HEAD):
```bash
# Typical MacOS X installations rename 'libtoolize' to 'glibtoolize', so
# adjust to that.
if test "`uname -s`" = "Darwin"; then
  glibtoolize --version
else
  libtoolize --version
fi
```

The workaround `inreplace "autogen.sh", "libtoolize", "glibtoolize"` replaces `glibtoolize --version` with `gglibtoolize --version` which does not exist and the build in turn fails:
```
./autogen.sh: line 22: gglibtoolize: command not found
couldn't understand kern.osversion `14.5.0'
```