### PR TITLE
quassel 0.12.2

### DIFF
--- a/Library/Formula/quassel.rb
+++ b/Library/Formula/quassel.rb
@@ -4,15 +4,16 @@ class Quassel < Formula
   head "https://github.com/quassel/quassel.git"
 
   stable do
-    url "http://www.quassel-irc.org/pub/quassel-0.11.0.tar.bz2"
-    sha256 "99a191b8bc2a410f7020b890ec57e0be49313f539da9f4843675bb108b0f4504"
+    url "http://www.quassel-irc.org/pub/quassel-0.12.2.tar.bz2"
+    sha256 "6bd6f79ecb88fb857bea7e89c767a3bd0f413ff01bae9298dd2e563478947897"
 
-    # http://www.openwall.com/lists/oss-security/2015/03/20/12
+    # Fix Qt 5.5 build failure.
     patch do
-      url "https://github.com/quassel/quassel/commit/b5e38970ffd55.diff"
-      sha256 "324ce0edfe5744544846a4796187ceda77921434498089c49c2e50a7f8654fa1"
+      url "https://github.com/quassel/quassel/commit/078477395aaec1edee90922037ebc8a36b072d90.patch"
+      sha256 "85adfbe4613688d0f282deb5250fb39f7534d9e6ac7450cf035cca7bbcb25cda"
     end
   end
+
   bottle do
     sha256 "4402382ffaf05fb19a596f6e7fc1eeb07580ac28fbe1a864ed03b57ca3cbc7ce" => :yosemite
     sha256 "02b90ddfb94c0be796a5941174b8887c3ebbbaf3d01c1dca22c1abfe07ec4c11" => :mavericks


### PR DESCRIPTION
Also fixes a build failure that existed since Qt 5.5.0 was introduced.