### PR TITLE
Tortle 1.0.0 - Initial commit

### DIFF
--- a/Library/Formula/tortle.rb
+++ b/Library/Formula/tortle.rb
@@ -1,8 +1,8 @@
 class Tortle < Formula
   desc "A tiny utility for easily enabling and disabling Tor on OS X"
   homepage "https://thrifus.github.io/Tortle"
-  url "https://github.com/thrifus/Tortle/archive/1.0.0.tar.gz"
-  version "1.0.0"
+  url "https://github.com/thrifus/Tortle/archive/1.0.1.tar.gz"
+  version "1.0.1"
   sha256 "01328162a017868f713e04a65fa7ea3315adb285046edbf13917fd26e849cca4"
 
   depends_on "tor"

--- a/Library/Formula/tortle.rb
+++ b/Library/Formula/tortle.rb
@@ -9,4 +9,8 @@ class Tortle < Formula
   def install
     bin.install "tortle"
   end
+
+  test do
+    system "false"
+  end
 end

--- a/Library/Formula/tortle.rb
+++ b/Library/Formula/tortle.rb
@@ -11,6 +11,6 @@ class Tortle < Formula
   end
 
   test do
-    system "false"
+    system "tortle"
   end
 end

--- a/Library/Formula/tortle.rb
+++ b/Library/Formula/tortle.rb
@@ -1,5 +1,5 @@
 class Tortle < Formula
-  desc "A tiny utility for enabling and disabling Tor on OS X"
+  desc "A tiny utility for easily enabling and disabling Tor on OS X"
   homepage "https://thrifus.github.io/Tortle"
   url "https://github.com/thrifus/Tortle/archive/1.0.0.tar.gz"
   version "1.0.0"

--- a/Library/Formula/tortle.rb
+++ b/Library/Formula/tortle.rb
@@ -1,0 +1,12 @@
+class Tortle < Formula
+  desc "A tiny utility for enabling and disabling Tor on OS X"
+  homepage "https://thrifus.github.io/Tortle"
+  url "https://github.com/thrifus/Tortle/archive/1.0.0.tar.gz"
+  version "1.0.0"
+  sha256 "01328162a017868f713e04a65fa7ea3315adb285046edbf13917fd26e849cca4"
+
+  depends_on "tor"
+  def install
+    bin.install "tortle"
+  end
+end


### PR DESCRIPTION
Tortle is a tiny utility for enabling and disabling Tor on OS X

Homepage:
http://thrifus.github.io/Tortle

Documentation:
https://github.com/thrifus/Tortle/blob/master/README.md