### PR TITLE
camlp4: bump to 4.02.3+6 to keep in sync with OCaml version

### DIFF
--- a/Library/Formula/camlp4.rb
+++ b/Library/Formula/camlp4.rb
@@ -2,10 +2,9 @@ class Camlp4 < Formula
   desc "Tool to write extensible parsers in OCaml"
   homepage "https://github.com/ocaml/camlp4"
   url "https://github.com/ocaml/camlp4/archive/4.02+6.tar.gz"
-  version "4.02.2+6"
+  version "4.02.3+6"
   sha256 "820c35b69fdff3225bda6045fabffe5d7c54dda00fb157444ac8bda5e1778d45"
   head "https://github.com/ocaml/camlp4.git", :branch => "trunk"
-  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Although the distribution here is the same as 4.02.2+6, it must
be recompiled with the version of OCaml that is installed.
OCaml is now 4.02.3 in the tree, and @dsheets reports a failure
due to having a camlp4 that was not recompiled after the OCaml
compiler was updated.