### PR TITLE
Fix broken link in README

### DIFF
--- a/Library/Homebrew/README.md
+++ b/Library/Homebrew/README.md
@@ -3,6 +3,6 @@ This is the (partially) documented public API for Homebrew.
 
 The main class you should look at is the {Formula} class (and classes linked from there). That's the class that's used to create Homebrew formulae (i.e. package descriptions). Assume anything else you stumble upon is private.
 
-You may also find the [Formula Cookbook](Formula-Cookbook.md) and [Ruby Style Guide](https://github.com/styleguide/ruby) helpful in creating formulae.
+You may also find the [Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md) and [Ruby Style Guide](https://github.com/styleguide/ruby) helpful in creating formulae.
 
 Good luck!


### PR DESCRIPTION
Fixing the link to the Formula Cookbook in the Library/Homebrew README.