### PR TITLE
librest 0.7.93

### DIFF
--- a/Library/Formula/librest.rb
+++ b/Library/Formula/librest.rb
@@ -32,8 +32,20 @@ class Librest < Formula
         return EXIT_SUCCESS;
       }
     EOS
+    glib = Formula["glib"]
+    libsoup = Formula["libsoup"]
     flags = (ENV.cflags || "").split + (ENV.ldflags || "").split
-    flags += `pkg-config --cflags --libs rest-0.7`.split
+    flags += %W[
+      -I#{libsoup.opt_include}/libsoup-2.4
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/rest-0.7
+      -L#{libsoup.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -lrest-0.7
+      -lgobject-2.0
+    ]
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end

--- a/Library/Formula/librest.rb
+++ b/Library/Formula/librest.rb
@@ -1,5 +1,5 @@
 class Librest < Formula
-  desc "librest is a library access web services that claim to be RESTful"
+  desc "Library to access RESTful web services"
   homepage "https://wiki.gnome.org/Projects/Librest"
   url "https://download.gnome.org/sources/rest/0.7/rest-0.7.93.tar.xz"
   sha256 "c710644455340a44ddc005c645c466f05c0d779993138ea21a62c6082108b216"

--- a/Library/Formula/librest.rb
+++ b/Library/Formula/librest.rb
@@ -1,0 +1,40 @@
+class Librest < Formula
+  desc "librest is a library access web services that claim to be RESTful"
+  homepage "https://wiki.gnome.org/Projects/Librest"
+  url "https://download.gnome.org/sources/rest/0.7/rest-0.7.93.tar.xz"
+  sha256 "c710644455340a44ddc005c645c466f05c0d779993138ea21a62c6082108b216"
+
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libsoup"
+  depends_on "gobject-introspection"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--without-gnome",
+                          "--without-ca-certificates",
+                          "--enable-introspection=yes"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdlib.h>
+      #include <rest/rest-proxy.h>
+
+      int main(int argc, char *argv[]) {
+        RestProxy *proxy = rest_proxy_new("http://localhost", FALSE);
+
+        g_object_unref(proxy);
+
+        return EXIT_SUCCESS;
+      }
+    EOS
+    flags = (ENV.cflags || "").split + (ENV.ldflags || "").split
+    flags += `pkg-config --cflags --libs rest-0.7`.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
librest (sometimes just called rest) is a rather small library to access
RESTful APIs as a part of the GNOME project.

After issues #31480 and #31501 weren't successful in adding librest to
Homebrew. Here is my try ;)

The test is rather useless (doesn't do anything useful) but should
compile if the library is installed correctly and works.