### PR TITLE
elasticsearch 2.0.0

### DIFF
--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -1,14 +1,15 @@
 class Elasticsearch < Formula
   desc "Distributed real-time search & analytics engine for the cloud"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.3.tar.gz"
-  sha256 "af517611493374cfb2daa8897ae17e63e2efea4d0377d316baa351c1776a2bca"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0/elasticsearch-2.0.0.tar.gz"
+  sha256 "b25f13f615337c2072964fd9fc5c7250f8a2a983b22198daf93548285d5d16df"
 
   bottle :unneeded
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"
-    depends_on "maven" => :build
+    depends_on :java => "1.8"
+    depends_on "gradle" => :build
   end
 
   depends_on :java => "1.7+"
@@ -20,80 +21,66 @@ class Elasticsearch < Formula
   def install
     if build.head?
       # Build the package from source
-      system "mvn", "clean", "package", "-DskipTests"
+      system "gradle", "clean", "assemble"
       # Extract the package to the current directory
-      system "tar", "--strip", "1", "-xzf", "target/releases/elasticsearch-*.tar.gz"
+      targz = Dir["distribution/tar/build/distributions/elasticsearch-*.tar.gz"].first
+      system "tar", "--strip-components=1", "-xf", targz
     end
 
     # Remove Windows files
     rm_f Dir["bin/*.bat"]
     rm_f Dir["bin/*.exe"]
 
-    # Move libraries to `libexec` directory
-    libexec.install Dir["lib/*.jar"]
-    (libexec/"sigar").install Dir["lib/sigar/*.{jar,dylib}"]
-
     # Install everything else into package directory
-    prefix.install Dir["*"]
-
-    # Remove unnecessary files
-    rm_f Dir["#{lib}/sigar/*"]
-    if build.head?
-      rm_rf "#{prefix}/pom.xml"
-      rm_rf "#{prefix}/src/"
-      rm_rf "#{prefix}/target/"
-    end
+    libexec.install "bin", "config", "lib"
 
     # Set up Elasticsearch for local development:
-    inreplace "#{prefix}/config/elasticsearch.yml" do |s|
+    inreplace "#{libexec}/config/elasticsearch.yml" do |s|
       # 1. Give the cluster a unique name
-      s.gsub!(/#\s*cluster\.name\: elasticsearch/, "cluster.name: #{cluster_name}")
+      s.gsub!(/#\s*cluster\.name\: .*/, "cluster.name: #{cluster_name}")
 
       # 2. Configure paths
       s.sub!(%r{#\s*path\.data: /path/to.+$}, "path.data: #{var}/elasticsearch/")
       s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/elasticsearch/")
-      s.sub!(%r{#\s*path\.plugins: /path/to.+$}, "path.plugins: #{var}/lib/elasticsearch/plugins")
-
-      # 3. Bind to loopback IP for laptops roaming different networks
-      s.gsub!(/#\s*network\.host\: [^\n]+/, "network.host: 127.0.0.1")
     end
 
-    inreplace "#{bin}/elasticsearch.in.sh" do |s|
+    inreplace "#{libexec}/bin/elasticsearch.in.sh" do |s|
       # Configure ES_HOME
-      s.sub!(%r{#\!/bin/sh\n}, "#!/bin/sh\n\nES_HOME=#{prefix}")
-      # Configure ES_CLASSPATH paths to use libexec instead of lib
-      s.gsub!(%r{ES_HOME/lib/}, "ES_HOME/libexec/")
+      s.sub!(%r{#\!/bin/sh\n}, "#!/bin/sh\n\nES_HOME=#{libexec}")
     end
 
-    inreplace "#{bin}/plugin" do |s|
+    inreplace "#{libexec}/bin/plugin" do |s|
       # Add the proper ES_CLASSPATH configuration
-      s.sub!(/SCRIPT="\$0"/, %(SCRIPT="$0"\nES_CLASSPATH=#{libexec}))
+      s.sub!(/SCRIPT="\$0"/, %(SCRIPT="$0"\nES_CLASSPATH=#{libexec}/lib))
       # Replace paths to use libexec instead of lib
       s.gsub!(%r{\$ES_HOME/lib/}, "$ES_CLASSPATH/")
     end
 
     # Move config files into etc
-    (etc/"elasticsearch").install Dir[prefix/"config/*"]
-    (prefix/"config").rmtree
+    (etc/"elasticsearch").install Dir[libexec/"config/*"]
+    (etc/"elasticsearch/scripts").mkdir unless File.exists?(etc/"elasticsearch/scripts")
+    (libexec/"config").rmtree
+
+    bin.write_exec_script Dir[libexec/"bin/*"]
   end
 
   def post_install
     # Make sure runtime directories exist
     (var/"elasticsearch/#{cluster_name}").mkpath
     (var/"log/elasticsearch").mkpath
-    (var/"lib/elasticsearch/plugins").mkpath
-    ln_s etc/"elasticsearch", prefix/"config"
+    ln_s etc/"elasticsearch", libexec/"config"
+    (libexec/"plugins").mkdir
   end
 
   def caveats; <<-EOS.undent
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
-    Plugins: #{var}/lib/elasticsearch/plugins/
+    Plugins: #{libexec}/plugins/
     Config:  #{etc}/elasticsearch/
     EOS
   end
 
-  plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch/config/elasticsearch.yml"
+  plist_options :manual => "elasticsearch"
 
   def plist; <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>
@@ -107,12 +94,9 @@ class Elasticsearch < Formula
           <key>ProgramArguments</key>
           <array>
             <string>#{HOMEBREW_PREFIX}/bin/elasticsearch</string>
-            <string>--config=#{etc}/elasticsearch/elasticsearch.yml</string>
           </array>
           <key>EnvironmentVariables</key>
           <dict>
-            <key>ES_JAVA_OPTS</key>
-            <string>-Xss200000</string>
           </dict>
           <key>RunAtLoad</key>
           <true/>
@@ -128,6 +112,14 @@ class Elasticsearch < Formula
   end
 
   test do
-    system "#{bin}/plugin", "--list"
+    system "#{bin}/plugin", "list"
+    pid = "#{testpath}/pid"
+    begin
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "--path.data", testpath
+      sleep 10
+      system "curl", "-XGET", "localhost:9200/"
+    ensure
+      Process.kill(9, File.read(pid).to_i)
+    end
   end
 end


### PR DESCRIPTION
This commit addresses several issues that exist in the Elasticsearch
formula.

1. Upgrades formula to install 2.0.0, the latest stable release of
Elasticsearch
2. Changes `HEAD` builds to require Java 8 (cf.
elastic/elasticsearch@11314336b6f5bf45fdb69a3d7c11ce29386535af)
3. Changes `HEAD` builds to use gradle for assembling (due to
Elasticsearch build system change, cf.
elastic/elasticsearch@c86100f636e9bddf9fd578c52dff3722b0ccd488)
4. Stop moving lib to libexec (due to security enhancements in
Elasticsearch; cf.
elastic/elasticsearch@052cf1446f9caea16454e0db5860e8e694c61119)
5. Keep plugins under Elasticsearch home
6. Fix startup command
7. Remove stack size setting (cf.
elastic/elasticsearch@09b4d0e097fe5b40c7c1b4469ed76629cc9860b9)

Closes elastic/elasticsearch#14424