### PR TITLE
watchman 3.9.0

### DIFF
--- a/Library/Formula/watchman.rb
+++ b/Library/Formula/watchman.rb
@@ -1,8 +1,7 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/v3.9.0-rc1.tar.gz"
-  version "3.9.0"
+  url "https://github.com/facebook/watchman/archive/v3.9.0.tar.gz"
   sha256 "50c6770872dcc7bac6e6e31d69e80bf8cc4f25deec95916bf65d7086f6c0b0d9"
   head "https://github.com/facebook/watchman.git"
 

--- a/Library/Formula/watchman.rb
+++ b/Library/Formula/watchman.rb
@@ -2,7 +2,7 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v3.9.0.tar.gz"
-  sha256 "50c6770872dcc7bac6e6e31d69e80bf8cc4f25deec95916bf65d7086f6c0b0d9"
+  sha256 "1739cd2d6846cc688b12911c37406fae5601d76c0d11f3da957c2b7273941221"
   head "https://github.com/facebook/watchman.git"
 
   bottle do

--- a/Library/Formula/watchman.rb
+++ b/Library/Formula/watchman.rb
@@ -1,8 +1,9 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/v3.8.0.tar.gz"
-  sha256 "10d1e134e6ff110044629a517e7c69050fb9e4a26f21079b267989119987b40d"
+  url "https://github.com/facebook/watchman/archive/v3.9.0-rc1.tar.gz"
+  version "3.9.0"
+  sha256 "50c6770872dcc7bac6e6e31d69e80bf8cc4f25deec95916bf65d7086f6c0b0d9"
   head "https://github.com/facebook/watchman.git"
 
   bottle do


### PR DESCRIPTION
Tested via:

```
brew install watchman
brew audit watchman
brew test watchman
```

Note: I'll update this to point to the final 3.9.0 tag after we see the results from the brew CI build.

I'm using an API introduced in 10.10 so I wouldn't be surprised if we see a failure on the older releases.
Assuming that it builds fine on all systems, I'll add the tag and update.