### PR TITLE
gist-logs: Friendlier titles and display for log gists

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -3,25 +3,36 @@ require "cmd/config"
 require "net/http"
 require "net/https"
 require "stringio"
+require "socket"
 
 module Homebrew
   def gistify_logs(f)
     files = load_logs(f.logs)
+    build_time = f.logs.ctime
+    timestamp = build_time.strftime("%Y-%m-%d_%H-%M-%S")
 
     s = StringIO.new
     Homebrew.dump_verbose_config(s)
-    files["config.out"] = { :content => s.string }
-    files["doctor.out"] = { :content => `brew doctor 2>&1` }
+    # Dummy summary file, asciibetically first, to control display title of gist
+    files["# #{f.name} - #{timestamp}.txt"] = { :content => brief_build_info(f) }
+    files["00.config.out"] = { :content => s.string }
+    files["00.doctor.out"] = { :content => `brew doctor 2>&1` }
     unless f.core_formula?
       tap = <<-EOS.undent
         Formula: #{f.name}
         Tap: #{f.tap}
         Path: #{f.path}
       EOS
-      files["tap.out"] = { :content => tap }
+      files["00.tap.out"] = { :content => tap }
     end
 
-    url = create_gist(files)
+    # Description formatted to work well as page title when viewing gist
+    if f.core_formula?
+      descr = "#{f.name} on #{OS_VERSION} - Homebrew build logs"
+    else
+      descr = "#{f.name} (#{f.full_name}) on #{OS_VERSION} - Homebrew build logs"
+    end
+    url = create_gist(files, descr)
 
     if ARGV.include?("--new-issue") || ARGV.switch?("n")
       auth = :AUTH_TOKEN
@@ -38,6 +49,19 @@ module Homebrew
     end
 
     puts url if url
+  end
+
+  def brief_build_info(f)
+    build_time_str = f.logs.ctime.strftime("%Y-%m-%d %H:%M:%S")
+    s = <<-EOS.undent
+      Homebrew build logs for #{f.full_name} on #{OS_VERSION}
+    EOS
+    if ARGV.include?("--with-hostname")
+      hostname = Socket.gethostname
+      s << "Host: #{hostname}\n"
+    end
+    s << "Build date: #{build_time_str}\n"
+    s
   end
 
   # Hack for ruby < 1.9.3
@@ -68,8 +92,8 @@ module Homebrew
     logs
   end
 
-  def create_gist(files)
-    post("/gists", "public" => true, "files" => files)["html_url"]
+  def create_gist(files, descr)
+    post("/gists", { "public" => true, "files" => files, "description" => descr })["html_url"]
   end
 
   def new_issue(repo, title, body, auth)


### PR DESCRIPTION
Here's a suggestion for making the gists produced by `gist-log` easier to work with.

Adds a summary file and description to get more informative displays on gist.github.com. Adds `--with-hostname` to include host name in summary, for differentiating different machines if you have several.

The summary file starts with "#" so it sorts asciibetically before other files in the gist, and is thus taken by the gist webpage as the display title to use for the gist, and the summary text displayed for it when it's in a list of multiple gists.

Adds a description to the gist, which is used as the title of the page when the gist is viewed on gist.github.com. This may also come in handy if some new page displays a denser list of gists that uses just the text descriptions, instead of an excerpt from the first file.

This makes it easier to identify Homebrew log gists when working with more than one. For example, when you're displaying the list of "my gists", or have several bug reports open in browser windows at once. As it stands now, the effective title of the gists is always something like `01.configure` or `01.cmake`, and not the name of the formula in question. The name of the formula may not even appear in the first several lines of that file, so when looking at the gist preview, you can't necessarily tell what it is.

Old:

<img width="1168" alt="screen shot 2015-10-16 at 5 49 59 am" src="https://cloud.githubusercontent.com/assets/2618447/10538905/ca19e4d6-73c9-11e5-9ba1-42e09fb731e3.png">

With this change, the formula name is in the gist's "title" and the summary is always in the preview text when listing multiple gists. And it shows up in the tab title too, once you open them.

<img width="1165" alt="screen shot 2015-10-16 at 5 51 08 am" src="https://cloud.githubusercontent.com/assets/2618447/10538956/2681aaf6-73ca-11e5-9fe4-f0530b9024d2.png">

This PR adds `gist-logs` option `--with-hostname` which includes the host name in that new summary, which is useful if, like me, you run Homebrew on several different machines with different configurations. I left it off by default, because it has some mild potential privacy implications, so it should probably be opt-in.