### PR TITLE
libpng: Add command to set up HEAD build config

### DIFF
--- a/Library/Formula/libpng.rb
+++ b/Library/Formula/libpng.rb
@@ -28,6 +28,7 @@ class Libpng < Formula
 
   def install
     ENV.universal_binary if build.universal?
+    system "autoreconf", "--force", "--install" if head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
libpng requires ./autogen.sh to be run if the source is retrieved from
the git repository because that repo does not include the config files.
The script fails, though, due to it thinking the installed autotools is
incompatible. Turns out running the autoreconf command manually works
fine, so set up formula to run that step