### PR TITLE
haskell-stack v0.1.6.0

### DIFF
--- a/Library/Formula/haskell-stack.rb
+++ b/Library/Formula/haskell-stack.rb
@@ -5,8 +5,8 @@ class HaskellStack < Formula
 
   desc "The Haskell Tool Stack"
   homepage "https://www.stackage.org"
-  url "https://github.com/commercialhaskell/stack/archive/v0.1.6.0.tar.gz"
-  sha256 "71014893d9a01f33c8e7400357813f610cc264a011d5e6af3ca8f9b598940d36"
+  url "https://hackage.haskell.org/package/stack-0.1.6.0/stack-0.1.6.0.tar.gz"
+  sha256 "a47ffc204b9caef8281d1e5daebc21bc9d4d2414ed695dc10d32fcca4d81978d"
 
   head "https://github.com/commercialhaskell/stack.git"
 

--- a/Library/Formula/haskell-stack.rb
+++ b/Library/Formula/haskell-stack.rb
@@ -5,8 +5,8 @@ class HaskellStack < Formula
 
   desc "The Haskell Tool Stack"
   homepage "https://www.stackage.org"
-  url "https://github.com/commercialhaskell/stack/archive/v0.1.5.0.tar.gz"
-  sha256 "2e32a0ac6a7e2a602eb039298925097141d00149119b2aa490a083b02a2002e2"
+  url "https://github.com/commercialhaskell/stack/archive/v0.1.6.0.tar.gz"
+  sha256 "71014893d9a01f33c8e7400357813f610cc264a011d5e6af3ca8f9b598940d36"
 
   head "https://github.com/commercialhaskell/stack.git"
 


### PR DESCRIPTION
Hope you don't mind my submitting this PR.  I'm the release manager for Stack and noticed this here, so figured I might as well update it right away.

Side note: I'm thinking it might be better to use the sdist from Hackage (http://hackage.haskell.org/package/stack-0.1.6.0/stack-0.1.6.0.tar.gz), or just `cabal install stack-0.1.6.0` directly, since the .cabal file on Hackage will have more precise version bounds which reduces the risk of bugs being introduced due to using the wrong Hackage dependency versions.

Ping @superlukas @fboyer @bjpbakker