### PR TITLE
Update task to 2.5.0

### DIFF
--- a/Library/Formula/task.rb
+++ b/Library/Formula/task.rb
@@ -6,7 +6,7 @@ class Task < Formula
     url "https://taskwarrior.org/download/task-2.5.0.tar.gz"
     sha256 "4d8e67415a6993108c11b8eeef99b76a991af11b22874adbb7ae367e09334636"
 
-    depends_on "gnutls" => :optional
+    depends_on "gnutls"
   end
 
   bottle do

--- a/Library/Formula/task.rb
+++ b/Library/Formula/task.rb
@@ -3,8 +3,8 @@ class Task < Formula
   homepage "https://taskwarrior.org/"
 
   stable do
-    url "https://taskwarrior.org/download/task-2.4.4.tar.gz"
-    sha256 "7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b"
+    url "https://taskwarrior.org/download/task-2.5.0.tar.gz"
+    sha256 "4d8e67415a6993108c11b8eeef99b76a991af11b22874adbb7ae367e09334636"
 
     depends_on "gnutls" => :optional
   end
@@ -16,16 +16,8 @@ class Task < Formula
     sha256 "0e06847ebc7af012af157ed90129c632a60eec6c335f0d05feeafb9793ec874b" => :mavericks
   end
 
-  devel do
-    url "http://taskwarrior.org/download/task-2.5.0.beta3.tar.gz"
-    sha256 "ed41e7d4344da57b6cbc24971e7ddba08486f54e8030779f2ebd939086e11bc8"
-    version "2.5.0.beta3"
-
-    depends_on "gnutls"
-  end
-
   head do
-    url "https://git.tasktools.org/scm/tm/task.git", :branch => "2.5.0", :shallow => false
+    url "https://git.tasktools.org/scm/tm/task.git", :branch => "2.5.1", :shallow => false
 
     depends_on "gnutls"
   end


### PR DESCRIPTION
Remove devel-block since 2.5.0 is stable now. Bump head-block to make
use of branch 2.5.1.