### PR TITLE
fpp 0.7.0

### DIFF
--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,8 +1,8 @@
 class Fpp < Formula
   desc "CLI program that accepts piped input and presents files for selection"
   homepage "https://facebook.github.io/PathPicker/"
-  url "https://github.com/facebook/PathPicker/releases/download/0.6.2/fpp.0.6.2.tar.gz"
-  sha256 "a437e8d779053cac28f582e8b9f8621bc872af9cd7a0afdce5cdd0912f974513"
+  url "https://github.com/facebook/PathPicker/releases/download/0.7.0/fpp.0.7.0.tar.gz"
+  sha256 "41f14991f8b0dc673863d4ee274c69048913927b973f52e58f15aa632a55a381"
   head "https://github.com/facebook/pathpicker.git"
 
   bottle :unneeded


### PR DESCRIPTION
PathPicker 0.7.0 release! Notes here:
https://github.com/facebook/PathPicker/releases/tag/0.7.0

```
[pcottle:~/Dropbox (Facebook)/wip/homebrew/Library/Formula:pathPicker0.7.0]$ brew style ./fpp.rb
1 file inspected, no offenses detected
[pcottle:~/Dropbox (Facebook)/wip/homebrew/Library/Formula:pathPicker0.7.0]$ brew audit ./fpp.rb --strict
==> brew style fpp
1 file inspected, no offenses detected
[pcottle:~/Dropbox (Facebook)/wip/homebrew/Library/Formula:pathPicker0.7.0]$ brew install ./fpp.rb
==> Downloading https://github.com/facebook/PathPicker/releases/download/0.7.0/fpp.0.7.0.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/34887588/04a3c668-94e4-11e5-8384-41659795f27b.gz
######################################################################## 100.0%
🍺  /usr/local/Cellar/fpp/0.7.0: 19 files, 132K, built in 4 seconds
```
