### PR TITLE
appledoc 2.2.1 (new formula)

### DIFF
--- a/Library/Formula/appledoc.rb
+++ b/Library/Formula/appledoc.rb
@@ -1,4 +1,5 @@
 class Appledoc < Formula
+  desc "Objective-C API documentation generator"
   homepage "http://appledoc.gentlebytes.com/"
   url "https://github.com/tomaz/appledoc/archive/2.2.1.tar.gz"
   sha256 "0ec881f667dfe70d565b7f1328e9ad4eebc8699ee6dcd381f3bd0ccbf35c0337"

--- a/Library/Formula/appledoc.rb
+++ b/Library/Formula/appledoc.rb
@@ -48,6 +48,7 @@ class Appledoc < Formula
                            "--create-html",
                            "--no-install-docset",
                            "--keep-intermediate-files",
+                           "--docset-install-path", testpath,
                            "--output", testpath,
                            testpath/"test.h"
   end

--- a/Library/Formula/appledoc.rb
+++ b/Library/Formula/appledoc.rb
@@ -23,6 +23,32 @@ class Appledoc < Formula
   end
 
   test do
-    system "#{bin}/appledoc", "--version"
+    (testpath/"test.h").write <<-EOS.undent
+      /**
+       * This is a test class. It does stuff.
+       *
+       * Here **is** some `markdown`.
+       */
+
+      @interface X : Y
+
+      /**
+       * Does a thing.
+       *
+       * @returns An instance of X.
+       * @param thing The thing to copy.
+       */
+      + (X *)thingWithThing:(X *)thing;
+
+      @end
+    EOS
+
+    system bin/"appledoc", "--project-name", "Test",
+                           "--project-company", "Homebrew",
+                           "--create-html",
+                           "--no-install-docset",
+                           "--keep-intermediate-files",
+                           "--output", testpath,
+                           testpath/"test.h"
   end
 end

--- a/Library/Formula/appledoc.rb
+++ b/Library/Formula/appledoc.rb
@@ -6,7 +6,7 @@ class Appledoc < Formula
 
   head "https://github.com/tomaz/appledoc.git"
 
-  depends_on :xcode
+  depends_on :xcode => :build
   depends_on :macos => :lion
 
   def install

--- a/Library/Formula/appledoc.rb
+++ b/Library/Formula/appledoc.rb
@@ -1,0 +1,27 @@
+class Appledoc < Formula
+  homepage "http://appledoc.gentlebytes.com/"
+  url "https://github.com/tomaz/appledoc/archive/2.2.1.tar.gz"
+  sha256 "0ec881f667dfe70d565b7f1328e9ad4eebc8699ee6dcd381f3bd0ccbf35c0337"
+
+  head "https://github.com/tomaz/appledoc.git"
+
+  depends_on :xcode
+  depends_on :macos => :lion
+
+  def install
+    xcodebuild "-project", "appledoc.xcodeproj",
+               "-target", "appledoc",
+               "-configuration", "Release",
+               "clean", "install",
+               "SYMROOT=build",
+               "DSTROOT=build",
+               "INSTALL_PATH=/bin",
+               "OTHER_CFLAGS='-DCOMPILE_TIME_DEFAULT_TEMPLATE_PATH=@\"#{prefix}/Templates\"'"
+    bin.install "build/bin/appledoc"
+    prefix.install "Templates/"
+  end
+
+  test do
+    system "#{bin}/appledoc", "--version"
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -5,7 +5,6 @@ TAP_MIGRATIONS = {
   "aimage" => "homebrew/boneyard",
   "aplus" => "homebrew/boneyard",
   "apple-gcc42" => "homebrew/dupes",
-  "appledoc" => "homebrew/boneyard",
   "appswitch" => "homebrew/binary",
   "archivemount" => "homebrew/fuse",
   "atari++" => "homebrew/x11",


### PR DESCRIPTION
Appledoc seems to have been removed a year ago because it relied on garbage collection, which was removed in Xcode 5.1. 2.2.1 transitioned to using ARC, and thus it builds on any recent release of clang again.