### PR TITLE
w3m: add test, ssl prefix, bottles

### DIFF
--- a/Library/Formula/w3m.rb
+++ b/Library/Formula/w3m.rb
@@ -4,6 +4,7 @@ class W3m < Formula
   url "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
   sha256 "e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3"
 
+  depends_on "pkg-config" => :build
   depends_on "bdw-gc"
   depends_on "openssl"
 
@@ -14,11 +15,16 @@ class W3m < Formula
   patch :DATA
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-image"
+    system "./configure", "--prefix=#{prefix}", "--disable-image",
+                          "--with-ssl=#{Formula["openssl"].opt_prefix}"
     # Race condition in build reported in:
     # https://github.com/Homebrew/homebrew/issues/12854
-    ENV.j1 #
+    ENV.j1
     system "make", "install"
+  end
+
+  test do
+    assert_match /DuckDuckGo/, shell_output("#{bin}/w3m -dump https://duckduckgo.com")
   end
 end
 


### PR DESCRIPTION
Stops `w3m` wandering around trying to find the correct SSL, generates bottles, adds a test, etc.