### PR TITLE
groonga-normalizer-mysql: avoid sandbox problem

### DIFF
--- a/Library/Formula/groonga-normalizer-mysql.rb
+++ b/Library/Formula/groonga-normalizer-mysql.rb
@@ -15,7 +15,12 @@ class GroongaNormalizerMysql < Formula
   depends_on "groonga"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
-    system "make", "install"
+    system "./configure"
+    system "make"
+
+    mkdir "stage"
+    system "make", "install", "DESTDIR=#{buildpath}/stage"
+    lib.install Dir["stage/**/lib/*"]
+    (share/"doc/groonga-normalizer-mysql").install Dir["stage/**/share/doc/groonga-normalizer-mysql/*"]
   end
 end


### PR DESCRIPTION
Use similar way to https://github.com/Homebrew/homebrew/pull/45611.

Otherwise, installation will be failed with sandbox feature like this:

```log
% brew install groonga-normalizer-mysql -v --sandbox
==> Using the sandbox
...
make[2]: Nothing to be done for `install-exec-am'.
 .././install-sh -c -d '/usr/local/Cellar/groonga/5.0.8/lib/groonga/plugins/normalizers'
 /bin/sh ../libtool   --mode=install /usr/bin/install -c   mysql.la '/usr/local/Cellar/groonga/5.0.8/lib/groonga/plugins/normalizers'
libtool: install: /usr/bin/install -c .libs/mysql.so /usr/local/Cellar/groonga/5.0.8/lib/groonga/plugins/normalizers/mysql.so
install: /usr/local/Cellar/groonga/5.0.8/lib/groonga/plugins/normalizers/mysql.so: Operation not permitted
make[2]: *** [install-normalizers_pluginsLTLIBRARIES] Error 71
make[1]: *** [install-am] Error 2
make: *** [install-recursive] Error 1
==> Sandbox log
```