### PR TITLE
Fix typo: hyphen-minus instead of en dash in command

### DIFF
--- a/share/doc/homebrew/Tips-N'-Tricks.md
+++ b/share/doc/homebrew/Tips-N'-Tricks.md
@@ -71,7 +71,7 @@ name }}-{{ version }}</code>.  In the case of Erlang, this requires
 renaming the file from <code>otp_src_R13B03</code> to
 <code>erlang-R13B03</code>.
 
-`brew –-cache -s erlang` will print the correct name of the cached
+`brew --cache -s erlang` will print the correct name of the cached
 download.  This means instead of manually renaming a formula, you can
 run `mv the_tarball $(brew --cache -s $FORMULA)`.
 


### PR DESCRIPTION
An en dash slipped into the command `brew –-cache -s erlang`... So if an unsuspecting reader (that is I) copies it into the terminal, he will get an `Error: Unknown command: –-cache`.