### PR TITLE
poppler: refuse to build with incompatible options

### DIFF
--- a/Library/Formula/poppler.rb
+++ b/Library/Formula/poppler.rb
@@ -52,7 +52,9 @@ class Poppler < Formula
       --enable-introspection=yes
     ]
 
-    if build.with? "qt"
+    if build.with?("qt") && build.with?("qt5")
+      raise "poppler: --with-qt and --with-qt5 cannot be used at the same time"
+    elsif build.with? "qt"
       args << "--enable-poppler-qt4"
     elsif build.with? "qt5"
       args << "--enable-poppler-qt5"


### PR DESCRIPTION
Previously, if both `--with-qt` and `--with-qt5` were passed, the latter was silently ignored. This sometimes caused confusion because the Qt 5 bindings were missing. The build now aborts in such cases and prints a helpful error message.

This PR is motivated by #44150. The reasons for using `odie` instead of something non-fatal are:

- A message that does not interrupt the build will very likely stay unnoticed. The resulting absence of the requested Qt 5 bindings will confuse the user.
- There are already formulae that prefer to fail instead of partially ignoring some arguments, e.g., `pyqt`, `pyqt5`, `sip`.