### PR TITLE
swiftgen 0.5.0

### DIFF
--- a/Library/Formula/swiftgen.rb
+++ b/Library/Formula/swiftgen.rb
@@ -1,8 +1,8 @@
 class Swiftgen < Formula
   desc "Collection of Swift tools to generate Swift code"
   homepage "https://github.com/AliSoftware/SwiftGen"
-  url "https://github.com/AliSoftware/SwiftGen/archive/0.4.4.tar.gz"
-  sha256 "429e50b33d1cd3e34fa81b5becff865ce5663284380e91602783bfa109c96b83"
+  url "https://github.com/AliSoftware/SwiftGen/archive/0.5.0.tar.gz"
+  sha256 "555f190f2ffef940eebd80a926eeb05d3d0de573412028c5bd2184e2b9542929"
   head "https://github.com/AliSoftware/SwiftGen.git"
 
   bottle do
@@ -14,33 +14,34 @@ class Swiftgen < Formula
   depends_on :xcode => "7.0"
 
   def install
-    ENV["SWIFTGEN_VERSION"] = "#{version} (via Homebrew)"
-    rake "install[#{bin},/]"
+    rake "install[#{bin},#{lib}]"
 
     fixtures = %w[
-      Tests/Assets/fixtures/Images.xcassets
-      Tests/Colors/fixtures/colors.txt
-      Tests/L10n/fixtures/Localizable.strings
-      Tests/Storyboard/fixtures/Message.storyboard
+      UnitTests/fixtures/Images.xcassets
+      UnitTests/fixtures/colors.txt
+      UnitTests/fixtures/Localizable.strings
+      UnitTests/fixtures/Message.storyboard
+      UnitTests/expected/Images-File-Defaults.swift.out
+      UnitTests/expected/Colors-File-Defaults.swift.out
+      UnitTests/expected/Strings-File-Defaults.swift.out
+      UnitTests/expected/Storyboards-Message-Defaults.swift.out
     ]
     pkgshare.install fixtures
-    pkgshare.install "Tests/Assets/expected/FileDefaults.swift.out" => "assets.swift"
-    pkgshare.install "Tests/Colors/expected/FileDefaults.swift.out" => "colors.swift"
-    pkgshare.install "Tests/L10n/expected/FileWithDefaults.swift.out" => "l10n.swift"
-    pkgshare.install "Tests/Storyboard/expected/MessageWithDefaults.swift.out" => "storyboard.swift"
   end
 
   test do
-    output = shell_output("#{bin}/swiftgen-assets #{pkgshare}/Images.xcassets").strip
-    assert_equal output, (pkgshare/"assets.swift").read.strip, "swiftgen-assets failed"
+    system "#{bin}/swiftgen --version"
 
-    output = shell_output("#{bin}/swiftgen-colors #{pkgshare}/colors.txt").strip
-    assert_equal output, (pkgshare/"colors.swift").read.strip, "swiftgen-colors failed"
+    output = shell_output("#{bin}/swiftgen images #{pkgshare}/Images.xcassets").strip
+    assert_equal output, (pkgshare/"Images-File-Defaults.swift.out").read.strip, "swiftgen images failed"
 
-    output = shell_output("#{bin}/swiftgen-l10n #{pkgshare}/Localizable.strings").strip
-    assert_equal output, (pkgshare/"l10n.swift").read.strip, "swiftgen-l10n failed"
+    output = shell_output("#{bin}/swiftgen colors #{pkgshare}/colors.txt").strip
+    assert_equal output, (pkgshare/"Colors-File-Defaults.swift.out").read.strip, "swiftgen colors failed"
 
-    output = shell_output("#{bin}/swiftgen-storyboard #{pkgshare}/Message.storyboard").strip
-    assert_equal output, (pkgshare/"storyboard.swift").read.strip, "swiftgen-storyboard failed"
+    output = shell_output("#{bin}/swiftgen strings #{pkgshare}/Localizable.strings").strip
+    assert_equal output, (pkgshare/"Strings-File-Defaults.swift.out").read.strip, "swiftgen strings failed"
+
+    output = shell_output("#{bin}/swiftgen storyboards #{pkgshare}/Message.storyboard").strip
+    assert_equal output, (pkgshare/"Storyboards-Message-Defaults.swift.out").read.strip, "swiftgen storyboards failed"
   end
 end


### PR DESCRIPTION
Simple version bump with new features

Notes:
* The `rake install` command as changed and now takes the directories where to install `$bin` and `$lib` (Frameworks)
* The fixtures have been reorganized in the source repo, and as a consequence it's now easier to install them in `pkgshare` (hence the big diff in the formula there)