### PR TITLE
Chicken: Add an optional arg to allow forcing 64 bit build ENV

### DIFF
--- a/Library/Formula/chicken.rb
+++ b/Library/Formula/chicken.rb
@@ -12,6 +12,10 @@ class Chicken < Formula
     sha256 "1f46226c58b1b7cd92f4d0c68cc0583e2c5ec4c2cce60b53193afca9a5d8be19" => :mountain_lion
   end
 
+  # Sometimes chicken detects a 32-bit environment by mistake, causing errors,
+  # see https://github.com/Homebrew/homebrew/issues/45648
+  option "with-force-64-bit", "Build with forced 64-bit build environment"
+
   def install
     ENV.deparallelize
 
@@ -22,6 +26,8 @@ class Chicken < Formula
       LIBRARIAN=ar
       POSTINSTALL_PROGRAM=install_name_tool
     ]
+
+    args << "ARCH=x86-64" if build.with? "force-64-bit"
 
     system "make", *args
     system "make", "install", *args

--- a/Library/Formula/chicken.rb
+++ b/Library/Formula/chicken.rb
@@ -12,10 +12,6 @@ class Chicken < Formula
     sha256 "1f46226c58b1b7cd92f4d0c68cc0583e2c5ec4c2cce60b53193afca9a5d8be19" => :mountain_lion
   end
 
-  # Sometimes chicken detects a 32-bit environment by mistake, causing errors,
-  # see https://github.com/Homebrew/homebrew/issues/45648
-  option "with-force-64-bit", "Build with forced 64-bit build environment"
-
   def install
     ENV.deparallelize
 
@@ -27,7 +23,9 @@ class Chicken < Formula
       POSTINSTALL_PROGRAM=install_name_tool
     ]
 
-    args << "ARCH=x86-64" if build.with? "force-64-bit"
+    # Sometimes chicken detects a 32-bit environment by mistake, causing errors,
+    # see https://github.com/Homebrew/homebrew/issues/45648
+    args << "ARCH=x86-64" if MacOS.prefer_64_bit?
 
     system "make", *args
     system "make", "install", *args


### PR DESCRIPTION
Chicken has [a known error](http://code.call-cc.org/cgi-bin/gitweb.cgi?p=chicken-core.git;a=blob;f=README;h=2b8b2901284a368628d81be6636424ccbc3cf4a7;hb=b25963183b63530eda36ddca14466baffdff01ee#l463) that it will not compile without the right
make option on some older OSX versions. This commit adds the make option
as a build option, so people encountering the error, can rectify it.

Read more: issue #45648 