### PR TITLE
Fixes Xaric config issue with openssl

### DIFF
--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -1,7 +1,7 @@
 class Hbase < Formula
   desc "Hadoop database: a distributed, scalable, big data store"
   homepage "https://hbase.apache.org"
-  url "https://www.apache.org/dist/hbase/stable/hbase-1.1.2-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=hbase/1.1.2/hbase-1.1.2-bin.tar.gz"
   sha256 "8ca5bf0203cef86b4a0acbba89afcd5977488ebc73eec097e93c592b16f8bede"
 
   depends_on :java => "1.6+"

--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -1,8 +1,8 @@
 class Hbase < Formula
   desc "Hadoop database: a distributed, scalable, big data store"
   homepage "https://hbase.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=hbase/1.0.1.1/hbase-1.0.1.1-bin.tar.gz"
-  sha256 "fd20fd98e9c11d96d0281077e3040c81f45bafcc1e4f14318cede31e45819fdf"
+  url "https://www.apache.org/dist/hbase/stable/hbase-1.1.2-bin.tar.gz"
+  sha256 "8ca5bf0203cef86b4a0acbba89afcd5977488ebc73eec097e93c592b16f8bede"
 
   depends_on :java => "1.6+"
   depends_on "hadoop"
@@ -28,6 +28,6 @@ class Hbase < Formula
   end
 
   test do
-    assert_match /#{version}/, shell_output("#{bin}/hbase mapredcp")
+    system "hbase", "version"
   end
 end

--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -28,6 +28,6 @@ class Hbase < Formula
   end
 
   test do
-    system "hbase", "version"
+    assert_match /#{version}/, shell_output("#{bin}/hbase mapredcp")
   end
 end

--- a/Library/Formula/xaric.rb
+++ b/Library/Formula/xaric.rb
@@ -15,12 +15,12 @@ class Xaric < Formula
 
   def install
     system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "withval=#{Formula["openssl"].opt_prefix}"
     system "make", "install"
   end
 
   test do
-    assert_match(/Xaric #{version}/,
-                 shell_output("script -q /dev/null xaric -v"))
+    assert_match(/Xaric #{version}/, shell_output("script -q /dev/null xaric -v"))
   end
 end


### PR DESCRIPTION
This should fix [issue 44048](https://github.com/Homebrew/homebrew/issues/44048). The configure script needed a path to openssl opt directory and the only way to pass it was to assign it to an undocumented variable used only for this check.