### PR TITLE
JavaRequirement: check satisfaction directly

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -5,7 +5,12 @@ class JavaRequirement < Requirement
   cask "java"
   download "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
-  satisfy(:build_env => false) { java_version }
+  satisfy :build_env => false do
+    args = %w[--failfast]
+    args << "--version" << "#{@version}" if @version
+    @java_home = Utils.popen_read("/usr/libexec/java_home", *args).chomp
+    $?.success?
+  end
 
   env do
     java_home = Pathname.new(@java_home)
@@ -22,13 +27,6 @@ class JavaRequirement < Requirement
   def initialize(tags)
     @version = tags.shift if /(\d\.)+\d/ === tags.first
     super
-  end
-
-  def java_version
-    args = %w[--failfast]
-    args << "--version" << "#{@version}" if @version
-    @java_home = Utils.popen_read("/usr/libexec/java_home", *args).chomp
-    $?.success?
   end
 
   def message


### PR DESCRIPTION
It made less sense to call a method `java_version` when it returns
boolean value.