### PR TITLE
maximum_macos_requirement: reword message

### DIFF
--- a/Library/Homebrew/requirements/maximum_macos_requirement.rb
+++ b/Library/Homebrew/requirements/maximum_macos_requirement.rb
@@ -12,7 +12,11 @@ class MaximumMacOSRequirement < Requirement
 
   def message
     <<-EOS.undent
-      OS X #{@version.pretty_name} or older is required.
+      This formula either does not compile or function as expected on newer
+      OS X versions than #{@version.pretty_name} due to an upstream incompatibility.
+
+      You can try to install the formula with `--HEAD` but one may not be
+      defined or the issue may still be present upstream.
     EOS
   end
 end


### PR DESCRIPTION
*Whole bunch* of confusion about the purpose of the MMOSR, largely with people believing we're adding artificial caps ourselves rather than having them enforced on us by upstream issues.

New wording looks like:

```
ld64: This formula either does not compile or function as expected on newer
OS X versions than Snow Leopard due to an upstream issue.

You can try to install the formula with `--HEAD` but one may not be
defined or the issue may still be present upstream.
```