### PR TITLE
icmake 7.23.02

### DIFF
--- a/Library/Formula/icmake.rb
+++ b/Library/Formula/icmake.rb
@@ -1,0 +1,42 @@
+class Icmake < Formula
+  desc "Make utility using a C-line grammar"
+  homepage "https://fbb-git.github.io/icmake/"
+  url "https://github.com/fbb-git/icmake/archive/7.23.02.tar.gz"
+  sha256 "f030086d0630c2c1755519556b9cf88b8495bc8debf36b257e0c69d3b199c46b"
+
+  depends_on "gnu-sed" => :build
+
+  def install
+    ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin"
+
+    # override the existing file
+    (buildpath/"icmake/INSTALL.im").open("w") do |f|
+      f.write <<-EOS.undent
+        #define BINDIR      "#{bin}"
+        #define SKELDIR     "#{share}"
+        #define MANDIR      "#{man}"
+        // not a typo; the install script puts binaries under LIBDIR/
+        #define LIBDIR      "#{bin}"
+        #define CONFDIR     "#{etc}"
+        #define DOCDIR      "#{doc}"
+        #define DOCDOCDIR   "#{doc}"
+      EOS
+    end
+
+    cd "icmake" do
+      system "./icm_bootstrap", "/"
+      system "./icm_install", "all", "/"
+    end
+  end
+
+  test do
+    (testpath/"script.im").write <<-EOS.undent
+      string TEST;
+
+      void main() {
+        TEST = "foobar";
+      }
+    EOS
+    system "#{bin}/icmake", "script.im", (testpath/"test")
+  end
+end


### PR DESCRIPTION
The GitHub repo has no stars/forks because it was recently imported here. This is a 13-years-old project with 29 releases and [Debian](https://packages.debian.org/search?keywords=icmake&searchon=names&suite=all&section=all), [Ubuntu](http://packages.ubuntu.com/search?keywords=icmake&searchon=names&suite=all&section=all), and [MacPorts](https://trac.macports.org/browser/trunk/dports/devel/icmake/Portfile) packages.