### PR TITLE
Not everything under /usr/local is owned by brew

### DIFF
--- a/share/doc/homebrew/El_Capitan_and_Homebrew.md
+++ b/share/doc/homebrew/El_Capitan_and_Homebrew.md
@@ -16,6 +16,10 @@ This is how to fix Homebrew on El Capitan if you see permission issues:
 sudo chown -R $(whoami):admin /usr/local
 ```
 
+### If you MySQL installed from mysql.com, do not chown with -R, only the directory.
+
+sudo chown $(whoami):admin /usr/local
+
 ## If `/usr/local` does not exist:
 First, try to create `/usr/local` the normal way:
 


### PR DESCRIPTION
If you have MySQL installed from http://www.mysql.com/downloads/, running a recursive chmod will mess with your database.

MySQL installs too

    /usr/local/mysql-5.6.23-osx10.8-x86_64/

and sym links to

    /usr/local/mysql