### PR TITLE
Update gnuradio.rb formula. numpy version 1.10.1

### DIFF
--- a/Library/Formula/gnuradio.rb
+++ b/Library/Formula/gnuradio.rb
@@ -49,8 +49,8 @@ class Gnuradio < Formula
   depends_on "portaudio" => :recommended
 
   resource "numpy" do
-    url "https://downloads.sourceforge.net/project/numpy/NumPy/1.10.0b1/numpy-1.10.0b1.tar.gz"
-    sha256 "855695405092686264dc8ce7b3f5c939a6cf1a5639833e841a5bb6fb799cd6a8"
+    url "http://downloads.sourceforge.net/project/numpy/NumPy/1.10.1/numpy-1.10.1.tar.gz"
+    sha256 "8b9f453f29ce96a14e625100d3dcf8926301d36c5f622623bf8820e748510858"
   end
 
   # cheetah starts here

--- a/Library/Formula/gnuradio.rb
+++ b/Library/Formula/gnuradio.rb
@@ -49,7 +49,7 @@ class Gnuradio < Formula
   depends_on "portaudio" => :recommended
 
   resource "numpy" do
-    url "http://downloads.sourceforge.net/project/numpy/NumPy/1.10.1/numpy-1.10.1.tar.gz"
+    url "https://downloads.sourceforge.net/project/numpy/NumPy/1.10.1/numpy-1.10.1.tar.gz"
     sha256 "8b9f453f29ce96a14e625100d3dcf8926301d36c5f622623bf8820e748510858"
   end
 


### PR DESCRIPTION
Existing download link return 404

```
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "gnuradio--numpy"
Download failed: https://downloads.sourceforge.net/project/numpy/NumPy/1.10.0b1/numpy-1.10.0b1.tar.gz
```