### PR TITLE
Provide better link when rate limit exceeded error is thrown

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -636,6 +636,8 @@ can take several different forms:
     <https://developer.github.com/v3/#rate-limiting> for more information.
     Homebrew uses the GitHub API for features such as `brew search`.
 
+    *NOTE*: Homebrew doesn't require permissions for any of the scopes.
+
   * HOMEBREW\_LOGS:
     If set, Homebrew will use the given directory to store log files.
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -419,10 +419,10 @@ module GitHub
     def initialize(reset, error)
       super <<-EOS.undent
         GitHub #{error}
-        Try again in #{pretty_ratelimit_reset(reset)}, or create an personal access token:
-          https://github.com/settings/tokens
+        Try again in #{pretty_ratelimit_reset(reset)}, or create a personal access token:
+          https://github.com/settings/tokens/new?scopes=&description=Homebrew
         and then set the token as: HOMEBREW_GITHUB_API_TOKEN
-                    EOS
+      EOS
     end
 
     def pretty_ratelimit_reset(reset)


### PR DESCRIPTION
The form at https://github.com/settings/tokens/new can be prefilled using query parameters. This is purely for convenience.

Example Error with improved link:
```
Error: GitHub API rate limit exceeded for 212.51.144.2. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
Try again in 47 minutes 1 seconds, or create an personal access token:
  https://github.com/settings/tokens/new?scopes=&description=Homebrew+on+Sledgehammer.local
and then set the token as: HOMEBREW_GITHUB_API_TOKEN
```

Result:

![screen shot 2015-10-19 at 14 55 50](https://cloud.githubusercontent.com/assets/600097/10578431/5e79513e-7672-11e5-8f16-37314180a278.png)
