### PR TITLE
Fix header file issue on Mountain Lion

### DIFF
--- a/Library/Formula/gstreamer.rb
+++ b/Library/Formula/gstreamer.rb
@@ -28,6 +28,7 @@ class Gstreamer < Formula
   # Snow Leopard)
   # https://bugzilla.gnome.org/show_bug.cgi?id=756136
   patch :DATA if MacOS.version <= :snow_leopard
+  patch :DATA if MacOS.version <= :mountain_lion
 
   def install
     args = %W[

--- a/Library/Formula/gstreamer.rb
+++ b/Library/Formula/gstreamer.rb
@@ -27,7 +27,6 @@ class Gstreamer < Formula
   # Fix header file issue (exact OS versions affected unknown; first noticed on
   # Snow Leopard)
   # https://bugzilla.gnome.org/show_bug.cgi?id=756136
-  patch :DATA if MacOS.version <= :snow_leopard
   patch :DATA if MacOS.version <= :mountain_lion
 
   def install


### PR DESCRIPTION
Fix header file issue on Mountain Lion (10.8.5). Same fix as for Snow Leopard worked for me.
https://bugzilla.gnome.org/show_bug.cgi?id=756136