### PR TITLE
wine-1.7.53 devel

### DIFF
--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -42,7 +42,7 @@ class Wine < Formula
       url "https://bugs.winehq.org/attachment.cgi?id=52485"
       sha256 "59f1831a1b49c1b7a4c6e6af7e3f89f0bc60bec0bead645a615b251d37d232ac"
     end
-    
+
     # Patch to fix texture compression issues. Still relevant on 1.7.53.
     # https://bugs.winehq.org/show_bug.cgi?id=14939
     patch do

--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -5,7 +5,6 @@
 class Wine < Formula
   desc "Wine Is Not an Emulator"
   homepage "https://www.winehq.org/"
-  revision 1
 
   stable do
     url "https://downloads.sourceforge.net/project/wine/Source/wine-1.6.2.tar.bz2"

--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -29,18 +29,25 @@ class Wine < Formula
   end
 
   devel do
-    url "https://downloads.sourceforge.net/project/wine/Source/wine-1.7.52.tar.bz2"
-    mirror "http://mirrors.ibiblio.org/wine/source/1.7/wine-1.7.52.tar.bz2"
-    sha256 "0773b32a0c358323db4c383ceb1e9e28d5d4ed4ea37570af2bcb41fecf0d554b"
+    url "https://downloads.sourceforge.net/project/wine/Source/wine-1.7.53.tar.bz2"
+    mirror "https://ftp.winehq.org/pub/wine/source/1.7/wine-1.7.53.tar.bz2"
+    sha256 "efba70b106cde683a50a4b1f42df3d900f8ffc291a3689cb897afcc12cc2c6a3"
 
     depends_on "samba" => :optional
     depends_on "gnutls"
 
-    # Patch to fix screen-flickering issues. Still relevant on 1.7.23.
+    # Patch to fix screen-flickering issues. Still relevant on 1.7.53.
     # https://bugs.winehq.org/show_bug.cgi?id=34166
     patch do
       url "https://bugs.winehq.org/attachment.cgi?id=52485"
       sha256 "59f1831a1b49c1b7a4c6e6af7e3f89f0bc60bec0bead645a615b251d37d232ac"
+    end
+    
+    # Patch to fix texture compression issues. Still relevant on 1.7.53.
+    # https://bugs.winehq.org/show_bug.cgi?id=14939
+    patch do
+      url "https://bugs.winehq.org/attachment.cgi?id=52384"
+      sha256 "30766403f5064a115f61de8cacba1defddffe2dd898b59557956400470adc699"
     end
   end
 

--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -5,6 +5,7 @@
 class Wine < Formula
   desc "Wine Is Not an Emulator"
   homepage "https://www.winehq.org/"
+  revision 1
 
   stable do
     url "https://downloads.sourceforge.net/project/wine/Source/wine-1.6.2.tar.bz2"


### PR DESCRIPTION
Travis-ci passes for OSX 10.10 (others in progress): https://travis-ci.org/samrussell/homebrew

I can confirm that flicker patch works just like on 1.7.52

Also includes compressed texture patch to fix games like Black and White etc