### PR TITLE
upscaledb 2.1.12 (rename)

### DIFF
--- a/Library/Formula/upscaledb.rb
+++ b/Library/Formula/upscaledb.rb
@@ -1,15 +1,8 @@
-class Hamsterdb < Formula
+class Upscaledb < Formula
   desc "Database for embedded devices"
-  homepage "http://hamsterdb.com"
-  url "http://files.hamsterdb.com/dl/hamsterdb-2.1.10.tar.gz"
-  sha256 "8fced5607847e234133b2baa379e7ff3d763ffa51546b27f1e3c5f1aef33493e"
-
-  head do
-    url "https://github.com/cruppstahl/hamsterdb.git"
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
-    depends_on "libtool" => :build
-  end
+  homepage "http://upscaledb.com/"
+  url "http://files.upscaledb.com/dl/upscaledb-2.1.12.tar.gz"
+  sha256 "f68c7e7b8f5aaf41ab47d60e351db35506f96ebf8be2ad695a0d8a12035001df"
 
   bottle do
     sha256 "27151089e42c383b22ddf599b0d9f42498e8b30564b8306f80ceab16ea79741f" => :yosemite
@@ -17,11 +10,20 @@ class Hamsterdb < Formula
     sha256 "5c2645a8d1f51613bfa0aa05f1045836f5b0117d674af297878ca5e78bb136a6" => :mountain_lion
   end
 
+  head do
+    url "https://github.com/cruppstahl/upscaledb.git"
+
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
+
   option "without-java", "Do not build the Java wrapper"
   option "without-remote", "Disable access to remote databases"
 
   depends_on "boost"
   depends_on "gnutls"
+  depends_on "openssl"
   depends_on :java => :recommended
   depends_on "protobuf" if build.with? "remote"
 
@@ -56,7 +58,7 @@ class Hamsterdb < Formula
 
     if build.with? "remote"
       resource("libuv").stage do
-        system "make", "libuv.dylib"
+        system "make", "libuv.dylib", "SO_LDFLAGS=-Wl,-install_name,#{libexec}/libuv/lib/libuv.dylib"
         (libexec/"libuv/lib").install "libuv.dylib"
         (libexec/"libuv").install "include"
       end
@@ -70,13 +72,14 @@ class Hamsterdb < Formula
 
     system "./configure", *args
     system "make", "install"
+    # https://github.com/cruppstahl/upscaledb/commit/b435cc4fdfd8750aa3e717321608ef0c059d15ca
+    mv include/"ham", include/"ups" if build.stable?
 
     share.install "samples"
   end
 
   test do
-    system bin/"ham_info", "-h"
-    system ENV.cc, "-I#{include}", "-L#{lib}", "-lhamsterdb",
+    system ENV.cc, "-I#{include}", "-L#{lib}", "-lupscaledb",
            share/"samples/db1.c", "-o", "test"
     system "./test"
   end

--- a/Library/Homebrew/formula_renames.rb
+++ b/Library/Homebrew/formula_renames.rb
@@ -5,6 +5,7 @@ FORMULA_RENAMES = {
   "go-app-engine-64" => "app-engine-go-64",
   "app-engine-java-sdk" => "app-engine-java",
   "google-app-engine" => "app-engine-python",
+  "hamsterdb" => "upscaledb",
   "libcppa" => "caf",
   "objective-caml" => "ocaml",
   "mpich2" => "mpich",


### PR DESCRIPTION
`install_name_tool` is failing to fix the vendored libuv; I've only dealt with this problem once before and I forget how to fix it, so cc @mistydemeo and @UniqMartin I guess.