### PR TITLE
Agda 2.4.2.4

### DIFF
--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -5,10 +5,8 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
-  url "https://hackage.haskell.org/package/Agda-2.4.2.3/Agda-2.4.2.3.tar.gz"
-  mirror "https://github.com/agda/agda/archive/2.4.2.3.tar.gz"
-  sha256 "bc6def45e32498f51863d67acfbe048c039d630c6a36761ed27e99a5f68d7b27"
-  revision 2
+  url "https://github.com/agda/agda/archive/2.4.2.4.tar.gz"
+  sha256 "0147f8a1395a69bee1e7a452682094e45c83126233f9864544b8a14f956ce8c3"
 
   bottle do
     sha256 "2dc343203159551613fa7346a93d3e2931064026dccab6c30b68a8490845643b" => :el_capitan


### PR DESCRIPTION
Updates Agda to 2.4.2.4.

cc @DomT4 @nijikon 

Initially, I also proposed the following:

> Changes the installation location of the Agda standard library from `prefix/agda-stdlib` to `prefix/lib`.

> Adds a dependency on GHC, in order to support compiling programs to native code using the MAlonzo backend.  Installing GHC can be disabled using the `--without-malonzo` option.

> Removes the `--with-malonzo-ffi` option.

> Ensures the tests using the MAlonzo backend are run only when GHC is installed.

> Ensures the test using the standard library's FFI bindings for the MAlonzo backend is run properly.

> Changes the dependency on Emacs from optional to recommended.

> Fixes compilation of the Emacs mode by patching the code to add a dependency on the `fontset` Emacs package.  The patch is intended to be removed once https://github.com/agda/agda/pull/1700 is merged.

> Adds a caveats section explaining how to set up the Emacs mode, and how to reference the standard library.