### PR TITLE
crosstool-ng should set full path for gmake

### DIFF
--- a/Library/Formula/crosstool-ng.rb
+++ b/Library/Formula/crosstool-ng.rb
@@ -42,7 +42,7 @@ class CrosstoolNg < Formula
 
     args << "--with-grep=ggrep" if build.with? "grep"
 
-    args << "--with-make=gmake" if build.with? "make"
+    args << "--with-make=#{Formula["make"].opt_bin}/gmake" if build.with? "make"
 
     args << "CFLAGS=-std=gnu89"
 


### PR DESCRIPTION
crosstool-ng installs the script `bin/ct-ng` with a shbang, using exactly
what's provided to configure for `--with-make`. When `--with-make` is
provided to this formula, that results in a shbang line of

    #!gmake -rf

which is not not a valid interpreter

    $ ct-ng version
    -bash: /usr/local/bin/ct-ng: gmake: bad interpreter: No such file or directory