### PR TITLE
apache-spark 1.5.1

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -2,9 +2,9 @@ class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
   head "https://github.com/apache/spark.git"
-  url "https://www.apache.org/dyn/closer.cgi?path=spark/spark-1.5.0/spark-1.5.0-bin-hadoop2.6.tgz"
-  version "1.5.0"
-  sha256 "d8d8ac357b9e4198dad33042f46b1bc09865105051ffbd7854ba272af726dffc"
+  url "https://www.apache.org/dyn/closer.lua?path=spark/spark-1.5.1/spark-1.5.1-bin-hadoop2.6.tgz"
+  version "1.5.1"
+  sha256 "41ab59b28581b7952e3b0cfd8182980f033d2bf22d0f6a088ee6d120ddf24953"
 
   def install
     # Rename beeline to distinguish it from hive's beeline


### PR DESCRIPTION
Apache Spark has a new maintenance release, 1.5.1: [release blog post](https://spark.apache.org/news/spark-1-5-1-released.html)