### PR TITLE
inspircd: use the 2.0 branch as head instead of master

### DIFF
--- a/Library/Formula/inspircd.rb
+++ b/Library/Formula/inspircd.rb
@@ -3,7 +3,7 @@ class Inspircd < Formula
   homepage "http://www.inspircd.org"
   url "https://github.com/inspircd/inspircd/archive/v2.0.20.tar.gz"
   sha256 "5156e2da5da4cfa377705ecd633aee41cdcd785d12627497d55cab5f70dd686f"
-  head "https://github.com/inspircd/inspircd.git"
+  head "https://github.com/inspircd/inspircd.git", :branch => "insp20"
 
   bottle do
     revision 1


### PR DESCRIPTION
This updates the InspIRCd formula to use the 2.0 branch when `--HEAD` is specified.

The reason for this is that I will soon be merging in several changes into InspIRCd master (the development branch) which will (unintentionally) break the formula completely. Rather than have to file several updates to fix it I believe it is a more sensible move to switch it to a branch which is not receiving breaking changes.