### PR TITLE
Update formula for 'when' to version 1.1.35.

### DIFF
--- a/Library/Formula/when.rb
+++ b/Library/Formula/when.rb
@@ -1,9 +1,9 @@
 class When < Formula
   desc "Tiny personal calendar"
   homepage "http://www.lightandmatter.com/when/when.html"
-  url "https://mirrors.kernel.org/debian/pool/main/w/when/when_1.1.34.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/when/when_1.1.34.orig.tar.gz"
-  sha256 "ce0540bde96b361d6d0770803901364a687d971ffedd33e36f8f8bef32b19600"
+  url "https://mirrors.kernel.org/debian/pool/main/w/when/when_1.1.35.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/when/when_1.1.35.orig.tar.gz"
+  sha256 "f880c0d80b1023a05df99690e36be133c46071657b9921fc9e8d16115fb13ae6"
   head "https://github.com/bcrowell/when.git"
 
   bottle do


### PR DESCRIPTION
Version 1.1.34 no longer exists at the download url.