### PR TITLE
libcdr 0.1.1

### DIFF
--- a/Library/Formula/libcdr.rb
+++ b/Library/Formula/libcdr.rb
@@ -1,8 +1,8 @@
 class Libcdr < Formula
   desc "C++ library to parse the file format of CorelDRAW documents"
   homepage "https://wiki.documentfoundation.org/DLP/Libraries/libcdr"
-  url "http://dev-www.libreoffice.org/src/libcdr/libcdr-0.1.1.tar.bz2"
-  sha256 "72fe7bbbf2275242acdf67ad2f9b6c71ac9146a56c409def360dabcac5695b49"
+  url "http://dev-www.libreoffice.org/src/libcdr/libcdr-0.1.1.tar.xz"
+  sha256 "d0a6e0667e5a37fe059bcb81d5077fc2abffc7e7bac86fe302fbcf927d58df1f"
   revision 1
 
   bottle do


### PR DESCRIPTION
Changed the target compression from tar.bz2 to tar.xz to save 94kb. 
Also future changes will keep the tar.xz