### PR TITLE
emacs_requirement: set $EMACS

### DIFF
--- a/Library/Homebrew/requirements/emacs_requirement.rb
+++ b/Library/Homebrew/requirements/emacs_requirement.rb
@@ -16,6 +16,7 @@ class EmacsRequirement < Requirement
 
   env do
     ENV.prepend_path "PATH", which("emacs").dirname
+    ENV["EMACS"] = "emacs"
   end
 
   def message


### PR DESCRIPTION
The Emacs shell sets $EMACS to "t" for detection purposes, but it causes
builds to fail when they attempt to call Emacs using the variable.

Fixes Homebrew/homebrew-emacs#30.