### PR TITLE
linkapps: stop linking .app bundles from 'bin/'

### DIFF
--- a/Library/Homebrew/cmd/linkapps.rb
+++ b/Library/Homebrew/cmd/linkapps.rb
@@ -23,11 +23,9 @@ module Homebrew
     end
 
     kegs.each do |keg|
-      keg = keg.opt_record if keg.optlinked?
-      Dir["#{keg}/*.app", "#{keg}/bin/*.app", "#{keg}/libexec/*.app"].each do |app|
+      keg.apps.each do |app|
         puts "Linking #{app} to #{target_dir}."
-        app_name = File.basename(app)
-        target = "#{target_dir}/#{app_name}"
+        target = "#{target_dir}/#{app.basename}"
 
         if File.exist?(target) && !File.symlink?(target)
           onoe "#{target} already exists, skipping."

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -253,8 +253,13 @@ class Keg
     Dir["#{path}/lib/python2.7/site-packages/*.pth"].any?
   end
 
+  def apps
+    app_prefix = optlinked? ? opt_record : path
+    Pathname.glob("#{app_prefix}/{,libexec/}*.app")
+  end
+
   def app_installed?
-    Dir["#{path}/{,libexec/}*.app"].any?
+    !apps.empty?
   end
 
   def elisp_installed?


### PR DESCRIPTION
`Keg#app_installed?` only checks the formula prefix and `libexec/` for .app bundles to determine if a formula provides any. This is used by `Caveats#app_caveats` to generate an appropriate message.

For consistency, `brew linkapps` should use the same set of directories.