### PR TITLE
Optimize Rust's `cargo` binary

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -66,7 +66,7 @@ class Rust < Formula
         end
       end
 
-      system "./configure", "--prefix=#{prefix}", "--local-rust-root=#{prefix}"
+      system "./configure", "--prefix=#{prefix}", "--local-rust-root=#{prefix}", "--enable-optimize"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
Historical source trees of Cargo have not optimized the produced binary by default (unlike the Rust compiler itself). Although this discrepancy should be fixed by https://github.com/rust-lang/cargo/pull/2035, I figured it'd be good to submit this here for the current Cargo regardless!