### PR TITLE
audit: warn about unknown bottle modifiers

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -463,6 +463,12 @@ class FormulaAuditor
     end
   end
 
+  def audit_bottle_spec
+    if formula.bottle_disabled? && !formula.bottle_disable_reason.valid?
+      problem "Unrecognized bottle modifier"
+    end
+  end
+
   def audit_github_repository
     return unless @online
 
@@ -904,6 +910,7 @@ class FormulaAuditor
     audit_specs
     audit_desc
     audit_homepage
+    audit_bottle_spec
     audit_github_repository
     audit_deps
     audit_conflicts

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -58,6 +58,8 @@ end
 
 # Used to annotate formulae that don't require compiling or cannot build bottle.
 class BottleDisableReason
+  SUPPORTED_TYPES = [:unneeded, :disabled]
+
   def initialize(type, reason)
     @type = type
     @reason = reason
@@ -65,6 +67,10 @@ class BottleDisableReason
 
   def unneeded?
     @type == :unneeded
+  end
+
+  def valid?
+    SUPPORTED_TYPES.include? @type
   end
 
   def to_s


### PR DESCRIPTION
This prevents typos like `bottle :uneeded` or `bottle :disable`.