### PR TITLE
cmake: don't hardcode bitness in .cmake files

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -13,6 +13,12 @@ class Cmake < Formula
     sha256 "cb0c73778120fcd899df10b1a06d9fbe1a1778645f252ac498bce1d0bd3ec63c" => :mavericks
   end
 
+  patch do
+    # skip bitness check (see https://cmake.org/Bug/view.php?id=15835)
+    url "https://gist.githubusercontent.com/d235j/695144126c2b9b8d5eec/raw/9c6f0a752c978ec35bd2ea9b423318b40120e78b/cmake-skip-archcheck.diff"
+    sha256 "ce0d53a362ac217680b11bef669d5992bc469a06e267e71075b1192f9ac88330"
+  end
+
   option "without-docs", "Don't build man pages"
   option "with-completion", "Install Bash completion (Has potential problems with system bash)"
 


### PR DESCRIPTION
CMake normally hardcodes architecture in the .cmake files. For formulas that use a library's .cmake file for config, this causes build failure when the library is built as universal.
This is a direct port of https://trac.macports.org/ticket/41835 from MacPorts.