### PR TITLE
command: fail early if no command is given

### DIFF
--- a/Library/Homebrew/cmd/command.rb
+++ b/Library/Homebrew/cmd/command.rb
@@ -1,5 +1,6 @@
 module Homebrew
   def command
+    abort "This command requires a command argument" if ARGV.empty?
     cmd = ARGV.first
     cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
 


### PR DESCRIPTION
I’m not sure the message is clear enough. Without this line the command aborts in the following way:

```
$ brew command
Error: Unknown command:
```