### PR TITLE
zsh: add HEAD support

### DIFF
--- a/Library/Formula/zsh.rb
+++ b/Library/Formula/zsh.rb
@@ -11,6 +11,11 @@ class Zsh < Formula
     sha256 "932fe97487753363d3ddd683918210367ec29104e700001bbf5cd18c2f4d59fa" => :mavericks
   end
 
+  head do
+    url "git://git.code.sf.net/p/zsh/code"
+    depends_on "autoconf" => :build
+  end
+
   option "without-etcdir", "Disable the reading of Zsh rc files in /etc"
 
   deprecated_option "disable-etcdir" => "without-etcdir"
@@ -19,6 +24,8 @@ class Zsh < Formula
   depends_on "pcre"
 
   def install
+    system "Util/preconfig" if build.head?
+
     args = %W[
       --prefix=#{prefix}
       --enable-fndir=#{share}/zsh/functions
@@ -46,8 +53,14 @@ class Zsh < Formula
     inreplace ["Makefile", "Src/Makefile"],
       "$(libdir)/$(tzsh)/$(VERSION)", "$(libdir)"
 
-    system "make", "install"
-    system "make", "install.info"
+    if build.head?
+      # disable target install.man, because the required yodl comes neither with OS X nor Homebrew
+      # also disable install.runhelp and install.info because they would also fail or have no effect
+      system "make", "install.bin", "install.modules", "install.fns"
+    else
+      system "make", "install"
+      system "make", "install.info"
+    end
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
I needed to test the master branch of Zsh, and turned out that it's a non-trivial task, so I figured I would submit this to make life easier for future testers.

Unfortunately, building man pages on master requires [`yodl`](https://fbb-git.github.io/yodl/), which in turn depends on [`icmake`](https://fbb-git.github.io/icmake/), both of which are not available from either OS X or Homebrew, and a bit nontrivial to build too. Release tarballs bypass this problem by shipping with precompiled `.1` files. Therefore, I've disabled the `install.man` target for `HEAD` and other related targets (`install.info` and `install.runhelp`). Hopefully this isn't too bad.

P.S. Looks like [zchee/homebrew-zsh](https://github.com/zchee/homebrew-zsh) has implemented formulae for `yodl` and `icmake`. I haven't tested them.