### PR TITLE
node: use bundled npm dependency during install

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -32,14 +32,6 @@ class Node < Formula
     fails_with :gcc => n
   end
 
-  # We track major/minor from upstream Node releases.
-  # We will accept *important* npm patch releases when necessary.
-  # https://github.com/Homebrew/homebrew/pull/46098#issuecomment-157802319
-  resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-3.3.12.tgz"
-    sha256 "09475d7096731d93c0aacd7dfe58794d67c52ee6562675aee6c1f734ddba8158"
-  end
-
   resource "icu4c" do
     url "https://ssl.icu-project.org/files/icu4c/56.1/icu4c-56_1-src.tgz"
     mirror "https://ftp.mirrorservice.org/sites/download.qt-project.org/development_releases/prebuilt/icu/src/icu4c-56_1-src.tgz"
@@ -48,7 +40,7 @@ class Node < Formula
   end
 
   def install
-    args = %W[--prefix=#{prefix} --without-npm]
+    args = %W[--prefix=#{prefix}]
     args << "--debug" if build.with? "debug"
     args << "--shared-openssl" if build.with? "openssl"
     if build.with? "full-icu"
@@ -63,21 +55,9 @@ class Node < Formula
     system "make", "install"
 
     if build.with? "npm"
-      resource("npm").stage buildpath/"npm_install"
-
-      # make sure npm can find node
-      ENV.prepend_path "PATH", bin
-      # set log level temporarily for npm's `make install`
-      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
-
-      cd buildpath/"npm_install" do
-        system "./configure", "--prefix=#{libexec}/npm"
-        system "make", "install"
-      end
-
       if build.with? "completion"
         bash_completion.install \
-          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+          "#{lib}/node_modules/npm/lib/utils/completion.sh" => "npm"
       end
     end
   end
@@ -85,19 +65,7 @@ class Node < Formula
   def post_install
     return if build.without? "npm"
 
-    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
-    node_modules.mkpath
-    npm_exec = node_modules/"npm/bin/npm-cli.js"
-    # Kill npm but preserve all other modules across node updates/upgrades.
-    rm_rf node_modules/"npm"
-
-    cp_r libexec/"npm/lib/node_modules/npm", node_modules
-    # This symlink doesn't hop into homebrew_prefix/bin automatically so
-    # remove it and make our own. This is a small consequence of our bottle
-    # npm make install workaround. All other installs **do** symlink to
-    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
-    # so mimics npm's normal install.
-    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+    node_modules = lib/"node_modules"
 
     # Let's do the manpage dance. It's just a jump to the left.
     # And then a step to the right, with your hand on rm_f.
@@ -105,7 +73,7 @@ class Node < Formula
       # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
       mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
-      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
+      ln_sf Dir[lib/"node_modules/npm/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 
     npm_root = node_modules/"npm"


### PR DESCRIPTION
This simplifies the installation of `npm` when installed with `node`.
Note that the existing behavior is still maintained where `npm` modules
are properly installed under `/usr/local/lib/node_modules` and will
remain stable across upgrades.

Closes #46131

Figured out a more elegant solution compared to #46139.