### PR TITLE
audit fixes: A 03: aescrypt - ant-contrib

### DIFF
--- a/Library/Formula/afsctool.rb
+++ b/Library/Formula/afsctool.rb
@@ -7,7 +7,8 @@ class Afsctool < Formula
 
   def install
     cd "afsctool_34" do
-      system "#{ENV.cc} #{ENV.cflags} -lz -framework CoreServices -o afsctool afsctool.c"
+      system ENV.cc, ENV.cflags, "-lz",
+         "-framework", "CoreServices", "-o", "afsctool", "afsctool.c"
       bin.install "afsctool"
     end
   end

--- a/Library/Formula/ant-contrib.rb
+++ b/Library/Formula/ant-contrib.rb
@@ -2,8 +2,8 @@ class AntContrib < Formula
   desc "Collection of tasks for Apache Ant"
   homepage "http://ant-contrib.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
-  sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"
   version "1.0b3"
+  sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"
 
   depends_on "ant"
 


### PR DESCRIPTION
audit fixes for: aescrypt-packetizer afio afsctool ant-contrib

(originally included agda, android-ndk, apache-spark, but they were removed due to build/test issues)