### PR TITLE
Reflect move of cloc to github in recipe

### DIFF
--- a/Library/Formula/cloc.rb
+++ b/Library/Formula/cloc.rb
@@ -1,7 +1,7 @@
 class Cloc < Formula
   desc "Statistics utility to count lines of code"
-  homepage "http://cloc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cloc/cloc/v1.64/cloc-1.64.pl"
+  homepage "https://github.com/AlDanial/cloc/"
+  url "https://github.com/AlDanial/cloc/releases/download/1.64/cloc-1.64.pl"
   sha256 "79edea7ea1f442b1632001e23418193ae4571810e60de8bd25e491036d60eb3d"
 
   bottle do


### PR DESCRIPTION
Second attempt to correct the cloc formula reflecting the move to github.