### PR TITLE
heroku-toolbelt: Remove outdated caveat

### DIFF
--- a/Library/Formula/heroku-toolbelt.rb
+++ b/Library/Formula/heroku-toolbelt.rb
@@ -18,14 +18,6 @@ class HerokuToolbelt < Formula
     bin.write_exec_script libexec/"bin/heroku"
   end
 
-  def caveats
-    <<-EOS.undent
-      Unlike the standalone download for Heroku Toolbelt, the Homebrew package
-      does not come with Foreman. It is available via RubyGems, direct download,
-      and other installation methods. See https://ddollar.github.io/foreman/ for more info.
-    EOS
-  end
-
   test do
     system "#{bin}/heroku", "version"
   end


### PR DESCRIPTION
The Heroku Toolbelt has replaced Foreman with `heroku local`, which internally uses Forego but does not require any separate installation. See: https://devcenter.heroku.com/articles/heroku-local