### PR TITLE
.gitignore: ignore IDEA RubyMine project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 /Library/PinnedKegs
 /Library/Taps
 /Library/PinnedTaps
+# RubyMine project files:
+.idea


### PR DESCRIPTION
Folks,

What do you think about adding `.idea` to the `.gitignore` like this, so the RubyMine IDE can be more easily used with the local Homebrew installation? I'm experimenting with using it instead of a plain text editor.

You can still use RubyMine without this in the ignore by creating an empty project at a separate location and then adding `/usr/local/Library` as a separate content root in the project definition. But that's a little unwieldy imho. And adding `.idea` seems benign: we'd never want one checked in to the repo anyway, since it's IDE-specific and contains local per-user settings.