### PR TITLE
keg_relocate: remove options from Keg#dylib_id_for

### DIFF
--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -186,7 +186,7 @@ module Homebrew
     keg.lock do
       begin
         keg.relocate_install_names prefix, Keg::PREFIX_PLACEHOLDER,
-          cellar, Keg::CELLAR_PLACEHOLDER, :keg_only => f.keg_only?
+          cellar, Keg::CELLAR_PLACEHOLDER
         keg.relocate_text_files prefix, Keg::PREFIX_PLACEHOLDER,
           cellar, Keg::CELLAR_PLACEHOLDER
 
@@ -223,7 +223,7 @@ module Homebrew
       ensure
         ignore_interrupts do
           keg.relocate_install_names Keg::PREFIX_PLACEHOLDER, prefix,
-            Keg::CELLAR_PLACEHOLDER, cellar, :keg_only => f.keg_only?
+            Keg::CELLAR_PLACEHOLDER, cellar
         end
       end
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -671,7 +671,7 @@ class FormulaInstaller
   end
 
   def fix_install_names(keg)
-    keg.fix_install_names(:keg_only => formula.keg_only?)
+    keg.fix_install_names
   rescue Exception => e
     onoe "Failed to fix install names"
     puts "The formula built, but you may encounter issues using it or linking other"
@@ -720,7 +720,7 @@ class FormulaInstaller
     keg = Keg.new(formula.prefix)
     unless formula.bottle_specification.skip_relocation?
       keg.relocate_install_names Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
-        Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s, :keg_only => formula.keg_only?
+        Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s
     end
     keg.relocate_text_files Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
       Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -2,10 +2,10 @@ class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@".freeze
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@".freeze
 
-  def fix_install_names(options = {})
+  def fix_install_names
     mach_o_files.each do |file|
       file.ensure_writable do
-        change_dylib_id(dylib_id_for(file, options), file) if file.dylib?
+        change_dylib_id(dylib_id_for(file), file) if file.dylib?
 
         each_install_name_for(file) do |bad_name|
           # Don't fix absolute paths unless they are rooted in the build directory
@@ -27,11 +27,11 @@ class Keg
     end
   end
 
-  def relocate_install_names(old_prefix, new_prefix, old_cellar, new_cellar, options = {})
+  def relocate_install_names(old_prefix, new_prefix, old_cellar, new_cellar)
     mach_o_files.each do |file|
       file.ensure_writable do
         if file.dylib?
-          id = dylib_id_for(file, options).sub(old_prefix, new_prefix)
+          id = dylib_id_for(file).sub(old_prefix, new_prefix)
           change_dylib_id(id, file)
         end
 
@@ -148,7 +148,7 @@ class Keg
     dylibs.each(&block)
   end
 
-  def dylib_id_for(file, options)
+  def dylib_id_for(file)
     # The new dylib ID should have the same basename as the old dylib ID, not
     # the basename of the file itself.
     basename = File.basename(file.dylib_id)


### PR DESCRIPTION
No longer used since commit 3b0cbe6a56d9133941482a9e2d033ad86cdb5e79.