### PR TITLE
Cspice fondu conflicts

### DIFF
--- a/Library/Formula/cspice.rb
+++ b/Library/Formula/cspice.rb
@@ -16,6 +16,7 @@ class Cspice < Formula
   conflicts_with "openhmd", :because => "both install `simple` binaries"
   conflicts_with "libftdi0", :because => "both install `simple` binaries"
   conflicts_with "enscript", :because => "both install `states` binaries"
+  conflicts_with "fondu", :because => "both install `tobin` binaries"
 
   def install
     rm_f Dir["lib/*"]

--- a/Library/Formula/fondu.rb
+++ b/Library/Formula/fondu.rb
@@ -11,6 +11,8 @@ class Fondu < Formula
     sha256 "0f31a728e0e74b6cefb369fa804572a2e6cb00756074183a931fe51e44edfc23" => :mountain_lion
   end
 
+  conflicts_with "cspice", :because => "both install `tobin` binaries"
+
   resource "cminch.ttf" do
     url "http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cminch.ttf"
     sha256 "03aacbe19eac7d117019b6a6bf05197086f9de1a63cb4140ff830c40efebac63"


### PR DESCRIPTION
Following [issue 42766](https://github.com/Homebrew/homebrew/issues/42766), add conflicts_with between `cscpice` and `fondu` over `tobin` binaries.