### PR TITLE
dfmt 0.4.1

### DIFF
--- a/Library/Formula/dfmt.rb
+++ b/Library/Formula/dfmt.rb
@@ -1,0 +1,34 @@
+class Dfmt < Formula
+  desc "Formatter for D source code"
+  homepage "https://github.com/Hackerpilot/dfmt"
+  url "https://github.com/Hackerpilot/dfmt.git",
+      :tag => "v0.4.1",
+      :revision => "5ce683bab21598db69e399768ecd143caa57ef34"
+  head "https://github.com/Hackerpilot/dfmt.git", :shallow => false
+
+  depends_on "dmd" => :build
+
+  def install
+    system "make"
+    bin.install "bin/dfmt"
+  end
+
+  test do
+    (testpath/"test.d").write <<-EOS.undent
+    import std.stdio; void main() { writeln("Hello, world without explicit compilations!"); }
+    EOS
+
+    expected = <<-EOS.undent
+    import std.stdio;
+
+    void main()
+    {
+        writeln("Hello, world without explicit compilations!");
+    }
+    EOS
+
+    system "#{bin}/dfmt", "-i", "test.d"
+
+    assert_equal expected, (testpath/"test.d").read
+  end
+end


### PR DESCRIPTION
dfmt is a tool for formatting D source code. It's well maintained and in the long term is likely to become part of the main DMD distribution (At some point I will split all the constituent parts of `dmd.rb` out into separate packages, so don't worry, this formula won't become obsolete).

No, there isn't a `make install`.