### PR TITLE
Remove broken dockutil dependency

### DIFF
--- a/Library/Formula/dockutil.rb
+++ b/Library/Formula/dockutil.rb
@@ -13,15 +13,8 @@ class Dockutil < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
 
-  resource "plistlib" do
-    url "https://pypi.python.org/packages/source/p/plist/plist-0.2.tar.gz"
-    sha256 "531595d63ee4b7de6a168fc4ca715c475be9700de93455a7c73a176a1e1f3345"
-  end
-
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python2.7/site-packages"
-
-    resource("plistlib").stage { system "python", "setup.py", "install", "--prefix=#{libexec}" }
 
     bin.install "scripts/dockutil"
   end


### PR DESCRIPTION
plistlib has been removed from pypi. As far as I can tell, the default
OS X python ships with plistlib, so this isn't necessary. I wouldn't be
surprised if this wasn't the case for some of the older versions
supported by this formula.

I'm not sure what the best way to deal with this case is, since this might have broken older operating systems, but those are also already broken. Let me know how we should handle this case!