### PR TITLE
Debian various.

### DIFF
--- a/Library/Formula/logcheck.rb
+++ b/Library/Formula/logcheck.rb
@@ -1,8 +1,8 @@
 class Logcheck < Formula
   desc "Mail anomalies in the system logfiles to the administrator"
   homepage "https://logcheck.alioth.debian.org/"
-  url "https://mirrors.kernel.org/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.17.tar.xz"
   sha256 "c2d3fc323e8c6555e91d956385dbfd0f67b55872ed0f6a7ad8ad2526a9faf03a"
 
   bottle do
@@ -21,6 +21,7 @@ class Logcheck < Formula
   end
 
   test do
-    system "#{sbin}/logtail", "-f", "#{HOMEBREW_REPOSITORY}/README.md"
+    cp HOMEBREW_REPOSITORY/"README.md", testpath
+    system "#{sbin}/logtail", "-f", "README.md"
   end
 end

--- a/Library/Formula/lsh.rb
+++ b/Library/Formula/lsh.rb
@@ -16,7 +16,8 @@ class Lsh < Formula
   depends_on "gmp"
 
   resource "liboop" do
-    url "https://mirrors.kernel.org/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
     sha256 "34d83c6e0f09ee15cb2bc3131e219747c3b612bb57cf7d25318ab90da9a2d97c"
   end
 
@@ -41,7 +42,7 @@ class Lsh < Formula
 
     # Find the sandboxed liboop.
     ENV.append "LDFLAGS", "-L#{libexec}/liboop/lib"
-    # Compile lsh without the 89 flag? Ha, Nope!
+    # Compile fails without passing gnu89.
     ENV.append_to_cflags "-I#{libexec}/liboop/include -std=gnu89"
 
     system "./configure", *args

--- a/Library/Formula/mdf2iso.rb
+++ b/Library/Formula/mdf2iso.rb
@@ -1,8 +1,8 @@
 class Mdf2iso < Formula
   desc "Tool to convert MDF (Alcohol 120% images) images to ISO images"
   homepage "https://packages.debian.org/sid/mdf2iso"
-  url "https://mirrors.kernel.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
   sha256 "906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7"
 
   bottle do
@@ -19,6 +19,6 @@ class Mdf2iso < Formula
   end
 
   test do
-    assert_match /#{version}/, shell_output("#{bin}/mdf2iso --help")
+    assert_match version.to_s, shell_output("#{bin}/mdf2iso --help")
   end
 end

--- a/Library/Formula/mkcue.rb
+++ b/Library/Formula/mkcue.rb
@@ -1,8 +1,8 @@
 class Mkcue < Formula
   desc "Generate a CUE sheet from a CD"
-  homepage "https://packages.debian.org/source/stable/mkcue"
-  url "https://mirrors.kernel.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  homepage "https://packages.debian.org/sid/mkcue"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
   version "1"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
 

--- a/Library/Formula/mmv.rb
+++ b/Library/Formula/mmv.rb
@@ -1,8 +1,8 @@
 class Mmv < Formula
   desc "Move, copy, append, and link multiple files"
   homepage "https://packages.debian.org/unstable/utils/mmv"
-  url "https://mirrors.kernel.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
-  mirror "http://ftp.us.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
   sha256 "0399c027ea1e51fd607266c1e33573866d4db89f64a74be8b4a1d2d1ff1fdeef"
 
   bottle do
@@ -13,7 +13,7 @@ class Mmv < Formula
   end
 
   patch do
-    url "http://ftp.us.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
+    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
     sha256 "9ad3e3d47510f816b4a18bae04ea75913588eec92248182f85dd09bc5ad2df13"
   end
 

--- a/Library/Formula/pmccabe.rb
+++ b/Library/Formula/pmccabe.rb
@@ -1,8 +1,8 @@
 class Pmccabe < Formula
   desc "Calculate McCabe-style cyclomatic complexity for C/C++ code"
   homepage "https://packages.debian.org/sid/pmccabe"
