### PR TITLE
Add --with-libevent to Bitlbee formula.

### DIFF
--- a/Library/Formula/bitlbee.rb
+++ b/Library/Formula/bitlbee.rb
@@ -14,6 +14,7 @@ class Bitlbee < Formula
 
   option "with-pidgin", "Use finch/libpurple for all communication with instant messaging networks"
   option "with-libotr", "Build with otr (off the record) support"
+  option "with-libevent", "Use libevent for the event-loop handling rather than glib."
 
   deprecated_option "with-finch" => "with-pidgin"
 
@@ -24,6 +25,7 @@ class Bitlbee < Formula
   depends_on "libgcrypt"
   depends_on "pidgin" => :optional
   depends_on "libotr" => :optional
+  depends_on "libevent" => :optional
 
   def install
     args = %W[
@@ -37,6 +39,7 @@ class Bitlbee < Formula
 
     args << "--purple=1" if build.with? "pidgin"
     args << "--otr=1" if build.with? "libotr"
+    args << "--events=libevent" if build.with? "libevent"
 
     system "./configure", *args
 


### PR DESCRIPTION
Libevent handlers are considered more stable than the glib ones.