### PR TITLE
cc: disable RUBYOPT variable.

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -W0
+#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -W0 --disable-rubyopt
 
 $:.unshift Dir["/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/lib/ruby/{1.8,2.0.0}"].first
 require "pathname"


### PR DESCRIPTION
If this was set at build-time (i.e. by the Ruby 1.8.7 buildsystem) then `cc` could be passed arguments and fail to run.