### PR TITLE
Fix xaric configure with a path to openssl

### DIFF
--- a/Library/Formula/xaric.rb
+++ b/Library/Formula/xaric.rb
@@ -15,12 +15,12 @@ class Xaric < Formula
 
   def install
     system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "withval=#{Formula["openssl"].opt_prefix}"
     system "make", "install"
   end
 
   test do
-    assert_match(/Xaric #{version}/,
-                 shell_output("script -q /dev/null xaric -v"))
+    assert_match(/Xaric #{version}/, shell_output("script -q /dev/null xaric -v"))
   end
 end


### PR DESCRIPTION
This should fix [issue 44048](https://github.com/Homebrew/homebrew/issues/44048). The configure script needed a path to openssl opt directory and the only way to pass it was to assign it to an undocumented variable used only for this check.