### PR TITLE
ejabberd: fix HEAD build, use resources

### DIFF
--- a/Library/Formula/ejabberd.rb
+++ b/Library/Formula/ejabberd.rb
@@ -4,13 +4,30 @@ class Ejabberd < Formula
   url "https://www.process-one.net/downloads/ejabberd/15.07/ejabberd-15.07.tgz"
   sha256 "87d5001521cbb779b84bc74879e032e2514d9a651e24c4e40cce0907ab405bd1"
 
-  head "https://github.com/processone/ejabberd.git"
-
   bottle do
     sha256 "4001c8bf43972697862ead67f944177c6a6b771c96a4d6de75f68694ed7aa620" => :el_capitan
     sha256 "592a3412890d52da9d8a9f43a288dca8eab233dcd0c59d17d4bd8f89b7b4567b" => :yosemite
     sha256 "17b97c88ea724e8816c445a944ad71a9be141cf9afe8e4f168dd271ea2bd8448" => :mavericks
     sha256 "f53c7307acaee6aafa813785ede998900c0c32db2d0f28dfb5dd51c45b6f5366" => :mountain_lion
+  end
+
+  head do
+    url "https://github.com/processone/ejabberd.git"
+
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+
+    resource "oauth2" do
+      url "https://github.com/prefiks/oauth2",
+          :using => :git,
+          :revision => "e6da9912e5d8f658e7e868f41a102d085bdbef59"
+    end
+
+    resource "xmlrpc" do
+      url "https://github.com/rds13/xmlrpc",
+          :using => :git,
+          :revision => "42e6e96a0fe7106830274feed915125feb1056f3"
+    end
   end
 
   option "32-bit"
@@ -21,6 +38,138 @@ class Ejabberd < Formula
   # for CAPTCHA challenges
   depends_on "imagemagick" => :optional
 
