### PR TITLE
Shibboleth SP

### DIFF
--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -30,7 +30,7 @@ class ShibbolethSp < Formula
       "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
-      "--prefix=#{prefix}"
+      "--prefix=#{prefix}",
     ]
     args << "--with-xmltooling=#{Formula["xml-tooling-c"].opt_prefix}"
     args << "--with-saml=#{Formula["opensaml"].opt_prefix}"
@@ -96,7 +96,7 @@ class ShibbolethSp < Formula
     unless File.exist? "#{prefix}/var/run/shibboleth"
       (prefix/"var/run/shibboleth/").mkpath
     end
-    unless File.exists? "#{prefix}/var/cache/shibboleth"
+    unless File.exist? "#{prefix}/var/cache/shibboleth"
       (prefix/"var/cache/shibboleth").mkpath
     end
   end

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -4,9 +4,6 @@ class ShibbolethSp < Formula
   url "http://shibboleth.net/downloads/service-provider/latest/shibboleth-sp-2.5.5.tar.gz"
   sha256 "30da36e0bba2ce4606a9effc37c05cd110dafdd6d3141468c4aa0f57ce4d96ce"
 
-  option "with-homebrew-httpd22", "Use Homebrew Apache httpd 2.2"
-  option "with-homebrew-httpd24", "Use Homebrew Apache httpd 2.4"
-
   depends_on "curl" => "with-openssl"
   depends_on "opensaml"
   depends_on "xml-tooling-c" => "with-openssl"
@@ -14,16 +11,13 @@ class ShibbolethSp < Formula
   depends_on "xml-security-c"
   depends_on "log4shib"
   depends_on "boost"
-  depends_on "homebrew/apache/httpd22" if build.with? "homebrew-httpd22"
-  depends_on "homebrew/apache/httpd24" if build.with? "homebrew-httpd24"
-
-  skip_clean "var/run/shibboleth"
-  skip_clean "var/cache/shibboleth"
+  depends_on "homebrew/apache/httpd22" => :optional
+  depends_on "homebrew/apache/httpd24" => :optional
 
   def apache_configdir
-    if build.with? "homebrew-httpd22"
+    if build.with? "httpd22"
       "#{etc}/apache2/2.2"
-    elsif build.with? "homebrew-httpd24"
+    elsif build.with? "httpd24"
       "#{etc}/apache2/2.4"
     else
       "/etc/apache2"
@@ -48,8 +42,6 @@ class ShibbolethSp < Formula
     end
     system "./configure", *args
     system "make", "install"
-    (prefix/"var/run/shibboleth/").mkpath
-    (prefix/"var/cache/shibboleth").mkpath
   end
 
   def plist; <<-EOS.undent
@@ -98,6 +90,15 @@ class ShibbolethSp < Formula
         https://wiki.shibboleth.net/confluence/display/EDS10/3.1+Configuring+the+Service+Provider
     EOS
     s
+  end
+
+  def post_install
+    unless File.exist? "#{prefix}/var/run/shibboleth"
+      (prefix/"var/run/shibboleth/").mkpath
+    end
+    unless File.exists? "#{prefix}/var/cache/shibboleth"
+      (prefix/"var/cache/shibboleth").mkpath
+    end
   end
 
   test do

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -26,17 +26,18 @@ class ShibbolethSp < Formula
     elsif build.with? "homebrew-httpd24"
       "#{etc}/apache2/2.4"
     else
-       "/etc/apache2"
+      "/etc/apache2"
     end
   end
 
   def install
     ENV.O2
-    args = []
-    args << "--disable-debug"
-    args << "--disable-dependency-tracking"
-    args << "--disable-silent-rules"
-    args << "--prefix=#{prefix}"
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
+    ]
     args << "--with-xmltooling=#{Formula["xml-tooling-c"].opt_prefix}"
     args << "--with-saml=#{Formula["opensaml"].opt_prefix}"
     args << "--with-boost=#{Formula["boost"].opt_prefix}"
@@ -44,7 +45,7 @@ class ShibbolethSp < Formula
     args << "--with-xmlsec=#{Formula["xml-security-c"].opt_prefix}"
     args << "LDFLAGS=-L#{Formula["curl"].opt_prefix}/curl/lib"
     args << "CPPFLAGS=-I#{Formula["curl"].opt_prefix}/curl/include"
-    args << "DYLD_LIBRARY_PATH=#{prefix}/lib"
+    args << "DYLD_LIBRARY_PATH=#{lib}"
     if build.with? "homebrew-httpd22"
       args << "--enable-apache-22"
     elsif build.with? "homebrew-httpd24"
