### PR TITLE
Update docker-compose stable to 1.5.0

### DIFF
--- a/Library/Formula/docker-compose.rb
+++ b/Library/Formula/docker-compose.rb
@@ -3,18 +3,8 @@ class DockerCompose < Formula
   homepage "https://docs.docker.com/compose/"
 
   stable do
-    url "https://github.com/docker/compose/archive/1.4.2.tar.gz"
-    sha256 "cc11f8281f0cf99fcb5502edb6e0d49caca26f4a11570b8ad68943bd3a97dd5c"
-
-    resource "docker-py" do
-      url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.3.1.tar.gz"
-      sha256 "743f3fc78f6159d14ac603def6470cf1b4edefc04de8b1ad8c349b380b503f50"
-    end
-
-    resource "requests" do
-      url "https://pypi.python.org/packages/source/r/requests/requests-2.6.1.tar.gz"
-      sha256 "490b111c824d64b84797a899a4c22618bbc45323ac24a0a0bb4b73a8758e943c"
-    end
+    url "https://github.com/docker/compose/archive/1.5.0.tar.gz"
+    sha256 "d44d7c966c3ec6b2baf493fb8c8f94b0c23cb03609517cc174884c7ff46cf809"
   end
 
   bottle do
@@ -27,31 +17,6 @@ class DockerCompose < Formula
 
   head do
     url "https://github.com/docker/compose.git"
-
-    resource "docker-py" do
-      url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.4.0.tar.gz"
-      sha256 "933bd55ec332adfe69b2825d81e7d238f51d970d5b16f63a14199789cd04c7b8"
-    end
-
-    resource "requests" do
-      url "https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz"
-      sha256 "398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d"
-    end
-
-    resource "enum34" do
-      url "https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz"
-      sha256 "d3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447"
-    end
-
-    resource "jsonschema" do
-      url "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-2.5.1.tar.gz"
-      sha256 "36673ac378feed3daa5956276a829699056523d7961027911f064b52255ead41"
-    end
-
-    resource "functools32" do
-      url "https://pypi.python.org/packages/source/f/functools32/functools32-3.2.3-2.tar.gz"
-      sha256 "f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
-    end
   end
 
   depends_on :python if MacOS.version <= :snow_leopard
@@ -62,14 +27,39 @@ class DockerCompose < Formula
   depends_on "docker" => :recommended
   depends_on "docker-machine" => :recommended
 
+  resource "docker-py" do
+    url "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.5.0.tar.gz"
+    sha256 "6924128fac46afef0de16ebdffc30a8c071246312260f289d895129f4e00f8d0"
+  end
+
+  resource "requests" do
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz"
+    sha256 "398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d"
+  end
+
+  resource "enum34" do
+    url "https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz"
+    sha256 "d3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447"
+  end
+
+  resource "jsonschema" do
+    url "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-2.5.1.tar.gz"
+    sha256 "36673ac378feed3daa5956276a829699056523d7961027911f064b52255ead41"
+  end
+
+  resource "functools32" do
+    url "https://pypi.python.org/packages/source/f/functools32/functools32-3.2.3-2.tar.gz"
+    sha256 "f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
+  end
+
   resource "pyyaml" do
-    url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.11.tar.gz"
-    sha256 "c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8"
+    url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.10.tar.gz"
+    sha256 "e713da45c96ca53a3a8b48140d4120374db622df16ab71759c9ceb5b8d46fe7c"
   end
 
   resource "six" do
-    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
-    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
+    url "https://pypi.python.org/packages/source/s/six/six-1.7.3.tar.gz"
+    sha256 "7a842c9f882c0b2ab1064d567bb9fff6a21c9efbc3d9992083ad6193787ed393"
   end
 
   resource "dockerpty" do
@@ -78,13 +68,13 @@ class DockerCompose < Formula
   end
 
   resource "texttable" do
-    url "https://pypi.python.org/packages/source/t/texttable/texttable-0.8.3.tar.gz"
-    sha256 "f333ac915e7c5daddc7d4877b096beafe74ea88b4b746f82a4b110f84e348701"
+    url "https://pypi.python.org/packages/source/t/texttable/texttable-0.8.2.tar.gz"
+    sha256 "c0c5b2aa4eab132d40aadb7c4e81f98fc93d3a1e6cb44e9be76779d74f32e6be"
   end
 
   resource "docopt" do
-    url "https://pypi.python.org/packages/source/d/docopt/docopt-0.6.2.tar.gz"
-    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+    url "https://pypi.python.org/packages/source/d/docopt/docopt-0.6.1.tar.gz"
+    sha256 "71ad940a773fbc23be6093e9476ad57b2ecec446946a28d30127501f3b29aa35"
   end
 
   resource "websocket-client" do


### PR DESCRIPTION
1.5.0 went stable yesterday. Stable and HEAD are equivalent in dependencies right now.