### PR TITLE
Convert jsoncpp formula to use cmake

### DIFF
--- a/Library/Formula/jsoncpp.rb
+++ b/Library/Formula/jsoncpp.rb
@@ -2,6 +2,7 @@ class Jsoncpp < Formula
   desc "Library for interacting with JSON"
   homepage "https://github.com/open-source-parsers/jsoncpp"
   url "https://github.com/open-source-parsers/jsoncpp/archive/0.10.5.tar.gz"
+  head "https://github.com/open-source-parsers/jsoncpp.git"
   sha256 "56afb14d2ef1c52e72771a221346d4b94f0d46d4e67f796bbcaedb176ca823df"
 
   bottle do
@@ -12,32 +13,13 @@ class Jsoncpp < Formula
     sha256 "7d3400af12dbe322fec3aab9894a920e68b711d01e6205767966ad102cbd8e14" => :mountain_lion
   end
 
-  depends_on "scons" => :build
+  depends_on "cmake" => :build
 
   def install
-    gccversion = `g++ -dumpversion`.strip
-    libs = buildpath/"libs/linux-gcc-#{gccversion}/"
-
-    scons "platform=linux-gcc"
-    system "install_name_tool", "-id", lib/"libjsoncpp.dylib", libs/"libjson_linux-gcc-#{gccversion}_libmt.dylib"
-
-    lib.install libs/"libjson_linux-gcc-#{gccversion}_libmt.dylib" => "libjsoncpp.dylib"
-    lib.install libs/"libjson_linux-gcc-#{gccversion}_libmt.a" =>"libjsoncpp.a"
-    (include/"jsoncpp").install buildpath/"include/json"
-
-    (lib/"pkgconfig/jsoncpp.pc").write <<-EOS.undent
-      prefix=#{prefix}
-      exec_prefix=${prefix}
-      libdir=#{lib}
-      includedir=#{include}
-
-      Name: jsoncpp
-      Description: API for manipulating JSON
-      Version: #{version}
-      URL: https://github.com/open-source-parsers/jsoncpp
-      Libs: -L${libdir} -ljsoncpp
-      Cflags: -I${includedir}/jsoncpp/
-    EOS
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_STATIC_LIBS=ON" << "-DBUILD_SHARED_LIBS=ON" << "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
+    system "cmake", ".", *cmake_args
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
This simplifies the formula greatly. Additionally, a cmake build file and a pkgconfig file are automatically provided.