### PR TITLE
Blas dependency

### DIFF
--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -1,0 +1,18 @@
+class Blastest < Formula
+  desc "blas test"
+  homepage "https://tds.xyz"
+  url "https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c"
+  sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
+  version "1.0"
+
+  depends_on :blas if OS.linux?
+
+  def install
+    system "#{ENV.cc} blastest.c #{ENV["HOMEBREW_BLAS_CFLAGS"]} -o blastest #{ENV["HOMEBREW_BLAS_LDFLAGS"]}"
+    bin.install "blastest"
+  end
+
+  test do
+    system bin/"blastest"
+  end
+end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -8,13 +8,9 @@ class Blastest < Formula
   depends_on :blas
 
   def install
-    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
-    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
-    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -5,10 +5,17 @@ class Blastest < Formula
   sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
   version "1.0"
 
-  depends_on :blas if OS.linux?
+  depends_on :blas
 
   def install
-    system "#{ENV.cc} blastest.c #{ENV["HOMEBREW_BLAS_CFLAGS"]} -o blastest #{ENV["HOMEBREW_BLAS_LDFLAGS"]}"
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags   += " -pthread -lm"
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end
 

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -11,6 +11,7 @@ class Blastest < Formula
     ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
+    ohai "Full path: " + BlasRequirement.full_path(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"],";")
     system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -2,16 +2,16 @@ class Blastest < Formula
   desc "blas test"
   homepage "https://tds.xyz"
   url "https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c"
-  sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
   version "1.0"
+  sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
 
   depends_on :blas
 
   def install
-    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"], ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
-    ohai "Full path: " + BlasRequirement.full_path(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"],";")
+    ohai "Full path: " + BlasRequirement.full_path(ENV["HOMEBREW_BLASLAPACK_LIB"], ENV["HOMEBREW_BLASLAPACK_NAMES"], ";")
     system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -1,6 +1,6 @@
 class Blastest < Formula
   desc "blas test"
-  homepage "https://tds.xyz"
+  homepage "https://github.com/tdsmith"
   url "https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c"
   version "1.0"
   sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
@@ -12,7 +12,8 @@ class Blastest < Formula
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     ohai "Full path: " + BlasRequirement.full_path(ENV["HOMEBREW_BLASLAPACK_LIB"], ENV["HOMEBREW_BLASLAPACK_NAMES"], ";")
-    system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
+    to_run = "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
+    system to_run
     bin.install "blastest"
   end
 

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -1,0 +1,26 @@
+class BlastestSingle < Formula
+  desc "blas test for veclibfort (single)"
+  homepage "https://tds.xyz"
+  url "https://gist.githubusercontent.com/davydden/1f9ebf3692beca2438f8/raw/0ba39c8775db3bb21c09c3440bf78ff5f778277d/blas.f90"
+  sha256 "9fad00d1d7e8d5d0be3c16fd25755c5d089205fae9dd4716481f8072a6a7f954"
+  version "1.0"
+
+  depends_on :fortran
+  depends_on :blas => :fortran
+
+  def install
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags   += " -pthread -lm"
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
+    bin.install "blastest_single"
+  end
+ 
+  test do
+    system bin/"blastest_single"
+  end
+end

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -9,13 +9,9 @@ class BlastestSingle < Formula
   depends_on :blas => :fortran
 
   def install
-    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
-    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
-    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
     bin.install "blastest_single"
   end

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -12,7 +12,8 @@ class BlastestSingle < Formula
     ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"], ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
-    system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
+    to_run = "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
+    system to_run
     bin.install "blastest_single"
   end
 

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -1,21 +1,21 @@
 class BlastestSingle < Formula
-  desc "blas test for veclibfort (single)"
-  homepage "https://tds.xyz"
+  desc "blas test for veclibfort (single Fortran BLAS)"
+  homepage "https://github.com/davydden"
   url "https://gist.githubusercontent.com/davydden/1f9ebf3692beca2438f8/raw/0ba39c8775db3bb21c09c3440bf78ff5f778277d/blas.f90"
-  sha256 "9fad00d1d7e8d5d0be3c16fd25755c5d089205fae9dd4716481f8072a6a7f954"
   version "1.0"
+  sha256 "9fad00d1d7e8d5d0be3c16fd25755c5d089205fae9dd4716481f8072a6a7f954"
 
   depends_on :fortran
   depends_on :blas => :fortran
 
   def install
-    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"], ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
     bin.install "blastest_single"
   end
- 
+
   test do
     system bin/"blastest_single"
   end

--- a/Library/Formula/veclibfort.rb
+++ b/Library/Formula/veclibfort.rb
@@ -1,0 +1,37 @@
+require 'formula'
+
+class Veclibfort < Formula
+  homepage 'https://github.com/mcg1969/vecLibFort'
+  url 'https://github.com/mcg1969/vecLibFort/archive/0.4.2.tar.gz'
+  sha1 'fee75b043a05f1dc7ec6649cbab73e23a71a9471'
+  head 'https://github.com/mcg1969/vecLibFort.git'
+  revision 2
+
+  bottle do
+    cellar :any
+    sha256 "e981968fc514cbccfa297059be14bab5f75cf769a2da51a571c6c737e5a77a02" => :yosemite
+    sha256 "3260bc42e14b071a2b02b482baed8443b35835972b5edbbae9903864cb164fee" => :mavericks
+    sha256 "7fa568f525a34092d731ebdcc181636f9e733a2716dc42b51a94d01182b359ee" => :mountain_lion
+  end
+
+  option "without-check", "Skip build-time tests (not recommended)"
+
+  depends_on :fortran
+
+  def install
+    ENV.m64 if MacOS.prefer_64_bit?
+    system "make", "all"
+    system "make", "check" if build.with? "check"
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  def caveats
+    caveats = <<-EOS.undent
+      Installs the following files:
+        * libvecLibFort.a: static library; link with -framework vecLib
+        * libvecLibFort.dylib: dynamic library; *replaces* -framework vecLib
+        * libvecLibFortI.dylib: preload (interpose) library.
+      Please see the home page for usage details.
+    EOS
+  end
+end

--- a/Library/Formula/veclibfort.rb
+++ b/Library/Formula/veclibfort.rb
@@ -1,10 +1,9 @@
-require 'formula'
-
 class Veclibfort < Formula
-  homepage 'https://github.com/mcg1969/vecLibFort'
-  url 'https://github.com/mcg1969/vecLibFort/archive/0.4.2.tar.gz'
-  sha1 'fee75b043a05f1dc7ec6649cbab73e23a71a9471'
-  head 'https://github.com/mcg1969/vecLibFort.git'
+  desc "Gnu Fortran interface to Accelerate/vecLib"
+  homepage "https://github.com/mcg1969/vecLibFort"
+  url "https://github.com/mcg1969/vecLibFort/archive/0.4.2.tar.gz"
+  sha256 "c61316632bffa1c76e3c7f92b11c9def4b6f41973ecf9e124d68de6ae37fbc85"
+  head "https://github.com/mcg1969/vecLibFort.git"
   revision 2
 
   bottle do
@@ -26,7 +25,7 @@ class Veclibfort < Formula
   end
 
   def caveats
-    caveats = <<-EOS.undent
+    <<-EOS.undent
       Installs the following files:
         * libvecLibFort.a: static library; link with -framework vecLib
         * libvecLibFort.dylib: dynamic library; *replaces* -framework vecLib

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -126,6 +126,8 @@ class DependencyCollector
       Dependency.new("libtool", tags)
     when :python2
       PythonRequirement.new(tags)
+    when :blas
+      BlasRequirement.new(tags)
     else
       raise ArgumentError, "Unsupported special dependency #{spec.inspect}"
     end

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,5 +1,6 @@
 require "requirement"
 require "requirements/apr_requirement"
+require "requirements/blas_requirement"
 require "requirements/fortran_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -1,0 +1,47 @@
+require "requirement"
+
+class BlasRequirement < Requirement
+  fatal true
+  default_formula "openblas"
+
+  # This ensures that HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS
+  # are always set. It does _not_ add them to CFLAGS or LDFLAGS; that
+  # should happen inside the formula.
+  env do
+    if @satisfied_result
+      ENV["HOMEBREW_BLAS_CFLAGS"] ||= ""
+      ENV["HOMEBREW_BLAS_LDFLAGS"] ||= "-lblas -llapack"
+    else
+      ENV["HOMEBREW_BLAS_CFLAGS"] = "-I#{Formula["openblas"].opt_include}"
+      ENV["HOMEBREW_BLAS_LDFLAGS"] = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+    end
+  end
+
+  satisfy :build_env => true do
+    cflags = ENV["HOMEBREW_BLAS_CFLAGS"] || ""
+    ldflags = ENV["HOMEBREW_BLAS_LDFLAGS"] || "-lblas -llapack"
+    success = nil
+    Dir.mktmpdir do |tmpdir|
+      tmpdir = Pathname.new tmpdir
+      (tmpdir/"blastest.c").write <<-EOS.undent
+        double cblas_ddot(const int, const double*, const int, const double*, const int);
+        int main() {
+          double x[] = {1.0, 2.0, 3.0}, y[] = {4.0, 5.0, 6.0};
+          cblas_ddot(3, x, 1, y, 1);
+          return 0;
+        }
+      EOS
+      success = system "#{ENV["CC"]} #{cflags} #{tmpdir}/blastest.c -o #{tmpdir}/blastest #{ldflags}",
+                :err => "/dev/null"
+    end
+    if !success
+      opoo "BLAS not configured"
+      puts <<-EOS.undent
+        Falling back to brewed openblas. If you prefer to use a system BLAS,
+        please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
+        values.
+      EOS
+    end
+    success
+  end
+end

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -25,13 +25,27 @@ class BlasRequirement < Requirement
     end
   end
 
+  def self.ldflags(blas_lib,blas_names)
+    res  = blas_lib != "" ? "-L#{blas_lib} " : ""
+    res += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    return res
+  end
+
+  def self.cflags(blas_inc)
+    return blas_inc != "" ? "-I#{blas_inc}"  : ""
+  end
+
+  def self.full_path(blas_lib,blas_names,separator)
+    exten = (OS.mac?) ? "dylib" : "so"
+    return blas_names.split(";").map { |word| "#{blas_lib}/lib#{word}.#{exten}" }.join(separator)
+  end
+
   satisfy :build_env => true do
     blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"] || "blas;lapack"
     blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]   || ""
     blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]   || ""
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    cflags     = BlasRequirement.cflags(blas_inc)
+    ldflags    = BlasRequirement.ldflags(blas_lib,blas_names)
     # MKL BLAS may want to link against libpthread (e.g. pthread_mutex_trylock)
     # and we most likely need basic math (atan2, sin, etc) from libm
     # Adding both won't make much harm:

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -37,7 +37,8 @@ class BlasRequirement < Requirement
 
   def self.full_path(blas_lib,blas_names,separator)
     exten = (OS.mac?) ? "dylib" : "so"
