### PR TITLE
Upgrade repo launcher command to 1.22

### DIFF
--- a/Library/Formula/repo.rb
+++ b/Library/Formula/repo.rb
@@ -1,9 +1,10 @@
 class Repo < Formula
   desc "Repository tool for Android development"
   homepage "https://source.android.com/source/developing.html"
-  url "https://raw.githubusercontent.com/android/tools_repo/v1.12.32/repo"
+  url "https://gerrit.googlesource.com/git-repo.git",
+      :tag => "v1.12.32",
+      :revision => "745b4ad660f8050045b521c4e15b7d3ac0b3d70e"
   version "1.22"
-  sha256 "9907c36d63cf5222d73ab270fee5249dc84f6b4580cda03ddd7ac309f11b289e"
 
   def install
     bin.install "repo"


### PR DESCRIPTION
The old android source on github is no longer maintained, so switch to the official git repository.