### PR TITLE
ENV: warn_if_universal_binaries_not_supported

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -306,4 +306,10 @@ module SharedEnvExtension
       end
     end
   end
+
+  def check_for_compiler_universal_support
+    if homebrew_cc =~ GNU_GCC_REGEXP
+      raise "Non-Apple GCC can't build universal binaries"
+    end      
+  end
 end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -269,6 +269,8 @@ module Stdenv
   end
 
   def universal_binary
+    check_for_compiler_universal_support
+
     append_to_cflags Hardware::CPU.universal_archs.as_arch_flags
     append "LDFLAGS", Hardware::CPU.universal_archs.as_arch_flags
 

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -263,6 +263,8 @@ module Superenv
   end
 
   def universal_binary
+    check_for_compiler_universal_support
+
     self["HOMEBREW_ARCHFLAGS"] = Hardware::CPU.universal_archs.as_arch_flags
 
     # GCC doesn't accept "-march" for a 32-bit CPU with "-arch x86_64"


### PR DESCRIPTION
Raise an error when attempting to create universal binaries with a GCC
that can't do so.

Without this, Homebrew will just silently create 32-bit only binaries when using a GNU GCC.

(Is `homebrew_cc` the right thing to test here? Is there a different way I should have done this? `ENV` seems like an odd place to put this check but given that `ENV.universal_binary` is already here it seemed minimally disruptive. Very open to feedback.)