### PR TITLE
fontconfig: enable static libraries

### DIFF
--- a/Library/Formula/fontconfig.rb
+++ b/Library/Formula/fontconfig.rb
@@ -32,6 +32,7 @@ class Fontconfig < Formula
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--enable-static",
                           "--with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",


### PR DESCRIPTION
For writing a redistributable R packages, we need to statically link `libcairo`. Currently `cairo` includes `libcairo.a` but it depends on `fontconfig` which does not include `libfontconfig.a`. Would be really nice if the fontconfig static library would be included with the bottles as well.

Thank you! :star:

 