### PR TITLE
Formula for Carina CLI

### DIFF
--- a/Library/Formula/carina.rb
+++ b/Library/Formula/carina.rb
@@ -1,0 +1,27 @@
+class Carina < Formula
+  desc "Work with Swarm clusters on Carina"
+  homepage "https://github.com/getcarina/carina"
+  url "https://github.com/getcarina/carina.git",
+        :tag => "v0.8.0",
+        :revision => "094a0d2cfb24e245015f980127b9492889ed86f9"
+  head "https://github.com/getcarina/carina.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    carinapath = buildpath/"src/github.com/getcarina/carina"
+    carinapath.install Dir["{*,.git}"]
+
+    cd carinapath do
+      system "make", "get-deps"
+      system "make", "carina", "VERSION=#{version}"
+      bin.install "carina"
+    end
+  end
+
+  test do
+    system "#{bin}/carina", "--version"
+  end
+end


### PR DESCRIPTION
Client for [Carina](https://getcarina.com/). This is my first formula.

One awkwardness here: the Makefile for `carina` set the version using `git describe --tags --dirty='-dev'`. When the homebrew build is going on, the repository ends up in a dirty state (dotfiles missing, not sure why). This formula gets the right tag directly, based on trusting that homebrew has checked out the right tag.

UPDATE: Looks like I'll be back in two weeks since the newer repo has only existed for 15 days. This CLI used to be a part of the go bindings before being broken out separately, so it's existed for longer but its not a big deal.