### PR TITLE
desk 0.3.1 (new formula)

### DIFF
--- a/Library/Formula/desk.rb
+++ b/Library/Formula/desk.rb
@@ -9,7 +9,6 @@ class Desk < Formula
   end
 
   test do
-    system "mkdir", "-p", testpath/".desk/desks"
     (testpath/".desk/desks/test-desk.sh").write("#\n# Description: A test desk\n#")
     list = pipe_output("#{bin}/desk list")
     assert_match /test-desk/, list

--- a/Library/Formula/desk.rb
+++ b/Library/Formula/desk.rb
@@ -1,0 +1,18 @@
+class Desk < Formula
+  desc "Lightweight workspace manager for the shell"
+  homepage "https://github.com/jamesob/desk"
+  url "https://github.com/jamesob/desk/archive/v0.3.1.tar.gz"
+  sha256 "b687e2cfa742f763d689391f67a5b5225324e282a0fed100487b1570988d7758"
+
+  def install
+    bin.install "desk"
+  end
+
+  test do
+    system "mkdir", "-p", testpath/".desk/desks"
+    (testpath/".desk/desks/test-desk.sh").write("#\n# Description: A test desk\n#")
+    list = pipe_output("#{bin}/desk list")
+    assert_match /test-desk/, list
+    assert_match /A test desk/, list
+  end
+end


### PR DESCRIPTION
Added [desk](https://github.com/jamesob/desk).

Previous attempts at adding desk have been made (see: https://github.com/Homebrew/homebrew/pull/45366), but the tests were somewhat of an issue. I believe the reason the test was failing there was because `desk init` uses the `read` command, and was thus waiting in ruby's `system` method.

I changed the tests from the previous PR to instead:
* manually set up the `.desk/desks` directory
* add a desk
* assert that the desk gets listed when calling `desk list`