### PR TITLE
Remove brew-any-tap and brew-desc from external commands docs

### DIFF
--- a/share/doc/homebrew/External-Commands.md
+++ b/share/doc/homebrew/External-Commands.md
@@ -64,19 +64,6 @@ These commands have been contributed by Homebrew users but are not included in t
 > $ brew tap youtux/livecheck
 > ```
 
-### brew-any-tap
-
-> Like `brew tap` but works on *any* git repository, whether public or private, on GitHub or not.
->
-> Install using (ironically enough) `brew tap`:
->
-> ```
-> brew tap telemachus/anytap
-> brew install brew-any-tap
-> ```
->
-> See the  [`README`](https://github.com/telemachus/homebrew-anytap/blob/master/README.md) for further explanation and examples of use.
-
 ### brew-cask
 
 >Install .app and other "Drag to install" packages from Homebrew.
@@ -87,14 +74,6 @@ These commands have been contributed by Homebrew users but are not included in t
 > ```
   $ brew tap caskroom/cask
   $ brew install brew-cask
-> ```
-
-### brew-desc
->Get short descriptions for Homebrew formulae or search formulae by description: [https://github.com/telemachus/brew-desc](https://github.com/telemachus/homebrew-desc)
-
->You can install manually or using `brew tap`:
-> ```
-> $ brew tap telemachus/desc
 > ```
 
 ### brew-gem


### PR DESCRIPTION
The functionality of both external commands have been merged into core (#40326 and #39911).