### PR TITLE
(formula) dockutil: no plistlib needed because it is integrated in python

### DIFF
--- a/Library/Formula/dockutil.rb
+++ b/Library/Formula/dockutil.rb
@@ -13,15 +13,8 @@ class Dockutil < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
 
-  resource "plistlib" do
-    url "https://pypi.python.org/packages/source/p/plist/plist-0.2.tar.gz"
-    sha256 "531595d63ee4b7de6a168fc4ca715c475be9700de93455a7c73a176a1e1f3345"
-  end
-
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python2.7/site-packages"
-
-    resource("plistlib").stage { system "python", "setup.py", "install", "--prefix=#{libexec}" }
 
     bin.install "scripts/dockutil"
   end


### PR DESCRIPTION
dockutil is not installable because the URL in "resource" is not available. plistlib is now integrated in python as far as I know and so it should not be needed as dependency. 
I don't know what happens, if a user uses an older version of OSX or Python. 
How should this be handled within homebrew formulas?