@@ -85,9 +86,10 @@ class ShibbolethSp < Formula
     s += <<-EOS.undent
     You must manually edit #{apache_configdir}/httpd.conf to include
     EOS
-    mod = "mod_shib_24.so"
     if build.with? "homebrew-httpd22"
       mod = "mod_shib_22.so"
+    else
+      mod = "mod_shib_24.so"
     end
 
     s += <<-EOS.undent
@@ -95,10 +97,10 @@ class ShibbolethSp < Formula
     EOS
 
     s+= <<-EOS.undent
-    You must also manually configure
-      #{opt_prefix}/shibboleth-sp/etc/shibboleth/shibboleth2.xml
-    as per your own requirements. For more information please see
-      https://wiki.shibboleth.net/confluence/display/EDS10/3.1+Configuring+the+Service+Provider
+      You must also manually configure
+        #{opt_prefix}/shibboleth-sp/etc/shibboleth/shibboleth2.xml
+      as per your own requirements. For more information please see
+        https://wiki.shibboleth.net/confluence/display/EDS10/3.1+Configuring+the+Service+Provider
     EOS
     s
   end

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -35,9 +35,9 @@ class ShibbolethSp < Formula
     args << "--with-xmltooling=#{Formula["xml-tooling-c"].opt_prefix}"
     args << "--with-saml=#{Formula["opensaml"].opt_prefix}"
     args << "DYLD_LIBRARY_PATH=#{lib}"
-    if build.with? "homebrew-httpd22"
+    if build.with? "httpd22"
       args << "--enable-apache-22"
-    elsif build.with? "homebrew-httpd24"
+    elsif build.with? "httpd24"
       args << "--enable-apache-24"
     end
     system "./configure", *args
@@ -73,7 +73,7 @@ class ShibbolethSp < Formula
     s += <<-EOS.undent
       You must manually edit #{apache_configdir}/httpd.conf to include
     EOS
-    if build.with? "homebrew-httpd22"
+    if build.with? "httpd22"
       mod = "mod_shib_22.so"
     else
       mod = "mod_shib_24.so"

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -40,11 +40,6 @@ class ShibbolethSp < Formula
     ]
     args << "--with-xmltooling=#{Formula["xml-tooling-c"].opt_prefix}"
     args << "--with-saml=#{Formula["opensaml"].opt_prefix}"
-    args << "--with-boost=#{Formula["boost"].opt_prefix}"
-    args << "--with-xerces=#{Formula["xerces-c"].opt_prefix}"
-    args << "--with-xmlsec=#{Formula["xml-security-c"].opt_prefix}"
-    args << "LDFLAGS=-L#{Formula["curl"].opt_prefix}/curl/lib"
-    args << "CPPFLAGS=-I#{Formula["curl"].opt_prefix}/curl/include"
     args << "DYLD_LIBRARY_PATH=#{lib}"
     if build.with? "homebrew-httpd22"
       args << "--enable-apache-22"

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -4,7 +4,7 @@ class ShibbolethSp < Formula
   url "http://shibboleth.net/downloads/service-provider/latest/shibboleth-sp-2.5.5.tar.gz"
   sha256 "30da36e0bba2ce4606a9effc37c05cd110dafdd6d3141468c4aa0f57ce4d96ce"
 
-  option "enable-apache-22"
+  option "with-apache-22"
 
   depends_on "curl" => "with-openssl"
   depends_on "opensaml"
@@ -26,7 +26,7 @@ class ShibbolethSp < Formula
     args << "--with-xmltooling=#{Formula["xml-tooling-c"].opt_prefix}"
     args << "--with-saml=#{Formula["opensaml"].opt_prefix}"
     args << "DYLD_LIBRARY_PATH=#{lib}"
-    if build.with? "enable-apache-22"
+    if build.with? "apache-22"
       args << "--enable-apache-22"
     else
       args << "--enable-apache-24"
@@ -66,7 +66,7 @@ class ShibbolethSp < Formula
     s += <<-EOS.undent
       You must manually edit httpd.conf to include
     EOS
-    if build.with? "enable-apache-22"
+    if build.with? "apache-22"
       mod = "mod_shib_22.so"
     else
       mod = "mod_shib_24.so"

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -79,7 +79,7 @@ class ShibbolethSp < Formula
   def caveats
     s = ""
     s += <<-EOS.undent
-    You must manually edit #{apache_configdir}/httpd.conf to include
+      You must manually edit #{apache_configdir}/httpd.conf to include
     EOS
     if build.with? "homebrew-httpd22"
       mod = "mod_shib_22.so"

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -14,8 +14,8 @@ class ShibbolethSp < Formula
   depends_on "xml-security-c"
   depends_on "log4shib"
   depends_on "boost"
