### PR TITLE
ruby 1.8: address syntax warnings in Homebrew core

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -600,7 +600,7 @@ class FormulaAuditor
       problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
     end
 
-    if text =~ /system "npm", "install"/ && text !~ %r[opt_libexec}/npm/bin]
+    if text =~ /system "npm", "install"/ && text !~ %r[opt_libexec\}/npm/bin]
       need_npm = "\#{Formula[\"node\"].opt_libexec\}/npm/bin"
       problem <<-EOS.undent
        Please add ENV.prepend_path \"PATH\", \"#{need_npm}"\ to def install

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -33,7 +33,7 @@ class FormulaTests < Homebrew::TestCase
     refute_predicate f, :any_version_installed?
     prefix = HOMEBREW_CELLAR+f.name+"0.1"
     prefix.mkpath
-    FileUtils.touch (prefix+Tab::FILENAME)
+    FileUtils.touch prefix+Tab::FILENAME
     assert_predicate f, :any_version_installed?
   ensure
     f.rack.rmtree

--- a/Library/Homebrew/test/test_migrator.rb
+++ b/Library/Homebrew/test/test_migrator.rb
@@ -184,7 +184,7 @@ class MigratorTests < Homebrew::TestCase
 
     assert_predicate @new_keg_record, :exist?
     assert_predicate @old_keg_record.parent, :symlink?
-    refute_predicate (HOMEBREW_LIBRARY/"LinkedKegs/oldname"), :exist?
+    refute_predicate HOMEBREW_LIBRARY/"LinkedKegs/oldname", :exist?
     assert_equal @new_keg_record.realpath, (HOMEBREW_LIBRARY/"LinkedKegs/newname").realpath
     assert_equal @new_keg_record.realpath, @old_keg_record.realpath
     assert_equal @new_keg_record.realpath, (HOMEBREW_PREFIX/"opt/oldname").realpath

--- a/Library/Homebrew/test/test_pathname.rb
+++ b/Library/Homebrew/test/test_pathname.rb
@@ -216,7 +216,7 @@ class PathnameInstallTests < Homebrew::TestCase
     assert_predicate @dst+"bin", :directory?
     assert_predicate @dst+"bin/a.txt", :exist?
     assert_predicate @dst+"bin/b.txt", :exist?
-    assert_predicate (@dst+"bin").readlink, :relative?
+    assert_predicate((@dst+"bin").readlink, :relative?)
   end
 
   def test_install_relative_symlink


### PR DESCRIPTION
I figured we might want to address these before turning on the Ruby 1.8 CI. All of them are reported as warnings when running `brew readall --aliases --syntax` with Ruby 1.8.7.

CC @mikemcquaid @DomT4