### PR TITLE
git-extras: disable its own updater and redirect users to Homebrew

### DIFF
--- a/Library/Formula/git-extras.rb
+++ b/Library/Formula/git-extras.rb
@@ -4,6 +4,7 @@ class GitExtras < Formula
   url "https://github.com/tj/git-extras/archive/3.0.0.tar.gz"
   sha256 "490742428824d6e807e894c3b6612be37a9a9a4e8fbea747d1813e5d62b2a807"
   head "https://github.com/tj/git-extras.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,6 +13,10 @@ class GitExtras < Formula
     sha256 "14471fe41a1162813ed803fe9edc91aca493d7529340e8f15e2cea9aa269d586" => :mavericks
     sha256 "7655c7e7f926d58b28a8ef503b406ff2c0f6fb2102a2915cb7d05b36b26f9d9b" => :mountain_lion
   end
+
+  # Disable "git extras update", which will produce a broken install under Homebrew
+  # https://github.com/Homebrew/homebrew/issues/44520
+  patch :DATA
 
   def install
     inreplace "Makefile", %r{\$\(DESTDIR\)(?=/etc/bash_completion\.d)}, "$(DESTDIR)$(PREFIX)"
@@ -23,3 +28,33 @@ class GitExtras < Formula
     assert_match /#{testpath}/, shell_output("#{bin}/git-root")
   end
 end
+
+__END__
+diff --git a/bin/git-extras b/bin/git-extras
+index c9b2bfe..96168fc 100755
+--- a/bin/git-extras
++++ b/bin/git-extras
+@@ -3,17 +3,12 @@
+ VERSION="3.0.0"
+ 
+ update() {
+-  local bin=$(which git-extras)
+-  local prefix=${bin%/*/*}
+-  local orig=$PWD
+-
+-  cd /tmp \
+-    && rm -fr ./git-extras \
+-    && git clone --depth 1 https://github.com/tj/git-extras.git \
+-    && cd git-extras \
+-    && PREFIX="$prefix" make install \
+-    && cd "$orig" \
+-    && echo "... updated git-extras $VERSION -> $(git extras --version)"
++  echo "This git-extras installation is managed by Homebrew."
++  echo "If you'd like to update git-extras, run the following:"
++  echo
++  echo "  brew upgrade git-extras"
++  echo
++  return 1
+ }
+ 
+ case "$1" in


### PR DESCRIPTION
Fixes  #44520.

Now when you try to update from within Homebrew-installed `git-extras`, you'll get this.

```
[~]
$ git extras update
This git-extras installation is managed by Homebrew.
If you'd like to update git-extras, run the following:

  brew upgrade git-extras

[✘ ~]
$
```