### PR TITLE
gtk+3: quartz input module fixes for El Capitan

### DIFF
--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -3,6 +3,7 @@ class Gtkx3 < Formula
   homepage "http://gtk.org/"
   url "https://download.gnome.org/sources/gtk+/3.18/gtk+-3.18.2.tar.xz"
   sha256 "5dbec561c4a00070073bf9cf4cfdd61fab4a14c8ff5b15d700bd378f8185e152"
+  revision 1
 
   bottle do
     sha256 "e9c3c4b941da618f48feedded0be5c4d381df4b4c2a6f576895e961931a3d30c" => :el_capitan
@@ -31,6 +32,13 @@ class Gtkx3 < Formula
       url "https://bugzilla.gnome.org/attachment.cgi?id=313599&format=raw"
       sha256 "a090b19d3c15364914917d9893be292225e8b8a016f2833a5b8354f079475a73"
     end
+  end
+
+  # Fixes input module bug on El Capitan
+  # see https://bugzilla.gnome.org/show_bug.cgi?id=753992
+  patch do
+    url "https://github.com/GNOME/gtk/commit/571704824f78de9d8b262793397a4e4ea6cedf7d.patch"
+    sha256 "99d9d7bb46e129e264bc324c9b736050bd9be3a04da8e143d05785a0bafdb3c1"
   end
 
   def install


### PR DESCRIPTION
Closes #44722
Closes Homebrew/homebrew-x11#114