### PR TITLE
qt5: raise minimum OS X requirement to 10.8

### DIFF
--- a/Library/Formula/qt5.rb
+++ b/Library/Formula/qt5.rb
@@ -62,9 +62,11 @@ class Qt5 < Formula
 
   deprecated_option "qtdbus" => "with-d-bus"
 
-  # Snow Leopard is untested and support has been removed in 5.4
-  # https://qt.gitorious.org/qt/qtbase/commit/5be81925d7be19dd0f1022c3cfaa9c88624b1f08
-  depends_on :macos => :lion
+  # OS X 10.7 Lion is still supported in Qt 5.5, but is no longer a reference
+  # configuration and thus untested in practice. Builds on OS X 10.7 have been
+  # reported to fail: <https://github.com/Homebrew/homebrew/issues/45284>.
+  depends_on :macos => :mountain_lion
+
   depends_on "d-bus" => :optional
   depends_on :mysql => :optional
   depends_on :xcode => :build


### PR DESCRIPTION
Qt 5.5.1 has been reported to fail to build on OS X 10.7 with the latest available Xcode for that OS X release. There is no easy workaround.

Also fail early if user tries to specify a compiler different from Apple Clang, as that is the only one currently supported and the Qt build system doesn't exactly facilitate switching to other compilers (except for the even more outdated Apple GCC).

*This is in response to [this comment](https://github.com/Homebrew/homebrew/issues/44998#issuecomment-156093215) and what followed it. It is probably safe to abort the CI build after the PR has passed the first few tests and just merge this. Or the CI timeout needs to be bumped.*

CC @mikemcquaid