-    return blas_names.split(";").map { |word| "#{blas_lib}/lib#{word}.#{exten}" }.join(separator)
+    tmp = blas_lib.chomp("/")
+    return blas_names.split(";").map { |word| "#{tmp}/lib#{word}.#{exten}" }.join(separator)
   end
 
   satisfy :build_env => true do

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -4,22 +4,32 @@ class BlasRequirement < Requirement
   fatal true
   default_formula "openblas"
 
-  # This ensures that HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS
-  # are always set. It does _not_ add them to CFLAGS or LDFLAGS; that
-  # should happen inside the formula.
+  # This ensures that HOMEBREW_BLASLAPACK_NAMES, HOMEBREW_BLASLAPACK_LIB 
+  # and HOMEBREW_BLASLAPACK_INC are always set. It does _not_ add them to 
+  # CFLAGS or LDFLAGS; that should happen inside the formula.
   env do
     if @satisfied_result
-      ENV["HOMEBREW_BLAS_CFLAGS"] ||= ""
-      ENV["HOMEBREW_BLAS_LDFLAGS"] ||= "-lblas -llapack"
+      ENV["HOMEBREW_BLASLAPACK_NAMES"] ||= "blas;lapack"
+      ENV["HOMEBREW_BLASLAPACK_LIB"]   ||= ""
+      ENV["HOMEBREW_BLASLAPACK_INC"]   ||= ""
     else
