### PR TITLE
describe commit message format in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,11 @@ Please read:
 
 * [Code of Conduct](https://github.com/Homebrew/homebrew/blob/master/CODEOFCONDUCT.md#code-of-conduct)
 
+Commit message format for simple version updates:
+
+* `"FORMULA_NAME NEW_VERSION"`, e.g. `"source-highlight 3.1.8"`
+* devel version bumps should have the commit message marked with addtional (devel) suffix like `"nginx 1.9.1 (devel)"`
+
 To contribute code please read:
 
 * [Formula API](http://www.rubydoc.info/github/Homebrew/homebrew/master/frames)


### PR DESCRIPTION
Each time I open new pull requests to bump formula versions, I need to lookup the desired commit message/pr title format. I end up on the wiki or docs and then contributing, and finally following the link from the contributing doc. As the contributing doc is the quickest thing to review from an in-progress pull request, I think it would be best served to describe the desired commit message format front and center in the contributing doc. At least, as an intermittent contributor, that's where I think it's most helpful.