### PR TITLE
google-sparsehash: fix builds on Yosemite and El Capitan

### DIFF
--- a/Library/Formula/google-sparsehash.rb
+++ b/Library/Formula/google-sparsehash.rb
@@ -20,6 +20,13 @@ class GoogleSparsehash < Formula
     sha256 "c12f68278bce1ebf893ffa791e43df7f09e5452db3fbd13bd30fcf91cbf6ad36"
   end
 
+  # see discussion in #41087
+  # patch taken from upstream
+  patch do
+    url "https://github.com/sparsehash/sparsehash/commit/7f6351fb06241b96fdb39ae3aff53c2acb1cd7a4.diff"
+    sha256 "3a0b3facdf2b5e61274239b754f4f8ef1c1da185a14e1549f27855d4aa5973ea"
+  end
+
   def install
     ENV.cxx11 if build.cxx11?
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
see also #41087
The latest Xcode release for Yosemite produces the same error that was
previously seen on El Capitan