### PR TITLE
Add `:branch => "trunk"` to kafka head

### DIFF
--- a/Library/Formula/kafka.rb
+++ b/Library/Formula/kafka.rb
@@ -1,7 +1,7 @@
 class Kafka < Formula
   desc "Publish-subscribe messaging rethought as a distributed commit log"
   homepage "https://kafka.apache.org"
-  head "https://git-wip-us.apache.org/repos/asf/kafka.git"
+  head "https://git-wip-us.apache.org/repos/asf/kafka.git", :branch => "trunk"
   url "http://mirrors.ibiblio.org/apache/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz"
   mirror "https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz"
   sha256 "77e9ed27c25650c07d00f380bd7c04d6345cbb984d70ddc52bbb4cb512d8b03c"


### PR DESCRIPTION
The `--HEAD` switch wasn't working in the Kafka formula.  Kafka (like other ASF projects) uses "trunk" instead of "master" as the mainline branch.  I fixed accordingly.