### PR TITLE
zanata-cli 3.7.4 (new formula)

### DIFF
--- a/Library/Formula/zanata-client.rb
+++ b/Library/Formula/zanata-client.rb
@@ -1,0 +1,18 @@
+class ZanataClient < Formula
+  desc "Zanata translation system command-line client"
+  homepage "http://zanata.org/"
+  url "https://search.maven.org/remotecontent?filepath=org/zanata/zanata-cli/3.7.4/zanata-cli-3.7.4-dist.tar.gz"
+  sha256 "4424322bffb81f5185f87d1f11c7e92cde504c736695dbb4ced5854e49672037"
+
+  depends_on :java => "1.7+"
+
+  def install
+    libexec.install Dir["*"]
+    (bin/"zanata-cli").write_env_script libexec/"bin/zanata-cli", Language::Java.java_home_env("1.7+")
+    bash_completion.install libexec/"bin/zanata-cli-completion"
+  end
+
+  test do
+    assert_match /Zanata Java command-line client/, shell_output("zanata-cli --help")
+  end
+end


### PR DESCRIPTION
~~I'm not sure on the name.  The resultant bin file is `zanata-cli`, but the RPM package for Fedora is called `zanata-client`.~~  UPDATE: Using `zanata-client`

---
Some more info:

"Zanata is a web-based system for translators, content creators and developers to manage localisation projects."
Some notable projects using Zanata are [Fedora](https://fedoraproject.org/wiki/L10N) and [OpenStack](https://translate.openstack.org/).

http://zanata.org/
https://github.com/zanata/
https://github.com/zanata/zanata-client

