### PR TITLE
git: Fix git-svn --with-brewed-subversion lib path

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -53,7 +53,10 @@ class Git < Formula
     perl_version = /\d\.\d+/.match(`perl --version`)
 
     if build.with? "brewed-svn"
-      ENV["PERLLIB_EXTRA"] = "#{Formula["subversion"].opt_prefix}/Library/Perl/#{perl_version}/darwin-thread-multi-2level"
+      ENV["PERLLIB_EXTRA"] = %W[
+        #{Formula["subversion"].opt_prefix}/lib/perl5/site_perl
+        #{Formula["subversion"].opt_prefix}/Library/Perl/#{perl_version}/darwin-thread-multi-2level
+      ].join(":")
     elsif MacOS.version >= :mavericks
       ENV["PERLLIB_EXTRA"] = %W[
         #{MacOS.active_developer_dir}


### PR DESCRIPTION
On newer systems perl installs modules into the standard `lib/perl5/site_perl` hierarchy, instead of the Mac OS X specific `Library/Perl`. This fix makes sure that both old and new directories are considered.

Without this fix `git-svn` is broken on Mac OS X 10.11.2 Beta (15C47a) with the system built-in `/usr/bin/perl` 5.18.2.

I'm not sure which perl version switched the directory structure, so I'm keeping the old lib path.