### PR TITLE
ldid 1.1.2 (new formula)

### DIFF
--- a/Library/Formula/ldid.rb
+++ b/Library/Formula/ldid.rb
@@ -1,0 +1,25 @@
+class Ldid < Formula
+  desc "Lets you manipulate the signature block in a Mach-O binary"
+  homepage "https://cydia.saurik.com/info/ldid/"
+  url "https://git.saurik.com/ldid.git",
+    :tag => "v1.1.2",
+    :revision => "604cc486bdefb246c984a21dbb30cdaf8b0a7f4d"
+
+  head "git://git.saurik.com/ldid.git", :branch => "master"
+
+  depends_on "openssl"
+
+  def install
+    system "./make.sh"
+    bin.install "ldid"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      int main(int argc, char **argv) { return 0; }
+      EOS
+
+    system "#{ENV.cc}", "test.c", "-o", "test"
+    system bin/"ldid", "-S", "test"
+  end
+end

--- a/Library/Formula/ldid.rb
+++ b/Library/Formula/ldid.rb
@@ -5,7 +5,7 @@ class Ldid < Formula
     :tag => "v1.1.2",
     :revision => "604cc486bdefb246c984a21dbb30cdaf8b0a7f4d"
 
-  head "git://git.saurik.com/ldid.git", :branch => "master"
+  head "git://git.saurik.com/ldid.git"
 
   depends_on "openssl"
 
@@ -17,7 +17,7 @@ class Ldid < Formula
   test do
     (testpath/"test.c").write <<-EOS.undent
       int main(int argc, char **argv) { return 0; }
-      EOS
+    EOS
 
     system ENV.cc, "test.c", "-o", "test"
     system bin/"ldid", "-S", "test"

--- a/Library/Formula/ldid.rb
+++ b/Library/Formula/ldid.rb
@@ -1,7 +1,7 @@
 class Ldid < Formula
   desc "Lets you manipulate the signature block in a Mach-O binary"
   homepage "https://cydia.saurik.com/info/ldid/"
-  url "https://git.saurik.com/ldid.git",
+  url "git://git.saurik.com/ldid.git",
     :tag => "v1.1.2",
     :revision => "604cc486bdefb246c984a21dbb30cdaf8b0a7f4d"
 

--- a/Library/Formula/ldid.rb
+++ b/Library/Formula/ldid.rb
@@ -19,7 +19,7 @@ class Ldid < Formula
       int main(int argc, char **argv) { return 0; }
       EOS
 
-    system "#{ENV.cc}", "test.c", "-o", "test"
+    system ENV.cc, "test.c", "-o", "test"
     system bin/"ldid", "-S", "test"
   end
 end


### PR DESCRIPTION
ldid (link identity editor) can perform [fake codesigning](http://iphonedevwiki.net/index.php/Code_Signing) on a mach-o binary, and read/write an entitlements plist on the binary.