### PR TITLE
debian various

### DIFF
--- a/Library/Formula/analog.rb
+++ b/Library/Formula/analog.rb
@@ -3,7 +3,8 @@ class Analog < Formula
   homepage "https://tracker.debian.org/pkg/analog"
   # The previous long-time homepage and url are stone-cold dead. Using Debian instead.
   # homepage "http://analog.cx"
-  url "https://mirrors.kernel.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
   sha256 "31c0e2bedd0968f9d4657db233b20427d8c497be98194daf19d6f859d7f6fcca"
   revision 1
 
@@ -24,13 +25,16 @@ class Analog < Formula
                    "DEFS='-DLANGDIR=\"#{share/"analog/lang/"}\"' -DHAVE_ZLIB",
                    "LIBS=-lz",
                    "OS=OSX"
+
     bin.install "analog"
-    (share/"analog").install "examples", "how-to", "images", "lang"
-    (share/"analog").install "analog.cfg" => "analog.cfg-dist"
+    pkgshare.install "examples", "how-to", "images", "lang"
+    pkgshare.install "analog.cfg" => "analog.cfg-dist"
+    (pkgshare/"examples").install "logfile.log"
     man1.install "analog.man" => "analog.1"
   end
 
   test do
-    system "\"#{bin}/analog\" > /dev/null"
+    output = pipe_output("#{bin}/analog #{pkgshare}/examples/logfile.log")
+    assert_match /(United Kingdom)/, output
   end
 end

--- a/Library/Formula/axel.rb
+++ b/Library/Formula/axel.rb
@@ -1,8 +1,8 @@
 class Axel < Formula
   desc "Light UNIX download accelerator"
   homepage "https://packages.debian.org/sid/axel"
-  url "https://mirrors.kernel.org/debian/pool/main/a/axel/axel_2.4.orig.tar.gz"
-  mirror "http://ftp.de.debian.org/debian/pool/main/a/axel/axel_2.4.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/axel/axel_2.4.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/axel/axel_2.4.orig.tar.gz"
   sha256 "359a57ab4e354bcb6075430d977c59d33eb3e2f1415a811948fa8ae657ca8036"
 
   bottle do

--- a/Library/Formula/bip.rb
+++ b/Library/Formula/bip.rb
@@ -1,7 +1,8 @@
 class Bip < Formula
   desc "IRC proxy"
   homepage "https://bip.milkypond.org" # Self-signed cert.
-  url "https://mirrors.kernel.org/debian/pool/main/b/bip/bip_0.8.9.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/b/bip/bip_0.8.9.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/b/bip/bip_0.8.9.orig.tar.gz"
   sha256 "3c950f71ef91c8b686e6835f9b722aa7ccb88d3da4ec1af19617354fd3132461"
   revision 1
 
@@ -22,7 +23,7 @@ class Bip < Formula
                           "--sysconfdir=#{etc}/bip"
 
     system "make", "install"
-    (etc+"bip").install "samples/bip.conf"
+    (etc/"bip").install "samples/bip.conf"
   end
 
   def caveats; <<-EOS.undent

--- a/Library/Formula/debianutils.rb
+++ b/Library/Formula/debianutils.rb
@@ -1,8 +1,8 @@
 class Debianutils < Formula
   desc "Miscellaneous utilities specific to Debian"
-  homepage "https://packages.debian.org/unstable/utils/debianutils"
-  url "https://mirrors.kernel.org/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
+  homepage "https://packages.debian.org/sid/debianutils"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/debianutils/debianutils_4.5.1.tar.xz"
   sha256 "a531c23e0105fe01cfa928457a8343a1e947e2621b3cd4d05f4e9656020c63b7"
 
   bottle do
@@ -14,10 +14,11 @@ class Debianutils < Formula
 
   def install
     system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make"
 
-    # some commands are Debian Linux specific and we don't want them, so install specific tools
+    # Some commands are Debian Linux specific and we don't want them, so install specific tools
     bin.install "run-parts", "ischroot", "tempfile"
     man1.install "ischroot.1", "tempfile.1"
     man8.install "run-parts.8"

