### PR TITLE
manpage: add --debug/-d to main brew synopsis

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -4,7 +4,7 @@ brew(1) -- The missing package manager for OS X
 ## SYNOPSIS
 
 `brew` `--version`<br>
-`brew` <command> [`--verbose`|`-v`] [<options>] [<formula>] ...
+`brew` <command> [`--verbose`|`-v`] [`--debug`|`-d`] [<options>] [<formula>] ...
 
 ## DESCRIPTION
 
@@ -15,7 +15,10 @@ didn't include with OS X.
 
 For the full command list, see the [COMMANDS][] section.
 
-With `--verbose` or `-v`, many commands print extra debugging information. Note that these flags should only appear after a command.
+With `--verbose` or `-v`, many commands print extra debugging information. 
+With `--debug` or `-d`, additional debugging output and behaviors are enabled.
+Details are documented under the individual commands below.
+Note that these flags should only appear after a command.
 
   * `install` <formula>:
     Install <formula>.

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -7,7 +7,7 @@
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p><code>brew</code> <code>--version</code><br />
-<code>brew</code> <var>command</var> [<code>--verbose</code>|<code>-v</code>] [<var>options</var>] [<var>formula</var>] ...</p>
+<code>brew</code> <var>command</var> [<code>--verbose</code>|<code>-v</code>] [<code>--debug</code>|<code>-d</code>] [<var>options</var>] [<var>formula</var>] ...</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -18,7 +18,10 @@ didn't include with OS X.</p>
 
 <p>For the full command list, see the <a href="#COMMANDS" title="COMMANDS" data-bare-link="true">COMMANDS</a> section.</p>
 
-<p>With <code>--verbose</code> or <code>-v</code>, many commands print extra debugging information. Note that these flags should only appear after a command.</p>
+<p>With <code>--verbose</code> or <code>-v</code>, many commands print extra debugging information.
+With <code>--debug</code> or <code>-d</code>, additional debugging output and behaviors are enabled.
+Details are documented under the individual commands below.
+Note that these flags should only appear after a command.</p>
 
 <dl>
 <dt><code>install</code> <var>formula</var></dt><dd><p>Install <var>formula</var>.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -10,7 +10,7 @@
 \fBbrew\fR \fB\-\-version\fR
 .
 .br
-\fBbrew\fR \fIcommand\fR [\fB\-\-verbose\fR|\fB\-v\fR] [\fIoptions\fR] [\fIformula\fR] \.\.\.
+\fBbrew\fR \fIcommand\fR [\fB\-\-verbose\fR|\fB\-v\fR] [\fB\-\-debug\fR|\fB\-d\fR] [\fIoptions\fR] [\fIformula\fR] \.\.\.
 .
 .SH "DESCRIPTION"
 Homebrew is the easiest and most flexible way to install the UNIX tools Apple didn\'t include with OS X\.
@@ -19,7 +19,7 @@ Homebrew is the easiest and most flexible way to install the UNIX tools Apple di
 For the full command list, see the \fICOMMANDS\fR section\.
 .
 .P
-With \fB\-\-verbose\fR or \fB\-v\fR, many commands print extra debugging information\. Note that these flags should only appear after a command\.
+With \fB\-\-verbose\fR or \fB\-v\fR, many commands print extra debugging information\. With \fB\-\-debug\fR or \fB\-d\fR, additional debugging output and behaviors are enabled\. Details are documented under the individual commands below\. Note that these flags should only appear after a command\.
 .
 .TP
 \fBinstall\fR \fIformula\fR


### PR DESCRIPTION
Adds `--debug`|`-d` to the main `brew` synopsis, establishing that it may be recognized for all commands (which it is), and establishing that other commands shouldn't use `-d` for other meanings.

Follows up discussion in #43864.