### PR TITLE
version: parse opam archives

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -350,4 +350,15 @@ class VersionParsingTests < Homebrew::TestCase
     assert_version_detected "4.0.18",
       "http://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb"
   end
+
+  def test_opam_version
+    assert_version_detected "2.18.3",
+      "https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz"
+    assert_version_detected "1.9",
+      "https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz"
+    assert_version_detected "0.99.2",
+      "https://opam.ocaml.org/archives/ppx_tools.0.99.2+opam.tar.gz"
+    assert_version_detected "1.0.2",
+      "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
+  end
 end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -328,6 +328,13 @@ class Version
     m = /-(\d+\.\d+(?:\.\d+)?)-w(?:in)?(?:32|64)$/.match(stem)
     return m.captures.first unless m.nil?
 
+    # Opam packages
+    # e.g. https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz
+    # e.g. https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz
+    # e.g. https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz
+    m = /\.(\d+\.\d+(?:\.\d+)?)\+opam$/.match(stem)
+    return m.captures.first unless m.nil?
+
     # e.g. http://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm
     # e.g. http://ftpmirror.gnu.org/autogen/autogen-5.5.7-5.i386.rpm
     # e.g. http://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip


### PR DESCRIPTION
These are not properly detected right now, e.g.:

```
>> Version.parse "https://opam.ocaml.org/archives/react.1.2.0+opam.tar.gz"
=> nil
>> Version.parse "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
=> #<Version:0x007f8069853928 @version="format.1.0.2+opam">
```