### PR TITLE
Add local bin folder to path for interactive shell

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -120,6 +120,8 @@ def interactive_shell(f = nil)
     FileUtils.touch "#{ENV["HOME"]}/.zshrc"
   end
 
+  ENV["PATH"] = ENV["PATH"].split(File::PATH_SEPARATOR).insert(1, "#{HOMEBREW_PREFIX}/bin").join(File::PATH_SEPARATOR)
+
   Process.wait fork { exec ENV["SHELL"] }
 
   if $?.success?


### PR DESCRIPTION
This lets you use your Homebrew-installed and linked binaries when running commands such as `brew install --interactive --git $formula` to, for example, quickly open the package directory in Atom (using `atom .`).