### PR TITLE
brew doctor: per formula doctor blocks

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -1257,6 +1257,15 @@ class Checks
     s
   end
 
+  # define custom checks provided by installed formulas
+  Formula.installed.each do |f|
+    if f.respond_to?(:doctor)
+      define_method "check_#{f.name}" do
+        f.doctor
+      end
+    end
+  end
+
   def all
     methods.map(&:to_s).grep(/^check_/)
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1860,6 +1860,10 @@ class Formula
       define_method(:test, &block)
     end
 
+    def doctor(&block)
+      define_method(:doctor, &block)
+    end
+
     # @private
     def link_overwrite(*paths)
       paths.flatten!


### PR DESCRIPTION
**Feature idea**

The gist is formulas themselves can provide `doctor do` blocks (similar to `test do`) that are included in `brew doctor`.

Since this is more of a debugging feature, I'm wondering how useful this would be to the homebrew maintainers? Are there enough use cases for certain problematic formulas that'd it be useful to have some custom doctor logic?

Could this also cleanup existing brew doctor checks? Could some existing formula specific checks be organized into the relevant formula itself?

--
To: @mikemcquaid 