### PR TITLE
yubico-piv-tool 1.1.0

### DIFF
--- a/Library/Formula/yubico-piv-tool.rb
+++ b/Library/Formula/yubico-piv-tool.rb
@@ -1,8 +1,8 @@
 class YubicoPivTool < Formula
   desc "Command-line tool for the YubiKey NEO PIV applet"
   homepage "https://developers.yubico.com/yubico-piv-tool/"
-  url "https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-1.0.3.tar.gz"
-  sha256 "4cec162dda45851741a3b58c492797cc051ef59192ca35a3bdd125fc2ebd6210"
+  url "https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-1.1.0.tar.gz"
+  sha256 "457407e462d8d11c80788641516d65b92cc327b120b4e5bbf43f0d0679db1c39"
 
   bottle do
     cellar :any
@@ -22,6 +22,6 @@ class YubicoPivTool < Formula
   end
 
   test do
-    assert_match "yubico-piv-tool 1.0.3", shell_output("#{bin}/yubico-piv-tool --version")
+    assert_match "yubico-piv-tool 1.1.0", shell_output("#{bin}/yubico-piv-tool --version")
   end
 end


### PR DESCRIPTION
Version 1.1.0 (released 2015-11-06)
* Add support for new YubiKey 4.
* Add ykcs11.