### PR TITLE
app-engine-python: Add remaining executable symlinks to PATH.

### DIFF
--- a/Library/Formula/app-engine-python.rb
+++ b/Library/Formula/app-engine-python.rb
@@ -3,6 +3,7 @@ class AppEnginePython < Formula
   homepage "https://cloud.google.com/appengine/docs"
   url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.27.zip"
   sha256 "6192f295969dabf8659ce9a698450154f7c8c35b89c6e3cb52908c8f50d7c1f4"
+  revision 1
 
   bottle :unneeded
 
@@ -19,6 +20,7 @@ class AppEnginePython < Formula
       _php_runtime.py
       api_server.py
       appcfg.py
+      backends_conversion.py
       bulkload_client.py
       bulkloader.py
       dev_appserver.py
@@ -26,7 +28,10 @@ class AppEnginePython < Formula
       endpointscfg.py
       gen_protorpc.py
       google_sql.py
+      php_cli.py
       remote_api_shell.py
+      run_tests.py
+      wrapper_util.py
     ].each do |fn|
       bin.install_symlink share/name/fn
     end

--- a/Library/Formula/twoping.rb
+++ b/Library/Formula/twoping.rb
@@ -4,6 +4,13 @@ class Twoping < Formula
   url "http://www.finnie.org/software/2ping/2ping-3.0.1.tar.gz"
   sha256 "d6997cd1680151e6f7d5e60137d45cd41bf385d26029878afdaaf5dc4f63dcc4"
 
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "115f515900391449e9f22602744c680ea54451f534cac89eddb4bc133f38c6cb" => :el_capitan
+    sha256 "01b54ba53327fa3c8da79add6ee0bc9549f7b2f8ee18cf340f30049b17388719" => :yosemite
+    sha256 "dbc7b643c3cea44b8e00956d530244f7722c0d3ccebcec34913a3051d5cd348e" => :mavericks
+  end
+
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
     system "python", *Language::Python.setup_install_args(libexec)


### PR DESCRIPTION
The Google App Engine GUI symlinks 16 additional executables to the
PATH. The existing formula missed a handful of these, causing
dev_appserver to raise an error when attempting to import them (e.g.
`import wrapper_util.py`). This simply adds the remaining executables to
the list of those to be linked.