### PR TITLE
valgrind: build on Xcode-only systems

### DIFF
--- a/Library/Formula/valgrind.rb
+++ b/Library/Formula/valgrind.rb
@@ -39,6 +39,12 @@ class Valgrind < Formula
     end
 
     system "./autogen.sh" if build.head?
+
+    # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
+    unless MacOS::CLT.installed?
+      inreplace "coregrind/Makefile.in", %r{(?<=\s)(?=/usr/include/mach/)}, MacOS.sdk_path.to_s
+    end
+
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
This partially reverts commit a41a44debd69cadc1f7490968ae1312676376c4.

I'm not sure why this stuff was removed to begin with - valgrind doesn't build on my machine without it.