### PR TITLE
mpd: Allow optional libmad dependency

### DIFF
--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -61,6 +61,7 @@ class Mpd < Formula
   depends_on "opus" => :optional        # Opus support
   depends_on "libvorbis" => :optional
   depends_on "libnfs" => :optional
+  depends_on "mad" => :optional
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -82,7 +83,7 @@ class Mpd < Formula
       --disable-libwrap
     ]
 
-    args << "--disable-mad"
+    args << "--disable-mad" if build.without? "mad"
     args << "--disable-curl" if MacOS.version <= :leopard
 
     args << "--enable-zzip" if build.with? "libzzip"


### PR DESCRIPTION
I have been unable to stream from internet radio stations (any mp3 streams I have tried, such as "http://relay2.hirschmilch.de:5000/psytrance.mp3") due to a crash in ffmpeg:

<pre>
Oct 14 16:46 : ffmpeg: detected input format 'mp3' (MP2/3 (MPEG audio layer 2/3))
mpd(24330,0x112aad000) malloc: *** error for object 0x112aaabe0: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
</pre>

This pull request enables an optional dependency on libmad as a workaround.