### PR TITLE
brew: check xcode license status

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -25,18 +25,30 @@ elsif ARGV.first == "-v"
   exit 0 if ARGV.length == 1
 end
 
-# Check for bad xcode-select before anything else, because `doctor` and
-# many other things will hang
-# Note that this bug was fixed in 10.9
-if OS.mac? && MacOS.version < :mavericks && MacOS.active_developer_dir == "/"
-  odie <<-EOS.undent
-  Your xcode-select path is currently set to '/'.
-  This causes the `xcrun` tool to hang, and can render Homebrew unusable.
-  If you are using Xcode, you should:
-    sudo xcode-select -switch /Applications/Xcode.app
-  Otherwise, you should:
-    sudo rm -rf /usr/share/xcode-select
-  EOS
+# Check for bad xcode-select before other checks, because `doctor` and
+# many other things will hang. Note that this bug was fixed in 10.9
+if OS.mac?
+  if MacOS.version < :mavericks && MacOS.active_developer_dir == "/"
+    odie <<-EOS.undent
+    Your xcode-select path is currently set to '/'.
+    This causes the `xcrun` tool to hang, and can render Homebrew unusable.
+    If you are using Xcode, you should:
+      sudo xcode-select -switch /Applications/Xcode.app
+    Otherwise, you should:
+      sudo rm -rf /usr/share/xcode-select
+    EOS
+  end
+
+  # Check for user agreement of the Xcode license before permitting
+  # any other brew usage to continue. This prevents the situation where
+  # people are instructed to "please re-run as root via sudo" on brew commands.
+  # The check can only fail when Xcode is installed & the active developer dir.
+  if MacOS::Xcode.installed? && `/usr/bin/xcrun clang 2>&1` =~ /license/ && !$?.success?
+    odie <<-EOS.undent
+      You have not agreed to the Xcode license. Please resolve this by running:
+        sudo xcodebuild -license
+    EOS
+  end
 end
 
 case HOMEBREW_PREFIX.to_s
@@ -45,7 +57,7 @@ when "/", "/usr"
   abort "Cowardly refusing to continue at this prefix: #{HOMEBREW_PREFIX}"
 end
 
-if OS.mac? and MacOS.version < "10.6"
+if OS.mac? && MacOS.version < "10.6"
   abort <<-EOABORT.undent
     Homebrew requires Snow Leopard or higher. For Tiger and Leopard support, see:
     https://github.com/mistydemeo/tigerbrew
@@ -88,7 +100,7 @@ begin
   sudo_check = %w[ install link pin unpin upgrade ]
 
   if sudo_check.include? cmd
-    if Process.uid.zero? and not File.stat(HOMEBREW_BREW_FILE).uid.zero?
+    if Process.uid.zero? && !File.stat(HOMEBREW_BREW_FILE).uid.zero?
       raise <<-EOS.undent
         Cowardly refusing to `sudo brew #{cmd}`
         You can use brew with sudo, but only if the brew executable is owned by root.


### PR DESCRIPTION
Code stolen right out of the INSTALL script.

Check for user agreement of the Xcode license before permitting any other brew usage to continue. This prevents the situation where people are instructed to "please re-run as root via sudo" on brew commands. The check can only fail when Xcode is installed & the active developer dir.

It turns out to be quicker to just run the command than checking the OS & if Xcode is installed first. Some benchmarks:

**WITH CHECK:**
* brew  0.16s user 0.04s system 99% cpu 0.201 total
* brew  0.17s user 0.06s system 45% cpu 0.491 total
* brew  0.16s user 0.04s system 87% cpu 0.235 total
* brew  0.16s user 0.04s system 99% cpu 0.204 total
* brew  0.15s user 0.04s system 98% cpu 0.200 total

**NO CHECK:**
* brew  0.15s user 0.04s system 73% cpu 0.256 total
* brew  0.15s user 0.04s system 98% cpu 0.192 total
* brew  0.14s user 0.04s system 90% cpu 0.199 total
* brew  0.14s user 0.04s system 99% cpu 0.180 total
* brew  0.15s user 0.04s system 99% cpu 0.186 total

**WITH `if OS.mac? && MacOS::Xcode.installed?` precondition:**
* brew  0.19s user 0.05s system 97% cpu 0.247 total
* brew  0.18s user 0.05s system 98% cpu 0.238 total
* brew  0.18s user 0.05s system 97% cpu 0.240 total
* brew  0.20s user 0.05s system 91% cpu 0.277 total
* brew  0.18s user 0.05s system 98% cpu 0.239 total