### PR TITLE
Tippecanoe 1.3.1

### DIFF
--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -1,8 +1,8 @@
 class Tippecanoe < Formula
   desc "Build vector tilesets from collections of GeoJSON features"
   homepage "https://github.com/mapbox/tippecanoe"
-  url "https://github.com/mapbox/tippecanoe/archive/v1.2.0.tar.gz"
-  sha256 "237510a1a92a8626407c29c8d8047e73bbb22c1a8af8f9d1b8931d994c8fac2d"
+  url "https://github.com/mapbox/tippecanoe/archive/v1.3.1.tar.gz"
+  sha256 "6c393e99ab7a75c9a3a5a7da4681794df283c0f2312d58edfcf2910a6726c676"
 
   bottle do
     cellar :any

--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -2,7 +2,7 @@ class Tippecanoe < Formula
   desc "Build vector tilesets from collections of GeoJSON features"
   homepage "https://github.com/mapbox/tippecanoe"
   url "https://github.com/mapbox/tippecanoe/archive/v1.3.1.tar.gz"
-  sha256 "6c393e99ab7a75c9a3a5a7da4681794df283c0f2312d58edfcf2910a6726c676"
+  sha256 "89fa8a0becbbea90c655790ee428c529c932b6134349c1ffa8e10c62f8b049a1"
 
   bottle do
     cellar :any


### PR DESCRIPTION
* Tile generation is multithreaded to take advantage of multiple CPUs
* More compact data representation reduces memory usage and improves speed
* Polygon clipping uses [Clipper](http://www.angusj.com/delphi/clipper/documentation/Docs/_Body.htm)
  and makes sure interior and exterior rings are distinguished by winding order
* Individual GeoJSON features can specify their own minzoom and maxzoom
* New `tile-join` utility can add new properties from a CSV file to an existing tileset
* Feature coalescing, line-reversing, and reordering by attribute are now options, not defaults
* Output of `decode` utility is now in GeoJSON format
* Tile generation with a minzoom spends less time on unused lower zoom levels
* Bare geometries without a Feature wrapper are accepted
* Default tile resolution is 4096 units at all zooms since renderers assume it