### PR TITLE
magicrescue 1.1.9 (new formula)

### DIFF
--- a/Library/Formula/magicrescue.rb
+++ b/Library/Formula/magicrescue.rb
@@ -1,0 +1,14 @@
+class Magicrescue < Formula
+  desc "Magic Rescue extracts files of known types from a block device."
+  homepage "http://www.itu.dk/people/jobr/magicrescue/"
+  url "http://www.itu.dk/people/jobr/magicrescue/release/magicrescue-1.1.9.tar.gz"
+  sha256 "a920b174efd664afe9760a43700588c9c5e6182cb13d7421e07ab613bceeb3c7"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+  end
+end


### PR DESCRIPTION
This PR add's a new formular to Homebrew for Magic Rescue.

Magic Rescue scans a block device for file types it knows how to recover and calls an external program to extract them. It looks at "magic bytes" in file contents, so it can be used both as an undelete utility and for recovering a corrupted drive or partition. As long as the file data is there, it will find it.