-      ENV["HOMEBREW_BLAS_CFLAGS"] = "-I#{Formula["openblas"].opt_include}"
-      ENV["HOMEBREW_BLAS_LDFLAGS"] = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+      ENV["HOMEBREW_BLASLAPACK_NAMES"]   = "openblas"
+      ENV["HOMEBREW_BLASLAPACK_LIB"]     = "#{Formula["openblas"].opt_lib}"
+      ENV["HOMEBREW_BLASLAPACK_INC"]     = "#{Formula["openblas"].opt_include}"
     end
   end
 
   satisfy :build_env => true do
-    cflags = ENV["HOMEBREW_BLAS_CFLAGS"] || ""
-    ldflags = ENV["HOMEBREW_BLAS_LDFLAGS"] || "-lblas -llapack"
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"] || "blas;lapack"
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]   || ""
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]   || ""
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    # MKL BLAS may want to link against libpthread (e.g. pthread_mutex_trylock)
+    # and we most likely need basic math (atan2, sin, etc) from libm
+    # Adding both won't make much harm:
+    ldflags   += " -lpthread -lm"
     success = nil
     Dir.mktmpdir do |tmpdir|
       tmpdir = Pathname.new tmpdir
@@ -37,9 +47,11 @@ class BlasRequirement < Requirement
     if !success
       opoo "BLAS not configured"
       puts <<-EOS.undent