--- a/Library/Formula/delta.rb
+++ b/Library/Formula/delta.rb
@@ -1,7 +1,8 @@
 class Delta < Formula
   desc "Programatically minimize files to isolate features of interest"
   homepage "http://delta.tigris.org/"
-  url "https://mirrors.kernel.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
   sha256 "38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0"
 
   bottle do

--- a/Library/Formula/iprint.rb
+++ b/Library/Formula/iprint.rb
@@ -1,10 +1,10 @@
 class Iprint < Formula
   desc "Provides a print_one function"
   homepage "https://www.samba.org/ftp/unpacked/junkcode/i.c"
-  url "https://mirrors.kernel.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
   version "1.3-9"
+  sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
 
   bottle do
     cellar :any
@@ -15,14 +15,14 @@ class Iprint < Formula
   end
 
   patch do
-    url "https://mirrors.kernel.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
     sha256 "3a1ff260e6d639886c005ece754c2c661c0d3ad7f1f127ddb2943c092e18ab74"
   end
 
   def install
     system "make"
     bin.install "i"
-    man1.mkpath
     man1.install "i.1"
   end
 

--- a/Library/Formula/lcrack.rb
+++ b/Library/Formula/lcrack.rb
@@ -1,10 +1,10 @@
 class Lcrack < Formula
   desc "Generic password cracker"
   homepage "https://packages.debian.org/sid/lcrack"
-  url "https://mirrors.kernel.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/lcrack/lcrack_20040914.orig.tar.gz"
   version "20040914"
+  sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
 
   bottle do
     cellar :any
@@ -26,14 +26,10 @@ class Lcrack < Formula
   end
 
   test do
-    (testpath/"secrets.txt").write <<-EOS.undent
-      root:5ebe2294ecd0e0f08eab7690d2a6ee69:SECRET
-    EOS
+    (testpath/"secrets.txt").write "root:5ebe2294ecd0e0f08eab7690d2a6ee69:SECRET"
+    (testpath/"dict.txt").write "secret"
 
-    (testpath/"dict.txt").write <<-EOS.undent
-      secret
-    EOS
-
-    assert_match /Found: 1/, pipe_output("#{bin}/lcrack -m md5 -d dict.txt -xf+ -s a-z -l 1-8 secrets.txt 2>&1")
+    output = pipe_output("#{bin}/lcrack -m md5 -d dict.txt -xf+ -s a-z -l 1-8 secrets.txt 2>&1")
+    assert_match "Found: 1", output
   end
 end

--- a/Library/Formula/liblockfile.rb
+++ b/Library/Formula/liblockfile.rb
@@ -1,8 +1,8 @@
 class Liblockfile < Formula
   desc "Library providing functions to lock standard mailboxes"
-  homepage "https://packages.qa.debian.org/libl/liblockfile.html"
-  url "https://mirrors.kernel.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
-  mirror "http://ftp.us.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
+  homepage "https://tracker.debian.org/pkg/liblockfile"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
   sha256 "16979eba05396365e1d6af7100431ae9d32f9bc063930d1de66298a0695f1b7f"
 
   bottle do
@@ -26,5 +26,12 @@ class Liblockfile < Formula
     man3.mkpath
     system "make"
     system "make", "install"
+  end
+
+  test do
+    system bin/"dotlockfile", "-l", "locked"
+    assert File.exist?("locked")
+    system bin/"dotlockfile", "-u", "locked"
+    assert !File.exist?("locked")
   end
 end


### PR DESCRIPTION
* Bottle generation for newer OS X versions
* Moving away from `https://mirrors.kernel.org/debian` as it uses a SHA1 certificate chain which causes it to no longer be shown as secure in Google Chrome, which looks more worrying than it technically is but is an easy enough thing to fix.
* Adding fallback mirrors.
* Improving/Adding tests.

All these are 2 minute compiles, hence combining 8 of them in the same PR. All built and tested locally first, so should be fine.
