### PR TITLE
New formula: pldebugger.

### DIFF
--- a/Library/Formula/pldebugger.rb
+++ b/Library/Formula/pldebugger.rb
@@ -1,0 +1,41 @@
+class Pldebugger < Formula
+  desc "PL/pgSQL debugger server-side code"
+  homepage "http://git.postgresql.org/gitweb/"
+  url "http://git.postgresql.org/git/pldebugger.git",
+      :tag => "REL-9_5_0",
+      :revision => "85d7b3b2821301e182d5974d9e6f353d7a241eff"
+  version "1.0" # See default_version field in pldbgapi.control
+  sha256 "2bb8e27aa8f8434a4861fdbc70adb9cb4b47e1dfe472910d62d6042cb80a2ee1"
+
+  head "git://git.postgresql.org/git/pldebugger.git"
+
+  depends_on "postgresql"
+
+  def install
+    ENV["USE_PGXS"] = "1"
+    pg_config = "#{Formula["postgresql"].opt_bin}/pg_config"
+    system "make", "PG_CONFIG=#{pg_config}"
+    mkdir "stage"
+    system "make", "DESTDIR=#{buildpath}/stage", "PG_CONFIG=#{pg_config}", "install"
+    lib.install Dir["stage/**/lib/*"]
+    (doc/"postgresql/extension").install Dir["stage/**/share/doc/postgresql/extension/*"]
+    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
+  end
+
+  test do
+    pg_bin = Formula["postgresql"].opt_bin
+    pg_port = "55561"
+    system "#{pg_bin}/initdb", testpath/"test"
+    pid = fork { exec "#{pg_bin}/postgres", "-D", testpath/"test", "-p", pg_port }
+
+    begin
+      sleep 2
+      system "#{pg_bin}/createdb", "-p", pg_port
+      system "#{pg_bin}/psql", "-p", pg_port, "--command", "CREATE DATABASE test;"
+      system "#{pg_bin}/psql", "-p", pg_port, "-d", "test", "--command", "CREATE EXTENSION pldbgapi;"
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
This is not meant to be accepted as is. I open this pull request to get some feedback and see if there is any chance to ever get it accepted.

- pldebugger has a stable 1.0 version (not tagged as such, though), but no packaged release. Is the formula acceptable if the source is a Git tag?

- The formula installs files in `$HOMEBREW/share/postgresql/extension`. They persist there after `brew remove pldebugger` (I think that `pgtap` is a similar case). An alternative might be to include pldebugger in the `postgresql` formula (presumably, as an optional resource). What do you think?

- Assuming that this formula might be ok, how should I change the test for automated testing?

- In case this doesn't get accepted, is homebrew-head-only a viable alternative?
