### PR TITLE
maven 3.3.9

### DIFF
--- a/Library/Formula/maven.rb
+++ b/Library/Formula/maven.rb
@@ -1,9 +1,9 @@
 class Maven < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
-  mirror "https://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
-  sha256 "3a8dc4a12ab9f3607a1a2097bbab0150c947ad6719d8f1bb6d5b47d0fb0c4779"
+  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+  sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
 
   bottle :unneeded
 
@@ -49,6 +49,6 @@ class Maven < Formula
         }
       }
     EOS
-    system "#{bin}/mvn", "compile"
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
   end
 end


### PR DESCRIPTION
This pull request updates the Maven formula from version 3.3.3 to version
3.3.9, the latest stable version of Maven as of 2015-11-18.