### PR TITLE
bazel: add version information to the binary

### DIFF
--- a/Library/Formula/bazel.rb
+++ b/Library/Formula/bazel.rb
@@ -20,6 +20,8 @@ class Bazel < Formula
       "/etc/bazel.bazelrc",
       "#{etc}/bazel/bazel.bazelrc"
 
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+
     system "./compile.sh"
 
     (prefix/"base_workspace").mkdir


### PR DESCRIPTION
The previous recipe was missing the version in the compiled binary
and `bazel version` resulted in a `HEAD (@non-git)` version which
makes hard for Bazel developers to track issues.

Instead uses `#{version}-homebrew` (for instances `0.1.1-homebrew`
for `0.1.1` release).