### PR TITLE
Homebrew Bundle speedup changes

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -13,41 +13,12 @@ module Homebrew
     Homebrew.failed = ARGV.resolved_formulae.any? && outdated.any?
   end
 
-  def outdated_brews(formulae)
-    formulae.map do |f|
-      all_versions = []
-      older_or_same_tap_versions = []
-
-      if f.oldname && !f.rack.exist? && (dir = HOMEBREW_CELLAR/f.oldname).directory? &&
-        !dir.subdirs.empty? && f.tap == Tab.for_keg(dir.subdirs.first).tap
-        raise Migrator::MigrationNeededError.new(f)
-      end
-
-      f.rack.subdirs.each do |keg_dir|
-        keg = Keg.new keg_dir
-        version = keg.version
-        all_versions << version
-        older_version = f.pkg_version <= version
-
-        tap = Tab.for_keg(keg).tap
-        if tap.nil? || f.tap == tap || older_version
-          older_or_same_tap_versions << version
-        end
-      end
-
-      if older_or_same_tap_versions.all? { |version| f.pkg_version > version }
-        yield f, all_versions if block_given?
-        f
-      end
-    end.compact
-  end
-
   def print_outdated(formulae)
     verbose = ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
 
-    outdated_brews(formulae) do |f, versions|
+    formulae.select(&:outdated?).each do |f|
       if verbose
-        puts "#{f.full_name} (#{versions*", "} < #{f.pkg_version})"
+        puts "#{f.full_name} (#{f.outdated_versions*", "} < #{f.pkg_version})"
       else
         puts f.full_name
       end
@@ -56,9 +27,10 @@ module Homebrew
 
   def print_outdated_json(formulae)
     json = []
-    outdated = outdated_brews(formulae) do |f, versions|
+    outdated = formulae.select(&:outdated?).each do |f|
+
       json << { :name => f.full_name,
-                :installed_versions => versions.collect(&:to_s),
+                :installed_versions => f.outdated_versions.collect(&:to_s),
                 :current_version => f.pkg_version.to_s }
     end
     puts Utils::JSON.dump(json)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -1,5 +1,4 @@
 require "cmd/install"
-require "cmd/outdated"
 require "cmd/cleanup"
 
 module Homebrew
@@ -9,10 +8,10 @@ module Homebrew
     Homebrew.perform_preinstall_checks
 
     if ARGV.named.empty?
-      outdated = Homebrew.outdated_brews(Formula.installed)
+      outdated = Formula.installed.select(&:outdated?)
       exit 0 if outdated.empty?
     elsif ARGV.named.any?
-      outdated = Homebrew.outdated_brews(ARGV.resolved_formulae)
+      outdated = ARGV.resolved_formulae.select(&:outdated?)
 
       (ARGV.resolved_formulae - outdated).each do |f|
         if f.rack.directory?

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -9,6 +9,11 @@ require "utils/json"
 # `Tab.create`.
 class Tab < OpenStruct
   FILENAME = "INSTALL_RECEIPT.json"
+  CACHE = {}
+
+  def self.clear_cache
+    CACHE.clear
+  end
 
   def self.create(formula, compiler, stdlib, build)
     attributes = {
@@ -32,7 +37,7 @@ class Tab < OpenStruct
   end
 
   def self.from_file(path)
-    from_file_content(File.read(path), path)
+    CACHE.fetch(path) { |p| CACHE[p] = from_file_content(File.read(p), p) }
   end
 
   def self.from_file_content(content, path)
@@ -217,6 +222,7 @@ class Tab < OpenStruct
   end
 
   def write
+    CACHE[tabfile] = self
     tabfile.atomic_write(to_json)
   end
 

--- a/Library/Homebrew/test/test_formula_installer.rb
+++ b/Library/Homebrew/test/test_formula_installer.rb
@@ -20,10 +20,12 @@ class InstallTests < Homebrew::TestCase
     assert_predicate formula, :installed?
 
     begin
+      Tab.clear_cache
       refute_predicate Tab.for_keg(keg), :poured_from_bottle
 
       yield formula
     ensure
+      Tab.clear_cache
       keg.unlink
       keg.uninstall
       formula.clear_cache


### PR DESCRIPTION
 I'm working on speeding up `brew bundle check` so as part of that I'm needing to make a few core changes. These are:

- Make `brew info --json=v1` also output outdated and pinned formulae.
- Make `tab` use a in-memory cache to avoid unnecessary rereading the same `Tab` multiple times per process.

CC @xu-cheng 