### PR TITLE
influxdb: Fix Too Many Open Files Error

### DIFF
--- a/Library/Formula/influxdb.rb
+++ b/Library/Formula/influxdb.rb
@@ -3,11 +3,9 @@ require "language/go"
 class Influxdb < Formula
   desc "Time series, events, and metrics database"
   homepage "https://influxdb.com"
-
-  stable do
-    url "https://github.com/influxdb/influxdb/archive/v0.9.4.2.tar.gz"
-    sha256 "aaea27228d7f242fe37d436506592189081beda0e7d2fba3f82c6b233fd913bc"
-  end
+  url "https://github.com/influxdb/influxdb/archive/v0.9.4.2.tar.gz"
+  sha256 "aaea27228d7f242fe37d436506592189081beda0e7d2fba3f82c6b233fd913bc"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -159,6 +157,11 @@ class Influxdb < Formula
         <string>#{var}/log/influxdb.log</string>
         <key>StandardOutPath</key>
         <string>#{var}/log/influxdb.log</string>
+        <key>SoftResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>10240</integer>
+        </dict>
       </dict>
     </plist>
     EOS


### PR DESCRIPTION
This raises the softlimit for open files in the plist from the MacOS X default for launchd agents of 256 open files to 10240 (which is the default limit returned by `sysctl kern.maxfilesperproc`).

**For comparison:**
The default softlimit for the login shell is 7168 files (see `ulimit -n` and `launchctl limit` for launchd).

Without this change influxdb runs out of open file handles very quickly and stops accepting connections, even during moderate use.

