### PR TITLE
improve brew info

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -105,18 +105,13 @@ module Homebrew
 
     specs << "HEAD" if f.head
 
-    puts "#{f.full_name}: #{specs*", "}#{" (pinned)" if f.pinned?}"
+    attrs = []
+    attrs << "pinned at #{f.pinned_version}" if f.pinned?
+    attrs << "keg-only" if f.keg_only?
 
+    puts "#{f.full_name}: #{specs * ", "}#{" [#{attrs * ", "}]" if attrs.any?}"
     puts f.desc if f.desc
-
-    puts f.homepage
-
-    if f.keg_only?
-      puts
-      puts "This formula is keg-only."
-      puts f.keg_only_reason
-      puts
-    end
+    puts "#{Tty.em}#{f.homepage}#{Tty.reset}" if f.homepage
 
     conflicts = f.conflicts.map(&:name).sort!
     puts "Conflicts with: #{conflicts*", "}" unless conflicts.empty?
@@ -132,8 +127,7 @@ module Homebrew
       puts "Not installed"
     end
 
-    history = github_info(f)
-    puts "From: #{history}" if history
+    puts "From: #{Tty.em}#{github_info(f)}#{Tty.reset}"
 
     unless f.deps.empty?
       ohai "Dependencies"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -937,6 +937,11 @@ class Formula
   end
 
   # @private
+  def pinned_version
+    @pin.pinned_version
+  end
+
+  # @private
   def pin
     @pin.pin
   end

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -18,7 +18,7 @@ class FormulaPin
   end
 
   def pin
-    pin_at(@f.rack.subdirs.map { |d| Keg.new(d).version }.first)
+    pin_at(@f.rack.subdirs.map { |d| Keg.new(d).version }.max)
   end
 
   def unpin

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -33,4 +33,8 @@ class FormulaPin
   def pinnable?
     @f.rack.exist? && @f.rack.subdirs.length > 0
   end
+
+  def pinned_version
+    Keg.new(path.resolved_path).version if pinned?
+  end
 end


### PR DESCRIPTION
* Show pinned and keg-only as attributes, where pinned
     version is shown as well.
* Use brackets instead of parentheses to distinguish formula
     attributes(e.g. keg-only) with spec attributes(e.g. bottled)
* Don't show blank line for formula without homepage.
* Don't show duplicated keg-only message which will be shown later
     in caveats.
* Underline urls.
* Remove unnecessary github_info return value check, which is always
  existed.