### PR TITLE
Codec2 0.5 (new formula)

### DIFF
--- a/Library/Formula/codec2.rb
+++ b/Library/Formula/codec2.rb
@@ -1,7 +1,7 @@
 class Codec2 < Formula
   desc "Open source speech codec."
   homepage "http://www.rowetel.com/blog/?page_id=452"
-  url "http://files.freedv.org/codec2/codec2-0.5.tar.xz"
+  url "https://files.freedv.org/codec2/codec2-0.5.tar.xz"
   sha256 "1ffda04ec6629f5ad5a38349c6d9d38d29bfbc1c677c12014ff20d480a343f17"
 
   depends_on "cmake" => :build
@@ -16,6 +16,6 @@ class Codec2 < Formula
   test do
     # 8 bytes of raw audio data (silence).
     (testpath/"test.raw").write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
-    system "#{bin}/c2enc 2400 test.raw test.c2"
+    system "#{bin}/c2enc", "2400",  "test.raw",  "test.c2"
   end
 end

--- a/Library/Formula/codec2.rb
+++ b/Library/Formula/codec2.rb
@@ -15,7 +15,7 @@ class Codec2 < Formula
 
   test do
     # 8 bytes of raw audio data (silence).
-    (testpath/"test.raw").write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
-    system "#{bin}/c2enc", "2400",  "test.raw",  "test.c2"
+    (testpath/"test.raw").write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack("C*"))
+    system "#{bin}/c2enc", "2400", "test.raw", "test.c2"
   end
 end

--- a/Library/Formula/codec2.rb
+++ b/Library/Formula/codec2.rb
@@ -1,0 +1,21 @@
+class Codec2 < Formula
+  desc "Open source speech codec."
+  homepage "http://www.rowetel.com/blog/?page_id=452"
+  url "http://files.freedv.org/codec2/codec2-0.5.tar.xz"
+  sha256 "1ffda04ec6629f5ad5a38349c6d9d38d29bfbc1c677c12014ff20d480a343f17"
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build_osx" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    # 8 bytes of raw audio data (silence).
+    (testpath/"test.raw").write([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
+    system "#{bin}/c2enc 2400 test.raw test.c2"
+  end
+end


### PR DESCRIPTION
Codec 2 is an open source speech codec designed for communications
quality speech between 700 and 3200 bit/s. The main application is low
bandwidth HF/VHF digital radio. It fills a gap in open source,
free-as-in-speech voice codecs beneath 5000 bit/s and is released under
the GNU Lesser General Public License (LGPL).