### PR TITLE
Passenger: fix conf message

### DIFF
--- a/Library/Formula/passenger.rb
+++ b/Library/Formula/passenger.rb
@@ -72,7 +72,7 @@ class Passenger < Formula
     s += <<-EOS.undent if build.with? "apache2-module"
       To activate Phusion Passenger for Apache, create /etc/apache2/other/passenger.conf:
         LoadModule passenger_module #{opt_libexec}/buildout/apache2/mod_passenger.so
-        PassengerRoot #{opt_libexec}/lib/phusion_passenger/locations.ini
+        PassengerRoot #{opt_libexec}/src/ruby_supportlib/phusion_passenger/locations.ini
         PassengerDefaultRuby /usr/bin/ruby
 
       EOS


### PR DESCRIPTION
The locations.ini file got moved, but the recommended apache conf still referenced the old location.