### PR TITLE
Remove MacVTKITKPythonBottles from doc

### DIFF
--- a/share/doc/homebrew/Interesting-Taps-&-Branches.md
+++ b/share/doc/homebrew/Interesting-Taps-&-Branches.md
@@ -69,9 +69,6 @@ You can be added as a maintainer for one of the Homebrew organization taps and a
 *   [petere/postgresql](https://github.com/petere/homebrew-postgresql)
     - Allows installing multiple PostgreSQL versions in parallel.
 
-*   [iMichka/MacVTKITKPythonBottles](https://github.com/iMichka/homebrew-MacVTKITKPythonBottles)
-    - VTK and ITK binaries with Python wrapping.
-
 *   [edavis/emacs](https://github.com/edavis/homebrew-emacs)
     - A tap for Emacs packages.
 


### PR DESCRIPTION
Bottles for VTK and ITK python are no more provided.

ITK can be wrapped with Python since version 4.8, so this tap
is no more needed. Using the vanilla homebrew VTK and ITK formulas is
the way to go.