### PR TITLE
Handle uninstalled packages in outdated_versions

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -938,6 +938,8 @@ class Formula
         raise Migrator::MigrationNeededError.new(self)
       end
 
+      return [] unless rack.exist?
+
       rack.subdirs.each do |keg_dir|
         keg = Keg.new keg_dir
         version = keg.version


### PR DESCRIPTION
This should resolve #46463, which arises from the newly-added `outdated_versions` method triggering an error when asked to process a non-installed formula. The fix just implements @mistydemeo’s suggestion of having `outdated_versions` exit early, returning an empty array, if `rack.exist?` returns false.