### PR TITLE
fpc: Generate a default configuration file

### DIFF
--- a/Library/Formula/fpc.rb
+++ b/Library/Formula/fpc.rb
@@ -28,11 +28,15 @@ class Fpc < Formula
 
     # Prevent non-executable audit warning
     rm_f Dir[bin/"*.rsj"]
+
+    # Generate a default fpc.cfg to set up unit search paths
+    system "#{bin}/fpcmkcfg", "-p", "-d", "basepath=#{lib}/fpc/#{version}", "-o", "#{prefix}/etc/fpc.cfg"
   end
 
   test do
     hello = <<-EOS.undent
       program Hello;
+      uses GL;
       begin
         writeln('Hello Homebrew')
       end.


### PR DESCRIPTION
The file provides a set of default paths and options, which help in
unit search paths (equivalent to C search paths) so that formulas won't
need to specify them when needed. All options and variables can be
overridden at any time on the command line.

Fix #45783.

references
http://www.freepascal.org/docs-html/3.0.0/user/usersu10.html
http://wiki.freepascal.org/Installing_Lazarus#STEP_.234:_Create_fpc.cfg_file