### PR TITLE
Agda: Combo fix

### DIFF
--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -15,7 +15,16 @@ class Agda < Formula
     sha256 "d0e17808ee896cdedc499b010b67961dc3db3c430c501faef16c4b4482238447" => :mountain_lion
   end
 
-  head "https://github.com/agda/agda.git", :branch => "master"
+  head do
+    url "https://github.com/agda/agda.git", :branch => "master"
+    resource "stdlib" do
+      url "https://github.com/agda/agda-stdlib.git", :branch => "master"
+    end
+  end
+
+  resource "stdlib" do
+    url "https://github.com/agda/agda-stdlib.git", :branch => "2.4.2.4"
+  end
 
   option "without-stdlib", "Don't install the Agda standard library"
   option "without-malonzo", "Disable the MAlonzo backend"
@@ -31,16 +40,6 @@ class Agda < Formula
   depends_on "emacs" => :recommended
 
   setup_ghc_compilers
-
-  head do
-    resource "stdlib" do
-      url "https://github.com/agda/agda-stdlib.git", :branch => "master"
-    end
-  end
-
-  resource "stdlib" do
-    url "https://github.com/agda/agda-stdlib.git", :branch => "2.4.2.4"
-  end
 
   # fix compilation of the included Emacs mode
   # to be removed once https://github.com/agda/agda/pull/1700 is merged

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -25,7 +25,7 @@ class Agda < Formula
   depends_on "cabal-install" => :build
 
   depends_on "gmp"
-  depends_on "emacs" => :optional
+  depends_on "emacs" => :recommended
 
   setup_ghc_compilers
 
@@ -38,6 +38,10 @@ class Agda < Formula
   resource "stdlib" do
     url "https://github.com/agda/agda-stdlib.git", :branch => "2.4.2.4"
   end
+
+  # fix compilation of the included Emacs mode
+  # to be removed once https://github.com/agda/agda/pull/1700 is merged
+  patch :DATA
 
   def install
     # install Agda core
@@ -74,9 +78,8 @@ class Agda < Formula
       end
     end
 
-    # byte-compile and install Agda's included emacs mode
+    # compile the included Emacs mode
     if build.with? "emacs"
-      system bin/"agda-mode", "setup"
       system bin/"agda-mode", "compile"
     end
   end
@@ -119,3 +122,17 @@ class Agda < Formula
     end
   end
 end
+
+__END__
+diff --git a/src/data/emacs-mode/agda2-mode.el b/src/data/emacs-mode/agda2-mode.el
+index 04604ee..f6b3122 100644
+--- a/src/data/emacs-mode/agda2-mode.el
++++ b/src/data/emacs-mode/agda2-mode.el
+@@ -20,6 +20,7 @@ Note that the same version of the Agda executable must be used.")
+ (require 'time-date)
+ (require 'eri)
+ (require 'annotation)
++(require 'fontset)
+ (require 'agda-input)
+ (require 'agda2)
+ (require 'agda2-highlight)

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -58,14 +58,14 @@ class Agda < Formula
     if build.with? "stdlib"
       resource("stdlib").stage prefix/"agda-stdlib"
 
-      # install the standard library's helper tools
+      # generate the standard library's bytecode
       cd prefix/"agda-stdlib" do
         cabal_sandbox do
           cabal_install "--only-dependencies"
-          cabal_install "--prefix=#{prefix/"agda-stdlib"}"
-          system prefix/"agda-stdlib"/"bin"/"GenerateEverything"
+          cabal_install
+          system "GenerateEverything"
         end
-        cabal_clean_lib
+        rm_rf [".cabal", "dist"]
       end
 
       # install the standard library's FFI bindings for the MAlonzo backend

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -5,10 +5,8 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
-  url "https://hackage.haskell.org/package/Agda-2.4.2.3/Agda-2.4.2.3.tar.gz"
-  mirror "https://github.com/agda/agda/archive/2.4.2.3.tar.gz"
-  sha256 "bc6def45e32498f51863d67acfbe048c039d630c6a36761ed27e99a5f68d7b27"
-  revision 2
+  url "https://github.com/agda/agda/archive/2.4.2.4.tar.gz"
+  sha256 "0147f8a1395a69bee1e7a452682094e45c83126233f9864544b8a14f956ce8c3"
 
   bottle do
     sha256 "2dc343203159551613fa7346a93d3e2931064026dccab6c30b68a8490845643b" => :el_capitan

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -23,7 +23,9 @@ class Agda < Formula
   end
 
   resource "stdlib" do
-    url "https://github.com/agda/agda-stdlib.git", :branch => "2.4.2.4"
+    url "https://github.com/agda/agda-stdlib.git",
+        :tag => "v0.11",
+        :revision => "8602c29a7627eb001344cf50e6b74f880fb6bf18"
   end
 
   option "without-stdlib", "Don't install the Agda standard library"


### PR DESCRIPTION
Fixes a number of issues with the Agda formula.  To be merged after #45287.

### Broken --with-emacs option (#45322)

Changes the dependency on Emacs from optional to recommended.

Fixes compilation of the Emacs mode by patching the code to add a dependency on the `fontset` Emacs package.  The patch is intended to be removed once agda/agda#1700 is merged.

### Broken --with-malonzo-ffi option (#45321)

Removes the `--with-malonzo-ffi` option, as the FFI bindings for the MAlonzo backend are part of the Agda standard library.

Improves the attempt to compile and install the FFI bindings by using a dedicated GHC package database, and cleaning up leftover build products.

Ensures the test using the FFI bindings references them properly.

Adds a caveats section explaining how to reference the standard library.

### Test failures (#45318)

Adds a dependency on GHC, in order to support compiling programs to native code using the MAlonzo backend.  Installing GHC can be disabled using the `--without-malonzo` option.

Ensures the tests using the MAlonzo backend are run only when GHC is installed.

Ensures the test using the standard library's FFI bindings for the MAlonzo backend is run properly.

### Installation of unnecessary files (#45320)

Installs the standard library's helper tools within the Cabal sandbox already used as part of the build process.

Improves the standard library build process by cleaning up leftover build products.

### Bonus

Satisfies `brew audit agda --strict --online`.

Fixes the standard library’s version and revision.