### PR TITLE
Version bump jags Formula to 4.0.1

### DIFF
--- a/Library/Formula/jags.rb
+++ b/Library/Formula/jags.rb
@@ -1,16 +1,14 @@
 class Jags < Formula
   desc "Just Another Gibbs Sampler for Bayesian MCMC simulation"
   homepage "http://mcmc-jags.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mcmc-jags/JAGS/3.x/Source/JAGS-3.4.0.tar.gz"
-  sha256 "2beaa9a2672c2c95efc55ffa4c8b597a872f20232373daebd17ad539d3d7d82b"
+  url "https://downloads.sourceforge.net/project/mcmc-jags/JAGS/4.x/Source/JAGS-4.0.1.tar.gz"
+  sha256 "3619312cd9ce8163db4d5a51c961078061f6256382a2e93041ee22f7c09ba00e"
   bottle do
     cellar :any
     sha1 "ea59e194feb354ef474a6bd58d4556d0e68adfb0" => :yosemite
     sha1 "e3d0935caaf8a06b11efd1338d5444fdce87dc63" => :mavericks
     sha1 "49977edf0dc1571ae846f758c3ba74cf59a2f0f5" => :mountain_lion
   end
-
-  revision 1
 
   depends_on :fortran
 


### PR DESCRIPTION
Just a version bump. The 4.0.1 version JAGS contains changes so it now builds and links properly on current versions of OS X.