### PR TITLE
libressl: add vuln fix from upstream

### DIFF
--- a/Library/Formula/libressl.rb
+++ b/Library/Formula/libressl.rb
@@ -1,8 +1,22 @@
 class Libressl < Formula
   desc "Version of the SSL/TLS protocol forked from OpenSSL"
   homepage "http://www.libressl.org/"
-  url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.0.tar.gz"
-  sha256 "0451498d999ccff475226f5cfae07a3754a7b28c507c6bda007e316fc90d92a0"
+  revision 1
+
+  stable do
+    url "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.0.tar.gz"
+    sha256 "0451498d999ccff475226f5cfae07a3754a7b28c507c6bda007e316fc90d92a0"
+
+    # Fixes buffer overrun and memory leak. Combination of:
+    # https://github.com/libressl-portable/openbsd/commit/ea13bdff130
+    # https://github.com/libressl-portable/openbsd/commit/67bf52a96ba
+    # https://github.com/libressl-portable/openbsd/commit/f292734cabf
+    # Fixed in 2.2.4 but no 2.3.1 release yet.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/4d256375/libressl/libressl-2.3.0-qualys-vun-fix.diff"
+      sha256 "a8d8f2b763ee363d87bb06aa2f8da66b484a23907217265cc7faef85355b561f"
+    end
+  end
 
   bottle do
     sha256 "272ab831a43a9dbfcc7d2d57d14bcbd070e90a07f49797c34e8640771c30aa02" => :el_capitan


### PR DESCRIPTION
They pushed out a 2.2.4 release to fix the problem but no 2.3.1 release yet. Have given it a couple of weeks but not overly happy to leave it unpatched much longer. Gentoo have already [applied the change](https://github.com/gentoo/libressl/commit/9ebb9135d8e8f864dd9504cb0cc777c67a74a53b).