### PR TITLE
fix bugs #44211 and #44210

### DIFF
--- a/Library/Formula/czmq.rb
+++ b/Library/Formula/czmq.rb
@@ -19,15 +19,22 @@ class Czmq < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+
+    # Patch to fix zdir_test fail on `make check`
+    # https://github.com/Homebrew/homebrew/issues/44210
+    patch do
+      url "https://patch-diff.githubusercontent.com/raw/zeromq/czmq/pull/1127.patch"
+      sha256 "3a0672bf6e12ca7b400f70df36a93ecc31fbdc86bb977a94a5963754a4fc29b8"
+    end
   end
 
   option :universal
 
   depends_on "pkg-config" => :build
-  depends_on "libsodium" => :optional
+  depends_on "libsodium" => :recommended
 
-  if build.with? "libsodium"
-    depends_on "zeromq" => "with-libsodium"
+  if build.without? "libsodium"
+    depends_on "zeromq" => "without-libsodium"
   else
     depends_on "zeromq"
   end
@@ -44,8 +51,5 @@ class Czmq < Formula
     system "make", "check"
     system "make", "install"
     rm Dir["#{bin}/*.gsl"]
-
-    # makecert clashes with Mono. Rename it less generically.
-    mv bin/"makecert", bin/"czmq-makecert"
   end
 end


### PR DESCRIPTION
- `make test` now passes
- libsodium dependency handled correctly
- removed reference to "makecert" as zeromq now calls this "zmakecert"