### PR TITLE
BottleDisableReason: enforce the use of :disable

### DIFF
--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -58,7 +58,7 @@ end
 
 # Used to annotate formulae that don't require compiling or cannot build bottle.
 class BottleDisableReason
-  SUPPORTED_TYPES = [:unneeded, :disabled]
+  SUPPORTED_TYPES = [:unneeded, :disable]
 
   def initialize(type, reason)
     @type = type


### PR DESCRIPTION
#43935 introduced `BottleDisableReason` but never really enforced the use of any type beside `:unneeded`. Correct me if I’m wrong but it seems that one could use `:disable`, `:disabled` or even `:foobar` and get the same result. However the API docs mention `:disable`.

#45146 added an audit check that uses `:disable` too.

#45264 introduced `SUPPORTED_TYPES` with `:disabled`. This is what I’m fixing here.

Should we use `:disable` or `:disabled`? The former is already mentioned in the docs but the latter feels more in line with `:unneeded`. Thoughts?

cc @xu-cheng @DomT4 