### PR TITLE
Disable compression support for OpenSSL

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -33,7 +33,7 @@ class Openssl < Formula
     --prefix=#{prefix}
     --openssldir=#{openssldir}
     no-ssl2
-    zlib-dynamic
+    no-comp
     shared
     enable-cms
   ]


### PR DESCRIPTION
The current recommended way to build OpenSSL typically includes disabling compression. This is to help mitigate the risk of [CRIME](https://en.wikipedia.org/wiki/CRIME) and its successor [BREACH](https://en.wikipedia.org/wiki/BREACH_(security_exploit)) (although the latter also applies to HTTP compression, which TLS compression has nothing to do with).

Additionally, the way OpenSSL loads zlib (https://github.com/openssl/openssl/blob/33dd08320648ac71d7d9d732be774ed3818dccc5/crypto/comp/c_zlib.c#L343-L402, which ultimately calls https://github.com/openssl/openssl/blob/33dd08320648ac71d7d9d732be774ed3818dccc5/crypto/dso/dso_dlfcn.c#L170 and dlopens the library) appears to be denied in certain instances by System Integrity Protection depending on the executing binary's entitlements.

Turning this off will result in an ABI change as a significant number of `COMP` symbols will no longer exist in `libcrypto`, so either this change should wait for 1.0.2e or all formulas that depend on OpenSSL will need to be rebuilt.