### PR TITLE
valgrind: Fix the `inreplace' for systems without CLT

### DIFF
--- a/Library/Formula/valgrind.rb
+++ b/Library/Formula/valgrind.rb
@@ -42,7 +42,7 @@ class Valgrind < Formula
 
     # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
     unless MacOS::CLT.installed?
-      inreplace "coregrind/Makefile.in", %r{(\s)(?=/usr/include/mach/)}, '<\1>'+MacOS.sdk_path.to_s
+      inreplace "coregrind/Makefile.in", %r{(\s)(?=/usr/include/mach/)}, '\1'+MacOS.sdk_path.to_s
     end
 
     system "./configure", *args


### PR DESCRIPTION
This fixes:
<pre>
Making all in coregrind
make[2]: *** No rule to make target `&lt;', needed by `m_mach/mach_vmUser.c'.  Stop.
</pre>

See also PRs #45851 and #45801.