### PR TITLE
Add formula for wires webdriver

### DIFF
--- a/Library/Formula/wires.rb
+++ b/Library/Formula/wires.rb
@@ -1,0 +1,19 @@
+class Wires < Formula
+  desc "WebDriver <-> Marionette proxy"
+  homepage "https://github.com/jgraham/wires"
+  url "https://github.com/jgraham/wires/archive/v0.4.2.tar.gz"
+  sha256 "f86fdac8f69f94bd57dc9fdb45851585a24790b069605d033288e419653c9efe"
+
+  depends_on "rust" => :build
+
+  def install
+    puts "#{bin}"
+    system "cargo build"
+    bin.install "target/debug/wires"
+  end
+
+  test do
+    system "#{bin}/wires", "--help"
+  end
+
+end

--- a/Library/Formula/wires.rb
+++ b/Library/Formula/wires.rb
@@ -7,8 +7,7 @@ class Wires < Formula
   depends_on "rust" => :build
 
   def install
-    puts "#{bin}"
-    system "cargo build"
+    system "cargo", "build"
     bin.install "target/debug/wires"
   end
 

--- a/Library/Formula/wires.rb
+++ b/Library/Formula/wires.rb
@@ -14,5 +14,4 @@ class Wires < Formula
   test do
     system "#{bin}/wires", "--help"
   end
-
 end


### PR DESCRIPTION
Marionette is an automation driver for Mozilla's Gecko engine. Wires is the new webdriver.
https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver