### PR TITLE
allow tests to write to var

### DIFF
--- a/Library/Homebrew/cmd/test.rb
+++ b/Library/Homebrew/cmd/test.rb
@@ -50,6 +50,7 @@ module Homebrew
             sandbox.allow_write_temp_and_cache
             sandbox.allow_write_log(f)
             sandbox.allow_write_xcode
+            sandbox.allow_write_path(HOMEBREW_PREFIX/"var")
             sandbox.exec(*args)
           else
             exec(*args)


### PR DESCRIPTION
Fixes tests for things like salt that expect to be able to write to
prefix/var on launch.