### PR TITLE
os: centralize check for pre-release OS X versions

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -240,7 +240,7 @@ class Checks
   end
 
   def check_for_unsupported_osx
-    if !ARGV.homebrew_developer? && MacOS.version >= "10.12" then <<-EOS.undent
+    if !ARGV.homebrew_developer? && OS::Mac.prerelease? then <<-EOS.undent
     You are using OS X #{MacOS.version}.
     We do not provide support for this pre-release version.
     You may encounter build failures or other breakages.
@@ -259,8 +259,7 @@ class Checks
       end
     end
 
-    # TODO: bump version when new OS is released
-    if MacOS.version >= "10.12"
+    if OS::Mac.prerelease?
       def check_xcode_up_to_date
         if MacOS::Xcode.installed? && MacOS::Xcode.outdated?
           <<-EOS.undent

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -251,7 +251,7 @@ class BuildError < RuntimeError
       puts issues.map { |i| "#{i["title"]} #{i["html_url"]}" }.join("\n")
     end
 
-    if MacOS.version >= "10.11"
+    if OS::Mac.prerelease?
       require "cmd/doctor"
       opoo Checks.new.check_for_unsupported_osx
     end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -22,6 +22,11 @@ module OS
       @full_version ||= Version.new(`/usr/bin/sw_vers -productVersion`.chomp)
     end
 
+    def prerelease?
+      # TODO: bump version when new OS is released
+      version >= "10.12"
+    end
+
     def cat
       version.to_sym
     end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -18,7 +18,7 @@ module OS
         when "10.11" then "7.0.1"
         else
           # Default to newest known version of Xcode for unreleased OSX versions.
-          if MacOS.version > "10.11"
+          if OS::Mac.prerelease?
             "7.0.1"
           else
             raise "OS X '#{MacOS.version}' is invalid"


### PR DESCRIPTION
Provide `OS::Mac.prerelease?` for pre-release checks and use it where appropriate. This should simplify updating the test once a new OS X release lands.

This also fixes a bug in `BuildError#dump`, where an empty warning message was printed on El Capitan after a failed from-source build, because the check there and the one in `check_for_unsupported_osx` were out of sync.

(I replaced `MacOS` with `OS::Mac` in the affected lines, because `OS::Mac` in `os/mac.rb` has this line:
```
::MacOS = self # compatibility
```
Not sure though, if that's true, as `MacOS` seems much more widely used.)