-        Falling back to brewed openblas. If you prefer to use a system BLAS,
-        please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
-        values.
+        Falling back to brewed openblas. If you prefer to use a system BLAS, please set
+          HOMEBREW_BLASLAPACK_NAMES (e.g. "mkl_intel_lp64;mkl_sequential;mkl_core")
+          HOMEBREW_BLASLAPACK_LIB   (e.g. "${MKLROOT}/lib/intel64")
+          HOMEBREW_BLASLAPACK_INC   (e.g. "${MKLROOT}/include")
+        to correct values.
       EOS
     end
     success

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -6,9 +6,7 @@ class BlasRequirement < Requirement
   # the only case when test should fail is when we
   # need BLAS with single precision or complex with Fortran =>
   # use veclibfort
-  default_formula "veclibfort" if OS.mac?
-  # On Linux we can always fallback to openblas
-  default_formula "openblas"   unless OS.mac?
+  default_formula "veclibfort"
 
   def initialize(tags = [])
     # if we are on OSX and need fortran and veclibfort is installed


### PR DESCRIPTION
this is a result of a big disscussion about [linuxbrew on a cluster](https://github.com/Homebrew/linuxbrew/issues/504) with @Rombur @dpo @tjhei @jppelteret @dctrud @sjackman  and two PRs: [original by @tdsmith](https://github.com/Homebrew/linuxbrew/pull/511) and my further work [here](https://github.com/Homebrew/linuxbrew/pull/592).

By introducing `:blas` dependency we:

1. Avoid all `depends_on openblas => :optional`. If someone wants to compile everything with openblas, it's one place to set this;
2. Sometimes we need to use `veclibfort` to wrap `-framework Accelerate` to use single precision or complex valued BLAS Fortran routines. It's is now also done automatically inside the dependency. So in many formulae we will be able cut down something like `if OSX? use veclibfort else if "openblas" use openblas else use "-llapack -lblas"`.
3. As far as blas is concered, formulae in Homebrew-science will have the same code be it OS-X or Linuxbrew. 
4. Finally, the whole infrastructure is ready to use BLAS natively provided by computer vendors or other alternatives such as Atlas and most notably **Math-Kernel-Library (MKL)**, which recently [became free](https://software.intel.com/en-us/articles/free_mkl) and hopefully will be soon available for OSX. 


Summary of `:blas` usage cases which were tested on  a) **CentOS cluster + MKL**; b) **Ubuntu 14.04 + Openblas**;  b) **Ubuntu 14.04 + system blas** are:
1. library names (space/semicolon separated) + dir: [Hypre](https://github.com/davydden/homebrew-science/blob/mkl_dealii/hypre.rb#L39-L45), [Trilinos](https://github.com/davydden/homebrew-science/blob/mkl_dealii/trilinos.rb#L115-L120)
2. ldflags : [Superlu_dist](https://github.com/davydden/homebrew-science/blob/mkl_dealii/superlu_dist.rb#L31), [scalapack](https://github.com/davydden/homebrew-science/blob/mkl_dealii/scalapack.rb#L28-L29), [mumps](https://github.com/davydden/homebrew-science/blob/mkl_dealii/mumps.rb#L107-L108), [p4est](https://github.com/davydden/homebrew-science/blob/mkl_dealii/p4est.rb#L32)
3. full path (space/semicolon separated) : [Petsc](https://github.com/davydden/homebrew-science/blob/mkl_dealii/petsc.rb#L92-L93), [deal.II](https://github.com/davydden/homebrew-science/blob/mkl_dealii/dealii.rb#L58-L62)


@tdsmith [proposed](https://github.com/Homebrew/linuxbrew/pull/511#issuecomment-140774803) to name it `:blas_lapack`, which is cleaner. I have not changed the name yet as there are some static functions of `BlasRequirement` class. One can also discuss the name of the tag (currently `:fortran`), perhaps something like `:fortran_single` (single precision) will be more descriptive. But this are minor changes easy to make if desired. I am open to add further in-code comments if needed.


ps. 

here is a nice summary article about BLAS and LAPACK http://glennklockwood.blogspot.de/2014/02/quantum-espresso-compiling-and-choice.html

>BLAS is the lowest-level library and provides subroutines that do basic vector operations.  Netlib provides a reference implementation of BLAS written in Fortran, but the big idea behind BLAS is to allow hardware vendors to provide highly tuned versions of the BLAS subroutines that obviate the need for application developers to worry about optimizing their linear algebra for every possible computer architecture on which the application might run.  This motivation is also what gave rise to the MPI standard, but unlike MPI, BLAS is not an actual standard.
>
>LAPACK builds upon BLAS and provides higher-level matrix operations such as diagonalization (i.e., solving for eigenvectors and eigenvalues) and inversion.  BLAS and LAPACK seem to be bundled together when actually implemented (e.g., IBM ESSL and Intel MKL both provide both optimized BLAS and LAPACK), but they provide two distinct layers of abstracting the mathematical complexity away from application developers.
>