### PR TITLE
freealut: restore trailing space in embedded patch

### DIFF
--- a/Library/Formula/freealut.rb
+++ b/Library/Formula/freealut.rb
@@ -33,6 +33,6 @@ index 2b26d6d..4001db1 100644
 -AC_SEARCH_LIBS([alGetError], [openal32 openal])
 +# Use Mac OS X frameworks
 +LIBS="$LIBS -framework IOKit -framework OpenAL"
-
+ 
  ################################################################################
  # Checks for header files.


### PR DESCRIPTION
after 2c4e697863ede6525ee7da7685bf23d64c96fbf6