### PR TITLE
Added KiCad formula.

### DIFF
--- a/Library/Formula/kicad.rb
+++ b/Library/Formula/kicad.rb
@@ -15,9 +15,8 @@ class Kicad < Formula
   depends_on "cairo"
   depends_on "pcre"
   depends_on "glew"
-  depends_on "openssl"
   depends_on "boost"
-  depends_on :python => :recoommended
+  depends_on :python => :recommended
 
   fails_with :gcc
   fails_with :llvm
@@ -131,9 +130,9 @@ class Kicad < Formula
         args << "-DKICAD_SCRIPTING=OFF"
         args << "-DKICAD_SCRIPTING_MODULES=OFF"
         args << "-DKICAD_SCRIPTING_WXPYTHON=OFF"
+      end
         args << "-DCMAKE_C_COMPILER=#{ENV.cc}"
         args << "-DCMAKE_CXX_COMPILER=#{ENV.cxx}"
-      end
 
       if build.with? "menu-icons"
         args << "-DUSE_IMAGES_IN_MENUS=ON"

--- a/Library/Formula/kicad.rb
+++ b/Library/Formula/kicad.rb
@@ -1,0 +1,171 @@
+class Kicad < Formula
+  desc "Electronic Design Automation Suite"
+  homepage "http://www.kicad-pcb.org"
+  url "https://launchpad.net/kicad/4.0/4.0.0-rc1/+download/kicad-4.0.0-rc1.tar.xz"
+  sha256 "62c2e95a2d6b8a3cf30bb91146c3d2b1c0df0cbfc070b6e54bcfdf0da2df6973"
+  head "https://github.com/KiCad/kicad-source-mirror.git"
+
+  option "without-menu-icons", "Build without icons menus."
+  option "without-python", "Disables python scriptability."
+
+  depends_on "swig" => :build
+  depends_on "pkg-config" => :build
+  depends_on "bazaar" => :build
+  depends_on "cmake" => :build
+  depends_on "cairo"
+  depends_on "pcre"
+  depends_on "glew"
+  depends_on "openssl"
+  depends_on "boost"
+  depends_on :python => :recoommended
+
+  fails_with :gcc
+  fails_with :llvm
+
+  # KiCad requires wx to have several bugs fixed to function, but the patches have yet to be included with a wx release
+  # so KiCad, as part of its build system, builds its own wx binaries with these fixes included.  It uses a bash script
+  # for this, so I have simply concatenated all the patches into one patch to make it fit better into homebrew.  These
+  # Patches are the ones that come from the stable release archive of KiCad under the patches directory.
+  resource "wxpatch" do
+    url "https://gist.githubusercontent.com/metacollin/2d5760743df73c939d53/raw/b25008a92c8f518df582ad88d266dcf2d75f9d12/wxp.patch"
+    sha256 "0a19c475ded29186683a9e7f7d9316e4cbea4db7b342f599cee0e116fa019f3e"
+  end
+
+  resource "wxk" do
+    url "https://downloads.sourceforge.net/project/wxpython/wxPython/3.0.2.0/wxPython-src-3.0.2.0.tar.bz2"
+    sha256 "d54129e5fbea4fb8091c87b2980760b72c22a386cb3b9dd2eebc928ef5e8df61"
+  end
+
+  resource "kicad-library" do
+    url "https://github.com/KiCad/kicad-library.git"
+  end
+
+  def install
+    ENV["MAC_OS_X_VERSION_MIN_REQUIRED"] = "#{MacOS.version}"
+    ENV.append "ARCHFLAGS", "-Wunused-command-line-argument-hard-error-in-future"
+    ENV.append "LDFLAGS", "-headerpad_max_install_names"
+    if MacOS.version < :mavericks
+      ENV.libstdcxx
+    else
+      ENV.libcxx
+    end
+
+    inreplace "common/common.cpp", "/Library/Application Support/kicad", "#{etc}/kicad"
+    inreplace "common/common.cpp", "wxStandardPaths::Get().GetUserConfigDir()", "wxT( \"#{etc}/kicad/Prefences\" )"
+    inreplace "common/pgm_base.cpp", "DEFAULT_INSTALL_PATH", "\"#{etc}/kicad\""
+
+    resource("wxk").stage do
+      (Pathname.pwd).install resource("wxpatch")
+      safe_system "/usr/bin/patch", "-g", "0", "-f", "-d", Pathname.pwd, "-p1", "-i", "wxp.patch"
+
+      mkdir "wx-build" do
+        args = [
+          "--prefix=#{buildpath/"wxk"}",
+          "--with-opengl",
+          "--enable-aui",
+          "--enable-utf8",
+          "--enable-html",
+          "--enable-stl",
+          "--with-libjpeg=builtin",
+          "--with-libpng=builtin",
+          "--with-regex=builtin",
+          "--with-libtiff=builtin",
+          "--with-zlib=builtin",
+          "--with-expat=builtin",
+          "--without-liblzma",
+          "--with-macosx-version-min=#{MacOS.version}",
+          "--enable-universal_binary=i386,x86_64",
+          "CC=#{ENV.cc}",
+          "CXX=#{ENV.cxx}",
+        ]
+
+        system "../configure", *args
+        system "make"
+        system "make", "install"
+      end
+
+      if build.with? "python"
+        cd "wxPython" do
+          args = [
+            "WXPORT=osx_cocoa",
+            "WX_CONFIG=#{buildpath/"wxk"}/bin/wx-config",
+            "UNICODE=1",
+            "BUILD_BASE=#{buildpath}/wx-build",
+          ]
+
+          system "python", "setup.py", "build_ext", *args
+          system "python", "setup.py", "install", "--prefix=#{buildpath}/py", *args
+        end
+      end
+    end
+
+    mkdir "build" do
+      if build.with? "python"
+        ENV.prepend_create_path "PYTHONPATH", "#{buildpath}/py/lib/python2.7/site-packages"
+      end
+
+      args = %W[
+        -DCMAKE_INSTALL_PREFIX=#{prefix}
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=#{MacOS.version}
+        -DwxWidgets_CONFIG_EXECUTABLE=#{buildpath/"wxk"}/bin/wx-config
+        -DKICAD_REPO_NAME=brewed_product
+        -DKICAD_SKIP_BOOST=ON
+        -DBoost_USE_STATIC_LIBS=ON
+      ]
+
+      if build.with? "debug"
+        args << "-DCMAKE_BUILD_TYPE=Debug"
+        args << "-DwxWidgets_USE_DEBUG=ON"
+      else
+        args << "-DCMAKE_BUILD_TYPE=Release"
+      end
+
+      if build.with? "python"
+        args << "-DPYTHON_SITE_PACKAGE_PATH=#{buildpath}/py/lib/python2.7/site-packages"
+        args << "-DKICAD_SCRIPTING=ON"
+        args << "-DKICAD_SCRIPTING_MODULES=ON"
+        args << "-DKICAD_SCRIPTING_WXPYTHON=ON"
+        ENV["PYTHON_EX"] = which "python"
+        args << "-DPYTHON_EXECUTABLE=#{ENV["PYTHON_EX"]}"
+      else
+        args << "-DKICAD_SCRIPTING=OFF"
+        args << "-DKICAD_SCRIPTING_MODULES=OFF"
+        args << "-DKICAD_SCRIPTING_WXPYTHON=OFF"
+        args << "-DCMAKE_C_COMPILER=#{ENV.cc}"
+        args << "-DCMAKE_CXX_COMPILER=#{ENV.cxx}"
+      end
+
+      if build.with? "menu-icons"
+        args << "-DUSE_IMAGES_IN_MENUS=ON"
+      end
+
+      system "cmake", "../", *(std_cmake_args + args)
+      system "make"
+      system "make", "install"
+    end
+
+    resource("kicad-library").stage do
+      mkdir_p "#{etc}/kicad/Preferences" do
+        (etc/"kicad").install Dir["*"]
+      end
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    KiCad component libraries are located in:
+      /usr/local/etc/kicad
+
+    KiCad footprint table is located at:
+      /usr/local/etc/kicad/Preferences/fp-lib-table
+
+    Component libraries have been setup for you, but
+    footprints and 3D models must be downloaded from
+    within Pcbnew.  It will automatically guide you
+    through this process upon first lauch.
+    EOS
+  end
+
+  test do
+    system "stat", "#{prefix}/kicad.app/Contents/MacOS/kicad"
+  end
+end

