### PR TITLE
vera++: fix build error in 1.3.0

### DIFF
--- a/Library/Formula/vera++.rb
+++ b/Library/Formula/vera++.rb
@@ -19,9 +19,60 @@ class Veraxx < Formula
     sha256 "122a15e33a54265d62a6894974ca2f0a8f6ff98742cf8e6152d310cc23099400"
   end
 
+  # Custom-built boost, lua, and luabind are used by the build scripts
+  resource "boost" do
+    url "https://downloads.sourceforge.net/project/boost/boost/1.56.0/boost_1_56_0.tar.bz2"
+    sha256 "134732acaf3a6e7eba85988118d943f0fa6b7f0850f65131fff89823ad30ff1d"
+  end
+
+ resource "lua" do
+   url "https://github.com/LuaDist/lua/archive/5.2.3.tar.gz"
+   sha256 "c8aa2c74e8f31861cea8f030ece6b6cb18974477bd1e9e1db4c01aee8f18f5b6"
+ end
+
+ resource "luabind" do
+   url "https://github.com/verateam/luabind/archive/vera-1.3.0.tar.gz"
+   sha256 "7d93908b7d978e44ebe5dfad6624e6daa033f284a5f24013f37cac162a18f71a"
+ end
+
   def install
-    # don't use system lua to avoid a dependency on lua 5.1
-    system "cmake", ".", "-DVERA_USE_SYSTEM_LUA:BOOL=OFF", *std_cmake_args
+    resource("boost").stage do
+      system "./bootstrap.sh", "--prefix=#{buildpath}/3rdParty",
+             "--with-libraries=filesystem,system,program_options,regex,wave,python"
+      system "./b2", "install", "threading=multi", "link=static", "warnings=off",
+             "cxxflags=-DBOOST_WAVE_SUPPORT_MS_EXTENSIONS=1", "-s NO_BZIP2=1"
+    end
+
+    resource("lua").stage do
+      args = std_cmake_args
+      args << "-DBUILD_SHARED_LIBS:BOOL=OFF"
+      args << "-DCMAKE_INSTALL_PREFIX:PATH=#{buildpath}/3rdParty"
+      system "cmake", ".", *args
+      system "make", "install"
+    end
+
+    resource("luabind").stage do
+      args = std_cmake_args
+      args << "-DBUILD_TESTING:BOOL=OFF"
+      args << "-DLUA_INCLUDE_DIR:PATH=#{buildpath}/3rdParty/include"
+      args << "-DLUA_LIBRARIES:PATH=#{buildpath}/3rdParty/lib/liblua.a"
+      args << "-DBOOST_ROOT:PATH=#{buildpath}/3rdParty"
+      args << "-DCMAKE_INSTALL_PREFIX:PATH=#{buildpath}/3rdParty"
+      system "cmake", ".", *args
+      system "make", "install"
+    end
+
+    system "cmake", ".",
+           "-DVERA_USE_SYSTEM_BOOST:BOOL=ON", "-DBoost_USE_STATIC_LIBS:BOOL=ON",
+           "-DLUA_INCLUDE_DIR:PATH=#{buildpath}/3rdParty/include",
+           "-DLUA_LIBRARIES:PATH=#{buildpath}/3rdParty/lib/liblua.a",
+           "-DLUA_LIBRARY:PATH=#{buildpath}/3rdParty/lib/liblua.a",
+           "-DLUABIND_INCLUDE_DIR:PATH=#{buildpath}/3rdParty/include",
+           "-DLUABIND_LIBRARIES:PATH=#{buildpath}/3rdParty/lib/libluabind.a",
+           "-DLUABIND_LIBRARY:PATH=#{buildpath}/3rdParty/lib/libluabind.a",
+           "-DBoost_INCLUDE_DIR:PATH=#{buildpath}/3rdParty/include",
+           "-DBoost_LIBRARY_DIR_RELEASE:PATH=#{buildpath}/3rdParty/lib",
+           *std_cmake_args
     system "make", "install"
     system "ctest"
 


### PR DESCRIPTION
The error in #44036 was fixed in the vera source in commit [887350b](https://bitbucket.org/verateam/vera/commits/887350b1cb5ca35af940abaded33f85596d26104).  I applied this patch to v1.3.0 source and it built fine.