### PR TITLE
Disable AESNI on OSX <= 10.7 for pandoc dependency

### DIFF
--- a/Library/Formula/pandoc.rb
+++ b/Library/Formula/pandoc.rb
@@ -25,10 +25,7 @@ class Pandoc < Formula
   def install
     cabal_sandbox do
       args = []
-      if MacOS.version <= :lion
-        # disable AESNI for OSX <= 10.7
-        args << "--constraint=cryptonite -support_aesni"
-      end
+      args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
       cabal_install "--only-dependencies", *args
       cabal_install "--prefix=#{prefix}"
     end

--- a/Library/Formula/pandoc.rb
+++ b/Library/Formula/pandoc.rb
@@ -24,7 +24,12 @@ class Pandoc < Formula
 
   def install
     cabal_sandbox do
-      cabal_install "--only-dependencies"
+      args = []
+      if MacOS.version <= :lion
+        # disable AESNI for OSX <= 10.7
+        args << "--constraint=cryptonite -support_aesni"
+      end
+      cabal_install "--only-dependencies", *args
       cabal_install "--prefix=#{prefix}"
     end
     cabal_clean_lib


### PR DESCRIPTION
Pandoc depends on cryptonite, which fails on OSX <= 10.7,
since the system compiler doesn't understand the '-maes' option.
See: https://hackage.haskell.org/package/cryptonite

Unfortunately the changed code - as opposed to running `--interactive` and typing the exact same command - does not work yet and results in

    ==> cabal install --jobs=2 --constraint="cryptonite -support_aesni"
    cabal: expected a package name followed by a constraint, which is either a version range, 'installed', 'source' or flags

Maybe someone more proficient in the fine art of brewing can help out?

PS: Otherwise building works with an up to date GCC, but you need to have one (not necessarily the case) and type something like

    brew install pandoc --cc=gcc-5

Maybe that could be taken care of in the formula somehow.