### PR TITLE
metabase 0.13.0 (new formula)

### DIFF
--- a/Library/Formula/metabase.rb
+++ b/Library/Formula/metabase.rb
@@ -1,0 +1,61 @@
+class Metabase < Formula
+  desc "Business intelligence report server"
+  homepage "http://www.metabase.com/"
+  url "http://downloads.metabase.com/v0.12.1/metabase.jar"
+  version "0.12.1"
+  sha256 "6c3dc403c725f33e79b72e60ff19a6d1c41433a12945201c63267eddbc535f6c"
+
+  head do
+    url "https://github.com/metabase/metabase.git"
+
+    depends_on "node" => :build
+    depends_on "leiningen" => :build
+  end
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    if build.head?
+      ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"
+      system "./bin/build"
+      libexec.install "target/uberjar/metabase.jar"
+    else
+      libexec.install "metabase.jar"
+    end
+    bin.write_jar_script libexec/"metabase.jar", "metabase"
+  end
+
+  plist_options :startup => true, :manual => "metabase"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/metabase</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{var}/metabase</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/metabase/server.log</string>
+      <key>StandardErrorPath</key>
+      <string>/dev/null</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system bin/"metabase", "migrate", "up"
+  end
+end

--- a/Library/Formula/metabase.rb
+++ b/Library/Formula/metabase.rb
@@ -1,9 +1,9 @@
 class Metabase < Formula
   desc "Business intelligence report server"
   homepage "http://www.metabase.com/"
-  url "http://downloads.metabase.com/v0.12.1/metabase.jar"
-  version "0.12.1"
-  sha256 "6c3dc403c725f33e79b72e60ff19a6d1c41433a12945201c63267eddbc535f6c"
+  url "http://downloads.metabase.com/v0.13.0/metabase.jar"
+  version "0.13.0"
+  sha256 "d14c3a5daf543a362b14ee0215bdabcad40e23be7aa46f25986d67c62e5e5b07"
 
   head do
     url "https://github.com/metabase/metabase.git"


### PR DESCRIPTION
This commit contains a sort of hacky way of getting `npm` on the `PATH`, which is required for building from source (only for `--HEAD`), otherwise we get `./bin/build: line 22: npm: command not found`. If there's a better way I'd love to know about it.