### PR TITLE
gwyddion 2.42

### DIFF
--- a/Library/Formula/gwyddion.rb
+++ b/Library/Formula/gwyddion.rb
@@ -1,8 +1,8 @@
 class Gwyddion < Formula
   desc "Scanning Probe Microscopy visualization and analysis tool"
   homepage "http://gwyddion.net/"
-  url "http://gwyddion.net/download/2.41/gwyddion-2.41.tar.gz"
-  sha256 "093e5e20e85cbfc14786a8dcc319943ad30419bffd5ab883e7d0400161fb3cd4"
+  url "http://gwyddion.net/download/2.42/gwyddion-2.42.tar.gz"
+  sha256 "0bcafaafca1584ebcd4d7c1f1e437a67bd94749c78d9f33a74c8000bba3fb364"
 
   bottle do
     sha256 "557467222d7732e7ab0909336e60cf40e865db1802b424716c749c0acd1f3338" => :yosemite
@@ -21,14 +21,6 @@ class Gwyddion < Formula
   depends_on "gtksourceview" if build.with? "python"
 
   def install
-    # Add Python library path and prevent explicit linkage for the gwy module.
-    # Upstream patch: <http://sourceforge.net/p/gwyddion/mailman/message/34347458/>
-    inreplace "configure", 'PYTHON_LIBS=-l$libpython',
-                           %(py_prefix=`$PYTHON -c "import sys; print sys.prefix"`
-                           PYTHON_LIBS="-L${py_prefix}/lib -l$libpython")
-    inreplace "modules/pygwy/Makefile.in", '$(PYTHON_LIBS) $(PYGTK_LIBS) @GTK_LIBS@',
-                                           '-undefined dynamic_lookup $(PYGTK_LIBS) @GTK_LIBS@'
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-desktop-file-update",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
Update Gwyddion to 2.42. Hacking the build process to remove explicit Python
linkage is not required from this release on (see PR #42449).