### PR TITLE
rust-multirust conflict

### DIFF
--- a/Library/Formula/multirust.rb
+++ b/Library/Formula/multirust.rb
@@ -18,6 +18,8 @@ class Multirust < Formula
 
   depends_on :gpg => [:recommended, :run]
 
+  conflicts_with "rust", :because => "both install rustc, rustdoc, cargo, rust-lldb, rust-gdb"
+
   def install
     system "./build.sh"
     system "./install.sh", "--prefix=#{prefix}"

--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -39,6 +39,8 @@ class Rust < Formula
   depends_on "llvm" => :optional
   depends_on "openssl"
 
+  conflicts_with "multirust", :because => "both install rustc, rustdoc, cargo, rust-lldb, rust-gdb"
+
   # According to the official readme, GCC 4.7+ is required
   fails_with :gcc_4_0
   fails_with :gcc


### PR DESCRIPTION
> [Multirust](https://github.com/brson/multirust) is a tool for managing multiple installations of the Rust toolchain. It replaces the standard Rust toolchain with components that dynamically choose between alternate implementations based on context.

Both formulae fail with a link error, naturally, if the other one is installed, because they are both trying to link programs named `rustc`, `rustdoc`, `cargo`, `rust-lldb`, `rust-gdb`. They are mutually exclusive packages.