### PR TITLE
Add new command to fix Homebrew's permissions.

### DIFF
--- a/Library/Homebrew/cmd/fix-permissions.rb
+++ b/Library/Homebrew/cmd/fix-permissions.rb
@@ -1,0 +1,117 @@
+require "extend/ENV"
+
+module Homebrew
+  def fix_permissions
+    fix_permissions_shared(:wait => false)
+    system "/usr/bin/sudo", "-k"
+  end
+
+  ### !!!!!!!!!!
+  ### EVERYTHING between these markers is shared (and should be kept in sync)
+  ### with Homebrew/install/install
+  ### !!!!!!!!!!
+  def sudo *args
+    ohai "/usr/bin/sudo #{args.join ' '}"
+    system "/usr/bin/sudo", *args
+  end
+
+  def fix_permissions_shared(options={})
+    wait = options.fetch(:wait, true)
+
+    def chmod?(d)
+      File.directory?(d) && !(File.readable?(d) && File.writable?(d) && File.executable?(d))
+    end
+
+    def chown?(d)
+      File.directory?(d) && !File.owned?(d)
+    end
+
+    def chgrp?(d)
+      File.directory?(d) && !File.grpowned?(d)
+    end
+
+    def getc
+      system "/bin/stty raw -echo"
+      if STDIN.respond_to?(:getbyte)
+        STDIN.getbyte
+      else
+        STDIN.getc
+      end
+    ensure
+      system "/bin/stty -raw echo"
+    end
+
+    def wait_for_user
+      puts
+      puts "Press RETURN to continue or any other key to abort"
+      c = getc
+      # we test for \r and \n because some stuff does \r instead
+      abort unless c == 13 or c == 10
+    end
+
+    paths = %w(
+      .
+      bin
+      etc
+      include
+      lib
+      lib/pkgconfig
+      Library
+      sbin
+      share
+      var
+      var/log
+      share/locale
+      share/man
+      share/man/man1
+      share/man/man2
+      share/man/man3
+      share/man/man4
+      share/man/man5
+      share/man/man6
+      share/man/man7
+      share/man/man8
+      share/info
+      share/doc
+      share/aclocal
+    ).map { |d| File.join(HOMEBREW_PREFIX, d) }
+    chmods = paths.select { |d| chmod?(d) }
+    chowns = paths.select { |d| chown?(d) }
+    chgrps = paths.select { |d| chgrp?(d) }
+
+    unless chmods.empty?
+      ohai "The following directories will be made group writable:"
+      puts(*chmods)
+    end
+    unless chowns.empty?
+      ohai "The following directories will have their owner set to #{Tty.underline 39}#{ENV['USER']}#{Tty.reset}:"
+      puts(*chowns)
+    end
+    unless chgrps.empty?
+      ohai "The following directories will have their group set to #{Tty.underline 39}admin#{Tty.reset}:"
+      puts(*chgrps)
+    end
+
+    wait_for_user if wait && STDIN.tty?
+
+    if File.directory? HOMEBREW_PREFIX
+      sudo "/bin/chmod", "g+rwx", *chmods unless chmods.empty?
+      sudo "/usr/sbin/chown", ENV['USER'], *chowns unless chowns.empty?
+      sudo "/usr/bin/chgrp", "admin", *chgrps unless chgrps.empty?
+    else
+      sudo "/bin/mkdir", HOMEBREW_PREFIX
+      sudo "/bin/chmod", "g+rwx", HOMEBREW_PREFIX
+      # the group is set to wheel by default for some reason
+      sudo "/usr/sbin/chown", "#{ENV['USER']}:admin", HOMEBREW_PREFIX
+    end
+
+    sudo "/bin/mkdir", HOMEBREW_CACHE unless File.directory? HOMEBREW_CACHE
+    sudo "/bin/chmod", "g+rwx", HOMEBREW_CACHE if chmod? HOMEBREW_CACHE
+    sudo "/usr/sbin/chown", ENV['USER'], HOMEBREW_CACHE if chown? HOMEBREW_CACHE
+    sudo "/usr/bin/chgrp", "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
+  end
+  ### !!!!!!!!!!
+  ### EVERYTHING between these markers is shared (and should be kept in sync)
+  ### with Library/Homebrew/cmd/fix-permissions.rb
+  ### !!!!!!!!!!
+end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -53,18 +53,18 @@ class Tty
       str.to_s[0, width - 4]
     end
 
-    private
-
-    def color(n)
-      escape "0;#{n}"
-    end
-
     def bold(n)
       escape "1;#{n}"
     end
 
     def underline(n)
       escape "4;#{n}"
+    end
+
+    private
+
+    def color(n)
+      escape "0;#{n}"
     end
 
     def escape(n)


### PR DESCRIPTION
This involves some (nasty) code sharing with the install script which is a well-tested version of permissions fixing and is fairly conservative in what it fixes.

Also see https://github.com/Homebrew/install/pull/29.

CC @xu-cheng @bfontaine @DomT4 for thoughts.