### PR TITLE
cmd/install: skip installed formulae in search

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -100,7 +100,8 @@ module Homebrew
         query = query_regexp(e.name)
 
         ohai "Searching for similarly named formulae..."
-        formulae_search_results = search_formulae(query)
+        formulae_search_results = search_formulae(query, :installed => false)
+
         case formulae_search_results.length
         when 0
           ofail "No similarly named formulae found."


### PR DESCRIPTION
To avoid this:
```
🌰  brew install nex
Error: No available formula with the name "nex"
==> Searching for similarly named formulae...
These similarly named formulae were found:
git-annex (installed)                  homebrew/science/nexusformat           openexr (installed)
homebrew/science/nextflow              nexus                                  winexe
To install one of them, run (for example):
  brew install git-annex (installed)
==> Searching taps...
This formula was found in a tap:
Caskroom/cask/git-annex
To install it, run:
  brew install Caskroom/cask/git-annex
```
Should work whether it's ` (installed)` or the Unicode checkmark.