### PR TITLE
Update RethinkDB to 2.2.1

### DIFF
--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -1,8 +1,8 @@
 class Rethinkdb < Formula
   desc "The open-source database for the realtime web"
   homepage "https://www.rethinkdb.com/"
-  url "https://download.rethinkdb.com/dist/rethinkdb-2.2.0.tgz"
-  sha256 "5f51cecbb05282fff084bf838f9258a1d7171157c09e5f669f54b50f08489676"
+  url "https://download.rethinkdb.com/dist/rethinkdb-2.2.1.tgz"
+  sha256 "6611b4e62020a68c23e0a1f0a517b97677e0358c261a3e188d14b02b014a2c9e"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Updates the `rethinkdb` recipe to the 2.2.1 bug fix release https://github.com/rethinkdb/rethinkdb/releases/tag/v2.2.1 .
Tested on OS X Yosemite 10.10.5 .

Thanks!