### PR TITLE
XQuartz 2.7.8

### DIFF
--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -22,7 +22,8 @@ module OS
         "2.7.53" => "2.7.5_rc4",
         "2.7.54" => "2.7.5",
         "2.7.61" => "2.7.6",
-        "2.7.73" => "2.7.7"
+        "2.7.73" => "2.7.7",
+        "2.7.86" => "2.7.8"
       }.freeze
 
       # This returns the version number of XQuartz, not of the upstream X.org.
@@ -49,7 +50,7 @@ module OS
         when "10.5"
           "2.6.3"
         else
-          "2.7.7"
+          "2.7.8"
         end
       end
 


### PR DESCRIPTION
Available since October 17, first to officially support El Capitan.