### PR TITLE
`gcc`: Force DWARF-2 Debugging Data under Pre-Mavericks

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -122,9 +122,10 @@ class Gcc < Formula
     # -fPIC, -shared, -ldl and -rdynamic."
     args << "--enable-plugin" if MacOS.version > :tiger
 
-    # Otherwise make fails during comparison at stage 3
+    # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
+    # format to avoid failure during the stage 3 comparison of object files.
     # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
-    args << "--with-dwarf2" if MacOS.version < :leopard
+    args << "--with-dwarf2" if MacOS.version <= :mountain_lion
 
     args << "--disable-nls" if build.without? "nls"
 


### PR DESCRIPTION
This pull request fixes a [recently observed regression](https://github.com/Homebrew/homebrew/issues/38501#issuecomment-157605403) in long-standing issue #38501 under the most recently available version of Xcode (5.1.1) for the most recently available version of Mountain Lion (10.8.5) attempting to install the most recently available version of `gcc` (5.2.0).

The pre-Mavericks toolchain requires the legacy DWARF-2 debugging data format to avoid failure during the stage 3 comparison of object files compiled during stages 2 and 3. Failure to do so results in the following all-too familiar fatal error:

```
rm -f stage_current
Comparing stages 2 and 3
warning: gcc/cc1-checksum.o differs
warning: gcc/cc1obj-checksum.o differs
warning: gcc/cc1objplus-checksum.o differs
warning: gcc/cc1plus-checksum.o differs
Bootstrap comparison failure!
x86_64-apple-darwin12.6.0/libstdc++-v3/src/.libs/compatibility-chrono.o differs
x86_64-apple-darwin12.6.0/libstdc++-v3/src/c++11/chrono.o differs
x86_64-apple-darwin12.6.0/libstdc++-v3/src/compatibility-chrono.o differs
make[2]: *** [compare] Error 1
make[1]: *** [stage3-bubble] Error 2
make: *** [bootstrap] Error 2
```

See [my commentary](https://github.com/Homebrew/homebrew/issues/38501#issuecomment-157605403) at #38501 for possibly exhausting exhaustive details.

The `gcc` formula currently only forces DWARF-2 under Leopard (10.5). This trivial pull request extends that to Snow Leopard (10.6), Lion (10.7), and Mountain Lion (10.8) as well.

Thanks for the oodles of noodly hard work, all. :ramen: 