### PR TITLE
watchman 4.1.0

### DIFF
--- a/Library/Formula/watchman.rb
+++ b/Library/Formula/watchman.rb
@@ -1,8 +1,8 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/v3.9.0.tar.gz"
-  sha256 "1739cd2d6846cc688b12911c37406fae5601d76c0d11f3da957c2b7273941221"
+  url "https://github.com/facebook/watchman/archive/v4.1.0.tar.gz"
+  sha256 "5bc579475a8a26f5e1af58abbf848a7c3067524b9be448f98feba9e455284eeb"
   head "https://github.com/facebook/watchman.git"
 
   bottle do
@@ -11,18 +11,29 @@ class Watchman < Formula
     sha256 "eddac57652f6ef7b37026673ccdacc9524397b645f0d4f7eb7b442ff22b03c69" => :mavericks
   end
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "pkg-config" => :build
   depends_on "pcre"
 
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-pcre"
+                          "--with-pcre",
+                          # we'll do the homebrew specific python
+                          # installation below
+                          "--without-python"
     system "make"
     system "make", "install"
+
+    # Homebrew specific python application installation
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    Dir.chdir "python"
+    system "python", *Language::Python.setup_install_args(libexec)
+    Dir.chdir ".."
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
   test do

--- a/Library/Formula/watchman.rb
+++ b/Library/Formula/watchman.rb
@@ -29,9 +29,9 @@ class Watchman < Formula
 
     # Homebrew specific python application installation
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    Dir.chdir "python"
-    system "python", *Language::Python.setup_install_args(libexec)
-    Dir.chdir ".."
+    cd "python" do
+      system "python", *Language::Python.setup_install_args(libexec)
+    end
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end


### PR DESCRIPTION
In addition to various improvements in the watchman service, we also introduced two new python applications in this release, so the pythonic bits bear some scrutiny.

Tested via:

```
brew install watchman
brew audit watchman
brew test watchman
```

Previously we were shipping python bindings for the watchman client, but doing this blissfully unaware of the information in https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Python-for-Formula-Authors.md, which yields issues such as https://github.com/facebook/watchman/issues/184#issuecomment-152599517

This change embraces the idea that the `watchman` brew formula is about applications and that folks that want bindings can `pip install pywatchman`.

To do this we need to disable the automatic python detection in the watchman configure script and just use the homebrew python procedures from the linked guide to manage installing the scripts.