### PR TITLE
docker-machine: install completion scripts

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -24,6 +24,8 @@ class DockerMachine < Formula
 
     system "make", "build"
     bin.install Dir["bin/*"]
+
+    bash_completion.install Dir["contrib/completion/bash/*.bash"]
   end
 
   test do


### PR DESCRIPTION
docker-machine 0.5.0 introduces some new bash completion scripts. This patch installs them.