### PR TITLE
Let the user know what exactly was already tapped

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -15,7 +15,7 @@ module Homebrew
     else
       user, repo = tap_args
       clone_target = ARGV.named[1]
-      opoo "#{user}/#{repo} already tapped" unless install_tap(user, repo, clone_target)
+      opoo "#{user}/#{repo} already tapped!" unless install_tap(user, repo, clone_target)
     end
   end
 

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -15,7 +15,7 @@ module Homebrew
     else
       user, repo = tap_args
       clone_target = ARGV.named[1]
-      opoo "Already tapped!" unless install_tap(user, repo, clone_target)
+      opoo "#{user}/#{repo} already tapped" unless install_tap(user, repo, clone_target)
     end
   end
 


### PR DESCRIPTION
This will make it easier to debug scripts that might do multiple taps etc.

Before:

```sh
❯ brew tap homebrew/services
Warning: Already tapped!
```

After:

```
❯ brew tap homebrew/services
Warning: homebrew/services already tapped!
```