+  resource "p1_cache_tab" do
+    url "https://github.com/processone/cache_tab",
+        :using => :git,
+        :revision => "f7ea12b0ba962a3d2f9a406d2954cf7de4e27230"
+  end
+
+  resource "p1_tls" do
+    url "https://github.com/processone/tls",
+        :using => :git,
+        :revision => "e56321afd974e9da33da913cd31beebc8e73e75f"
+  end
+
+  resource "p1_stringprep" do
+    url "https://github.com/processone/stringprep",
+        :using => :git,
+        :revision => "941b454684d230caf514ee2877085dcf92722a97"
+  end
+
+  resource "p1_xml" do
+    url "https://github.com/processone/xml",
+        :using => :git,
+        :revision => "8d477a2cb8846a739fefa0714cc6812aed15c6e1"
+  end
+
+  resource "esip" do
+    url "https://github.com/processone/p1_sip",
+        :using => :git,
+        :revision => "d662d3fe7f6288b444ea321d854de0bd6d40e022"
+  end
+
+  resource "p1_stun" do
+    url "https://github.com/processone/stun",
+        :using => :git,
+        :revision => "061bdae484268cbf0457ad4797e74b8516df3ad1"
+  end
+
+  resource "p1_yaml" do
+    url "https://github.com/processone/p1_yaml",
+        :using => :git,
+        :revision => "79f756ba73a235c4d3836ec07b5f7f2b55f49638"
+  end
+
+  resource "p1_utils" do
+    url "https://github.com/processone/p1_utils",
+        :using => :git,
+        :revision => "0799907b75d1c23fc279a184ef4742a26d4242c5"
+  end
+
+  resource "jiffy" do
+    url "https://github.com/davisp/jiffy",
+        :using => :git,
+        :revision => "cfc61a2e952dc3182e0f9b1473467563699992e2"
+  end
+
+  resource "p1_mysql" do
+    url "https://github.com/processone/mysql",
+        :using => :git,
+        :revision => "dfa87da95f8fdb92e270741c2a53f796b682f918"
+  end
+
+  resource "p1_pgsql" do
+    url "https://github.com/processone/pgsql",
+        :using => :git,
+        :revision => "e72c03c60bfcb56bbb5d259342021d9cb3581dac"
+  end
+
+  resource "sqlite" do
+    url "https://github.com/alexeyr/erlang-sqlite3",
+        :using => :git,
+        :revision => "8350dc603804c503f99c92bfd2eab1dd6885758e"
+  end
+
+  resource "p1_pam" do
+    url "https://github.com/processone/epam",
+        :using => :git,
+        :revision => "d3ce290b7da75d780a03e86e7a8198a80e9826a6"
+  end
+
+  resource "p1_zlib" do
+    url "https://github.com/processone/zlib",
+        :using => :git,
+        :revision => "e3d4222b7aae616d7ef2e7e2fa0bbf451516c602"
+  end
+
+  resource "riakc" do
+    url "https://github.com/basho/riak-erlang-client",
+        :using => :git,
+        :revision => "527722d12d0433b837cdb92a60900c2cb5df8942"
+  end
+
+  resource "rebar_elixir_plugin" do
+    url "https://github.com/yrashk/rebar_elixir_plugin",
+        :using => :git,
+        :revision => "7058379b7c7e017555647f6b9cecfd87cd50f884"
+  end
+
+  resource "elixir" do
+    url "https://github.com/elixir-lang/elixir",
+        :using => :git,
+        :revisison => "805ee01b5f432625bfb74dd95ebcd70a57d7ea2f"
+  end
+
+  resource "p1_iconv" do
+    url "https://github.com/processone/eiconv",
+        :using => :git,
+        :revision => "8b7542b1aaf0a851f335e464956956985af6d9a2"
+  end
+
+  resource "lager" do
+    url "https://github.com/basho/lager",
+        :using => :git,
+        :revision => "1265b62df5ad9c874f3f3518d7b7f5eb087701fc"
+  end
+
+  resource "p1_logger" do
+    url "https://github.com/processone/p1_logger",
+        :using => :git,
+        :revision => "3e19507fd5606a73694917158767ecb3f5704e3f"
+  end
+
+  resource "meck" do
+    url "https://github.com/eproxus/meck",
+        :using => :git,
+        :revision => "be12fdf0522162f801093ec1d52ed2e99dc4c025"
+  end
+
+  resource "eredis" do
+    url "https://github.com/wooga/eredis",
+        :using => :git,
+        :revision => "bf12ecb30253c84a2331f4f0d93fd68856fcb9f4"
+  end
+
   def install
     ENV["TARGET_DIR"] = ENV["DESTDIR"] = "#{lib}/ejabberd/erlang/lib/ejabberd-#{version}"
     ENV["MAN_DIR"] = man
@@ -28,6 +177,15 @@ class Ejabberd < Formula
 
     if build.build_32_bit?
       ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
+    end
+
+    resources.each do |r|
+      r.fetch
+      if r.name == "oauth2" || r.name == "xmlrpc"
+        inreplace "rebar.config.script", "#{r.url}.git", r.cached_download
+      else
+        inreplace "rebar.config.script", r.url, r.cached_download
+      end
     end
 
     args = ["--prefix=#{prefix}",
@@ -39,13 +197,14 @@ class Ejabberd < Formula
             "--enable-pam",
            ]
 
+    system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make"
     system "make", "install"
 
-    (etc+"ejabberd").mkpath
-    (var+"lib/ejabberd").mkpath
-    (var+"spool/ejabberd").mkpath
+    (etc/"ejabberd").mkpath
+    (var/"lib/ejabberd").mkpath
+    (var/"spool/ejabberd").mkpath
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
Fixes #46460.

Ridiculous but I couldn't see how else to make Rebar use cached resources.  Also couldn't figure out a test since `ejabberdctl` tosses up a prompt about accepting incoming connections the first time it runs.