### PR TITLE
Update chisel formula to 1.3.0

### DIFF
--- a/Library/Formula/chisel.rb
+++ b/Library/Formula/chisel.rb
@@ -2,7 +2,7 @@ class Chisel < Formula
   desc "Collection of LLDB commands to assist debugging iOS apps"
   homepage "https://github.com/facebook/chisel"
   url "https://github.com/facebook/chisel/archive/1.3.0.tar.gz"
-  sha256 "7feed485053a2ee1a245be6f6fa43bda9565f936f36aa63309467812135e515b"
+  sha256 "6e8f64a1cb48b0937a98a7d62dc0c6de8cea5afa0040088b426d166e188a6f59"
 
   def install
     libexec.install Dir["*.py", "commands"]

--- a/Library/Formula/chisel.rb
+++ b/Library/Formula/chisel.rb
@@ -1,8 +1,8 @@
 class Chisel < Formula
   desc "Collection of LLDB commands to assist debugging iOS apps"
   homepage "https://github.com/facebook/chisel"
-  url "https://github.com/facebook/chisel/archive/1.2.0.tar.gz"
-  sha256 "af22dde2c5b4f0832f25ac0d3831c43a227f148f97ca7e6bab71e10b2b3225b5"
+  url "https://github.com/facebook/chisel/archive/1.3.0.tar.gz"
+  sha256 "7feed485053a2ee1a245be6f6fa43bda9565f936f36aa63309467812135e515b"
 
   def install
     libexec.install Dir["*.py", "commands"]


### PR DESCRIPTION
This updates the formula for [chisel](https://github.com/facebook/chisel) to 1.3.0. Release info can be found here: https://github.com/facebook/chisel/releases/tag/1.3.0

thanks!