### PR TITLE
ncmpcpp: bump for boost

### DIFF
--- a/Library/Formula/ncmpcpp.rb
+++ b/Library/Formula/ncmpcpp.rb
@@ -1,8 +1,9 @@
 class Ncmpcpp < Formula
   desc "Ncurses-based client for the Music Player Daemon"
-  homepage "http://ncmpcpp.rybczak.net/"
-  url "http://ncmpcpp.rybczak.net/stable/ncmpcpp-0.6.7.tar.bz2"
+  homepage "http://rybczak.net/ncmpcpp/"
+  url "http://rybczak.net/ncmpcpp/stable/ncmpcpp-0.6.7.tar.bz2"
   sha256 "08807dc515b4e093154a6e91cdd17ba64ebedcfcd7aa34d0d6eb4d4cc28a217b"
+  revision 1
 
   bottle do
     cellar :any
@@ -30,6 +31,7 @@ class Ncmpcpp < Formula
   depends_on "pkg-config" => :build
   depends_on "libmpdclient"
   depends_on "readline"
+  depends_on "fftw" if build.with? "visualizer"
 
   if MacOS.version < :mavericks
     depends_on "boost" => "c++11"
@@ -38,8 +40,6 @@ class Ncmpcpp < Formula
     depends_on "boost"
     depends_on "taglib"
   end
-
-  depends_on "fftw" if build.with? "visualizer"
 
   needs :cxx11
 
@@ -66,5 +66,9 @@ class Ncmpcpp < Formula
       system "./configure", *args
     end
     system "make", "install"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ncmpcpp --version")
   end
 end


### PR DESCRIPTION
The test is rubbish, but it will (should) break the CI if we update Boost again and `ncmpcpp` needs revisioning. Happy for someone who uses the tool to make the test *much better*.

Closes #45729.