### PR TITLE
gnupg url and mirror updates

### DIFF
--- a/Library/Formula/dirmngr.rb
+++ b/Library/Formula/dirmngr.rb
@@ -1,8 +1,8 @@
 class Dirmngr < Formula
   desc "Server for managing certificate revocation lists"
-  homepage "https://www.gnupg.org"
+  homepage "https://www.gnupg.org/"
   url "https://gnupg.org/ftp/gcrypt/dirmngr/dirmngr-1.1.1.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dirmngr/dirmngr_1.1.1.orig.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/dirmngr/dirmngr-1.1.1.tar.bz2"
   sha256 "d2280b8c314db80cdaf101211a47826734443436f5c3545cc1b614c50eaae6ff"
   revision 1
 

--- a/Library/Formula/gnupg.rb
+++ b/Library/Formula/gnupg.rb
@@ -1,9 +1,8 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://www.gnupg.org/"
-  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-1.4.19.tar.bz2"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.19.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-1.4.19.tar.bz2"
-  mirror "http://mirror.switch.ch/ftp/mirror/gnupg/gnupg/gnupg-1.4.19.tar.bz2"
   sha256 "7f09319d044b0f6ee71fe3587bb873be701723ac0952cff5069046a78de8fd86"
 
   bottle do

--- a/Library/Formula/gnupg2.rb
+++ b/Library/Formula/gnupg2.rb
@@ -2,7 +2,6 @@ class Gnupg2 < Formula
   desc "GNU Privacy Guard: a free PGP replacement"
   homepage "https://www.gnupg.org/"
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
-  mirror "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
   sha256 "68ed6b386ba78425b05a60e8ee22785ff0fef190bdc6f1c612f19a58819d4ac9"
 

--- a/Library/Formula/gnutls.rb
+++ b/Library/Formula/gnutls.rb
@@ -3,8 +3,9 @@
 # http://nmav.gnutls.org/2014/10/what-about-poodle.html
 class Gnutls < Formula
   desc "GNU Transport Layer Security (TLS) Library"
-  homepage "http://gnutls.org"
+  homepage "http://gnutls.org/"
   url "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.3/gnutls-3.3.18.tar.xz"
+  mirror "https://gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.18.tar.xz"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.3/gnutls-3.3.18.tar.xz"
   sha256 "7a87e7f486d1ada10007356917a412cde6c6114dac018e3569e3aa09e9f29395"
 

--- a/Library/Formula/gpg-agent.rb
+++ b/Library/Formula/gpg-agent.rb
@@ -2,7 +2,6 @@ class GpgAgent < Formula
   desc "GPG key agent"
   homepage "https://www.gnupg.org/"
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
-  mirror "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.0.29.tar.bz2"
   sha256 "68ed6b386ba78425b05a60e8ee22785ff0fef190bdc6f1c612f19a58819d4ac9"
 

--- a/Library/Formula/gpgme.rb
+++ b/Library/Formula/gpgme.rb
@@ -1,9 +1,8 @@
 class Gpgme < Formula
   desc "Library access to GnuPG"
   homepage "https://www.gnupg.org/related_software/gpgme/"
-  url "ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
+  url "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
-  mirror "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-1.6.0.tar.bz2"
   sha256 "b09de4197ac280b102080e09eaec6211d081efff1963bf7821cf8f4f9916099d"
 
   bottle do

--- a/Library/Formula/libassuan.rb
+++ b/Library/Formula/libassuan.rb
@@ -1,8 +1,7 @@
 class Libassuan < Formula
   desc "Assuan IPC Library"
-  homepage "https://www.gnupg.org/related_software/libassuan/index.en.html"
+  homepage "https://www.gnupg.org/related_software/libassuan/"
   url "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.3.0.tar.bz2"
-  mirror "ftp://ftp.gnupg.org/gcrypt/libassuan/libassuan-2.3.0.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-2.3.0.tar.bz2"
   sha256 "87c999f572047fa22a79ab5de4c8a1a5a91f292561b69573965cac7751320452"
   revision 1

