### PR TITLE
2ping 3.0.1 (new formula)

### DIFF
--- a/Library/Aliases/2ping
+++ b/Library/Aliases/2ping
@@ -1,0 +1,1 @@
+../Formula/twoping.rb

--- a/Library/Formula/twoping.rb
+++ b/Library/Formula/twoping.rb
@@ -1,0 +1,19 @@
+class Twoping < Formula
+  desc "Ping utility to determine directional packet loss"
+  homepage "http://www.finnie.org/software/2ping/"
+  url "http://www.finnie.org/software/2ping/2ping-3.0.1.tar.gz"
+  sha256 "d6997cd1680151e6f7d5e60137d45cd41bf385d26029878afdaaf5dc4f63dcc4"
+
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+    man1.install "doc/2ping.1"
+    man1.install_symlink "2ping.1" => "2ping6.1"
+    bin.install Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    system bin/"2ping", "-c", "5", "test.2ping.net"
+  end
+end


### PR DESCRIPTION
2ping is a bi-directional ping utility. It uses 3-way pings (akin to TCP
SYN, SYN/ACK, ACK) and after-the-fact state comparison between a 2ping
listener and a 2ping client to determine which direction packet loss
occurs.

New formula twoping.rb with a 2ping alias.