### PR TITLE
GitRequirement: use Utils.git_available?

### DIFF
--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -122,6 +122,6 @@ end
 class GitRequirement < Requirement
   fatal true
   default_formula "git"
-  satisfy { !!which("git") }
+  satisfy { Utils.git_available? }
 end
 


### PR DESCRIPTION
`which("git")` will return incorrect result for OS X without Xcode/CLT
installed, where `/usr/bin/git` is a stub.