### PR TITLE
Add java to SHARE_PATHS

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -72,7 +72,7 @@ class Keg
   # These paths relative to the keg's share directory should always be real
   # directories in the prefix, never symlinks.
   SHARE_PATHS = %w[
-    aclocal doc info locale man
+    aclocal doc info java locale man
     man/man1 man/man2 man/man3 man/man4
     man/man5 man/man6 man/man7 man/man8
     man/cat1 man/cat2 man/cat3 man/cat4


### PR DESCRIPTION
Add `java` to `SHARE_PATHS` so that `HOMEBREW_PREFIX/share/java` is a folder with symlinks in it, rather than a symlink to a folder for a specific formula.

This way we avoid conflicts if multiple formulas put `jar` files in the standard location `HOMEBREW_PREFIX/share/java`.

See also: [pull request 44420](https://github.com/Homebrew/homebrew/pull/44420)