### PR TITLE
cat: raise unless object is formulae

### DIFF
--- a/Library/Homebrew/cmd/cat.rb
+++ b/Library/Homebrew/cmd/cat.rb
@@ -3,9 +3,11 @@ module Homebrew
     # do not "fix" this to support multiple arguments, the output would be
     # unparsable, if the user wants to cat multiple formula they can call
     # brew cat multiple times.
+    formulae = ARGV.formulae
+    raise FormulaUnspecifiedError if formulae.empty?
+    raise "`brew cat` doesn't support multiple arguments" if formulae.size > 1
 
-    raise FormulaUnspecifiedError if ARGV.named.empty?
     cd HOMEBREW_REPOSITORY
-    exec "cat", ARGV.formulae.first.path, *ARGV.options_only
+    exec "cat", formulae.first.path, *ARGV.options_only
   end
 end


### PR DESCRIPTION
Until a point in time when the Cask/Homebrew codebases are harmonised a little more it probably makes sense to refuse to `cat` Casks. Right now the Homebrew codebase is only minimally aware of what a Cask is.

Fixes #45300.
Fixes #44630.