### PR TITLE
libmatroska 1.4.4, remove patch linking libebml

### DIFF
--- a/Library/Formula/libmatroska.rb
+++ b/Library/Formula/libmatroska.rb
@@ -3,13 +3,9 @@ class Libmatroska < Formula
   homepage "http://www.matroska.org/"
 
   stable do
-    url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.2.tar.bz2"
-    mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.2.tar.bz2"
-    sha256 "bea10320f1f1fd121bbd7db9ffc77b2518e8269f00903549c5425478bbf8393f"
-
-    # Apply upstream patch to link against libEBML
-    # https://github.com/Matroska-Org/libmatroska/commit/9466bf5f2b
-    patch :DATA
+    url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.4.tar.bz2"
+    mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.4.tar.bz2"
+    sha256 "d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7"
   end
 
   head do
@@ -48,39 +44,3 @@ class Libmatroska < Formula
     system "make", "install"
   end
 end
-
-__END__
-diff --git a/Makefile.am b/Makefile.am
-index f3b881d..c6a728d
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -27,6 +27,7 @@ libmatroska_la_SOURCES = \
-	src/KaxTracks.cpp \
-	src/KaxVersion.cpp
- libmatroska_la_LDFLAGS = -version-info 6:0:0 -no-undefined
-+libmatroska_la_LIBADD = $(EBML_LIBS)
-
- nobase_include_HEADERS = \
-	matroska/c/libmatroska.h \
-diff --git a/Makefile.in b/Makefile.in
-index dc52565..e677a4f 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -141,7 +141,8 @@ am__uninstall_files_from_dir = { \
- am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(pkgconfigdir)" \
-	"$(DESTDIR)$(includedir)"
- LTLIBRARIES = $(lib_LTLIBRARIES)
--libmatroska_la_LIBADD =
-+am__DEPENDENCIES_1 =
-+libmatroska_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
- am__dirstamp = $(am__leading_dot)dirstamp
- am_libmatroska_la_OBJECTS = src/FileKax.lo src/KaxAttached.lo \
-	src/KaxAttachments.lo src/KaxBlock.lo src/KaxBlockData.lo \
-@@ -387,6 +398,7 @@ libmatroska_la_SOURCES = \
-	src/KaxVersion.cpp
-
- libmatroska_la_LDFLAGS = -version-info 6:0:0 -no-undefined
-+libmatroska_la_LIBADD = $(EBML_LIBS)
- nobase_include_HEADERS = \
-	matroska/c/libmatroska.h \
-	matroska/c/libmatroska_t.h \

--- a/Library/Formula/libmatroska.rb
+++ b/Library/Formula/libmatroska.rb
@@ -5,7 +5,7 @@ class Libmatroska < Formula
   stable do
     url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.4.tar.bz2"
     mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.4.tar.bz2"
-    sha256 "d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7" 
+    sha256 "d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7"
   end
 
   head do

--- a/Library/Formula/libmatroska.rb
+++ b/Library/Formula/libmatroska.rb
@@ -5,7 +5,7 @@ class Libmatroska < Formula
   stable do
     url "http://dl.matroska.org/downloads/libmatroska/libmatroska-1.4.4.tar.bz2"
     mirror "https://www.bunkus.org/videotools/mkvtoolnix/sources/libmatroska-1.4.4.tar.bz2"
-    sha256 "d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7"
+    sha256 "d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7" 
   end
 
   head do


### PR DESCRIPTION
Patch in older formula was for 1.4.2, which was merged in 1.4.3. Upstream patch (Matroska-Org/libmatroska@9466bf5) should no longer be needed.