-  url "https://mirrors.kernel.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
   sha256 "e490fe7c9368fec3613326265dd44563dc47182d142f579a40eca0e5d20a7028"
 
   bottle do

--- a/Library/Formula/postmark.rb
+++ b/Library/Formula/postmark.rb
@@ -1,9 +1,9 @@
 class Postmark < Formula
   desc "File system benchmark from NetApp"
-  homepage "https://packages.debian.org/stable/utils/postmark"
-  url "https://mirrors.kernel.org/debian/pool/main/p/postmark/postmark_1.51.orig.tar.gz"
-  mirror "http://ftp.us.debian.org/debian/pool/main/p/postmark/postmark_1.51.orig.tar.gz"
-  sha256 "7cb7c31d4e7725ce8d8e11fb7df62ed700dee4dbd5ca1e31bf3a9161fc890b41"
+  homepage "https://packages.debian.org/sid/postmark"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
+  sha256 "8a88fd322e1c5f0772df759de73c42aa055b1cd36cbba4ce6ee610ac5a3c47d3"
 
   bottle do
     cellar :any
@@ -15,10 +15,17 @@ class Postmark < Formula
   def install
     system ENV.cc, "-o", "postmark", "postmark-#{version}.c"
     bin.install "postmark"
+    man1.install "postmark.1"
   end
 
   test do
-    assert_match(/PostMark v#{version}/,
-                 pipe_output("#{bin}/postmark", "run\n", 0))
+    (testpath/"config").write <<-EOS.undent
+      set transactions 50
+      set location #{testpath}
+      run
+    EOS
+
+    output = pipe_output("#{bin}/postmark #{testpath}/config")
+    assert_match /(50 per second)/, output
   end
 end

--- a/Library/Formula/tmpreaper.rb
+++ b/Library/Formula/tmpreaper.rb
@@ -1,10 +1,10 @@
 class Tmpreaper < Formula
   desc "Clean up files in directories based on their age"
-  homepage "https://packages.debian.org/tmpreaper"
-  url "https://mirrors.kernel.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
-  mirror "http://ftp.us.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
-  sha256 "c88f05b5d995b9544edb7aaf36ac5ce55c6fac2a4c21444e5dba655ad310b738"
+  homepage "https://packages.debian.org/sid/tmpreaper"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
   version "1.6.13_nmu1"
+  sha256 "c88f05b5d995b9544edb7aaf36ac5ce55c6fac2a4c21444e5dba655ad310b738"
 
   bottle do
     cellar :any
@@ -14,7 +14,7 @@ class Tmpreaper < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
     system "make", "install"
   end
 

--- a/Library/Formula/urlview.rb
+++ b/Library/Formula/urlview.rb
@@ -1,8 +1,8 @@
 class Urlview < Formula
   desc "URL extractor/launcher"
   homepage "https://packages.debian.org/sid/misc/urlview"
-  url "https://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
   sha256 "746ff540ccf601645f500ee7743f443caf987d6380e61e5249fc15f7a455ed42"
 
   bottle do
@@ -13,7 +13,8 @@ class Urlview < Formula
   end
 
   patch do
-    url "https://mirrors.kernel.org/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
     sha256 "056883c17756f849fb9235596d274fbc5bc0d944fcc072bdbb13d1e828301585"
   end
 
@@ -27,5 +28,14 @@ class Urlview < Formula
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"urls").write "https://github.com/Homebrew/homebrew"
+    io = IO.popen("#{bin}/urlview urls")
+    sleep 1
+    Process.kill("SIGINT", io.pid)
+    Process.wait(io.pid)
+    assert_match %r{https://github.com/Homebrew/homebrew}, io.read
   end
 end


### PR DESCRIPTION
* Bottle generation for newer OS X versions
* Moving away from `https://mirrors.kernel.org/debian` as it uses a SHA1 certificate chain which causes it to no longer be shown as secure in Google Chrome, which looks more worrying than it technically is but is an easy enough thing to fix.
* Adding fallback mirrors.
* Improving/Adding tests.

All these are <2 minute compiles, hence combining 9 of them in the same PR. All built and tested locally first, so should be fine.
