### PR TITLE
libuecc 5 (new formula)

### DIFF
--- a/Library/Formula/libuecc.rb
+++ b/Library/Formula/libuecc.rb
@@ -1,0 +1,32 @@
+class Libuecc < Formula
+  desc "Very small Elliptic Curve Cryptography library"
+  homepage "http://git.universe-factory.net/libuecc/"
+  url "http://git.universe-factory.net/libuecc/snapshot/libuecc-5.tar"
+  sha256 "5f4104e70e48f077f92395e6652d9a139e3fdbcc4dc51113ddc955bf2a82542a"
+
+  head "git://git.universe-factory.net/libuecc"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdlib.h>
+      #include <libuecc/ecc.h>
+
+      int main(void)
+      {
+          ecc_int256_t secret;
+          ecc_25519_gf_sanitize_secret(&secret, &secret);
+
+          return EXIT_SUCCESS;
+      }
+    EOS
+    system ENV.cc, "-I#{include}/libuecc-#{version}", "-L#{lib}", "-o", "test", "test.c", "-luecc"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This PR adds a new formular to Homebrew for `libuecc`.

`libuecc` is an essential dependency for projects like `fastd`[1] and `ecdsautils`[2]. These projects are very important to operate gateways for the Freifunk community[3]. In order to use these projects on OS X it is necessary to have this library installed. It would be nice to see it in Homebrew for a convenient installation.

- [1] https://projects.universe-factory.net/projects/fastd/
- [2] https://github.com/tcatm/ecdsautils
- [3] http://freifunk.net/en/