### PR TITLE
cspice & enscript: missing conflicts_with added

### DIFF
--- a/Library/Formula/cspice.rb
+++ b/Library/Formula/cspice.rb
@@ -2,8 +2,8 @@ class Cspice < Formula
   desc "Observation geometry system for robotic space science missions"
   homepage "https://naif.jpl.nasa.gov/naif/index.html"
   url "https://naif.jpl.nasa.gov/pub/naif/toolkit/C/MacIntel_OSX_AppleC_64bit/packages/cspice.tar.Z"
-  sha256 "c009981340de17fb1d9b55e1746f32336e1a7a3ae0b4b8d68f899ecb6e96dd5d"
   version "65"
+  sha256 "c009981340de17fb1d9b55e1746f32336e1a7a3ae0b4b8d68f899ecb6e96dd5d"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,6 +15,7 @@ class Cspice < Formula
 
   conflicts_with "openhmd", :because => "both install `simple` binaries"
   conflicts_with "libftdi0", :because => "both install `simple` binaries"
+  conflicts_with "enscript", :because => "both install `states` binaries"
 
   def install
     rm_f Dir["lib/*"]

--- a/Library/Formula/enscript.rb
+++ b/Library/Formula/enscript.rb
@@ -17,6 +17,8 @@ class Enscript < Formula
 
   depends_on "gettext"
 
+  conflicts_with "cspice", :because => "both install `states` binaries"
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Following [issue 42766](https://github.com/Homebrew/homebrew/issues/42766), add conflicts_with. Also move the revision line of cspice to make `audit` happy. 
