### PR TITLE
doc: add links to jenkins jobs

### DIFF
--- a/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
+++ b/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
@@ -3,13 +3,13 @@ If a build has run and passed on `brew test-bot` then it can be used to quickly 
 
 There are three types of Jenkins jobs:
 
-## Homebrew
+## [Homebrew](http://bot.brew.sh/job/Homebrew/)
 This job automatically builds anything committed to the master branch. On failure it sends an email to `brew-test-bot@googlegroups.com`. It tests rather than builds bottles.
 
-## Homebrew Pull Requests
+## [Homebrew Pull Requests](http://bot.brew.sh/job/Homebrew%20Pull%20Requests/)
 This job automatically builds any pull requests submitted to Homebrew/homebrew. On success or failure it updates the pull request status (see more details on the [main Brew Test Bot wiki page](Brew-Test-Bot.md)). On a successful build it automatically uploads bottles.
 
-## Homebrew Testing
+## [Homebrew Testing](http://bot.brew.sh/job/Homebrew%20Testing/)
 This job is manually triggered to run [`brew test-bot`](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/cmd/test-bot.rb) with user-specified parameters. On a successful build it automatically uploads bottles.
 
 You can manually start this job with parameters to run [`brew test-bot`](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/cmd/test-bot.rb) with the same parameters. It's often useful to pass a pull request URL, a commit URL, a commit SHA-1 and/or formula names to have `brew-test-bot` test them, report the results and produce bottles.


### PR DESCRIPTION
Add links to specific jenkins jobs described in
Brew-Test-Bot-For-Core-Contributors.md

I was reading through the documentation and thought it would be helpful to have links to the relevant jenkins jobs.

Also, if have general questions about how your build infrastructure works (ie. how do you trigger bottle builds of downstream packages when an upstream package is changed) where's the best place to ask those? [Tweet to machomebrew](https://twitter.com/machomebrew)?