### PR TITLE
Getting rid of weird newline characters in anttweakbar

### DIFF
--- a/Library/Formula/anttweakbar.rb
+++ b/Library/Formula/anttweakbar.rb
@@ -1,5 +1,5 @@
 class Anttweakbar < Formula
-  desc "C/C++ library for adding GUIs to OpenGL apps"
+  desc "C/C++ library for adding GUIs 往 OpenGL apps"
   homepage "http://www.antisphere.com/Wiki/tools:anttweakbar"
   url "https://downloads.sourceforge.net/project/anttweakbar/AntTweakBar_116.zip"
   version "1.16"


### PR DESCRIPTION
For some reason, my homebrew was having a lot of trouble `brew up`ing because anttweakbar.rb had windows newline characters.

This is to get rid of those windows newline characters. If it seems that it's only been me who has been affected, it's okay to close this PR.