### PR TITLE
allegro 5.1.12 (and other fixes)

### DIFF
--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -15,8 +15,8 @@ class Allegro < Formula
   end
 
   devel do
-    url "https://downloads.sourceforge.net/project/alleg/allegro-unstable/5.1.11/allegro-5.1.11.tar.gz"
-    sha256 "7a071635e39105ce52cd82c8641a8f3841efbdfe8fdb39f7a5ae1be6db3be07f"
+    url "http://download.gna.org/allegro/allegro-unstable/5.1.12/allegro-5.1.12.tar.gz"
+    sha256 "78d1056d6cc0e4527ef35646f612a80456442a7866445ca7cf61a11bd64e79c0"
 
     depends_on "theora" => :recommended
   end

--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -3,7 +3,7 @@ class Allegro < Formula
   homepage "http://liballeg.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/alleg/allegro/5.0.11/allegro-5.0.11.tar.gz"
+    url "http://download.gna.org/allegro/allegro/5.0.11/allegro-5.0.11.tar.gz"
     sha256 "49fe14c9571463ba08db4ff778d1fbb15e49f9c33bdada3ac8599e04330ea531"
   end
   bottle do


### PR DESCRIPTION
* Switch the stable download link to gna.org (see the upstream news announcement: http://liballeg.org/#allegro-on-gna)
* Update devel version to 5.1.12.