### PR TITLE
Improve libbpg formula

### DIFF
--- a/Library/Formula/libbpg.rb
+++ b/Library/Formula/libbpg.rb
@@ -16,7 +16,7 @@ class Libbpg < Formula
   option "without-x265", "Disable built-in x265 encoder - Multi threaded, faster but produce bigger file"
 
   depends_on "cmake" => :build
-  depends_on "yasm" => :build if !build.without? "x265"
+  depends_on "yasm" => :build if build.with? "x265"
   depends_on "libpng"
   depends_on "jpeg"
 
@@ -40,7 +40,7 @@ class Libbpg < Formula
       #system "#{bin}/bpgenc", "-e", "jctvc", test_fixtures("test.jpg")
     end
 
-    if !build.without? "x265"
+    if build.with? "x265"
       system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.png")
       # Unable to test 1x1 jpg
       #system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.jpg")

--- a/Library/Formula/libbpg.rb
+++ b/Library/Formula/libbpg.rb
@@ -3,6 +3,7 @@ class Libbpg < Formula
   homepage "http://bellard.org/bpg/"
   url "http://bellard.org/bpg/libbpg-0.9.6.tar.gz"
   sha256 "2800777d88a77fd64a4a9036b131f021a5bda8304e1dbe7996dd466567fb484e"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,24 +12,38 @@ class Libbpg < Formula
     sha256 "7b8d1585ee9e2de010abfab1aaab419d052cf35d82704587c2f75947d4fc8ee5" => :mavericks
   end
 
-  option "with-x265", "Enable x265 encoder"
-  option "without-jctvc", "Disable built-in JCTVC encoder"
+  option "with-jctvc", "Enable built-in JCTVC encoder - Mono threaded, slower but produce smaller file"
+  option "without-x265", "Disable built-in x265 encoder - Multi threaded, faster but produce bigger file"
 
   depends_on "cmake" => :build
-  depends_on "yasm" => :build
+  depends_on "yasm" => :build if !build.without? "x265"
   depends_on "libpng"
   depends_on "jpeg"
-  depends_on "x265" => :optional
 
   def install
     bin.mkpath
-    args = []
-    args << "USE_X265=y" if build.with? "x265"
-    args << "USE_JCTVC=" if build.without? "jctvc"
-    system "make", "install", "prefix=#{prefix}", "CONFIG_APPLE=y", *args
+
+    makeArgs = []
+    makeArgs << "install"
+    makeArgs << "prefix=#{prefix}"
+    makeArgs << "CONFIG_APPLE=y"
+    makeArgs << "USE_JCTVC=y" if build.with? "jctvc"
+    makeArgs << "USE_X265=" if build.without? "x265"
+
+    system "make", *makeArgs
   end
 
   test do
-    system "#{bin}/bpgenc", test_fixtures("test.png")
+    if build.with? "jctvc"
+      system "#{bin}/bpgenc", "-e", "jctvc", test_fixtures("test.png")
+      # Unable to test 1x1 jpg
+      #system "#{bin}/bpgenc", "-e", "jctvc", test_fixtures("test.jpg")
+    end
+
+    if !build.without? "x265"
+      system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.png")
+      # Unable to test 1x1 jpg
+      #system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.jpg")
+    end
   end
 end

--- a/Library/Formula/libbpg.rb
+++ b/Library/Formula/libbpg.rb
@@ -31,7 +31,5 @@ class Libbpg < Formula
 
   test do
     system "#{bin}/bpgenc", test_fixtures("test.png")
-    # Unable to test 1x1 jpg
-    #system "#{bin}/bpgenc", test_fixtures("test.jpg")
   end
 end

--- a/Library/Formula/libbpg.rb
+++ b/Library/Formula/libbpg.rb
@@ -3,7 +3,6 @@ class Libbpg < Formula
   homepage "http://bellard.org/bpg/"
   url "http://bellard.org/bpg/libbpg-0.9.6.tar.gz"
   sha256 "2800777d88a77fd64a4a9036b131f021a5bda8304e1dbe7996dd466567fb484e"
-  revision 1
 
   bottle do
     cellar :any
@@ -23,27 +22,16 @@ class Libbpg < Formula
   def install
     bin.mkpath
 
-    makeArgs = []
-    makeArgs << "install"
-    makeArgs << "prefix=#{prefix}"
-    makeArgs << "CONFIG_APPLE=y"
-    makeArgs << "USE_JCTVC=y" if build.with? "jctvc"
-    makeArgs << "USE_X265=" if build.without? "x265"
+    args = []
+    args << "USE_JCTVC=y" if build.with? "jctvc"
+    args << "USE_X265=" if build.without? "x265"
 
-    system "make", *makeArgs
+    system "make", "install", "prefix=#{prefix}", "CONFIG_APPLE=y", *args
   end
 
   test do
-    if build.with? "jctvc"
-      system "#{bin}/bpgenc", "-e", "jctvc", test_fixtures("test.png")
-      # Unable to test 1x1 jpg
-      #system "#{bin}/bpgenc", "-e", "jctvc", test_fixtures("test.jpg")
-    end
-
-    if build.with? "x265"
-      system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.png")
-      # Unable to test 1x1 jpg
-      #system "#{bin}/bpgenc", "-e", "x265", test_fixtures("test.jpg")
-    end
+    system "#{bin}/bpgenc", test_fixtures("test.png")
+    # Unable to test 1x1 jpg
+    #system "#{bin}/bpgenc", test_fixtures("test.jpg")
   end
 end


### PR DESCRIPTION
- Remove deps to x265 since x265 is included in source
- Allow to disable new default encoder (x265)
- Allow to enable old encode (jctvc)