### PR TITLE
ngrep: Fix ability to read Linux cooked-mode capture (SLL) pcaps

### DIFF
--- a/Library/Formula/ngrep.rb
+++ b/Library/Formula/ngrep.rb
@@ -24,7 +24,7 @@ class Ngrep < Formula
                           "--enable-ipv6",
                           "--prefix=#{prefix}",
                           # this line required to make configure succeed
-                          "--with-pcap-includes=#{MacOS.sdk_path}/usr/include",
+                          "--with-pcap-includes=#{MacOS.sdk_path}/usr/include/pcap",
                           # this line required to avoid segfaults
                           # see https://github.com/jpr5/ngrep/commit/e29fc29
                           # https://github.com/Homebrew/homebrew/issues/27171


### PR DESCRIPTION
Homebrew installs ngrep without including bpf.h.  As a result, attempting to read the packets from a Linux cooked-mode capture (SLL) pcap from a linux machine results in **fatal: unsupported interface type 113** like below:

```
my-mac] $ brew install ngrep

my-mac] $ ssh my-centos-box sudo /usr/sbin/tcpdump -i any -c 1 -w /tmp/test.pcap
tcpdump: listening on any, link-type LINUX_SLL (Linux cooked), capture size 65535 bytes
1 packets captured
3 packets received by filter
0 packets dropped by kernel

my-mac] $ scp my-centos-box:/tmp/test.pcap .

my-mac] $ ngrep -I test.pcap
input: test.pcap
fatal: unsupported interface type 113
```

Applying a fix based on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=546596 solves the issue.

Tested on Yosemite 10.10.2