### PR TITLE
FormulaValidationError: include full_name

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -23,11 +23,12 @@ class NoSuchKegError < RuntimeError
 end
 
 class FormulaValidationError < StandardError
-  attr_reader :attr
+  attr_reader :attr, :formula
 
-  def initialize(attr, value)
+  def initialize(formula, attr, value)
     @attr = attr
-    super "invalid attribute: #{attr} (#{value.inspect})"
+    @formula = formula
+    super "invalid attribute for formula '#{formula}': #{attr} (#{value.inspect})"
   end
 end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -182,17 +182,17 @@ class Formula
 
   def validate_attributes!
     if name.nil? || name.empty? || name =~ /\s/
-      raise FormulaValidationError.new(:name, name)
+      raise FormulaValidationError.new(full_name, :name, name)
     end
 
     url = active_spec.url
     if url.nil? || url.empty? || url =~ /\s/
-      raise FormulaValidationError.new(:url, url)
+      raise FormulaValidationError.new(full_name, :url, url)
     end
 
     val = version.respond_to?(:to_str) ? version.to_str : version
     if val.nil? || val.empty? || val =~ /\s/
-      raise FormulaValidationError.new(:version, val)
+      raise FormulaValidationError.new(full_name, :version, val)
     end
   end
 


### PR DESCRIPTION
This would make debugging easier.

You can try with the following:
```
$ brew install trash
$ vim trash.rb # edit the trash.rb formula to remove the version from the URL
$ brew cleanup trash
```

Before:
```
Error: invalid attribute: version (nil)
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/formula.rb:195:in `validate_attributes!'
…snip…
```

After:
```
Error: invalid attribute for formula 'trash': version (nil)
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/formula.rb:195:in `validate_attributes!'
…snip…
```

Don’t forget to checkout/edit the `trash.rb` formula to get the version back after the test.