### PR TITLE
dovecot: fix pigeonhole unfinished features option

### DIFF
--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -51,7 +51,7 @@ class Dovecot < Formula
           --prefix=#{prefix}
         ]
 
-        args << "--with-unfinished-features" if build.with? "unfinished-features"
+        args << "--with-unfinished-features" if build.with? "pigeonhole-unfinished-features"
 
         system "./configure", *args
         system "make"


### PR DESCRIPTION
As pointed out by @DomT4 , there was a bug on option to install unfinished pigeonhole features.

Reference: https://github.com/Homebrew/homebrew/commit/4beca86a86756504ab23cd8064b802b78b9d9876#commitcomment-14623650