### PR TITLE
swiftgen-0.6.0

### DIFF
--- a/Library/Formula/swiftgen.rb
+++ b/Library/Formula/swiftgen.rb
@@ -1,8 +1,8 @@
 class Swiftgen < Formula
   desc "Collection of Swift tools to generate Swift code"
   homepage "https://github.com/AliSoftware/SwiftGen"
-  url "https://github.com/AliSoftware/SwiftGen/archive/0.5.1.tar.gz"
-  sha256 "629b455724ec47cb7d1277a20bf7dcac997e04b3b2db30213ed17aecce647fed"
+  url "https://github.com/AliSoftware/SwiftGen/archive/0.6.0.tar.gz"
+  sha256 "4adf379c5d41b360c7fed32e21ba3476dc5e311b5e8a14cb755b0a6addd68e90"
   head "https://github.com/AliSoftware/SwiftGen.git"
 
   bottle do
@@ -14,7 +14,7 @@ class Swiftgen < Formula
   depends_on :xcode => "7.0"
 
   def install
-    rake "install[#{bin},#{lib}]"
+    rake "install[#{bin},#{lib},#{pkgshare}/templates]"
 
     fixtures = %w[
       UnitTests/fixtures/Images.xcassets
@@ -26,22 +26,24 @@ class Swiftgen < Formula
       UnitTests/expected/Strings-File-Defaults.swift.out
       UnitTests/expected/Storyboards-Message-Defaults.swift.out
     ]
-    pkgshare.install fixtures
+    (pkgshare/"fixtures").install fixtures
   end
 
   test do
     system bin/"swiftgen", "--version"
 
-    output = shell_output("#{bin}/swiftgen images #{pkgshare}/Images.xcassets").strip
-    assert_equal output, (pkgshare/"Images-File-Defaults.swift.out").read.strip, "swiftgen images failed"
+    fixtures = pkgshare/"fixtures"
 
-    output = shell_output("#{bin}/swiftgen colors #{pkgshare}/colors.txt").strip
-    assert_equal output, (pkgshare/"Colors-File-Defaults.swift.out").read.strip, "swiftgen colors failed"
+    output = shell_output("#{bin}/swiftgen images #{fixtures}/Images.xcassets").strip
+    assert_equal output, (fixtures/"Images-File-Defaults.swift.out").read.strip, "swiftgen images failed"
 
-    output = shell_output("#{bin}/swiftgen strings #{pkgshare}/Localizable.strings").strip
-    assert_equal output, (pkgshare/"Strings-File-Defaults.swift.out").read.strip, "swiftgen strings failed"
+    output = shell_output("#{bin}/swiftgen colors #{fixtures}/colors.txt").strip
+    assert_equal output, (fixtures/"Colors-File-Defaults.swift.out").read.strip, "swiftgen colors failed"
 
-    output = shell_output("#{bin}/swiftgen storyboards #{pkgshare}/Message.storyboard").strip
-    assert_equal output, (pkgshare/"Storyboards-Message-Defaults.swift.out").read.strip, "swiftgen storyboards failed"
+    output = shell_output("#{bin}/swiftgen strings #{fixtures}/Localizable.strings").strip
+    assert_equal output, (fixtures/"Strings-File-Defaults.swift.out").read.strip, "swiftgen strings failed"
+
+    output = shell_output("#{bin}/swiftgen storyboards #{fixtures}/Message.storyboard").strip
+    assert_equal output, (fixtures/"Storyboards-Message-Defaults.swift.out").read.strip, "swiftgen storyboards failed"
   end
 end


### PR DESCRIPTION
New features, including support for Stencil (Mustache/Django-like) templates.

Default templates now included with this formula and installed in `pkgshare/templates`