### PR TITLE
Add gitlab-ci-multi-runner v0.6.2 (new formula)

### DIFF
--- a/Library/Formula/gitlab-ci-multi-runner.rb
+++ b/Library/Formula/gitlab-ci-multi-runner.rb
@@ -1,4 +1,4 @@
-class GitlabRunner < Formula
+class GitlabCiMultiRunner < Formula
   desc "The official GitLab CI runner written in Go"
   homepage "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner"
   url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git",
@@ -22,12 +22,12 @@ class GitlabRunner < Formula
       commit_sha = `git rev-parse --short HEAD`
 
       # Copy from Makefile
-      system "go", "build", "-o", "gitlab-runner", "-ldflags", "-X main.NAME=gitlab-runner -X main.VERSION=#{version} -X main.REVISION=#{commit_sha}"
-      bin.install "gitlab-runner"
+      system "go", "build", "-o", "gitlab-ci-multi-runner", "-ldflags", "-X main.NAME=gitlab-ci-multi-runner -X main.VERSION=#{version} -X main.REVISION=#{commit_sha}"
+      bin.install "gitlab-ci-multi-runner"
     end
   end
 
   test do
-    assert_match /gitlab-runner version #{version}/, shell_output("gitlab-runner --version")
+    assert_match /gitlab-ci-multi-runner version #{version}/, shell_output("gitlab-ci-multi-runner --version")
   end
 end

--- a/Library/Formula/gitlab-runner.rb
+++ b/Library/Formula/gitlab-runner.rb
@@ -1,7 +1,9 @@
 class GitlabRunner < Formula
   desc "The official GitLab CI runner written in Go"
   homepage "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner"
-  url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git", :tag => "v0.6.2", :revision => "3227f0aa5be1d64d2ec694bd3758e0d43e92b36b"
+  url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git",
+    :tag => "v0.6.2",
+    :revision => "3227f0aa5be1d64d2ec694bd3758e0d43e92b36b"
 
   head "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git"
 

--- a/Library/Formula/gitlab-runner.rb
+++ b/Library/Formula/gitlab-runner.rb
@@ -26,6 +26,6 @@ class GitlabRunner < Formula
   end
 
   test do
-    assert_match /gitlab-runner version #{version} (.*)/, shell_output("gitlab-runner --version")
+    assert_match /gitlab-runner version #{version}/, shell_output("gitlab-runner --version")
   end
 end

--- a/Library/Formula/gitlab-runner.rb
+++ b/Library/Formula/gitlab-runner.rb
@@ -1,0 +1,31 @@
+class GitlabRunner < Formula
+  desc "The official GitLab CI runner written in Go"
+  homepage "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner"
+  url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git", :tag => "v0.6.2", :revision => "3227f0aa5be1d64d2ec694bd3758e0d43e92b36b"
+
+  head "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    mkdir_p buildpath/"src/gitlab.com/gitlab-org"
+    ln_sf buildpath, buildpath/"src/gitlab.com/gitlab-org/gitlab-ci-multi-runner"
+
+    # gitlab-ci-multi-runner's deps is managed by godeps
+    ENV.append_path "GOPATH", "#{buildpath}/Godeps/_workspace"
+
+    cd "src/gitlab.com/gitlab-org/gitlab-ci-multi-runner" do
+      commit_sha = `git rev-parse --short HEAD`
+
+      # Copy from Makefile
+      system "go", "build", "-o", "gitlab-runner", "-ldflags", "-X main.NAME=gitlab-runner -X main.VERSION=#{version} -X main.REVISION=#{commit_sha}"
+      bin.install "gitlab-runner"
+    end
+  end
+
+  test do
+    assert_match /gitlab-runner version #{version} (.*)/, shell_output("gitlab-runner --version")
+  end
+end


### PR DESCRIPTION
New formula for [gitlab-ci-multi-runner](https://gitlab.com/gitlab-org/gitlab-ci-multi-runne)