### PR TITLE
sonar 5.2

### DIFF
--- a/Library/Formula/sonar.rb
+++ b/Library/Formula/sonar.rb
@@ -1,8 +1,8 @@
 class Sonar < Formula
   desc "Manage code quality"
   homepage "http://www.sonarqube.org/"
-  url "http://dist.sonar.codehaus.org/sonarqube-5.1.2.zip"
-  sha256 "a8d63d837242d0d07c0b3f65cfa9c84d5ae82ee51c6cbb52248bcf0d1bc58491"
+  url "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-5.2.zip"
+  sha256 "b305630690e6021ae6f3f682b8f1224e2c2b037ebd40b12c1194befe1c8e227e"
 
   bottle :unneeded
 


### PR DESCRIPTION
Note that SonarSource (company behind SonarQube) made a change in URL for distributions.