### PR TITLE
xlslib 2.5.0

### DIFF
--- a/Library/Formula/xlslib.rb
+++ b/Library/Formula/xlslib.rb
@@ -1,9 +1,9 @@
 class Xlslib < Formula
   desc "C++/C library to construct Excel .xls files in code"
   homepage "https://sourceforge.net/projects/xlslib"
-  url "https://downloads.sourceforge.net/project/xlslib/xlslib-old/xlslib-package-2.4.0.zip"
-  mirror "https://dl.bintray.com/homebrew/mirror/xlslib-package-2.4.0.zip"
-  sha256 "acc92e31294f91d8ac8adbbfc84f7a8917f7ad649a6c97b71c9f95c25887f840"
+  url "https://downloads.sourceforge.net/project/xlslib/xlslib-package-2.5.0.zip"
+  mirror "https://dl.bintray.com/homebrew/mirror/xlslib-package-2.5.0.zip"
+  sha256 "05a5d052ffdd6590755949d80d16a56285561557bc9a5e887e3b8b3fef92a3f3"
 
   bottle do
     cellar :any
@@ -13,8 +13,13 @@ class Xlslib < Formula
     sha256 "a984b3016532ffaeee04cffb60b19e61aa44ab70ad4fcf91a6f8daa87319e744" => :mavericks
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
     cd "xlslib"
+    system "autoreconf", "-i" # shipped configure hardcodes automake-1.13
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
* Updated to latest upstream version 2.5.0
* Added autotools dependency and reconf, because shipped configure script hardcodes calls to `automake-1.13` in the generated Makefile