### PR TITLE
Update docker formula for v1.8.3

### DIFF
--- a/Library/Formula/docker.rb
+++ b/Library/Formula/docker.rb
@@ -1,8 +1,8 @@
 class Docker < Formula
   desc "Pack, ship and run any application as a lightweight container"
   homepage "https://www.docker.com/"
-  url "https://github.com/docker/docker.git", :tag => "v1.8.2",
-                                              :revision => "0a8c2e3717cb3a6fe4e8cb10243cb06473052541"
+  url "https://github.com/docker/docker.git", :tag => "v1.8.3",
+                                              :revision => "f4bf5c7026816785d9f63c07e87f9450a49f2403"
   head "https://github.com/docker/docker.git"
 
   bottle do


### PR DESCRIPTION
Fixes #44961 

Docker recently released a security update in v1.8.3, as mentioned in the issue I referenced. This PR updates the docker formula accordingly. All tests are passing locally and it should be good to go. Please let me know if I've missed anything. Thanks. 