### PR TITLE
teensy_loader_cli: add HEAD patch to avoid libusb access error on Mac OS

### DIFF
--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -1,13 +1,21 @@
 class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
-  head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
+  depends_on "libusb-compat"
+
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
   sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
 
+  head do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git"
+    patch do
+      url "https://github.com/rixtox/teensy_loader_cli/commit/747f3a249722eb07b494b2db8c7f872e603448f3.diff"
+      sha256 "be47f352d6f54a88db0bc8a88062f9ec470cab2c675655cfec14a9c238492677"
+    end
+  end
+
   def install
-    ENV["OS"] = "MACOSX"
-    ENV["SDK"] = MacOS.sdk_path || "/"
+    ENV["OS"] = "LINUX"
     system "make"
     bin.install "teensy_loader_cli"
   end

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -5,7 +5,6 @@ class TeensyLoaderCli < Formula
 
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
   sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
-  head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -1,7 +1,6 @@
 class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
-  depends_on "libusb-compat"
 
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
   sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
@@ -20,6 +19,8 @@ class TeensyLoaderCli < Formula
       sha256 "be47f352d6f54a88db0bc8a88062f9ec470cab2c675655cfec14a9c238492677"
     end
   end
+
+  depends_on "libusb-compat"
 
   def install
     ENV["OS"] = "LINUX"

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -1,6 +1,7 @@
 class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
+  head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
   sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
 


### PR DESCRIPTION
According to https://github.com/PaulStoffregen/teensy_loader_cli/issues/11
it's suggested to compile with `OS=LINUX` and include libusb, and due to an issue described in
https://github.com/PaulStoffregen/teensy_loader_cli/blob/master/teensy_loader_cli.c#L246-L248
libusb behave differently on Mac OS. Thus the patch comments out the lines as described to fix the problem.