### PR TITLE
libass: add option with-fontconfig

### DIFF
--- a/Library/Formula/libass.rb
+++ b/Library/Formula/libass.rb
@@ -11,15 +11,23 @@ class Libass < Formula
     sha256 "7303bf3c119bc80d850f8e16ac1212e70224c83df3f8a3c0bf2adb0d378a6e80" => :mavericks
   end
 
+  option "with-fontconfig", "Disable CoreText backend in favor of the more traditional fontconfig"
+
   depends_on "pkg-config" => :build
   depends_on "yasm" => :build
 
   depends_on "freetype"
   depends_on "fribidi"
   depends_on "harfbuzz" => :recommended
+  depends_on "fontconfig" => :optional
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    args = ["--disable-dependency-tracking",
+            "--prefix=#{prefix}"
+           ]
+    args << "--disable-coretext" if build.with? "fontconfig"
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
libass 0.13.0 (https://github.com/libass/libass/releases/tag/0.13.0) introduced CoreText support and turned it on by default on OS X. This is good news for some (no more fontconfig caching nightmare, which is especially confusing for users new to fontconfig) but a heavy blow to the rest of us who are heavily invested in fontconfig, and at the time of writing I just don't see the same level of customizability as fontconfig when CoreText support is enabled.

Therefore, this commit attempts to optionally restore the fontconfig legacy for the users concerned by adding a `--without-coretext` option.