### PR TITLE
unlinkapps: avoid deleting too many symlinks

### DIFF
--- a/Library/Homebrew/cmd/unlinkapps.rb
+++ b/Library/Homebrew/cmd/unlinkapps.rb
@@ -25,9 +25,9 @@ module Homebrew
 
   def should_unlink?(file)
     if ARGV.named.empty?
-      file.match(HOMEBREW_CELLAR) || file.match("#{HOMEBREW_PREFIX}/opt")
+      file.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_PREFIX}/opt/")
     else
-      ARGV.kegs.any? { |keg| file.match(keg.to_s) || file.match(keg.opt_record.to_s) }
+      ARGV.kegs.any? { |keg| file.start_with?("#{keg}/", "#{keg.opt_record}/") }
     end
   end
 end


### PR DESCRIPTION
Use `start_with?` to make sure the symlink actually points into one of the Homebrew directories (depending on given arguments). Previously, only a substring match was used, which would also remove a symlink to a hypothetical `/opt/unrelated/usr/local/opt/Unrelated.app`. Even if unlikely to occur, altering stuff unrelated to Homebrew is bad.

Furthermore, make sure to always use a trailing slash with directories. Otherwise, e.g., `brew unlinkapps qt` will unlink .app bundles of both `qt` and `qt5` if both are installed and `brew linkapps qt qt5` was issued before. (Please ignore that `qt` and `qt5` offer a conflicting set of .app bundles. This will have to be addressed elsewhere.)