### PR TITLE
fcgiwrap: update homepage

### DIFF
--- a/Library/Formula/fcgiwrap.rb
+++ b/Library/Formula/fcgiwrap.rb
@@ -1,6 +1,6 @@
 class Fcgiwrap < Formula
   desc "CGI support for Nginx"
-  homepage "http://nginx.localdomain.pl/wiki/FcgiWrap"
+  homepage "https://www.nginx.com/resources/wiki/start/topics/examples/fcgiwrap/"
   url "https://github.com/gnosek/fcgiwrap/archive/1.1.0.tar.gz"
   sha256 "4c7de0db2634c38297d5fcef61ab4a3e21856dd7247d49c33d9b19542bd1c61f"
 


### PR DESCRIPTION
As stated in #41610, the homepage of fcgiwrap leads to a certificate error. I believe this new page is the nearest wiki available. I also reported this upstream: https://github.com/gnosek/fcgiwrap/issues/30