### PR TITLE
winetricks 20151116

### DIFF
--- a/Library/Formula/winetricks.rb
+++ b/Library/Formula/winetricks.rb
@@ -1,8 +1,8 @@
 class Winetricks < Formula
   desc "Download and install various runtime libraries"
   homepage "https://github.com/Winetricks/winetricks"
-  url "https://github.com/Winetricks/winetricks/archive/20150826.tar.gz"
-  sha256 "9b7401aebe61656f0a75ab04261a1531967d93b762b650a98af5928961e98ab0"
+  url "https://github.com/Winetricks/winetricks/archive/20151116.tar.gz"
+  sha256 "a8947974f47ec575e62717abe591a737d7214557e7ece4c39de079599ba4bf70"
   head "https://github.com/Winetricks/winetricks.git"
 
   bottle :unneeded


### PR DESCRIPTION
Upgrade winetricks to 20151116.

Apparently Microsoft is not providing several files anymore. It is fixed in the latest release by this winetricks commit:
https://github.com/Winetricks/winetricks/commit/59d71b03520d401a8e504d8d4b8a3aa8a02a26f4
