### PR TITLE
jenv: change order of caveats

### DIFF
--- a/Library/Formula/jenv.rb
+++ b/Library/Formula/jenv.rb
@@ -13,11 +13,11 @@ class Jenv < Formula
    end
 
   def caveats; <<-EOS.undent
-     To enable shims and autocompletion add to your profile:
-       if which jenv > /dev/null; then eval "$(jenv init -)"; fi
-
      To use Homebrew's directories rather than ~/.jenv add to your profile:
        export JENV_ROOT=#{var}/jenv
+       
+     To enable shims and autocompletion add to your profile:
+       if which jenv > /dev/null; then eval "$(jenv init -)"; fi
      EOS
   end
 


### PR DESCRIPTION
Suggest to set the JENV_ROOT *before* setting the shims, so the `init` doesn‘t create the `~/.jenv` folder in the first place.