### PR TITLE
Encourage https for bottle hosting

### DIFF
--- a/share/doc/homebrew/Bottles.md
+++ b/share/doc/homebrew/Bottles.md
@@ -32,7 +32,7 @@ end
 A full example:
 ```ruby
 bottle do
-  root_url "http://mikemcquaid.com"
+  root_url "https://example.com"
   prefix "/opt/homebrew"
   cellar "/opt/homebrew/Cellar"
   revision 4


### PR DESCRIPTION
I assume that we want to encourage people hosting their own bottles to serve them using `https`. This PR has a trivial change in the example. We may consider adding some text to the `root_url` description with a discussion of security.