### PR TITLE
Upgrade texttable to 0.8.4 for docker-compose

### DIFF
--- a/Library/Formula/docker-compose.rb
+++ b/Library/Formula/docker-compose.rb
@@ -67,8 +67,8 @@ class DockerCompose < Formula
   end
 
   resource "texttable" do
-    url "https://pypi.python.org/packages/source/t/texttable/texttable-0.8.2.tar.gz"
-    sha256 "c0c5b2aa4eab132d40aadb7c4e81f98fc93d3a1e6cb44e9be76779d74f32e6be"
+    url "https://pypi.python.org/packages/source/t/texttable/texttable-0.8.4.tar.gz"
+    sha256 "8587b61cb6c6022d0eb79e56e59825df4353f0f33099b4ae3bcfe8d41bd1702e"
   end
 
   resource "docopt" do


### PR DESCRIPTION
Apparently texttable-0.8.2 has been removed.  I haven't done extensive testing, but things appear to work.