### PR TITLE
audit: fix GitHub repository audit

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -472,7 +472,7 @@ class FormulaAuditor
     end
 
     problem "GitHub fork (not canonical repository)" if metadata["fork"]
-    if (metadata["forks_count"] < 10) && (metadata["watchers_count"] < 10) &&
+    if (metadata["forks_count"] < 10) && (metadata["subscribers_count"] < 10) &&
        (metadata["stargazers_count"] < 20)
       problem "GitHub repository not notable enough (<10 forks, <10 watchers and <20 stars)"
     end


### PR DESCRIPTION
In the data returned from the GitHub API, `watchers_count` is actually the number of stars.

See https://developer.github.com/v3/activity/starring/#starring-vs-watching