### PR TITLE
choose 0.1.0 (import from head-only)

### DIFF
--- a/Library/Formula/choose.rb
+++ b/Library/Formula/choose.rb
@@ -1,0 +1,32 @@
+class Choose < Formula
+  desc "Make choices on the command-line"
+  homepage "https://github.com/geier/choose"
+  url "https://github.com/geier/choose/archive/v0.1.0.tar.gz"
+  sha256 "d09a679920480e66bff36c76dd4d33e8ad739a53eace505d01051c114a829633"
+
+  head "https://github.com/geier/choose.git"
+
+  resource "urwid" do
+    url "https://pypi.python.org/packages/source/u/urwid/urwid-1.2.1.tar.gz"
+    sha256 "9b9b5dabb7df6c0f12e84feed488f9a9ddd5c2d66d1b7c7c087055720b87c68c"
+  end
+
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+
+    resource("urwid").stage do
+      system "python", *Language::Python.setup_install_args(libexec)
+    end
+
+    bin.install "choose"
+
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    # There isn't really a better test than that the executable exists
+    # and is executable because you can't run it without producing an
+    # interactive selection ui.
+    File.executable?("#{bin}/choose")
+  end
+end


### PR DESCRIPTION
Regarding the test the `script -q /dev/null` trick doesn’t work nor any `expect` script I’ve tried (I asked a [question on SO](http://stackoverflow.com/q/33791936/735926) about that).

See https://github.com/Homebrew/homebrew-head-only/pull/192