### PR TITLE
duo_unix: 1.9.16

### DIFF
--- a/Library/Formula/duo_unix.rb
+++ b/Library/Formula/duo_unix.rb
@@ -1,9 +1,8 @@
 class DuoUnix < Formula
   desc "Two-factor authentication for SSH"
   homepage "https://www.duosecurity.com/docs/duounix"
-  url "https://dl.duosecurity.com/duo_unix-1.9.13.tar.gz"
-  sha256 "90397cd756669b22353d2ff024c6042affce23207e803bf9c1341ae3fc2e945a"
-  revision 1
+  url "https://dl.duosecurity.com/duo_unix-1.9.16.tar.gz"
+  sha256 "66a109723f5de0ad524a4ceb35e8a540d9fbbcecc9984be27ec91466cedd193b"
 
   bottle do
     cellar :any


### PR DESCRIPTION
We normally use the SHA1 for verification (https://www.duosecurity.com/docs/checksums#duo-unix), but you can confirm that the SHA256 is correct here.