### PR TITLE
glm 0.9.7.1 + cmake targets config

### DIFF
--- a/Library/Formula/glm.rb
+++ b/Library/Formula/glm.rb
@@ -8,9 +8,13 @@ class Glm < Formula
 
   option "with-doxygen", "Build documentation"
   depends_on "doxygen" => [:build, :optional]
+  depends_on "cmake" => :build
 
   def install
-    include.install "glm"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
 
     if build.with? "doxygen"
       cd "doc" do


### PR DESCRIPTION
Fixes regression introduced by https://github.com/Homebrew/homebrew/pull/44076 that was caused by the new build scripts of glm.