### PR TITLE
libtomcrypt: add head

### DIFF
--- a/Library/Formula/libtomcrypt.rb
+++ b/Library/Formula/libtomcrypt.rb
@@ -5,6 +5,7 @@ class Libtomcrypt < Formula
   url "http://libtom.org/files/crypt-1.17.tar.bz2"
   mirror "https://distfiles.macports.org/libtomcrypt/crypt-1.17.tar.bz2"
   sha256 "e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116"
+  head "https://github.com/libtom/libtomcrypt.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The build is failing under 10.10+ (#43906), and seems to be somewhat fixed in upstream head. The `--HEAD` build still fails when done under Homebrew, but having this in the formula should help test it out and maybe give feedback to upstream before the next release.