### PR TITLE
Reverse the entries in MacCPUs.universal_archs

### DIFF
--- a/Library/Homebrew/os/mac/hardware.rb
+++ b/Library/Homebrew/os/mac/hardware.rb
@@ -97,7 +97,11 @@ module MacCPUs
     if MacOS.version <= :leopard && !MacOS.prefer_64_bit?
       [arch_32_bit].extend ArchitectureListExtension
     else
-      [arch_32_bit, arch_64_bit].extend ArchitectureListExtension
+      # Amazingly, this order (64, then 32) matters. It shouldn't, but it
+      # does. GCC (some versions? some systems?) can blow up if the other
+      # order is used.
+      # http://superuser.com/questions/740563/gcc-4-8-on-macos-fails-depending-on-arch-order
+      [arch_64_bit, arch_32_bit].extend ArchitectureListExtension
     end
   end
 


### PR DESCRIPTION
The order ought not to matter, but GCC can fail with `-arch i386 -arch x86_64` (producing an error like `FATAL:Bad fx_size (0x8) in fix_to_relocation_info()`) but succeed with `-arch x86_64 -arch i386`.

[Here's at least one other person](http://superuser.com/questions/740563/gcc-4-8-on-macos-fails-depending-on-arch-order) on the planet who's seen this so that I'm not a crazy person, because honestly this report makes me feel a little bit like a crazy person.

This came up via `brew install libtiff --universal --cc=gcc-5`, which fails for me at configure time with a cryptic `configure: error: C compiler cannot create executables`. Probably comes up with other packages as long as they're being built with `--universal`, and probably other versions of GCC as well.

This might be a Snow Leopard thing for all I know, but it seems like a harmless change to give to everybody... of course, this seems like it would be harmless in either direction so what do I know?