### PR TITLE
Ignore QT dependencies for wireshark if not requested

### DIFF
--- a/Library/Formula/wireshark.rb
+++ b/Library/Formula/wireshark.rb
@@ -71,8 +71,11 @@ class Wireshark < Formula
 
     args << "--disable-wireshark" if no_gui
     args << "--disable-gtktest" if build.without?("gtk+3") && build.without?("gtk+")
-    args << "--with-qt" if build.with?("qt") || build.with?("qt5")
-    args << "--with-qt=no" if build.without?("qt") && build.without?("qt5")
+    if build.with?("qt") || build.with?("qt5")
+      args << "--with-qt"
+    else
+      args << "--with-qt=no"
+    end
     args << "--with-gtk3" if build.with? "gtk+3"
     args << "--with-gtk2" if build.with? "gtk+"
     args << "--with-libcap=#{Formula["libpcap"].opt_prefix}" if build.with? "libpcap"

--- a/Library/Formula/wireshark.rb
+++ b/Library/Formula/wireshark.rb
@@ -72,6 +72,7 @@ class Wireshark < Formula
     args << "--disable-wireshark" if no_gui
     args << "--disable-gtktest" if build.without?("gtk+3") && build.without?("gtk+")
     args << "--with-qt" if build.with?("qt") || build.with?("qt5")
+    args << "--with-qt=no" if build.without?("qt") && build.without?("qt5")
     args << "--with-gtk3" if build.with? "gtk+3"
     args << "--with-gtk2" if build.with? "gtk+"
     args << "--with-libcap=#{Formula["libpcap"].opt_prefix}" if build.with? "libpcap"


### PR DESCRIPTION
Wireshark configure automatically pulls in the QT dependency as long as you don't explicitly tell it to ignore the QT libs on the system. This removed the QT dependency if QT has not been request by one of the --with-qt options.