### PR TITLE
ghostscript 9.18

### DIFF
--- a/Library/Formula/ghostscript.rb
+++ b/Library/Formula/ghostscript.rb
@@ -38,10 +38,6 @@ class Ghostscript < Formula
 
   depends_on "pkg-config" => :build
   depends_on "djvulibre" if build.with? "djvu"
-  depends_on "freetype"
-  depends_on "jbig2dec"
-  depends_on "jpeg"
-  depends_on "libtiff"
   depends_on "little-cms2"
   depends_on :x11 => :optional
 
@@ -60,15 +56,6 @@ class Ghostscript < Formula
     sha256 "6236b14b79345eda87cce9ba22387e166e7614cca2ca86b1c6f0d611c26005df"
   end
 
-  def move_included_source_copies
-    # If the install version of any of these doesn't match
-    # the version included in ghostscript, we get errors
-    # Taken from the MacPorts portfile:
-    # https://trac.macports.org/browser/trunk/dports/print/ghostscript/Portfile#L64
-    renames = %w[freetype jbig2dec jpeg tiff]
-    renames.each { |lib| mv lib, "#{lib}_local" }
-  end
-
   def install
     if build.with? "djvu"
       resource("djvu").stage do
@@ -80,14 +67,11 @@ class Ghostscript < Formula
       end
     end
 
-    move_included_source_copies
-
     args = %W[
       --prefix=#{prefix}
       --disable-cups
       --disable-compile-inits
       --disable-gtk
-      --with-system-libtiff
     ]
     args << "--without-x" if build.without? "x11"
 

--- a/Library/Formula/libspectre.rb
+++ b/Library/Formula/libspectre.rb
@@ -3,6 +3,7 @@ class Libspectre < Formula
   homepage "https://wiki.freedesktop.org/www/Software/libspectre/"
   url "http://libspectre.freedesktop.org/releases/libspectre-0.2.7.tar.gz"
   sha256 "e81b822a106beed14cf0fec70f1b890c690c2ffa150fa2eee41dc26518a6c3ec"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,6 +13,11 @@ class Libspectre < Formula
   end
 
   depends_on "ghostscript"
+
+  patch do
+    url "https://github.com/Homebrew/patches/raw/master/libspectre/libspectre-0.2.7-gs918.patch"
+    sha256 "e4c186ddc6cebc92ee0aee24bc79c7f5fff147a0c0d9cadf7ebdc3906d44711c"
+  end
 
   def install
     ENV.append "CFLAGS", "-I#{Formula["ghostscript"].opt_include}/ghostscript"


### PR DESCRIPTION
Replacing the vendored dependencies with our own was causing problems; see https://github.com/Homebrew/homebrew/issues/43329