### PR TITLE
update: use git stash silently.

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -196,18 +196,17 @@ class Updater
   def initialize(repository)
     @repository = repository
     @stashed = false
+    @quiet_args = []
+    @quiet_args << "--quiet" unless ARGV.verbose?
   end
 
   def pull!(options = {})
-    quiet = []
-    quiet << "--quiet" unless ARGV.verbose?
-
     unless system "git", "diff", "--quiet"
-      unless options[:silent]
+      if ARGV.verbose?
         puts "Stashing your changes:"
         system "git", "status", "--short", "--untracked-files"
       end
-      safe_system "git", "stash", "save", "--include-untracked", *quiet
+      safe_system "git", "stash", "save", "--include-untracked", *@quiet_args
       @stashed = true
     end
 
@@ -242,7 +241,7 @@ class Updater
     end
 
     if @initial_branch != @upstream_branch && !@initial_branch.empty?
-      safe_system "git", "checkout", @upstream_branch, *quiet
+      safe_system "git", "checkout", @upstream_branch, *@quiet_args
     end
 
     @initial_revision = read_current_revision
@@ -253,7 +252,7 @@ class Updater
     args = ["pull"]
     args << "--ff"
     args << ((ARGV.include? "--rebase") ? "--rebase" : "--no-rebase")
-    args += quiet
+    args += @quiet_args
     args << "origin"
     # the refspec ensures that the default upstream branch gets updated
     args << "refs/heads/#{@upstream_branch}:refs/remotes/origin/#{@upstream_branch}"
@@ -263,12 +262,12 @@ class Updater
     @current_revision = read_current_revision
 
     if @initial_branch != "master" && !@initial_branch.empty?
-      safe_system "git", "checkout", @initial_branch, *quiet
+      safe_system "git", "checkout", @initial_branch, *@quiet_args
     end
 
     if @stashed
-      safe_system "git", "stash", "pop", *quiet
-      unless options[:silent]
+      safe_system "git", "stash", "pop", *@quiet_args
+      if ARGV.verbose?
         puts "Restored your changes:"
         system "git", "status", "--short", "--untracked-files"
       end
@@ -282,7 +281,8 @@ class Updater
     if $?.signaled? && $?.termsig == 2 # SIGINT
       safe_system "git", "checkout", @initial_branch unless @initial_branch.empty?
       safe_system "git", "reset", "--hard", @initial_revision
-      safe_system "git", "stash", "pop" if @stashed
+      safe_system "git", "stash", "pop", *@quiet_args if @stashed
+      @stashed = false
     end
   end
 


### PR DESCRIPTION
There's been a few issues where users have been confused about these errors. They may have modified stuff but we probably don't care about telling them that unless we're debugging other issues.