### PR TITLE
Add jack support for cmus

### DIFF
--- a/Library/Formula/cmus.rb
+++ b/Library/Formula/cmus.rb
@@ -23,6 +23,7 @@ class Cmus < Formula
   depends_on "libcue"
   depends_on "ffmpeg" => :optional
   depends_on "opusfile" => :optional
+  depends_on "jack" => :optional
 
   def install
     system "./configure", "prefix=#{prefix}", "mandir=#{man}"


### PR DESCRIPTION
In some cases, people may prefer to use jack instead of libao as an output plugin.