### PR TITLE
doc: be consistent when referring to official taps

### DIFF
--- a/share/doc/homebrew/Acceptable-Formulae.md
+++ b/share/doc/homebrew/Acceptable-Formulae.md
@@ -59,7 +59,7 @@ point it to the downloaded archive in order to avoid loading.
 Our policy is that formulae in the core repository
 ([Homebrew/homebrew](https://github.com/Homebrew/homebrew)) must be built
 from source (or produce cross-platform binaries like e.g. Java). Binary-only
-formulae should go to [Homebrew/homebrew-binary](https://github.com/Homebrew/homebrew-binary).
+formulae should go to [homebrew/binary](https://github.com/Homebrew/homebrew-binary).
 
 ### Stable versions
 Formulae in the core repository must have a stable version tagged by
@@ -68,7 +68,7 @@ tarballs should include the version in the filename whenever possible.
 
 Software that does not provide a stable, tagged version, or had guidance to
 always install the most recent version, should be put in
-[Homebrew/homebrew-head-only](https://github.com/Homebrew/homebrew-headonly) or [homebrew/devel-only](https://github.com/Homebrew/homebrew-devel-only).
+[homebrew/head-only](https://github.com/Homebrew/homebrew-head-only) or [homebrew/devel-only](https://github.com/Homebrew/homebrew-devel-only).
 
 ### Bindings
 First check that there is not already a binding available via

--- a/share/doc/homebrew/FAQ.md
+++ b/share/doc/homebrew/FAQ.md
@@ -221,9 +221,9 @@ Use `brew log $FORMULA` to find out!
 Sometimes formulae are moved to specialized repositories. These are the
 likely candidates:
 
-* [https://github.com/Homebrew/homebrew-dupes](https://github.com/Homebrew/homebrew-dupes)
-* [https://github.com/Homebrew/homebrew-versions](https://github.com/Homebrew/homebrew-versions)
-* [https://github.com/Homebrew/homebrew-games](https://github.com/Homebrew/homebrew-games)
+* [homebrew/dupes](https://github.com/Homebrew/homebrew-dupes)
+* [homebrew/games](https://github.com/Homebrew/homebrew-games)
+* [homebrew/versions](https://github.com/Homebrew/homebrew-versions)
 
 You can use `brew tap` to access these formulae:
 

--- a/share/doc/homebrew/How-to-Create-and-Maintain-a-Tap.md
+++ b/share/doc/homebrew/How-to-Create-and-Maintain-a-Tap.md
@@ -15,7 +15,7 @@ repository’s root, or under `Formula` or `HomebrewFormula` subdirectories. We
 recommend the latter options because it makes the repository organisation
 easier to grasp, and top-level files are not mixed with formulae.
 
-See [homebrew-tex](https://github.com/Homebrew/homebrew-tex) for an example of
+See [homebrew/tex](https://github.com/Homebrew/homebrew-tex) for an example of
 a tap with a `Formula` subdirectory.
 
 ### Installing
@@ -52,5 +52,5 @@ Once your tap installed, Homebrew will update it each time an user runs
 You can provide your tap users with custom `brew` commands by adding them in a
 `cmd` subdirectory. [Read more on external commands](External-Commands.md).
 
-See [homebrew-aliases](https://github.com/Homebrew/homebrew-aliases) for an
+See [homebrew/aliases](https://github.com/Homebrew/homebrew-aliases) for an
 example of a tap with external commands.

--- a/share/doc/homebrew/Python-for-Formula-Authors.md
+++ b/share/doc/homebrew/Python-for-Formula-Authors.md
@@ -8,7 +8,7 @@ Python libraries exist to be imported from other Python modules; they are often 
 
 Bindings are a special case of libraries that allow Python code to interact with a library or application implemented in another language.
 
-Homebrew is happy to accept applications that are built in Python, whether the apps are available from PyPI or not. Homebrew generally won't accept libraries that can be installed correctly with `pip install foo`. Libraries that can be pip-installed but have several Homebrew dependencies may be appropriate for the [homebrew-python tap](https://github.com/Homebrew/homebrew-python). Bindings may be installed for packages that provide them, especially if equivalent functionality isn't available through pip.
+Homebrew is happy to accept applications that are built in Python, whether the apps are available from PyPI or not. Homebrew generally won't accept libraries that can be installed correctly with `pip install foo`. Libraries that can be pip-installed but have several Homebrew dependencies may be appropriate for the [homebrew/python](https://github.com/Homebrew/homebrew-python) tap. Bindings may be installed for packages that provide them, especially if equivalent functionality isn't available through pip.
 
 # Running setup.py
 

--- a/share/doc/homebrew/Tips-N'-Tricks.md
+++ b/share/doc/homebrew/Tips-N'-Tricks.md
@@ -4,7 +4,7 @@
 
 The preferred and supported method of installing specific versions of
 formulae is to use the
-[Homebrew-versions](https://github.com/Homebrew/homebrew-versions)
+[homebrew/versions](https://github.com/Homebrew/homebrew-versions)
 tap.  If the version you’re looking for isn’t available, consider [opening a
 pull request](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md)!
 

--- a/share/doc/homebrew/Troubleshooting.md
+++ b/share/doc/homebrew/Troubleshooting.md
@@ -33,7 +33,7 @@ Thank you!
 
 ## Check to see if the issue has been reported
 * Browse open issues on the [issue tracker](https://github.com/Homebrew/homebrew/issues) to see if someone else has already reported the same problem.
-* Make sure you check issues on the correct repository. If the formula that failed to build is part of a tap, like [homebrew-science](https://github.com/Homebrew/homebrew-science) or [homebrew-dupes](https://github.com/Homebrew/homebrew-dupes), check there instead.
+* Make sure you check issues on the correct repository. If the formula that failed to build is part of a tap, like [homebrew/science](https://github.com/Homebrew/homebrew-science) or [homebrew/dupes](https://github.com/Homebrew/homebrew-dupes), check there instead.
 
 ## Create an issue
 


### PR DESCRIPTION
Always use the `<user/repo>` format as used by the `brew tap` command. Also fixed a link to `homebrew/head-only` and sorted a list in `FAQ.md` in alphabetical order.