### PR TITLE
Update libcurl pkgconfig file for 10.10

### DIFF
--- a/Library/ENV/pkgconfig/10.10/libcurl.pc
+++ b/Library/ENV/pkgconfig/10.10/libcurl.pc
@@ -27,13 +27,13 @@ prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMTP SMTPS TELNET TFTP"
-supported_features="SSL IPv6 libz AsynchDNS NTLM NTLM_WB GSS-API"
+supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="SSL IPv6 UnixSockets libz AsynchDNS GSS-API SPNEGO Kerberos NTLM NTLM_WB"
 
 Name: libcurl
 URL: http://curl.haxx.se/
 Description: Library to transfer files with ftp, http, etc.
-Version: 7.30.0
+Version: 7.43.0
 Libs: -L${libdir} -lcurl 
-Libs.private: -lssl -lcrypto -Wl,-weak-lldap -Wl,-weak-lgssapi_krb5 -lresolv -lssl -lcrypto -lz -lz 
+Libs.private: -lssl -lcrypto -Wl,-weak-lldap -Wl,-weak-lgssapi_krb5 -lresolv -lssl -lcrypto -lz -lz
 Cflags: -I${includedir}


### PR DESCRIPTION
 This matches the version shipped with 10.10.5.

 The list of supported features/protocols was obtained
 using `curl-config`:

``` bash
 features="`curl-config --features`"; echo "${features//$'\n'/ }"
 protocols="`curl-config --protocols`"; echo "${protocols//$'\n'/ }"
```

 `Libs.private` line removed as it only concerns static linking.

Signed-off-by: Mohammad AlSaleh <CE.Mohammad.AlSaleh@gmail.com>