-  depends_on "httpd22" if build.with? "homebrew-httpd22"
-  depends_on "httpd24" if build.with? "homebrew-httpd24"
+  depends_on "homebrew/apache/httpd22" if build.with? "homebrew-httpd22"
+  depends_on "homebrew/apache/httpd24" if build.with? "homebrew-httpd24"
 
   skip_clean "var/run/shibboleth"
   skip_clean "var/cache/shibboleth"

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -102,4 +102,8 @@ class ShibbolethSp < Formula
     EOS
     s
   end
+
+  test do
+    system "#{opt_prefix}/sbin/shibd", "-t"
+  end
 end

--- a/Library/Formula/shibboleth-sp.rb
+++ b/Library/Formula/shibboleth-sp.rb
@@ -1,0 +1,52 @@
+class ShibbolethSp < Formula
+  desc "Shibboleth 2 Service Provider daemon"
+  homepage "https://wiki.shibboleth.net/confluence/display/SHIB2"
+  url "http://shibboleth.net/downloads/service-provider/latest/shibboleth-sp-2.5.5.tar.gz"
+  sha256 "30da36e0bba2ce4606a9effc37c05cd110dafdd6d3141468c4aa0f57ce4d96ce"
+
+  depends_on "opensaml"
+  depends_on "xml-tooling-c"
+  depends_on "xerces-c"
+  depends_on "xml-security-c"
+  depends_on "log4shib"
+  depends_on "boost"
+
+  def install
+    ENV.O2
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-xmltooling=/usr/local/Cellar/xml-tooling-c/1.5.3",
+                          "--with-saml=/usr/local/Cellar/opensaml/2.5.3",
+                          "--with-boost=/usr/local/Cellar/boost/1.58.0",
+                          "--with-xerces=/usr/local/Cellar/xerces-c/3.1.2",
+                          "--with-xmlsec=/usr/local/Cellar/xml-security-c/1.7.3"
+    system "make", "install"
+    (var/"shibboleth/run").mkpath
+  end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ServiceDescription</key>
+      <string>Shibboleth 2 Service Provider daemon</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_prefix}/sbin/shibd</string>
+        <string>-F</string>
+        <string>-f</string>
+        <string>-p</string>
+        <string>#{prefix}/var/run/shibboleth/shibd.pid</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+end

--- a/Library/Formula/xml-tooling-c.rb
+++ b/Library/Formula/xml-tooling-c.rb
@@ -19,10 +19,6 @@ class XmlToolingC < Formula
     args << "--disable-debug"
     args << "--disable-dependency-tracking"
     args << "--prefix=#{prefix}"
-    if build.with? "openssl"
-      args << "CPPFLAGS=-I#{Formula["curl"].opt_prefix}/curl/include"
-      args << "LDFLAGS=-L#{Formula["curl"].opt_prefix}/curl/lib"
-    end
     system "./configure", *args
     system "make", "install"
   end

--- a/Library/Formula/xml-tooling-c.rb
+++ b/Library/Formula/xml-tooling-c.rb
@@ -4,17 +4,26 @@ class XmlToolingC < Formula
   url "http://shibboleth.net/downloads/c++-opensaml/2.5.3/xmltooling-1.5.3.tar.gz"
   sha256 "90e453deb738574b04f1f1aa08ed7cc9d8746bcbf93eb59f401a6e38f2ec9574"
 
+  option "with-openssl", "Build with OpenSSL instead of Secure Transport"
+
   depends_on "pkg-config" => :build
   depends_on "log4shib"
   depends_on "xerces-c"
   depends_on "xml-security-c"
   depends_on "boost"
+  depends_on "curl" => "with-openssl" if build.with? "openssl"
 
   def install
     ENV.O2 # Os breaks the build
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = []
+    args << "--disable-debug"
+    args << "--disable-dependency-tracking"
+    args << "--prefix=#{prefix}"
+    if build.with? "openssl"
+      args << "CPPFLAGS=-I#{Formula["curl"].opt_prefix}/curl/include"
+      args << "LDFLAGS=-L#{Formula["curl"].opt_prefix}/curl/lib"
+    end
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
Shibboleth Service Provider 2.5.5 based on the MacPorts portfile here: https://trac.macports.org/browser/trunk/dports/security/shibboleth/Portfile

as well as installation guide here:
https://wiki.shibboleth.net/confluence/display/SHIB2/Installation

Change to xml-tooling-c formula is required to allow xml-tooling-c to be built with curl with openssl support; shibboleth-sp otherwise cannot be built.

