### PR TITLE
docker 1.9.1, docker-machine 0.5.1, docker-machine-parallels 1.1.0

### DIFF
--- a/Library/Formula/docker-machine-parallels.rb
+++ b/Library/Formula/docker-machine-parallels.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachineParallels < Formula
   desc "Docker Machine Parallels Driver"
   homepage "https://github.com/Parallels/docker-machine-parallels"
-  url "https://github.com/Parallels/docker-machine-parallels/archive/v1.0.1.tar.gz"
-  sha256 "9a5abc454748aeb83c74c45efd3a73359a47e408e215318fbcc6446026581652"
+  url "https://github.com/Parallels/docker-machine-parallels/archive/v1.1.0.tar.gz"
+  sha256 "0f2ccc1c470a71b40e81b548b4587cdcbc098f0ceeea6295ec8bebbb06aa9135"
   head "https://github.com/Parallels/docker-machine-parallels.git"
 
   bottle do
@@ -15,18 +15,21 @@ class DockerMachineParallels < Formula
   end
 
   depends_on "go" => :build
+  depends_on "godep" => :build
   depends_on "docker-machine"
 
   go_resource "github.com/docker/docker" do
-    url "https://github.com/docker/docker.git", :revision => "76d6bc9a9f1690e16f3721ba165364688b626de2"
+    # Docker v1.9.1 release
+    url "https://github.com/docker/docker.git", :revision => "a34a1d598c6096ed8b5ce5219e77d68e5cd85462"
   end
 
   go_resource "github.com/docker/machine" do
-    url "https://github.com/docker/machine.git", :revision => "04cfa58445f063509699cdde41080a410330c4df"
+    # Docker Machine v0.5.1 release
+    url "https://github.com/docker/machine.git", :revision => "7e8e38e1485187c0064e054029bb1cc68c87d39a"
   end
 
   go_resource "golang.org/x/crypto" do
-    url "https://github.com/golang/crypto.git", :revision => "8b27f58b78dbd60e9a26b60b0d908ea642974b6d"
+    url "https://go.googlesource.com/crypto.git", :revision => "beef0f4390813b96e8e68fd78570396d0f4751fc"
   end
 
   def install
@@ -36,7 +39,7 @@ class DockerMachineParallels < Formula
     ln_sf buildpath, buildpath/"src/github.com/Parallels/docker-machine-parallels"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    system "make", "build"
+    system "godep", "go", "build", "-i", "-o", "./bin/docker-machine-driver-parallels", "./bin"
     bin.install "bin/docker-machine-driver-parallels"
   end
 

--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachine < Formula
   desc "Create Docker hosts locally and on cloud providers"
   homepage "https://docs.docker.com/machine"
-  url "https://github.com/docker/machine/archive/v0.5.0.tar.gz"
-  sha256 "35f2c9e95b962caf5557e6f1458fbf4ac85253a92ed04d3ace0f958a9e3c9676"
+  url "https://github.com/docker/machine/archive/v0.5.1.tar.gz"
+  sha256 "cd515d9b2d14edb9ce3429865cb9cdadc81d7c4ba685422fbd1ee10025987460"
   head "https://github.com/docker/machine.git"
 
   bottle do

--- a/Library/Formula/docker.rb
+++ b/Library/Formula/docker.rb
@@ -1,8 +1,8 @@
 class Docker < Formula
   desc "Pack, ship and run any application as a lightweight container"
   homepage "https://www.docker.com/"
-  url "https://github.com/docker/docker.git", :tag => "v1.9.0",
-                                              :revision => "76d6bc9a9f1690e16f3721ba165364688b626de2"
+  url "https://github.com/docker/docker.git", :tag => "v1.9.1",
+                                              :revision => "a34a1d598c6096ed8b5ce5219e77d68e5cd85462"
   head "https://github.com/docker/docker.git"
 
   bottle do


### PR DESCRIPTION
Atomic update of docker, docker-machine and docker-machine-parallels
as docker-machine v0.5.1 release broke binary driver interface