### PR TITLE
Update PredictionIO to latest version (0.9.5)

### DIFF
--- a/Library/Formula/predictionio.rb
+++ b/Library/Formula/predictionio.rb
@@ -1,7 +1,7 @@
 class Predictionio < Formula
   desc "Source machine learning server"
   homepage "https://prediction.io/"
-  url "https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-0.9.5.tar.gz"
+  url "http://download.prediction.io/PredictionIO-0.9.5.tar.gz"
   sha256 "6af81c03ac5d74fc331ab2248d2cacc752a6c2a54e0a55d63b57f7f17eae2fb0"
 
   bottle :unneeded

--- a/Library/Formula/predictionio.rb
+++ b/Library/Formula/predictionio.rb
@@ -1,8 +1,8 @@
 class Predictionio < Formula
   desc "Source machine learning server"
   homepage "https://prediction.io/"
-  url "http://download.prediction.io/PredictionIO-0.9.2.tar.gz"
-  sha256 "e4da196a1d67f545d6667f8368a7c6a64ff5c6de5135b085a12e9251b6076991"
+  url "https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-0.9.5.tar.gz"
+  sha256 "6af81c03ac5d74fc331ab2248d2cacc752a6c2a54e0a55d63b57f7f17eae2fb0"
 
   bottle :unneeded
 


### PR DESCRIPTION
This updates the download URL & checksum for PredictionIO's latest version - 0.9.5.