### PR TITLE
unicorn: removed capstone dependency

### DIFF
--- a/Library/Formula/unicorn.rb
+++ b/Library/Formula/unicorn.rb
@@ -16,7 +16,6 @@ class Unicorn < Formula
     "SPARC"
   option "with-debug", "Create a debug build"
 
-  depends_on "capstone"
   depends_on "glib"
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
I accidentally included capstone as a dependency in the formula for unicorn.