### PR TITLE
subversion: Fix build with PERL_MM_OPT set

### DIFF
--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -75,6 +75,11 @@ class Subversion < Formula
       inreplace "SConstruct", "unique=1", "unique=0"
 
       ENV.universal_binary if build.universal?
+
+      # Fix perl bindings Makefile.pl failing with:
+      # Only one of PREFIX or INSTALL_BASE can be given.  Not both.
+      ENV.delete "PERL_MM_OPT"
+
       # scons ignores our compiler and flags unless explicitly passed
       args = %W[PREFIX=#{serf_prefix} GSSAPI=/usr CC=#{ENV.cc}
                 CFLAGS=#{ENV.cflags} LINKFLAGS=#{ENV.ldflags}


### PR DESCRIPTION
Without this change, the build aborts in Makefile.pl with the following error:
> Only one of PREFIX or INSTALL_BASE can be given. Not both.

PERL_MB_OPT and PERL_MM_OPT usually get set from the shell's profile, if the user configured the CPAN shell to install modules to the users HOME.

For details see the similar issue #45091.