### PR TITLE
Common build environment methods moved from cmd/env.rb to build_environment.rb

### DIFF
--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -30,3 +30,34 @@ module BuildEnvironmentDSL
     @env.merge(settings)
   end
 end
+
+module Homebrew
+  def build_env_keys(env)
+    %w[
+      CC CXX LD OBJC OBJCXX
+      HOMEBREW_CC HOMEBREW_CXX
+      CFLAGS CXXFLAGS CPPFLAGS LDFLAGS SDKROOT MAKEFLAGS
+      CMAKE_PREFIX_PATH CMAKE_INCLUDE_PATH CMAKE_LIBRARY_PATH CMAKE_FRAMEWORK_PATH
+      MACOSX_DEPLOYMENT_TARGET PKG_CONFIG_PATH PKG_CONFIG_LIBDIR
+      HOMEBREW_DEBUG HOMEBREW_MAKE_JOBS HOMEBREW_VERBOSE
+      HOMEBREW_SVN HOMEBREW_GIT
+      HOMEBREW_SDKROOT HOMEBREW_BUILD_FROM_SOURCE
+      MAKE GIT CPP
+      ACLOCAL_PATH PATH CPATH].select { |key| env.key?(key) }
+  end
+
+  def dump_build_env(env, f = $stdout)
+    keys = build_env_keys(env)
+    keys -= %w[CC CXX OBJC OBJCXX] if env["CC"] == env["HOMEBREW_CC"]
+
+    keys.each do |key|
+      value = env[key]
+      s = "#{key}: #{value}"
+      case key
+      when "CC", "CXX", "LD"
+        s << " => #{Pathname.new(value).realpath}" if File.symlink?(value)
+      end
+      f.puts s
+    end
+  end
+end

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -1,4 +1,5 @@
 require "extend/ENV"
+require "build_environment"
 
 module Homebrew
   def __env
@@ -13,35 +14,6 @@ module Homebrew
       build_env_keys(ENV).each do |key|
         puts "export #{key}=\"#{ENV[key]}\""
       end
-    end
-  end
-
-  def build_env_keys(env)
-    %w[
-      CC CXX LD OBJC OBJCXX
-      HOMEBREW_CC HOMEBREW_CXX
-      CFLAGS CXXFLAGS CPPFLAGS LDFLAGS SDKROOT MAKEFLAGS
-      CMAKE_PREFIX_PATH CMAKE_INCLUDE_PATH CMAKE_LIBRARY_PATH CMAKE_FRAMEWORK_PATH
-      MACOSX_DEPLOYMENT_TARGET PKG_CONFIG_PATH PKG_CONFIG_LIBDIR
-      HOMEBREW_DEBUG HOMEBREW_MAKE_JOBS HOMEBREW_VERBOSE
-      HOMEBREW_SVN HOMEBREW_GIT
-      HOMEBREW_SDKROOT HOMEBREW_BUILD_FROM_SOURCE
-      MAKE GIT CPP
-      ACLOCAL_PATH PATH CPATH].select { |key| env.key?(key) }
-  end
-
-  def dump_build_env(env, f = $stdout)
-    keys = build_env_keys(env)
-    keys -= %w[CC CXX OBJC OBJCXX] if env["CC"] == env["HOMEBREW_CC"]
-
-    keys.each do |key|
-      value = env[key]
-      s = "#{key}: #{value}"
-      case key
-      when "CC", "CXX", "LD"
-        s << " => #{Pathname.new(value).realpath}" if File.symlink?(value)
-      end
-      f.puts s
     end
   end
 end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -241,7 +241,7 @@ class BuildError < RuntimeError
       end
     else
       require "cmd/config"
-      require "cmd/--env"
+      require "build_environment"
 
       ohai "Formula"
       puts "Tap: #{formula.tap}" if formula.tap?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1422,7 +1422,7 @@ class Formula
         log.puts
 
         require "cmd/config"
-        require "cmd/--env"
+        require "build_environment"
 
         env = ENV.to_hash
 


### PR DESCRIPTION
This is similar to #45965 but for `cmd/env`. ~~The other PR used `tap_utils.rb` because `tap.rb` is already taken. I used `env.rb` here because it was free.~~