### PR TITLE
Add /etc/shells caveat to zsh formula

### DIFF
--- a/Library/Formula/zsh.rb
+++ b/Library/Formula/zsh.rb
@@ -51,6 +51,8 @@ class Zsh < Formula
   end
 
   def caveats; <<-EOS.undent
+    In order to use this build of zsh as your login shell,
+    it must be added to /etc/shells.
     Add the following to your zshrc to access the online help:
       unalias run-help
       autoload run-help


### PR DESCRIPTION
As a result of a discussion held [here](https://github.com/herrbischoff/awesome-osx-command-line/pull/58#issuecomment-153714473), adding the caveat will advise users to add zsh to `/etc/shells` in order to use it as a login shell. Analoguous to the [bash formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/bash.rb#L44-L48).