### PR TITLE
Edit doctor.rb about El Cap upgrade permissions

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -514,9 +514,10 @@ module Homebrew
         unless HOMEBREW_PREFIX.writable_real? then <<-EOS.undent
         The /usr/local directory is not writable.
         Even if this directory was writable when you installed Homebrew, other
-        software may change permissions on this directory. Some versions of the
+        software may change permissions on this directory. For example, upgrading
+        to OS X El Capitan has been known to do this. Some versions of the
         "InstantOn" component of Airfoil or running Cocktail cleanup/optimizations
-        are known to do this.
+        are known to do this as well.
 
         You should probably change the ownership and permissions of /usr/local
         back to your user account.


### PR DESCRIPTION
On all of the machines I have upgraded to OS X El Capitan, my /usr/local
directory has changed ownership. Since this message shows up as an error
during `brew update`, I figured it would be good to beef up the
explanation.