### PR TITLE
skinny 2.0.1

### DIFF
--- a/Library/Formula/skinny.rb
+++ b/Library/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.0.0/skinny-2.0.0.tar.gz"
-  sha256 "b6bd65abbf61170b2802ca7d7fa27ef8692361ad49982a4269f6752058f79a67"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.0.1/skinny-2.0.1.tar.gz"
+  sha256 "3b827707094cfc59466753a7b9145996d45fad4929e2d3fea7190a46a4aa2481"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,22 +11,8 @@ class Skinny < Formula
     sha256 "06542db66377eb3b906859f610a3b8bfc628d07e9d14e006b1ef0cea17645cf4" => :mavericks
   end
 
-  option "without-npm-generator", "Yeoman generator will not be installed"
-
-  depends_on "node"
-
   def install
-    ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"
-
-    if build.with? "npm-generator"
-      system "npm", "install", "yo"
-      system "npm", "install", "generator-skinny"
-      libexec.install Dir["*"]
-      bin.install_symlink libexec/"node_modules/yo/lib/cli.js" => "yo"
-    else
-      libexec.install Dir["*"]
-    end
-
+    libexec.install Dir["*"]
     (bin/"skinny").write <<-EOS.undent
       #!/bin/bash
       export PATH=#{bin}:$PATH


### PR DESCRIPTION
This pull request bumps Skinny Framework version to 2.0.1. Since this version, we decided not to use our own Yeoman generator. So Node dependency is no longer required. formula class became much simpler.

https://github.com/skinny-framework/skinny-framework/releases/tag/2.0.1