### PR TITLE
gobject-introspection: depend on python

### DIFF
--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -16,7 +16,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
-  depends_on "python" if MacOS.version == :mavericks
+  depends_on "python" if MacOS.version <= :mavericks
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",


### PR DESCRIPTION
... for all older OS X versions that don't ship with Python >=2.7