### PR TITLE
brew install --auto added

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -43,23 +43,23 @@ module Homebrew
       FormulaInstaller.prevent_build_flags unless MacOS.has_apple_developer_tools?
 
       ARGV.formulae.each do |f|
-        # head-only without --HEAD is an error
-        if !ARGV.build_head? && f.stable.nil? && f.devel.nil?
+        # head-only without --HEAD nor --auto is an error
+        if !ARGV.build_auto? && !ARGV.build_head? && f.stable.nil? && f.devel.nil?
           raise <<-EOS.undent
           #{f.full_name} is a head-only formula
           Install with `brew install --HEAD #{f.full_name}`
           EOS
         end
 
-        # devel-only without --devel is an error
-        if !ARGV.build_devel? && f.stable.nil? && f.head.nil?
+        # devel-only without --devel nor --auto is an error
+        if !ARGV.build_auto? && !ARGV.build_devel? && f.stable.nil? && f.head.nil?
           raise <<-EOS.undent
           #{f.full_name} is a devel-only formula
           Install with `brew install --devel #{f.full_name}`
           EOS
         end
 
-        if ARGV.build_stable? && f.stable.nil?
+        if !ARGV.build_auto? && ARGV.build_stable? && f.stable.nil?
           raise "#{f.full_name} has no stable download, please choose --devel or --HEAD"
         end
 

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -156,6 +156,10 @@ module HomebrewArgvExtension
     !(build_head? || build_devel?)
   end
 
+  def build_auto?
+    include? "--auto"
+  end
+
   def build_universal?
     include? "--universal"
   end


### PR DESCRIPTION
This option disables the `--HEAD` and `--devel` checks for HEAD-only and devel-only formulae. This allows one to run `brew install --auto foo bar qux` without worrying about `--HEAD` or `--devel`.

For example if `a` has a stable and HEAD block; `b` has only a HEAD block and `c` only have a `devel` block; one needs to do the following to install all of them:
```
$ brew install a
$ brew install --HEAD b
$ brew install --devel c
```

With this change one could use the following command:
```
$ brew install --auto a b c
```