### PR TITLE
argp-standalone: fetch from svn

### DIFF
--- a/Library/Formula/argp-standalone.rb
+++ b/Library/Formula/argp-standalone.rb
@@ -15,6 +15,7 @@ class ArgpStandalone < Formula
   # This patch fixes compilation with Clang.
   patch :p0 do
     url "https://svn.macports.org/repository/macports/trunk/dports/devel/argp-standalone/files/patch-argp-fmtstream.h", :using => :curl
+    mirror "https://trac.macports.org/export/86556/trunk/dports/devel/argp-standalone/files/patch-argp-fmtstream.h"
     sha256 "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8"
   end
 

--- a/Library/Formula/argp-standalone.rb
+++ b/Library/Formula/argp-standalone.rb
@@ -14,7 +14,7 @@ class ArgpStandalone < Formula
 
   # This patch fixes compilation with Clang.
   patch :p0 do
-    url "https://trac.macports.org/export/86556/trunk/dports/devel/argp-standalone/files/patch-argp-fmtstream.h"
+    url "https://svn.macports.org/repository/macports/trunk/dports/devel/argp-standalone/files/patch-argp-fmtstream.h", :using => :curl
     sha256 "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8"
   end
 


### PR DESCRIPTION
trac is down. this fetches from svn similar to 4fe7455
