### PR TITLE
Fix incorrect patch hash for pygobject 2.28.6

### DIFF
--- a/Library/Formula/pygobject.rb
+++ b/Library/Formula/pygobject.rb
@@ -19,8 +19,8 @@ class Pygobject < Formula
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=668522
   patch do
-    url "https://git.gnome.org/browse/pygobject/patch/gio/gio-types.defs?id=42d01f060c5d764baa881d13c103d68897163a49"
-    sha256 "7bb60636a9731afd030820090062688a6b53af22c276d89d6af8db264d76edcc"
+    url "https://raw.githubusercontent.com/Homebrew/patches/master/pygobject/patch-enum-types.diff"
+    sha256 "99a39c730f9af499db88684e2898a588fdae9cd20eef70675a28c2ddb004cb19"
   end
 
   def install


### PR DESCRIPTION
With current `master`, this Formula will not install due to a changed hash of a patch. I modified the hash, and the Formula compiles and installs without any problems.
