### PR TITLE
cairo 1.14.4

### DIFF
--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -1,10 +1,9 @@
 class Cairo < Formula
   desc "Vector graphics library with cross-device output support"
   homepage "http://cairographics.org/"
-  url "http://cairographics.org/releases/cairo-1.14.2.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/cairo-1.14.2.tar.xz"
-  sha256 "c919d999ddb1bbbecd4bbe65299ca2abd2079c7e13d224577895afa7005ecceb"
-  revision 1
+  url "http://cairographics.org/releases/cairo-1.14.4.tar.xz"
+  mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/cairo-1.14.4.tar.xz"
+  sha256 "f6ec9c7c844db9ec011f0d66b57ef590c45adf55393d1fc249003512522ee716"
 
   bottle do
     revision 3


### PR DESCRIPTION
* NOTE: Using mirror is not synchronized released cairo-1.14.4.tar.xz yet.