### PR TITLE
mpd 0.19.11

### DIFF
--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -1,11 +1,16 @@
 class Mpd < Formula
   desc "Music Player Daemon"
   homepage "http://www.musicpd.org/"
-  revision 1
 
   stable do
-    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.10.tar.xz"
-    sha256 "c386eb3d22f98dc993b5ae3c272f969aa7763713483c6800040ebf1791b15851"
+    url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.11.tar.xz"
+    sha256 "7a5c66aa5af97a5b7af3dc49e3d2594071dafd62a14e2e9f7c9a5a86342836c6"
+
+    # Fixes build because of missing patch on 0.19 branch
+    patch :p1 do
+      url "http://git.musicpd.org/cgit/master/mpd.git/patch/?id=eae9cb4afe0e311a65dc566a0655a54656c8d807"
+      sha256 "0f60cfe354e1f81904cbdc469d49c65508d1f9c219f3d20332fbabdb17a17318"
+    end
   end
 
   bottle do


### PR DESCRIPTION
This is a bugfix release (2015/10/27):
* tags
  - ape: fix buffer overflow
* decoder
  - ffmpeg: fix crash due to wrong avio_alloc_context() call
  - gme: don't loop forever, fall back to GME's default play length
* encoder
  - flac: fix crash with 32 bit playback
* mixer
  - fix mixer lag after enabling/disabling output