### PR TITLE
open-scene-graph: force linking libiconv when using dcmtk

### DIFF
--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -109,3 +109,16 @@ index 321cede..6497589 100644
      ENDIF()
 
  ENDIF()
+diff --git a/src/osgPlugins/dicom/CMakeLists.txt b/src/osgPlugins/dicom/CMakeLists.txt
+index 55c2a57..e6e3f4a 100644
+--- a/src/osgPlugins/dicom/CMakeLists.txt
++++ b/src/osgPlugins/dicom/CMakeLists.txt
+@@ -5,7 +5,7 @@ IF  (DCMTK_FOUND)
+
+     SET(TARGET_SRC ReaderWriterDICOM.cpp )
+
+-    LINK_LIBRARIES(${DCMTK_LIBRARIES} ${ZLIB_LIBRARY})
++    LINK_LIBRARIES(${DCMTK_LIBRARIES} iconv ${ZLIB_LIBRARY})
+
+     ADD_DEFINITIONS(-DUSE_DCMTK)
+


### PR DESCRIPTION
Fixes #46356

Upstream OSG assumes that dcmtk was not built with libiconv. But on OS X it will be, even if it's not using the Homebrew dupe one. This gets OSG to link the required libiconv when linking dcmtk.