### PR TITLE
swiftgen 0.5.0 fix

### DIFF
--- a/Library/Formula/swiftgen.rb
+++ b/Library/Formula/swiftgen.rb
@@ -4,11 +4,18 @@ class Swiftgen < Formula
   url "https://github.com/AliSoftware/SwiftGen/archive/0.5.0.tar.gz"
   sha256 "555f190f2ffef940eebd80a926eeb05d3d0de573412028c5bd2184e2b9542929"
   head "https://github.com/AliSoftware/SwiftGen.git"
+  revision 1
 
   bottle do
     cellar :any
     sha256 "29391f183e1606e50008ad148b3665d240c28ab5cbd42a293d1ca99b29aa3793" => :el_capitan
     sha256 "c150775bf2f6b8e77a821eae7bd89233a134eb22ce5eed88de9eaf2822dd79ee" => :yosemite
+  end
+
+  def pour_bottle?
+    # The binary's @rpath points to Xcode.app internal dylibs, so using a bottle won't work if the user doesn't
+    # have an Xcode installed in /Applications/Xcode.app (= the path used when BrewBot built the bottle)
+    Pathname.new("/Applications/Xcode.app").exist?
   end
 
   depends_on :xcode => "7.0"
@@ -30,7 +37,7 @@ class Swiftgen < Formula
   end
 
   test do
-    system "#{bin}/swiftgen --version"
+    system bin/"swiftgen", "--version"
 
     output = shell_output("#{bin}/swiftgen images #{pkgshare}/Images.xcassets").strip
     assert_equal output, (pkgshare/"Images-File-Defaults.swift.out").read.strip, "swiftgen images failed"


### PR DESCRIPTION
Given [this issue](https://github.com/AliSoftware/SwiftGen/issues/35#issuecomment-148500711), we can't use bottles to install SwiftGen

### The Problem

What happens is that being a Swift script, it depends on Swift dylibs that are located in Xcode.app bundle, and the binary's `@rpath` points to the path to `Xcode.app` that was used to build the binary, in order to find those dylibs back when running.

If the user's `Xcode.app` is not in the same location as the `Xcode.app` used by BrewBot to build the _bottle_, then the binary will have an incorrect `@rpath` and the Swift libraries won't be found.

### What I tried

Instead of completely remove the support for the _bottle_, I first tried to fix the installed binary using a `post_install`, but to no avail, because when trying to run `install_name_tool -add_rpath /path/to/Xcode/in/local/machine/Contents/… /usr/local/bin/swiftgen` to fix that `@rpath`, it fails with a `Permission Denied` error. Here is the `post_install` code I tried for reference.

```ruby
def post_install
    if build.bottle?
      # Fix the path to Xcode's Swift dylibs if it's installed via bottle and Xcode is at a different path
      swiftc = Pathname.new `xcrun -find swiftc`
      rpath = swiftc/"../../lib/swift/macosx"
      # Problem here: if the rpath already exists, this command will fail. Can't find a way to check that first
      system(%Q(install_name_tool -add_rpath "#{rpath}" "#{bin/"swiftgen"}"))
    end
  end
```

Result:
```sh
error: /Applications/Xcode 7.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: 
can't open input file: /usr/local/Cellar/swiftgen/0.5.0/bin/swiftgen for writing (Permission denied)
```

### Workaround

Even if we find a way to fix it, in the meantime I need to disable the _bottle_ so that users can run it at least on any machine, whatever their Xcode.app path is.