### PR TITLE
fprobe 1.1 (new formula)

### DIFF
--- a/Library/Formula/fprobe.rb
+++ b/Library/Formula/fprobe.rb
@@ -1,0 +1,19 @@
+class Fprobe < Formula
+  desc "Libpcap-based NetFlow probe"
+  homepage "https://sourceforge.net/projects/fprobe/"
+  url "https://downloads.sourceforge.net/project/fprobe/fprobe/1.1/fprobe-1.1.tar.bz2"
+  sha256 "3a1cedf5e7b0d36c648aa90914fa71a158c6743ecf74a38f4850afbac57d22a0"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--mandir=#{man}",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "fprobe"
+  end
+end


### PR DESCRIPTION
fprobe is a libcap-based NetFlow probe that monitors the local system's network
interfaces and can send NetFlow data to one or more collectors. fprobe supports
NetFlow versions 1, 5, and 7.

I think any real tests for this would require running as root...
<img width="682" alt="fprobe-foreground-debug" src="https://cloud.githubusercontent.com/assets/5242016/11163479/40f70970-8a87-11e5-9689-50c0d1a83cd6.png">
To demonstrate fprobe in action, using the following logstash config:
```
input {
  udp {
    port => 9995
    codec => netflow {
      versions => [5]
    }
  }
  tcp {
    port => 9995
    codec => netflow {
      versions => [5]
    }
  }
}

output {
  stdout { codec => rubydebug }
  elasticsearch {
    index => "netflow-%{+YYYY.MM.dd}"
    hosts => ["localhost"]
  }
}
```
... and running fprobe aimed at port 9995 on the logstash server:

    sudo fprobe -i en0 -f ip -l 2 localhost:9995

Logstash (launched with -vv) emits a debug stanza for each NetFlow packet received, similar to:
```
{
    "@timestamp" => "2015-11-14T12:30:51.003Z",
       "netflow" => {
                   "version" => 5,
              "flow_seq_num" => 120,
               "engine_type" => 0,
                 "engine_id" => 0,
        "sampling_algorithm" => 0,
         "sampling_interval" => 0,
              "flow_records" => 1,
             "ipv4_src_addr" => "192.30.252.87",
             "ipv4_dst_addr" => "192.168.2.89",
             "ipv4_next_hop" => "0.0.0.0",
                "input_snmp" => 0,
               "output_snmp" => 0,
                   "in_pkts" => 12,
                  "in_bytes" => 810,
            "first_switched" => "2015-11-14T12:25:41.003Z",
             "last_switched" => "2015-11-14T12:30:43.002Z",
               "l4_src_port" => 443,
               "l4_dst_port" => 61694,
                 "tcp_flags" => 24,
                  "protocol" => 6,
                   "src_tos" => 32,
                    "src_as" => 0,
                    "dst_as" => 0,
                  "src_mask" => 0,
                  "dst_mask" => 0
    },
      "@version" => "1",
          "host" => "10.0.2.2"
}
```