### PR TITLE
moreutils: Don't conflict with parallel when building without it

### DIFF
--- a/Library/Formula/moreutils.rb
+++ b/Library/Formula/moreutils.rb
@@ -19,7 +19,9 @@ class Moreutils < Formula
 
   depends_on "docbook-xsl" => :build
 
-  conflicts_with "parallel", :because => "Both install a 'parallel' executable."
+  if build.with? "parallel"
+    conflicts_with "parallel", :because => "Both install a 'parallel' executable."
+  end
   conflicts_with "task-spooler", :because => "Both install a 'ts' executable."
 
   resource "Time::Duration" do


### PR DESCRIPTION
Previously, the following would occur:

```
$ brew install parallel
$ brew install moreutils --without-parallel
==> Installing moreutils with --without-parallel
Error: Cannot install moreutils because conflicting formulae are installed.

  parallel: because Both install a 'parallel' executable.
```

This fixes the erroneous failure.