### PR TITLE
rtorrent/libtorrent: remove extraneous build dependencies

### DIFF
--- a/Library/Formula/libtorrent.rb
+++ b/Library/Formula/libtorrent.rb
@@ -4,23 +4,9 @@ class Libtorrent < Formula
   url "http://rtorrent.net/downloads/libtorrent-0.13.6.tar.gz"
   sha256 "2838a08c96edfd936aff8fbf99ecbb930c2bfca3337dd1482eb5fccdb80d5a04"
 
-  def pour_bottle?
-    # https://github.com/Homebrew/homebrew/commit/5eb5e4499c9
-    false
-  end
-
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "cppunit" => :build
-  depends_on "pkg-config" => :build
   depends_on "openssl"
-
-  # https://github.com/Homebrew/homebrew/issues/24132
-  fails_with :clang do
-    cause "Causes segfaults at startup/at random."
-  end
 
   def install
     # Currently can't build against libc++; see:
@@ -28,7 +14,6 @@ class Libtorrent < Formula
     # https://github.com/rakshasa/libtorrent/issues/47
     ENV.libstdcxx if ENV.compiler == :clang
 
-    system "sh", "autogen.sh"
     system "./configure", "--prefix=#{prefix}",
                           "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Library/Formula/rtorrent.rb
+++ b/Library/Formula/rtorrent.rb
@@ -4,22 +4,16 @@ class Rtorrent < Formula
   url "http://rtorrent.net/downloads/rtorrent-0.9.6.tar.gz"
   sha256 "1e69c24f1f26f8f07d58d673480dc392bfc4317818c1115265b08a7813ff5b0e"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "cppunit" => :build
   depends_on "libtorrent"
   depends_on "xmlrpc-c" => :optional
 
-  # https://github.com/Homebrew/homebrew/issues/24132
-  fails_with :clang do
-    cause "Causes segfaults at startup/at random."
-  end
-
   def install
-    # Commented out since we're now marked as failing with clang - adamv
-    # ENV.libstdcxx if ENV.compiler == :clang
+    # Currently can't build against libc++; see:
+    # https://github.com/homebrew/homebrew/issues/23483
+    # https://github.com/rakshasa/libtorrent/issues/47
+    ENV.libstdcxx if ENV.compiler == :clang
 
     args = ["--disable-debug", "--disable-dependency-tracking", "--prefix=#{prefix}"]
     args << "--with-xmlrpc-c" if build.with? "xmlrpc-c"
@@ -29,11 +23,18 @@ class Rtorrent < Formula
           '  pkg_cv_libcurl_LIBS=`$PKG_CONFIG --libs "libcurl >= 7.15.4" | sed -e "s/-arch [^-]*/-arch $(uname -m) /" 2>/dev/null`'
       end
     end
-    system "sh", "autogen.sh"
+
     system "./configure", *args
     system "make"
     system "make", "install"
 
     doc.install "doc/rtorrent.rc"
+  end
+
+  test do
+    (testpath/"rtorrent.rc").write <<-EOF.undent
+      schedule = close_rtorrent,1,1,"execute={killall,-TERM,rtorrent}"
+    EOF
+    system bin/"rtorrent", "-n", "-o", "import=rtorrent.rc"
   end
 end


### PR DESCRIPTION
Removed build dependencies: `automake`, `autoconf` and `cppunit` for `rtorrent` stable release.
Added a test for `rtorrent` as discussed in PR - [#44425](https://github.com/Homebrew/homebrew/pull/44425#issuecomment-148315271).