### PR TITLE
yank 0.5.0

### DIFF
--- a/Library/Formula/yank.rb
+++ b/Library/Formula/yank.rb
@@ -1,8 +1,8 @@
 class Yank < Formula
   desc "Yank terminal output to clipboard"
   homepage "https://github.com/mptre/yank"
-  url "https://github.com/mptre/yank/archive/v0.4.1.tar.gz"
-  sha256 "cbd6b3c9d580fa619f3cba2c53b18d26674d587333976fe75b402f76ea01c4e5"
+  url "https://github.com/mptre/yank/archive/v0.5.0.tar.gz"
+  sha256 "237a8406130fda2f555ef2696e114ef508257743feb02865b21f62db43c52fa5"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Caveat: running `brew audit yank --strict --online` gives this
```
==> brew style yank

1 file inspected, no offenses detected

==> audit problems
yank:
 * Description shouldn't include the formula name

Error: 1 problem in 1 formula
```
I'm guessing that the audit rule "Description shouldn't include the formula name" was added to prevent people from writing things like "\<formula\> does blah blah blah." However I think this formula warrants an exception doesn't it?