### PR TITLE
cabal-install: Allow clang for Lion and above.

### DIFF
--- a/Library/Formula/cabal-install.rb
+++ b/Library/Formula/cabal-install.rb
@@ -13,7 +13,7 @@ class CabalInstall < Formula
 
   depends_on "ghc"
 
-  fails_with :clang if MacOS.version < :mavericks # Same as ghc.rb
+  fails_with :clang if MacOS.version < :lion # Same as ghc.rb
 
   def install
     system "sh", "bootstrap.sh", "--sandbox"


### PR DESCRIPTION
The GHC formula has allowed llvm for Lion and above since commit
b160b16 in April. There are problems building with GCC on Mountain Lion,
and this patch resolves them. In addition, the configuration now matches
ghc.rb as claimed in the inline comments again.

Fixes #45385.