### PR TITLE
nginx: Fix passenger caveat after upstream change

### DIFF
--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -137,7 +137,7 @@ class Nginx < Formula
 
   def passenger_caveats; <<-EOS.undent
     To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the 'http' context:
-      passenger_root #{Formula["passenger"].opt_libexec}/lib/phusion_passenger/locations.ini;
+      passenger_root #{Formula["passenger"].opt_libexec}/src/ruby_supportlib/phusion_passenger/locations.ini;
       passenger_ruby /usr/bin/ruby;
     EOS
   end


### PR DESCRIPTION
The locations.ini file changed location in #44333, this corrects the nginx caveat to show the current path. Existing installations of nginx using passenger will fail to start passenger until this change in nginx.conf is made.

> *Users with existing installations will have to make a change to their* `/usr/local/etc/nginx/nginx.conf`:
> `passenger_root` should be set to `/usr/local/opt/passenger/libexec/src/ruby_supportlib/phusion_passenger/locations.ini` starting with passenger 5.0.20.

> (If your homebrew installation is not in `/usr/local`, your path will differ.)