### PR TITLE
Enhance caveats section for Fish formulae

### DIFF
--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -36,9 +36,16 @@ class Fish < Formula
       chsh -s #{HOMEBREW_PREFIX}/bin/fish
     to make fish your default shell.
 
-    If you are upgrading from an older version of fish, you should now run:
+    And optionally:
+      fish_config
+    to review configuration.
+
+    If you are upgrading from an older version of fish, you should:
+
+    1. Terminate the outdated fish daemon:
       killall fishd
-    to terminate the outdated fish daemon.
+    2. Update tab completions:
+      fish_update_completions
     EOS
   end
 


### PR DESCRIPTION
Fish tab completions require manual rebuild. That has been added to the Caveats section. Furthermore, short note about stock web-based configuration manager `fish_config` has been included.

No post-install hook because of this commit: 8a108bed154ae79a766d59949f0e753484525a76 by @geoff-codes. There's no explanation why demon restart has been removed from that hook, so I decided to take the defensive approach as well.