### PR TITLE
poppler 0.37.0

### DIFF
--- a/Library/Formula/diff-pdf.rb
+++ b/Library/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha256 "cb90f2e0fd4bc3fe235111f982bc20455a1d6bc13f4219babcba6bd60c1fe466"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any

--- a/Library/Formula/pdf2htmlex.rb
+++ b/Library/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.13.6.tar.gz"
   sha256 "fc133a5791bfd76a4425af16c6a6a2460f672501b490cbda558213cb2b03d5d7"
-  revision 3
+  revision 4
 
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 

--- a/Library/Formula/poppler.rb
+++ b/Library/Formula/poppler.rb
@@ -1,8 +1,8 @@
 class Poppler < Formula
   desc "PDF rendering library (based on the xpdf-3.0 code base)"
   homepage "http://poppler.freedesktop.org"
-  url "http://poppler.freedesktop.org/poppler-0.36.0.tar.xz"
-  sha256 "93cc067b23c4ef7421380d3e8bd7c940b2027668446750787d7c1cb42720248e"
+  url "http://poppler.freedesktop.org/poppler-0.37.0.tar.xz"
+  sha256 "b89f9c5eae3bbb1046b0f767714afd75eca102a0406a3a30856778d42a685bee"
 
   bottle do
     sha256 "ee3a00acc6fc9ea30530e59a09b758cbde2fb64b762553a7de39268ec70aa174" => :el_capitan


### PR DESCRIPTION
The following break after upgrade because of missing libpoppler.so. Included formula revision bump in commit to force rebuild:

- [x] diff-pdf
- [x] pdf2htmlex

As above, also fails so a reinstall is needed. Not sure how to include in commit. 
- [ ] pdftoipe (using --HEAD homebrew/head-only/pdftoipe)

Don't break after poppler upgrade and build-from-source suceeds:
- [x] pdf2svg
- [x] pdfgrep
- [x] xournal (using --with-poppler option)
- [x] inkscape
- [x] pdf-tools