### PR TITLE
Stricter elisp handling

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -143,12 +143,7 @@ class Caveats
     if keg && keg.elisp_installed?
       <<-EOS.undent
         Emacs Lisp files have been installed to:
-        #{HOMEBREW_PREFIX}/share/emacs/site-lisp/
-
-        Add the following to your init file to have packages installed by
-        Homebrew added to your load-path:
-        (let ((default-directory "#{HOMEBREW_PREFIX}/share/emacs/site-lisp/"))
-          (normal-top-level-add-subdirs-to-load-path))
+        #{HOMEBREW_PREFIX}/share/emacs/site-lisp/#{f.name}
       EOS
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -600,6 +600,15 @@ class Formula
     prefix+"share"+name
   end
 
+  # The directory where Emacs Lisp files should be installed, with the
+  # formula name appended to avoid linking conflicts.
+  #
+  # Install an Emacs mode included with a software package:
+  # <pre>elisp.install "contrib/emacs/example-mode.el"</pre>
+  def elisp
+    prefix+"share/emacs/site-lisp"+name
+  end
+
   # The directory where the formula's Frameworks should be installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
@@ -757,6 +766,10 @@ class Formula
 
   def opt_pkgshare
     opt_prefix+"share"+name
+  end
+
+  def opt_elisp
+    opt_prefix+"share/emacs/site-lisp"+name
   end
 
   def opt_frameworks

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -173,19 +173,34 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_emacs_lisp(share, name)
+  def check_elisp_dirname(share, name)
     return unless (share/"emacs/site-lisp").directory?
+    # Emacs itself can do what it wants
+    return if name == "emacs"
 
+    bad_dir_name = (share/"emacs/site-lisp").children.any? do |child|
+      child.directory? && child.basename.to_s != name
+    end
+
+    return unless bad_dir_name
+    <<-EOS
+      Emacs Lisp files were installed into the wrong site-lisp subdirectory.
+      They should be installed into:
+      #{share}/emacs/site-lisp/#{name}
+    EOS
+  end
+
+  def check_elisp_root(share, name)
+    return unless (share/"emacs/site-lisp").directory?
     # Emacs itself can do what it wants
     return if name == "emacs"
 
     elisps = (share/"emacs/site-lisp").children.select { |file| %w[.el .elc].include? file.extname }
     return if elisps.empty?
-
     <<-EOS.undent
       Emacs Lisp files were linked directly to #{HOMEBREW_PREFIX}/share/emacs/site-lisp
-
-      This may cause conflicts with other packages; install to a subdirectory instead, such as
+      This may cause conflicts with other packages.
+      They should instead be installed into:
       #{share}/emacs/site-lisp/#{name}
 
       The offending files are:
@@ -206,7 +221,8 @@ module FormulaCellarChecks
     audit_check_output(check_easy_install_pth(formula.lib))
     audit_check_output(check_openssl_links)
     audit_check_output(check_python_framework_links(formula.lib))
-    audit_check_output(check_emacs_lisp(formula.share, formula.name))
+    audit_check_output(check_elisp_dirname(formula.share, formula.name))
+    audit_check_output(check_elisp_root(formula.share, formula.name))
   end
 
   private

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -263,7 +263,7 @@ class Keg
   end
 
   def elisp_installed?
-    Dir["#{path}/share/emacs/site-lisp/**/*.el"].any?
+    (path/"share/emacs/site-lisp"/name).children.any? { |f| %w[.el .elc].include? f.extname }
   end
 
   def version


### PR DESCRIPTION
Require that the subdirectory in site-lisp match the formula name
exactly.  This lets us provide better information in the caveats and
will make it easier for helper methods to write to the correct
location (as in in Homebrew/homebrew-emacs#13).

Also define `elisp` and `opt_elisp`. If this part is too niche I can just do it in the Emacs tap.