### PR TITLE
travis/test-bot: add Ruby 1.8 test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       os: osx
       osx_image: xcode7
       rvm: system
-    - env: OSX=10.9
+    - env: OSX=10.9 HOMEBREW_RUBY=1.8.7
       os: osx
       osx_image: beta-xcode6.2
       rvm: system
@@ -21,11 +21,19 @@ before_install:
   - sudo rm -rf /usr/local/.git/refs /usr/local/.git/packed-refs
   - sudo rsync -az "$TRAVIS_BUILD_DIR/" /usr/local/
   - export TRAVIS_BUILD_DIR="/usr/local"
-  - sudo chown -R $USER /usr/local
-  - env | grep TRAVIS_
-  - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow; fi
+  - if [ -f ".git/shallow" ]; then
+      travis_retry git fetch --unshallow;
+    fi
   - git reset --hard $TRAVIS_COMMIT
   - git clean -qxdff
+
+install:
+  - if [ "$HOMEBREW_RUBY" = "1.8.7" ]; then
+      brew install homebrew/versions/ruby187;
+      export PATH="/usr/local/opt/ruby187/bin:$PATH";
+      export HOMEBREW_RUBY_PATH="/usr/local/opt/ruby187/bin/ruby";
+    fi
+  - export HOMEBREW_DEVELOPER="1"
 
 script:
   - brew test-bot

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -632,7 +632,7 @@ module Homebrew
       else
         test "brew", "tests", "--no-compat"
         readall_args = ["--aliases"]
-        readall_args << "--syntax" if MacOS.version >= :mavericks
+        readall_args << "--syntax" if RUBY_VERSION.split(".").first.to_i >= 2
         test "brew", "readall", *readall_args
         test "brew", "update-test"
       end

--- a/bin/brew
+++ b/bin/brew
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-chdir () {
+chdir() {
   cd "$@" >/dev/null
 }
 
@@ -10,9 +9,9 @@ export HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"
 BREW_SYMLINK=$(readlink "$0")
 if [ -n "$BREW_SYMLINK" ]
 then
-    BREW_SYMLINK_DIRECTORY=$(dirname "$BREW_SYMLINK")
-    BREW_FILE_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY" &&
-                          chdir "$BREW_SYMLINK_DIRECTORY" && pwd -P)
+  BREW_SYMLINK_DIRECTORY=$(dirname "$BREW_SYMLINK")
+  BREW_FILE_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY" &&
+                        chdir "$BREW_SYMLINK_DIRECTORY" && pwd -P)
 fi
 
 BREW_LIBRARY_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)
@@ -22,10 +21,18 @@ BREW_LIBRARY_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)
 unset GEM_HOME
 unset GEM_PATH
 
-BREW_SYSTEM=$(uname -s | tr "[:upper:]" "[:lower:]")
-if [ "$BREW_SYSTEM" = "darwin" ]
+if [ -z "$HOMEBREW_DEVELOPER" ]
 then
-    exec "$BREW_LIBRARY_DIRECTORY/brew.rb" "$@"
-else
-    exec ruby -W0 "$BREW_LIBRARY_DIRECTORY/brew.rb" "$@"
+  unset HOMEBREW_RUBY_PATH
 fi
+
+if [ -z "$HOMEBREW_RUBY_PATH" ]; then
+  BREW_SYSTEM=$(uname -s | tr "[:upper:]" "[:lower:]")
+  if [ "$BREW_SYSTEM" = "darwin" ]; then
+    HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
+  else
+    HOMEBREW_RUBY_PATH="ruby"
+  fi
+fi
+
+exec "$HOMEBREW_RUBY_PATH" -W0 "$BREW_LIBRARY_DIRECTORY/brew.rb" "$@"


### PR DESCRIPTION
This should make it easier to verify we don't accidentally merge pull requests that aren't valid Ruby 1.8 (breaking OS X 10.8 and below).

CC @UniqMartin @xu-cheng @DomT4 