### PR TITLE
emacs: devel is now emacs-25

### DIFF
--- a/Library/Formula/emacs.rb
+++ b/Library/Formula/emacs.rb
@@ -14,8 +14,8 @@ class Emacs < Formula
   end
 
   devel do
-    url "http://git.sv.gnu.org/r/emacs.git", :branch => "emacs-24"
-    version "24.5-dev"
+    url "http://git.sv.gnu.org/r/emacs.git", :branch => "emacs-25"
+    version "25.0-dev"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end


### PR DESCRIPTION
emacs-25 has been created as the devel branch: http://lists.gnu.org/archive/html/emacs-devel/2015-11/msg01326.html