--- a/Library/Formula/kicad.rb
+++ b/Library/Formula/kicad.rb
@@ -14,6 +14,7 @@ class Kicad < Formula
   depends_on "cmake" => :build
   depends_on "cairo"
   depends_on "pcre"
+  depends_on "openssl"
   depends_on "glew"
   depends_on "boost"
   depends_on :python => :recommended
@@ -131,8 +132,8 @@ class Kicad < Formula
         args << "-DKICAD_SCRIPTING_MODULES=OFF"
         args << "-DKICAD_SCRIPTING_WXPYTHON=OFF"
       end
-        args << "-DCMAKE_C_COMPILER=#{ENV.cc}"
-        args << "-DCMAKE_CXX_COMPILER=#{ENV.cxx}"
+      args << "-DCMAKE_C_COMPILER=#{ENV.cc}"
+      args << "-DCMAKE_CXX_COMPILER=#{ENV.cxx}"
 
       if build.with? "menu-icons"
         args << "-DUSE_IMAGES_IN_MENUS=ON"


### PR DESCRIPTION
Hi, I am aware of that .app Formulae are frowned upon, and I completely understand if this pull request is rejected, but I am submitting it because I think this is one of those rare instances where it might be worth making an exception.

KiCad ( http://kicad-pcb.org/ ) is an open source Electronic Design Automation suite with heavy development from CERN (lab behind the Large Hadron Collider, and birthplace of the world wide web) and it is intended to be open source and completely cross platform.   

Unfortunately, OS X support is somewhat lacking, a familiar situation to all of us.  If you go to the website, and navigate to the OS X download section, there actually isn't any.  There is a link to a directory listing of nightly snapshots for OS X, but no stable version (but you can compile the stable version from source).  Beyond that, the current OS X builds are crippled, they are missing a key feature entirely, which is python scriptability.  I subscribe to the development mailing list for KiCad, and it doesn't look like the official builds will be getting this feature any time soon, either.  The developers have done an amazing job on the OS X version, but there are just very few contributors or developers on the project that are familiar with OS X.

Building KiCad on OS X is a nightmare - it has many dependencies, and is extremely difficult to build with python support - for whatever reason, cmake will mix and match libpython and python executables of different versions, various other issues.  Building KiCad for OS X has been frustrating for most users at best (I base this on the forums and mainling lists).  

Finally, the biggest issue is that KiCad, over the course of it's development, has actually uncovered many serious bugs in wx and wxPython, some which effect all platforms, and many that are OS X specific.  They have made patches that fix all of them, and submitted each one upstream, but the wx developers are focusing on wxPhoenix and, as near as I can tell, simply don't care enough to put out a new release with any of the fixes included.  KiCad does not work without these fixes.  There is a bug trac for every single fix, they are not any sort of KiCad specific modifications, but patches that ought to be included upstream.  

There is a similar but not entirely parallel situation with boost.  Yes, boost.  KiCad's development team found several bugs in boost as well, and created patches to fix them, and submitted them upstream.  Fortunately, the boost developers were happy to receive them and all of them have since been incorporated in the more recent versions of boost.  However, the project leader for KiCad is worried about potential issues that might not be known to them if they switch to a newer version of boost, especially when version 1.56 (the one they use) is known to be stable.  1.56 requires patching, unfortunately.  

If that were not issues enough, the included build scripts and system do not correctly handle issues relating to libc++ vs. libstdc++, and understandably so, it is a very OS X specific problem, and is not always easy to notice unless you try to support a wide number of OSes.  

There is one last thing (it really is the last!).  KiCad does not quite follow Apple's user experience recommendations as well as it could when it comes to file paths.  The nightlies require a huge number of files be manually copied from a completely different dmg than the one the snapshots come on into the global /Library/Application Support/ directory. It is an electronic CAD program, so new electronic components, both schematic symbols, CAD drawings, and 3D models, are constantly being added, so these files are also frequently updated.  In fact, the software treats them all like github repositories (well...and they ARE github repositories), so they cannot simply be stored in the .app bundle.  But /Library/ stuff is, in my opinion, a bit invasive.  It then further spreads other files in the user's Library/Preferences folder, when in reality, the only settings stored there are ones that would be global, and user preferences are stored per project, in the project file.  Oh, and you have to download and install these files manually on OS X, while all other platforms have automated ways to do this.

My formula solves all of this.  It builds the stable version as well as the --HEAD snapshots painlessly, handles building a patched and bugfixed wx and wxPython and all of these are sequestered away inside the KiCad .app bundle and will never cause trouble with anything on the system.  Python scripting is enabled by default.  I have tested it and it builds even on 10.6.  A friend of mine uses KiCad, but they only support 10.7+, and he uses 10.6 (...I know, I've been trying to get him to upgrade).  It fully integrates with homebrew's handling of python, populates library files and settings in /usr/local/etc, which I feel is much less invasive and more in the spirit of OS X.  It will just use homebrew's boost as a dependency instead of patching and building 1.56 (I have completed several major commercial circuit boards with KiCad built with 1.58 and there are no issues I can find).  

And in conclusion, while KiCad creates a .app bundle, this is not really a in anyway native, it is built as a suit of command line programs, and build scripts copy them into a .app bundle, but there there is an entire suite of programs in there.  It uses wx, and all the dependencies you'd expect for any other command line app.  I've been using it in the form of a homebrew tap, symlinked into my applications folder, and it works a treat.  It's also an app that has many build customizations, is impossible to get a stable build of for OS X, and the unstable nightlies are missing critical features that are enabled with my formula.  And there has been a need for centralized, robust, 'just works' way to build the OS X version of KiCad, a demand that has been largely unfilled.  

I feel that this is a unique situation, and that it many users would welcome a kicad formula into the official homebrew repository, and it makes sense to even by default producing a .app.  

For these (extensive) reasons, I politely request the powers that be consider, purely for the benefit of interested users and engineers who use OS X, to grant my pull request.  I feel it is a good fit, and certainly doesn't really fit with the rest of the casks.  The whole point of this formula is that it needs to be built, and one gains significant advantages to doing so, which is very much in the spirit of the homebrew project, in my opinion.  

If this is ultimately rejected, then I know it was for good reasons and I am simply not aware of them as I write this.  Either way, thanks for taking the time to read this, and I support whatever the decision will be. 

Thanks!