### PR TITLE
graphicsmagick 1.3.22

### DIFF
--- a/Library/Formula/graphicsmagick.rb
+++ b/Library/Formula/graphicsmagick.rb
@@ -1,8 +1,8 @@
 class Graphicsmagick < Formula
   desc "Image processing tools collection"
   homepage "http://www.graphicsmagick.org/"
-  url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.21/GraphicsMagick-1.3.21.tar.bz2"
-  sha256 "a0ce08f2710c158e39faa083463441f6eeeecce07dbd59510498ffa4e0b053d1"
+  url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.22/GraphicsMagick-1.3.22.tar.bz2"
+  sha256 "eccde8534de936e23a32466c08ae6ebab559f29ad553262ed648de8012c7b23f"
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg
 
   bottle do
@@ -29,7 +29,6 @@ class Graphicsmagick < Formula
 
   depends_on :x11 => :optional
   depends_on "libtiff" => :optional
-  depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
   depends_on "jasper" => :optional
   depends_on "libwmf" => :optional
@@ -72,7 +71,6 @@ class Graphicsmagick < Formula
     args << "--without-x" if build.without? "x11"
     args << "--without-ttf" if build.without? "freetype"
     args << "--without-xml" if build.without? "svg"
-    args << "--without-lcms" if build.without? "little-cms"
     args << "--without-lcms2" if build.without? "little-cms2"
 
     # versioned stuff in main tree is pointless for us


### PR DESCRIPTION
According to the `NEWS` file, this version drops support for little-cms v1, but little-cms2 is still supported.