### PR TITLE
set up Python sys.path from install HOME

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1237,7 +1237,7 @@ class Formula
     mktemp do
       @testpath = Pathname.pwd
       ENV["HOME"] = @testpath
-      setup_test_home @testpath
+      setup_home @testpath
       test
     end
   ensure
@@ -1273,8 +1273,8 @@ class Formula
 
   protected
 
-  def setup_test_home(home)
-    # keep Homebrew's site-packages in sys.path when testing with system Python
+  def setup_home(home)
+    # keep Homebrew's site-packages in sys.path when using system Python
     user_site_packages = home/"Library/Python/2.7/lib/python/site-packages"
     user_site_packages.mkpath
     (user_site_packages/"homebrew.pth").write <<-EOS.undent
@@ -1434,6 +1434,7 @@ class Formula
       mkdir_p env_home
 
       old_home, ENV["HOME"] = ENV["HOME"], env_home
+      setup_home env_home
 
       begin
         yield


### PR DESCRIPTION
Necessary to allow system Python to find Python modules installed by Homebrew.

Fixes #44813.