### PR TITLE
Skip pouring from a bottle if --cc is passed

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -80,6 +80,7 @@ class FormulaInstaller
     bottle = formula.bottle
     return true  if force_bottle? && bottle
     return false if build_from_source? || build_bottle? || interactive?
+    return false if ARGV.cc
     return false unless options.empty?
     return false if formula.bottle_disabled?
     return true  if formula.local_bottle_path

--- a/Library/Homebrew/test/test_formula_installer_bottle.rb
+++ b/Library/Homebrew/test/test_formula_installer_bottle.rb
@@ -3,8 +3,9 @@ require "formula"
 require "compat/formula_specialties"
 require "formula_installer"
 require "keg"
-require "testball_bottle"
+require "tab"
 require "testball"
+require "testball_bottle"
 
 class InstallBottleTests < Homebrew::TestCase
   def temporary_bottle_install(formula)
@@ -21,6 +22,8 @@ class InstallBottleTests < Homebrew::TestCase
     assert_predicate formula, :installed?
 
     begin
+      assert_predicate Tab.for_keg(keg), :poured_from_bottle
+
       yield formula
     ensure
       keg.unlink

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -1,3 +1,4 @@
+require "bundler"
 require "testing_env"
 
 class IntegrationCommandTests < Homebrew::TestCase

--- a/Library/Homebrew/test/testball_bottle.rb
+++ b/Library/Homebrew/test/testball_bottle.rb
@@ -12,4 +12,9 @@ class TestballBottle < Formula
     end
     super
   end
+
+  def install
+    prefix.install "bin"
+    prefix.install "libexec"
+  end
 end


### PR DESCRIPTION
A formula should be built from source by default if the --cc option is
passed to specify a particular compiler.

Added a test to test_formula_installer: test_not_poured_from_bottle_when_compiler_specified

Modified test_formula_installer to assert that the formula was not poured
from a bottle. Similarly modified test_formula_installer_bottle to assert
that the formula *was* installed from a bottle.

Added an install method to the TestballBottle formula (the same as the
Testball formula's install method) so that the TestballBottle formula can
be "built from source".

Fixes #46046 - Build from source should be the default behavior if --cc
option is passed