### PR TITLE
commands: ensure external commands are executable

### DIFF
--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -38,6 +38,7 @@ module Homebrew
 
   def external_commands
     paths.flat_map { |p| Dir["#{p}/brew-*"] }.
+      select { |f| File.executable?(f) }.
       map { |f| File.basename(f, ".rb")[5..-1] }.
       reject { |f| f =~ /\./ }.
       sort


### PR DESCRIPTION
For consistency with `brew command` and the logic in `brew.sh` (both use `which` to find/validate an external command), we need to filter files that are not executable.

Otherwise `brew commands` and thus bash completion will offer commands that will produce an error when attempting to use them.