### PR TITLE
node 5.1.0

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -1,8 +1,8 @@
 class Node < Formula
   desc "Platform built on the V8 JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v5.0.0/node-v5.0.0.tar.gz"
-  sha256 "698d9662067ae6a20a2586e5c09659735fc0050769a0d8f76f979189ceaccdf4"
+  url "https://nodejs.org/dist/v5.1.0/node-v5.1.0.tar.gz"
+  sha256 "25b2d3b7dd57fe47a483539fea240a3c6bbbdab4d89a45a812134cf1380ecb94"
   head "https://github.com/nodejs/node.git"
 
   bottle do
@@ -33,8 +33,8 @@ class Node < Formula
   end
 
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-3.3.9.tgz"
-    sha256 "b406bfc670045c2b92432aff419fe22ff28fd439bb0ef4faa14fd6f16bda0c22"
+    url "https://registry.npmjs.org/npm/-/npm-3.4.0.tgz"
+    sha256 "1ede9227f3db6ba86a04a9cc99fe6efedbca84abd85a2f08710b047a45c5941c"
   end
 
   resource "icu4c" do


### PR DESCRIPTION
This PR updates [Node to v5.1.0](https://nodejs.org/en/blog/release/v5.1.0/) and [npm to v3.4.0](https://github.com/npm/npm/releases/tag/v3.4.0).