--- a/Library/Formula/libgcrypt.rb
+++ b/Library/Formula/libgcrypt.rb
@@ -1,8 +1,7 @@
 class Libgcrypt < Formula
   desc "Cryptographic library based on the code from GnuPG"
-  homepage "https://gnupg.org/"
-  url "https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.6.4.tar.bz2"
-  mirror "ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.4.tar.bz2"
+  homepage "https://directory.fsf.org/wiki/Libgcrypt"
+  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.6.4.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.4.tar.bz2"
   sha256 "c9bc2c7fe2e5f4ea13b0c74f9d24bcbb1ad889bb39297d8082aebf23f4336026"
 

--- a/Library/Formula/libgpg-error.rb
+++ b/Library/Formula/libgpg-error.rb
@@ -1,8 +1,7 @@
 class LibgpgError < Formula
   desc "Common error values for all GnuPG components"
-  homepage "https://www.gnupg.org/"
-  url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
-  mirror "ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
+  homepage "https://www.gnupg.org/related_software/libgpg-error/"
+  url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.20.tar.bz2"
   sha256 "3266895ce3419a7fb093e63e95e2ee3056c481a9bc0d6df694cfd26f74e72522"
   revision 1
@@ -19,8 +18,9 @@ class LibgpgError < Formula
 
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
+    system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--prefix=#{prefix}",
                           "--enable-static"
     system "make", "install"
   end

--- a/Library/Formula/libksba.rb
+++ b/Library/Formula/libksba.rb
@@ -1,7 +1,7 @@
 class Libksba < Formula
   desc "X.509 and CMS library"
-  homepage "https://www.gnupg.org/related_software/libksba/index.en.html"
-  url "ftp://ftp.gnupg.org/gcrypt/libksba/libksba-1.3.3.tar.bz2"
+  homepage "https://www.gnupg.org/related_software/libksba/"
+  url "https://gnupg.org/ftp/gcrypt/libksba/libksba-1.3.3.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libksba/libksba-1.3.3.tar.bz2"
   sha256 "0c7f5ffe34d0414f6951d9880a46fcc2985c487f7c36369b9f11ad41131c7786"
 
@@ -16,8 +16,9 @@ class Libksba < Formula
   depends_on "libgpg-error"
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
-                          "--disable-silent-rules"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Library/Formula/npth.rb
+++ b/Library/Formula/npth.rb
@@ -1,7 +1,7 @@
 class Npth < Formula
   desc "New GNU portable threads library"
-  homepage "https://gnupg.org/index.html"
-  url "ftp://ftp.gnupg.org/gcrypt/npth/npth-1.2.tar.bz2"
+  homepage "https://gnupg.org/"
+  url "https://gnupg.org/ftp/gcrypt/npth/npth-1.2.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/npth/npth-1.2.tar.bz2"
   sha256 "6ddbdddb2cf49a4723f9d1ad6563c480d6760dcb63cb7726b8fc3bc2e1b6c08a"
 

--- a/Library/Formula/pinentry.rb
+++ b/Library/Formula/pinentry.rb
@@ -1,8 +1,8 @@
 class Pinentry < Formula
   desc "Passphrase entry dialog utilizing the Assuan protocol"
-  homepage "https://www.gnupg.org/related_software/pinentry/index.en.html"
-  url "ftp://ftp.gnupg.org/gcrypt/pinentry/pinentry-0.9.5.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/pinentry/pinentry_0.9.5.orig.tar.bz2"
+  homepage "https://www.gnupg.org/related_software/pinentry/"
+  url "https://gnupg.org/ftp/gcrypt/pinentry/pinentry-0.9.5.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/pinentry/pinentry-0.9.5.tar.bz2"
   sha256 "6a57fd3afc0d8aaa5599ffcb3ea4e7c42c113a181e8870122203ea018384688c"
 
   bottle do


### PR DESCRIPTION
* replace ftp with secure protocol
* sync mirrors across gnupg projects
* replace `mirrors.kernel.org` with `mirrorservice.org`
* consistent use of `gnupg.org` (for URLs) vs. `www.gnupg.org` (for homepages)
* remove insecure mirrors
* homepage updates and cleanups
* minor sync of build options formatting