### PR TITLE
Kes es conflict

### DIFF
--- a/Library/Formula/es.rb
+++ b/Library/Formula/es.rb
@@ -8,6 +8,8 @@ class Es < Formula
 
   depends_on "readline" => :optional
 
+  conflicts_with "kes", :because => "both install 'es' binary"
+
   def install
     args = ["--prefix=#{prefix}"]
     args << "--with-readline" if build.with? "readline"

--- a/Library/Formula/kes.rb
+++ b/Library/Formula/kes.rb
@@ -15,6 +15,8 @@ class Kes < Formula
 
   depends_on "readline"
 
+  conflicts_with "es", :because => "both install 'es' binary"
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",


### PR DESCRIPTION
Following [issue 42766](https://github.com/Homebrew/homebrew/issues/42766), add conflicts_with between `kes` and `es` over `es` binaries.