### PR TITLE
epubcheck 4.0.0

### DIFF
--- a/Library/Formula/epubcheck.rb
+++ b/Library/Formula/epubcheck.rb
@@ -1,11 +1,11 @@
 class Epubcheck < Formula
   desc "Validate IDPF EPUB files, version 2.0 and later"
   homepage "https://github.com/IDPF/epubcheck"
-  url "https://github.com/IDPF/epubcheck/releases/download/v3.0.1/epubcheck-3.0.1.zip"
-  sha256 "530d24e0a63961df205f96e78960e08543c387eb8afc0a260714c911574fd408"
+  url "https://github.com/IDPF/epubcheck/releases/download/v4.0.0/epubcheck-4.0.0.zip"
+  sha256 "6a2b73ddbe8aa5a83ee551b73297429daa73156192661ac28c1fbb39fa7edbdc"
 
   def install
-    jarname = "epubcheck-#{version}.jar"
+    jarname = "epubcheck.jar"
     libexec.install jarname, "lib"
     bin.write_jar_script libexec/jarname, "epubcheck"
   end


### PR DESCRIPTION
EpubCheck 4.0.0 has been released on Sept. 2 2015 and is now the recommended version to validate both EPUB 2 and EPUB 3 files.

Release 4.0.0: https://github.com/IDPF/epubcheck/releases/tag/v4.0.0