### PR TITLE
formula: websocketd 0.2.11

### DIFF
--- a/Library/Formula/websocketd.rb
+++ b/Library/Formula/websocketd.rb
@@ -32,14 +32,14 @@ class Websocketd < Formula
   end
 
   test do
-    pid = Process.fork
-    if pid.nil?
-      exec "#{bin}/websocketd", "--port=8080", "echo", "ok"
-    else
-      Process.detach(pid)
-    end
+    pid = Process.fork { exec "#{bin}/websocketd", "--port=8080", "echo", "ok" }
+    sleep 2
 
-    assert_equal("404 page not found\n", shell_output("curl -s http://localhost:8080"))
-    Process.kill(9, pid)
+    begin
+      assert_equal("404 page not found\n", shell_output("curl -s http://localhost:8080"))
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
   end
 end

--- a/Library/Formula/websocketd.rb
+++ b/Library/Formula/websocketd.rb
@@ -1,0 +1,45 @@
+require "language/go"
+
+class Websocketd < Formula
+  desc "WebSockets the Unix way"
+  homepage "http://websocketd.com"
+  url "https://github.com/joewalnes/websocketd/archive/v0.2.11.tar.gz"
+  sha256 "b67a07248cd8675344e4a8553b1ea6434d6789a3990aafe5ecb98d5210f85071"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/joewalnes/websocketd" do
+    url "https://github.com/joewalnes/websocketd.git",
+      :revision => "4ec0493c99e8c1885e524f6af6c1e41250e36202"
+  end
+
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+      :revision => "db8e4de5b2d6653f66aea53094624468caad15d2"
+  end
+
+  def install
+    ENV["GOBIN"] = bin
+    ENV["GOPATH"] = buildpath
+    ENV["GOHOME"] = buildpath
+
+    mkdir_p buildpath/"src/github.com/joewalnes/"
+    ln_sf buildpath, buildpath/"src/github.com/joewalnes/websocketd"
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    system "go", "build", "-ldflags", "-X main.version #{version}", "-o", bin/"websocketd", "main.go", "config.go", "help.go", "version.go"
+    man1.install "release/websocketd.man" => "websocketd.1"
+  end
+
+  test do
+    pid = Process.fork
+    if pid.nil?
+      exec "#{bin}/websocketd", "--port=8080", "echo", "ok"
+    else
+      Process.detach(pid)
+    end
+
+    assert_equal("404 page not found\n", shell_output("curl -s http://localhost:8080"))
+    Process.kill(9, pid)
+  end
+end


### PR DESCRIPTION
Here's a new attempt at creating a formula for [websocketd](https://github.com/bentranter/websocketd). The original attempt was #37030, which didn't use `go_resource`. This one does, and seems to work on a machine with and without Go previously installed.

The thing I'm most uncertain about in this PR is the test. Originally I just tested the output of `websocketd --version`, which I know isn't a great test, but then I saw @asergeyev's comment in #37030 about using `curl`. This seems like a much better test, since it tests the websocket behaviour, but I'm not sure if background processes are ok in the tests. If that isn't working out, I can work on it until we figure out the best approach.

In terms of other differences between this PR and the original one, I copied a lot of the formula from [Hugo's](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/hugo.rb). Their use of `go_resource` made the most the sense to me, so I hope it does here too.

If accepted, this will close https://github.com/joewalnes/websocketd/issues/77.