### PR TITLE
cspice & openhmd: missing conflicts_with added

### DIFF
--- a/Library/Formula/cspice.rb
+++ b/Library/Formula/cspice.rb
@@ -12,6 +12,9 @@ class Cspice < Formula
     sha1 "c9c33e2601e87f6608c4b58ba51b549b6e04a0c9" => :lion
   end
 
+  conflicts_with "openhmd", :because => "both install `simple` binaries"
+  conflicts_with "libftdi0", :because => "both install `simple` binaries"
+
   def install
     rm_f Dir["lib/*"]
     rm_f Dir["exe/*"]

--- a/Library/Formula/openhmd.rb
+++ b/Library/Formula/openhmd.rb
@@ -18,6 +18,9 @@ class Openhmd < Formula
     depends_on "libtool" => :build
   end
 
+  conflicts_with "cspice", :because => "both install `simple` binaries"
+  conflicts_with "libftdi0", :because => "both install `simple` binaries"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "hidapi"


### PR DESCRIPTION
I’m using a PR to build the El Cap bottles.