### PR TITLE
brew: tighten sudo checks

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -97,7 +97,7 @@ begin
 
   cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
 
-  sudo_check = %w[ install link pin unpin upgrade ]
+  sudo_check = %w[ install reinstall postinstall link pin unpin upgrade ]
 
   if sudo_check.include? cmd
     if Process.uid.zero? && !File.stat(HOMEBREW_BREW_FILE).uid.zero?
@@ -106,7 +106,7 @@ begin
         You can use brew with sudo, but only if the brew executable is owned by root.
         However, this is both not recommended and completely unsupported so do so at
         your own risk.
-        EOS
+      EOS
     end
   end
 


### PR DESCRIPTION
`reinstall` can currently be executed under sudo and has every chunk of problems running install under sudo does when `brew` isn't root owned.

Likewise with `postinstall` which we increasingly use to create directories and move/install files elsewhere. Using sudo there both masks deeper issues and makes uninstall troublesome.