### PR TITLE
brew-log: warn if shallow clone

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -4,11 +4,25 @@ module Homebrew
   def log
     if ARGV.named.empty?
       cd HOMEBREW_REPOSITORY
-      exec "git", "log", *ARGV.options_only
+      git_log
     else
       path = Formulary.path(ARGV.named.first)
       cd path.dirname # supports taps
-      exec "git", "log", *ARGV.options_only + ["--", path]
+      git_log path
     end
+  end
+
+  private
+
+  def git_log(path=nil)
+    if File.exist? "#{`git rev-parse --show-toplevel`.chomp}/.git/shallow"
+      opoo <<-EOS.undent
+        The git repository is a shallow clone therefore the filtering may be incorrect.
+        Use `git fetch --unshallow` to get the full repository.
+      EOS
+    end
+    args = ARGV.options_only
+    args += ["--", path] unless path.nil?
+    exec "git", "log", *args
   end
 end


### PR DESCRIPTION
Example output:
```
$ brew log rtmp-nginx-module
Warning: The git repository is a shallow clone.
Use `git fetch --unshallow` to get the full repository.
commit 2887af6f8034fd3d5efe51c114c9a7a8d404d896
Author: Denis Denisov <denji0k@gmail.com>
Date:   Thu Jul 23 19:21:06 2015 +0300

    notice-nginx-module: use new patch #101
```

cc @mikemcquaid 