### PR TITLE
Bump to version 0.5.0

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -3,7 +3,7 @@ require "language/go"
 class DockerMachine < Formula
   desc "Create Docker hosts locally and on cloud providers"
   homepage "https://docs.docker.com/machine"
-  url "https://github.com/docker/machine/archive/v0.4.1.tar.gz"
+  url "https://github.com/docker/machine/archive/v0.5.0.tar.gz"
   sha256 "f089657b2de7a3ce15374e69be3f654b0866f75eb077ca363f8a5933ccf51cda"
   head "https://github.com/docker/machine.git"
 


### PR DESCRIPTION
Upgrade to docker-machine 0.5.0 to remain compatible with docker client that is already upgraded in brew.