### PR TITLE
kotlin-compiler 1.0.0-beta-1103

### DIFF
--- a/Library/Formula/kotlin-compiler.rb
+++ b/Library/Formula/kotlin-compiler.rb
@@ -1,14 +1,9 @@
 class KotlinCompiler < Formula
   desc "Statically typed programming language for the JVM"
   homepage "https://kotlinlang.org/"
-  url "https://github.com/JetBrains/kotlin/releases/download/build-0.14.449/kotlin-compiler-0.14.449.zip"
-  sha256 "bbb55c84669b6d920dc89beab811b26dfbdbeb95d71e1d6d3384fbfbcd48ec70"
-
-  devel do
-    url "https://github.com/JetBrains/kotlin/releases/download/build-1.0.0-beta-1038/kotlin-compiler-1.0.0-beta-1038.zip"
-    version "1.0.0-beta-1038"
-    sha256 "53e1516eb95274ac58b5445d1d8a82d265166d7c5038a878395589604f35275c"
-  end
+  url "https://github.com/JetBrains/kotlin/releases/download/build-1.0.0-beta-1103/kotlin-compiler-1.0.0-beta-1103.zip"
+  sha256 "7636819143d5c7332f5fa5c29c1b7701c861ae6541e02a1ccae10af6ac90c980"
+  version "1.0.0-beta-1103"
 
   bottle :unneeded
 


### PR DESCRIPTION
I removed the 'stable' and 'dev' tag, the default download link on the official site points to this build.