### PR TITLE
fcitx-remote-for-osx 0.0.2 (new formula)

### DIFF
--- a/Library/Formula/fcitx-remote-for-osx.rb
+++ b/Library/Formula/fcitx-remote-for-osx.rb
@@ -1,0 +1,19 @@
+class FcitxRemoteForOsx < Formula
+  desc "handle input method in command-line"
+  homepage "https://github.com/CodeFalling/fcitx-remote-for-osx"
+  url "https://github.com/CodeFalling/fcitx-remote-for-osx/archive/0.0.2.tar.gz"
+  sha256 "746505694090d98d5ad572758e7597c49d3bea1b00208a8272c3648aad15ad69"
+
+  option "with-input-method=", "Select input method: baidu-pinyin(default), baidu-wubi, sogou-pinyin, qq-wubi, squirrel-rime, osx-pinyin"
+
+  def install
+    input_method = ARGV.value("with-input-method") || "baidu-pinyin"
+    system "./build.py", "build", input_method
+    bin.install "fcitx-remote-#{input_method}"
+    bin.install_symlink "fcitx-remote-#{input_method}" => "fcitx-remote"
+  end
+
+  test do
+    system "#{bin}/fcitx-remote"
+  end
+end


### PR DESCRIPTION
`fcitx-remote-for-osx` is a simulate fcitx-remote to handle osx input method in command line.It makes `fcitx.el` and `fcitx.vim` works in osx directly.
See more:https://github.com/CodeFalling/fcitx-remote-for-osx