### PR TITLE
mbedtls 2.1.1

### DIFF
--- a/Library/Aliases/mbedtls
+++ b/Library/Aliases/mbedtls
@@ -1,1 +1,0 @@
-../Formula/polarssl.rb

--- a/Library/Formula/mbedtls.rb
+++ b/Library/Formula/mbedtls.rb
@@ -1,8 +1,8 @@
 class Mbedtls < Formula
   desc "Cryptographic & SSL/TLS library"
   homepage "https://tls.mbed.org/"
-  url "https://tls.mbed.org/download/mbedtls-2.1.0-gpl.tgz"
-  sha256 "b61b5fe6aa33ed365289478ac48f1496b97eef0fb813295e534e0c2bd435dcfc"
+  url "https://tls.mbed.org/download/mbedtls-2.1.1-apache.tgz"
+  sha256 "8f25b6f156ae5081e91bcc58b02455926d9324035fe5f7028a6bb5bc0139a757"
   head "https://github.com/ARMmbed/mbedtls.git"
 
   bottle do
@@ -20,7 +20,7 @@ class Mbedtls < Formula
       s.gsub! "#define MBEDTLS_SSL_PROTO_SSL3", "//#define MBEDTLS_SSL_PROTO_SSL3"
     end
 
-    system "cmake", *std_cmake_argss
+    system "cmake", *std_cmake_args
     system "make"
     system "make", "install"
 

--- a/Library/Formula/mbedtls.rb
+++ b/Library/Formula/mbedtls.rb
@@ -1,4 +1,4 @@
-class Polarssl < Formula
+class Mbedtls < Formula
   desc "Cryptographic & SSL/TLS library"
   homepage "https://tls.mbed.org/"
   url "https://tls.mbed.org/download/mbedtls-2.1.0-gpl.tgz"
@@ -20,11 +20,11 @@ class Polarssl < Formula
       s.gsub! "#define MBEDTLS_SSL_PROTO_SSL3", "//#define MBEDTLS_SSL_PROTO_SSL3"
     end
 
-    system "cmake", *std_cmake_args
+    system "cmake", *std_cmake_argss
     system "make"
     system "make", "install"
 
-    # Why does PolarSSL ship with a "Hello World" executable. Let's remove that.
+    # Why does Mbedtls ship with a "Hello World" executable. Let's remove that.
     rm_f "#{bin}/hello"
     # Rename benchmark & selftest, which are awfully generic names.
     mv bin/"benchmark", bin/"mbedtls-benchmark"

--- a/Library/Homebrew/formula_renames.rb
+++ b/Library/Homebrew/formula_renames.rb
@@ -10,4 +10,5 @@ FORMULA_RENAMES = {
   "mpich2" => "mpich",
   "plt-racket" => "racket",
   "fig" => "docker-compose",
+  "polarssl" => "mbedtls",
 }


### PR DESCRIPTION
Rename from PolarSSL as well. There are no formulae which depend on PolarSSL in Versions/Science/Dupes/Core/Nginx/PHP/Games/Apache/Python so this should be relatively simple.