### PR TITLE
mutt: gettext dep, optional libidn

### DIFF
--- a/Library/Formula/mutt.rb
+++ b/Library/Formula/mutt.rb
@@ -48,8 +48,10 @@ class Mutt < Formula
 
   depends_on "openssl"
   depends_on "tokyo-cabinet"
-  depends_on "s-lang" => :optional
+  depends_on "gettext" => :optional
   depends_on "gpgme" => :optional
+  depends_on "libidn" => :optional
+  depends_on "s-lang" => :optional
 
   # original source for this went missing, patch sourced from Arch at
   # https://aur.archlinux.org/packages/mutt-ignore-thread/
@@ -89,8 +91,9 @@ class Mutt < Formula
     # we're running as an unprivileged user)
     args << "--with-homespool=.mbox" unless user_admin
 
-    args << "--with-slang" if build.with? "s-lang"
+    args << "--disable-nls" if build.without? "gettext"
     args << "--enable-gpgme" if build.with? "gpgme"
+    args << "--with-slang" if build.with? "s-lang"
 
     if build.with? "debug"
       args << "--enable-debug"


### PR DESCRIPTION
Currently a "fatal error" is being thrown during `make` if `gettext` isn't available, which for some reason doesn't stop the build: https://gist.github.com/dunn/2e653faa14ea5e0ab538#file-02-make-L30-L32

Mutt is distributed with a vendored gettext so this seems like a legitimate dependency: https://bitbucket.org/mutt/mutt/src/17991330c086d6b0de56ff091e449b220e633063/INSTALL?at=default&fileviewer=file-view-default#INSTALL-121:126