### PR TITLE
open-mpi: bump revision to rebottle.

### DIFF
--- a/Library/Formula/open-mpi.rb
+++ b/Library/Formula/open-mpi.rb
@@ -3,6 +3,7 @@ class OpenMpi < Formula
   homepage "https://www.open-mpi.org/"
   url "https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.1.tar.bz2"
   sha256 "7919ecde15962bab2e26d01d5f5f4ead6696bbcacb504b8560f2e3a152bfe492"
+  revision 1
 
   bottle do
     sha256 "257a75a3227ddc0b5e7c970a97c76cadeda417a259c54efbe25df955e0efe32b" => :el_capitan
@@ -83,5 +84,19 @@ class OpenMpi < Formula
     system "#{bin}/mpicc", "hello.c", "-o", "hello"
     system "./hello"
     system "#{bin}/mpirun", "-np", "4", "./hello"
+    (testpath/"hellof.f90").write <<-EOS.undent
+      program hello
+      include 'mpif.h'
+      integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
+      call MPI_INIT(ierror)
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierror)
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierror)
+      print*, 'node', rank, ': Hello Fortran world'
+      call MPI_FINALIZE(ierror)
+      end
+    EOS
+    system "#{bin}/mpif90", "hellof.f90", "-o", "hellof"
+    system "./hellof"
+    system "#{bin}/mpirun", "-np", "4", "./hellof"
   end
 end


### PR DESCRIPTION
We're having lots of MPI-related issues over at homebrew-science. It turns out the current bottles are incomplete:
```
$ mpif77 -v
--------------------------------------------------------------------------
No underlying compiler was specified in the wrapper compiler data file
(e.g., mpicc-wrapper-data.txt)
--------------------------------------------------------------------------
```
so many formulae fail to build. Building from source solves the issue, so I'm hoping re-bottling is the solution.