### PR TITLE
git-imerge: allow completion (for HEAD builds)

### DIFF
--- a/Library/Formula/git-imerge.rb
+++ b/Library/Formula/git-imerge.rb
@@ -16,6 +16,10 @@ class GitImerge < Formula
   def install
     bin.mkpath
     system "make", "install", "PREFIX=#{prefix}"
+    # completion hasn't been released in a tagged stable version yet
+    if build.head?
+      bash_completion.install "git-imerge.bashcomplete"
+    end
   end
 
   test do


### PR DESCRIPTION
git-imerge has provided bash-completion for a over a year now, but the project hasn't made a numbered version release in that time.

We can take advantage of it in the mean time (and drop the condition when the next version of git-imerge is formally released).