### PR TITLE
valgrind: build on Xcode-only systems

### DIFF
--- a/Library/Formula/valgrind.rb
+++ b/Library/Formula/valgrind.rb
@@ -39,6 +39,12 @@ class Valgrind < Formula
     end
 
     system "./autogen.sh" if build.head?
+
+    # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
+    unless MacOS::CLT.installed?
+      inreplace "coregrind/Makefile.in", %r{(\s)(?=/usr/include/mach/)}, '<\1>'+MacOS.sdk_path.to_s
+    end
+
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
This time, don't use lookbehind which Ruby 1.8.7 doesn't have.

@DomT4 cc #45801