### PR TITLE
download_strategy: silence curl on Travis CI.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -251,7 +251,7 @@ def curl(*args)
 
   args = [flags, HOMEBREW_USER_AGENT, *args]
   args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
-  args << "--silent" unless $stdout.tty?
+  args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
 
   safe_system curl, *args
 end


### PR DESCRIPTION
Use one of the Travis CI default environment variables:
http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables

CC @xu-cheng @scpeters @dunn @agarny

Closes #44446.
Closes https://github.com/travis-ci/travis-ci/issues/4936.