### PR TITLE
Add --cleanup to `brew upgrade` bash completion

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -554,6 +554,7 @@ _brew_upgrade ()
         __brewcomp "
             --all
             --build-from-source --build-bottle --force-bottle
+            --cleanup
             --debug
             --verbose
             "


### PR DESCRIPTION
Support tab completion for `brew upgrade --cleanup`, added in #44305.