### PR TITLE
BuildOptions#with{,out}?: support multiple args

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -23,22 +23,24 @@ class BuildOptions
   # else
   #   args << "--with-example1"
   # end</pre>
-  def with?(val)
-    name = val.respond_to?(:option_name) ? val.option_name : val
+  def with?(*vals)
+    vals.all? do |val|
+      name = val.respond_to?(:option_name) ? val.option_name : val
 
-    if option_defined? "with-#{name}"
-      include? "with-#{name}"
-    elsif option_defined? "without-#{name}"
-      !include? "without-#{name}"
-    else
-      false
+      if option_defined? "with-#{name}"
+        include? "with-#{name}"
+      elsif option_defined? "without-#{name}"
+        !include? "without-#{name}"
+      else
+        false
+      end
     end
   end
 
   # True if a {Formula} is being built without a specific option.
   # <pre>args << "--no-spam-plz" if build.without? "spam"
-  def without?(name)
-    !with? name
+  def without?(*names)
+    !names.any? { |name| with? name }
   end
 
   # True if a {Formula} is being built as a bottle (i.e. binary package).

--- a/Library/Homebrew/test/test_build_options.rb
+++ b/Library/Homebrew/test/test_build_options.rb
@@ -19,7 +19,10 @@ class BuildOptionsTests < Homebrew::TestCase
     assert @build.with?("foo")
     assert @build.with?("bar")
     assert @build.with?("baz")
+    assert @build.with?("bar", "baz")
     assert @build.without?("qux")
+    assert @build.without?("qux", "abc")
+    assert !@build.without?("qux", "baz")
   end
 
   def test_used_options


### PR DESCRIPTION
This would allow this:

```rb
something if build.without? "python", "python3"
```

Right now we have to use the following:

```rb
something if build.without?("python") && build.without?("python3")
```

Another possible implementation would be to accept an array: `build.without? %w[python python3]`.