### PR TITLE
lablgtk: regenerate the bottles

### DIFF
--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -29,9 +29,8 @@ class Lablgtk < Formula
 
   test do
     (testpath/"test.ml").write <<-EOS.undent
-      let main () =
+      let _ =
         GtkMain.Main.init ()
-      let _ = main ()
     EOS
     ENV["CAML_LD_LIBRARY_PATH"] = "#{lib}/ocaml/stublibs"
     system "ocamlc", "-I", "#{opt_lib}/ocaml/lablgtk2", "lablgtk.cma", "gtkInit.cmo", "test.ml", "-o", "test",


### PR DESCRIPTION
The bottles must be more recent than the OCaml ones to avoid the following error:

```
Error: Files /usr/local/lib/ocaml/lablgtk2/lablgtk.cmxa
       and /usr/local/lib/ocaml/stdlib.cmxa
       make inconsistent assumptions over implementation Printf
```