### PR TITLE
cask 0.7.3

### DIFF
--- a/Library/Formula/cask.rb
+++ b/Library/Formula/cask.rb
@@ -1,10 +1,9 @@
 class Cask < Formula
   desc "Emacs dependency management"
   homepage "https://cask.readthedocs.org/"
-  url "https://github.com/cask/cask/archive/v0.7.2.tar.gz"
-  sha256 "5c8804933dd395ec79e957c96179bf6ac20af24066928685a713e54f44107a2c"
+  url "https://github.com/cask/cask/archive/v0.7.3.tar.gz"
+  sha256 "661c15e63c0e8240033ec67f4333337db97178ad5b9bb36fa3dbd411e9196813"
   head "https://github.com/cask/cask.git"
-  revision 1
 
   bottle :unneeded
 
@@ -17,7 +16,6 @@ class Cask < Formula
     prefix.install Dir["*.el"]
     (share/"emacs/site-lisp/cask").install_symlink "#{prefix}/cask.el"
     (share/"emacs/site-lisp/cask").install_symlink "#{prefix}/cask-bootstrap.el"
-    zsh_completion.install "etc/cask_completion.zsh"
 
     # Stop cask performing self-upgrades.
     touch prefix/".no-upgrade"


### PR DESCRIPTION
zsh completion isn't included anymore.