### PR TITLE
libass: 0.13.0

### DIFF
--- a/Library/Formula/libass.rb
+++ b/Library/Formula/libass.rb
@@ -1,8 +1,8 @@
 class Libass < Formula
   desc "Subtitle renderer for the ASS/SSA subtitle format"
   homepage "https://github.com/libass/libass"
-  url "https://github.com/libass/libass/releases/download/0.12.3/libass-0.12.3.tar.gz"
-  sha256 "5aa6b02b00de7aa2d795e8afa77def47485fcc68a190f4326b6e4d40aee30560"
+  url "https://github.com/libass/libass/releases/download/0.13.0/libass-0.13.0.tar.gz"
+  sha256 "67692ef2a56e0423d22b142edb072c04949fe88c37be1d19cf22669c44f935f3"
 
   bottle do
     cellar :any
@@ -17,8 +17,7 @@ class Libass < Formula
 
   depends_on "freetype"
   depends_on "fribidi"
-  depends_on "fontconfig"
-  depends_on "harfbuzz" => :optional
+  depends_on "harfbuzz" => :recommended
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
Removed fontconfig since this version introduces CoreText support for
font lookup.

Also made Harfbuzz recommended because it's recommended by the upstream.
Libass can use Harfbuzz for text layouting instead of Freetype, and has
an internal high perfomance rasterizer. Using Harfbuzz fixes many
problems with asian and arabic scripts, as well as providing better
support for opentype features like ligatures, kerning, etc.
Freetype is still needed as a dependency to parse the actual font files.

**Note:** I did not change the bottle SHAs. No idea if I am supposed to when updating a formula.