### PR TITLE
dmidecode 3.0 (new formula)

### DIFF
--- a/Library/Formula/dmidecode.rb
+++ b/Library/Formula/dmidecode.rb
@@ -1,0 +1,17 @@
+class Dmidecode < Formula
+  desc "Dmidecode reports information about your system's hardware."
+  homepage "https://github.com/cavaliercoder/dmidecode-osx"
+  url "https://github.com/cavaliercoder/dmidecode-osx/archive/dmidecode-osx-3-0.tar.gz"
+  version "3.0"
+  sha256 "676eb69956b836759f2477dc5b71645bf88ec323512edc144d042ee7d1d78bb8"
+
+  def install
+    system "make", "dmidecode"
+    bin.install "dmidecode"
+    man8.install "man/dmidecode.8"
+  end
+
+  test do
+    system "#{bin}/dmidecode"
+  end
+end


### PR DESCRIPTION
OS X native port of dmidecode 3.0 for Intel based Macs.

This is a new and first time (though thoroughly tested) port of dmidecode onto the Mac. The code is currently under consideration by the dmidecode maintainer to be merged into their primary repo.

I'd really like to release this onto brew (as the default package manager for Mac!) ASAP to quickly increase the install base and get some substantial feedback from different Mac models.

Homepage: http://cavaliercoder.com/blog/dmidecode-for-apple-osx.html
Source: https://github.com/cavaliercoder/dmidecode-osx