### PR TITLE
libfabric 1.1.1 (new formula)

### DIFF
--- a/Library/Formula/libfabric.rb
+++ b/Library/Formula/libfabric.rb
@@ -1,0 +1,17 @@
+class Libfabric < Formula
+  desc "OpenFabrics libfabric"
+  homepage "https://ofiwg.github.io/libfabric/"
+  url "http://downloads.openfabrics.org/downloads/ofi/libfabric-1.1.1.tar.bz2"
+  sha256 "228c50d1f9595009a026bb2293f372a04d89ecb3b0f7fcde3905476dbf49fc95"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#(bin}/fi_info"
+  end
+end


### PR DESCRIPTION
OpenFabrics libfabric is an open source, community-developed library
designed to provide low-latency interfaces to high-performance fabric
hardware.  Support on OS-X is via the sockets "provider", which is
intended to be a development platform for middleware clients such as
MPICH, OpenMPI, OpenSHMEM and Chapel.