### PR TITLE
re2c: Remove --disable-debug from configure args

### DIFF
--- a/Library/Formula/re2c.rb
+++ b/Library/Formula/re2c.rb
@@ -13,8 +13,7 @@ class Re2c < Formula
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
--disable-debug is no longer recognized by the configure script.