### PR TITLE
ios-class-guard 0.8 (updated formula)

### DIFF
--- a/Library/Formula/ios-class-guard.rb
+++ b/Library/Formula/ios-class-guard.rb
@@ -2,8 +2,7 @@ class IosClassGuard < Formula
   desc "Objective-C obfuscator for Mach-O executables"
   homepage "https://github.com/Polidea/ios-class-guard/"
   head "https://github.com/Polidea/ios-class-guard.git"
-  url "https://github.com/Polidea/ios-class-guard/archive/0.6.tar.gz"
-  sha256 "0f4ce249a0690dce8fe762603611c0d26d0273929c736bf6c62b308c44fc4a4d"
+  url "https://github.com/Polidea/ios-class-guard/archive/0.8.tar.gz"
 
   bottle do
     cellar :any

--- a/Library/Formula/ios-class-guard.rb
+++ b/Library/Formula/ios-class-guard.rb
@@ -3,7 +3,8 @@ class IosClassGuard < Formula
   homepage "https://github.com/Polidea/ios-class-guard/"
   head "https://github.com/Polidea/ios-class-guard.git"
   url "https://github.com/Polidea/ios-class-guard/archive/0.8.tar.gz"
-
+  sha256 "4446993378f1e84ce1d1b3cbace0375661e3fe2fa1a63b9bf2c5e9370a6058ff"
+  
   bottle do
     cellar :any
     sha1 "e83dde7f68747d6b2d6c14beddbb737911632fad" => :mavericks

--- a/Library/Formula/ios-class-guard.rb
+++ b/Library/Formula/ios-class-guard.rb
@@ -4,7 +4,7 @@ class IosClassGuard < Formula
   head "https://github.com/Polidea/ios-class-guard.git"
   url "https://github.com/Polidea/ios-class-guard/archive/0.8.tar.gz"
   sha256 "4446993378f1e84ce1d1b3cbace0375661e3fe2fa1a63b9bf2c5e9370a6058ff"
-  
+
   bottle do
     cellar :any
     sha1 "e83dde7f68747d6b2d6c14beddbb737911632fad" => :mavericks


### PR DESCRIPTION
Bumped formula to use recent version of ios-class-guard