### PR TITLE
Update the link to HBase documentation

### DIFF
--- a/Library/Formula/hbase.rb
+++ b/Library/Formula/hbase.rb
@@ -25,7 +25,7 @@ class Hbase < Formula
     to reflect your environment.
 
     For more details:
-      https://wiki.apache.org/hadoop/Hbase
+      https://hbase.apache.org/book.html
     EOS
   end
 


### PR DESCRIPTION
The HBase section on the Hadoop wiki is obsolete.