### PR TITLE
Add missing require to formula.rb

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -1,6 +1,5 @@
 require "formula"
 require "keg"
-require "migrator"
 
 module Homebrew
   def outdated

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -12,6 +12,7 @@ require "pkg_version"
 require "tap"
 require "formula_renames"
 require "keg"
+require "migrator"
 
 # A formula provides instructions and metadata for Homebrew to install a piece
 # of software. Every Homebrew formula is a {Formula}.


### PR DESCRIPTION
Missing require statement breaks outdated checks in formula.rb (and hence it seems to break Chef as well).