### PR TITLE
audit: flag descs starting with the formula name

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -392,6 +392,10 @@ class FormulaAuditor
     if desc =~ /^([Aa]n?)\s/
       problem "Please remove the indefinite article \"#{$1}\" from the beginning of the description"
     end
+
+    if desc =~ /^#{formula.name} is\s/i
+      problem "Description shouldn't include the formula name"
+    end
   end
 
   def audit_homepage


### PR DESCRIPTION
This should prevent things like `"TheLibrary is …"`. That’s someone I often point out on PRs and it’d be nice to have it in the `audit`.