### PR TITLE
utils: improve highlighting in multi-column output

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -43,7 +43,7 @@ class Tty
     end
 
     def highlight
-      bold 43
+      bold 39
     end
 
     def width


### PR DESCRIPTION
The yellow background made the text unreadable for light-on-dark color schemes. ~~Fix by explicitly setting the foreground color to black.~~ Fix by making the highlighted text just bold.

Fixes #45028.

This fixes the issue of poor contrast for all users with a sane terminal color scheme (tested locally with quite a bunch). It doesn't solve the problem that everyone has a different favorite color. Text on colored background instead of bolded/colored text on default background was chosen for greater visibility.

Let the bikeshedding begin. :wink: