### PR TITLE
Add unix style default configuration file

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -17,6 +17,20 @@ fi
 
 BREW_LIBRARY_DIRECTORY=$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)
 
+# Debian style /etc/default management
+# This allows to have configuration variables such as
+# HOMEBREW_GITHUB_API_TOKEN not exposed to other processes
+if [ -n "$BREW_SYMLINK" ]
+then
+    BREW_DEFAULT_CONFIG=$BREW_FILE_DIRECTORY/../etc/default/${BREW_SYMLINK##*/}
+else
+    BREW_DEFAULT_CONFIG=$BREW_FILE_DIRECTORY/../etc/default/${0##*/}
+fi
+if [ -f $BREW_DEFAULT_CONFIG ]
+then
+    source $BREW_DEFAULT_CONFIG
+fi
+
 # Users may have these set, pointing the system Ruby
 # at non-system gem paths
 unset GEM_HOME


### PR DESCRIPTION
Inspired from the unix `/etc/default` or `/etc/sysconfig` custom parameters sourcing for system daemons, this PR adds the same mechanism to brew.

The main motivation for this PR is to be able to register the github token without having to expose it to other programs launched from the terminal.
More over, sourcing a script makes it easier to get this token encrypted through a third party tool such as pass (http://www.passwordstore.org/ | https://github.com/stuartsierra/password-store) 