### PR TITLE
trafficserver: Fix installation with INSTALL_BASE

### DIFF
--- a/Library/Formula/trafficserver.rb
+++ b/Library/Formula/trafficserver.rb
@@ -36,6 +36,9 @@ class Trafficserver < Formula
     ENV.enable_warnings
     # Needed for OpenSSL headers on Lion.
     ENV.append_to_cflags "-Wno-deprecated-declarations"
+    # Fix lib/perl/Makefile.pl failing with:
+    # Only one of PREFIX or INSTALL_BASE can be given.  Not both.
+    ENV.delete "PERL_MM_OPT"
     system "autoreconf", "-fvi" if build.head?
     args = [
       "--prefix=#{prefix}",


### PR DESCRIPTION
trafficserver 6.0.0 tries to install some perl modules into it's cellar, which fails if the perl INSTALL_BASE is set through the PERL_MM_OPT env var with the following error:

> Only one of PREFIX or INSTALL_BASE can be given.  Not both.

INSTALL_BASE is set in the environment variable PERL_MM_OPT if the user has gone through the CPAN setup wizard and chose to install perl modules to $HOME/perl5.

This fix unsets the environment var, so that the perl Makefile.pl can install into the PREFIX set to the cellar.

This problem only affects users that have something similar to this set in their shell's environment:
```bash
PERL_MB_OPT="--install_base \"/Users/felix/perl5\""; export PERL_MB_OPT;
PERL_MM_OPT="INSTALL_BASE=/Users/felix/perl5"; export PERL_MM_OPT;
```