### PR TITLE
brew irb to consider --noverbose flag

### DIFF
--- a/Library/Homebrew/cmd/irb.rb
+++ b/Library/Homebrew/cmd/irb.rb
@@ -21,8 +21,10 @@ module Homebrew
       puts ":lua.f.methods - 1.methods"
       puts ":mpd.f.recursive_dependencies.reject(&:installed?)"
     else
-      ohai "Interactive Homebrew Shell"
-      puts "Example commands available with: brew irb --examples"
+      unless ARGV.include? "--noverbose"
+        ohai "Interactive Homebrew Shell"
+        puts "Example commands available with: brew irb --examples"
+      end
       IRB.start
     end
   end


### PR DESCRIPTION
Don't print console messages if `--noverbose` is supplied to `brew irb`. This flag was chosen since it is an existing `irb` command-line argument.

Before this PR:

~~~
$ echo "puts 'boost'.f.stable.url" | brew irb --noverbose --noecho
==> Interactive Homebrew Shell
Example commands available with: brew irb --examples
https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2

~~~

After this PR:

~~~
$ echo "puts 'boost'.f.stable.url" | brew irb --noverbose --noecho
https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2

~~~
