### PR TITLE
Flvstream rtmpdump conflict

### DIFF
--- a/Library/Formula/flvstreamer.rb
+++ b/Library/Formula/flvstreamer.rb
@@ -11,6 +11,8 @@ class Flvstreamer < Formula
     sha256 "cc023cb31d4813460d8acb63cfd8f23dfe881b4d4b5bd5d7c84d4aae15369c28" => :mountain_lion
   end
 
+  conflicts_with "rtmpdump", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'rtmpsuck' binary"
+
   def install
     system "make", "posix"
     bin.install "flvstreamer", "rtmpsrv", "rtmpsuck", "streams"

--- a/Library/Formula/flvstreamer.rb
+++ b/Library/Formula/flvstreamer.rb
@@ -11,7 +11,7 @@ class Flvstreamer < Formula
     sha256 "cc023cb31d4813460d8acb63cfd8f23dfe881b4d4b5bd5d7c84d4aae15369c28" => :mountain_lion
   end
 
-  conflicts_with "rtmpdump", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'rtmpsuck' binary"
+  conflicts_with "rtmpdump", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'streams' binary"
 
   def install
     system "make", "posix"

--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -18,7 +18,7 @@ class Rtmpdump < Formula
     sha256 "90f87f1c3e8c68385576812bdfadc39152d3bd9166cafb982761d1a6cc915710" => :mountain_lion
   end
 
-  conflicts_with "flvstreamer", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'rtmpsuck' binary"
+  conflicts_with "flvstreamer", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'streams' binary"
 
   depends_on "openssl"
 

--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -18,6 +18,8 @@ class Rtmpdump < Formula
     sha256 "90f87f1c3e8c68385576812bdfadc39152d3bd9166cafb982761d1a6cc915710" => :mountain_lion
   end
 
+  conflicts_with "flvstreamer", :because => "both install 'rtmpsrv', 'rtmpsuck' and 'rtmpsuck' binary"
+
   depends_on "openssl"
 
   fails_with :llvm do


### PR DESCRIPTION
Following [issue 42766](https://github.com/Homebrew/homebrew/issues/42766), add conflicts_with between flvstreamer and rtmpdump over rtmpsrv, rtmpsuck and rtmpsuck binaries.