### PR TITLE
node: copy vanilla package.json for npm install

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -73,6 +73,10 @@ class Node < Formula
       cd buildpath/"npm_install" do
         system "./configure", "--prefix=#{libexec}/npm"
         system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
       end
 
       if build.with? "completion"


### PR DESCRIPTION
When installing `npm` via the `node` formula, `npm`'s `package.json`
remembers relative paths to where `make install` was invoked.  This
change copys back over the vanilla `package.json` so that `npm -g`
commands behave correctly.

Closes #46131

Hopefully this is better than ##46139 and #46139.