### PR TITLE
swiftgen 0.5.1

### DIFF
--- a/Library/Formula/swiftgen.rb
+++ b/Library/Formula/swiftgen.rb
@@ -1,21 +1,14 @@
 class Swiftgen < Formula
   desc "Collection of Swift tools to generate Swift code"
   homepage "https://github.com/AliSoftware/SwiftGen"
-  url "https://github.com/AliSoftware/SwiftGen/archive/0.5.0.tar.gz"
-  sha256 "555f190f2ffef940eebd80a926eeb05d3d0de573412028c5bd2184e2b9542929"
+  url "https://github.com/AliSoftware/SwiftGen/archive/0.5.1.tar.gz"
+  sha256 "629b455724ec47cb7d1277a20bf7dcac997e04b3b2db30213ed17aecce647fed"
   head "https://github.com/AliSoftware/SwiftGen.git"
-  revision 1
 
   bottle do
     cellar :any
     sha256 "2720dec00532d078ac959fd65f05ddf3cc2a0837f383e5e32d1d0a423527f4ae" => :el_capitan
     sha256 "ebedd73315bbe82499e3add958fbabbf6da70861d034793b416761f187460912" => :yosemite
-  end
-
-  def pour_bottle?
-    # The binary's @rpath points to Xcode.app internal dylibs, so using a bottle won't work if the user doesn't
-    # have an Xcode installed in /Applications/Xcode.app (= the path used when BrewBot built the bottle)
-    Pathname.new("/Applications/Xcode.app").exist?
   end
 
   depends_on :xcode => "7.0"


### PR DESCRIPTION
Fix more installation issues (see AliSoftware/SwiftGen#38)

Now the `rake install` executed by Homebrew will also copy the Swift dylibs over when installing `swiftgen`. This way, it won't depend on the user's `Xcode.app` install path anymore, as SwiftGen will use its own Swift dylibs.

* This ensure that `swiftgen` won't break if the Xcode installed at `/Applications/Xcode.app` is not the same version as the one used when BrewBot brew the bottle
* This allows to use the bottle for everyone, as the Swift dylibs used to build SwiftGen will now be provided with the bottle.

\cc @esttorhe