### PR TITLE
jack formula uses new berkeley-db5 formula

### DIFF
--- a/Library/Formula/berkeley-db5.rb
+++ b/Library/Formula/berkeley-db5.rb
@@ -40,7 +40,7 @@ class BerkeleyDb5 < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-L#{prefix}/lib", "-ldb-5", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-ldb-5", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/berkeley-db5.rb
+++ b/Library/Formula/berkeley-db5.rb
@@ -1,0 +1,57 @@
+class BerkeleyDb5 < Formula
+  desc "High performance key/value database"
+  homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
+  url "http://download.oracle.com/berkeley-db/db-5.3.28.tar.gz"
+  sha256 "e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628"
+
+  keg_only "BDB 5.3.28 is provided for software that doesn't compile against newer versions."
+
+  patch :DATA
+
+  def install
+    # BerkeleyDB dislikes parallel builds
+    ENV.deparallelize
+
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --enable-cxx
+      --enable-compat185
+    ]
+
+    # Berkeleydb requires you to build everything from the build_unix subdirectory
+    cd "build_unix" do
+      system "../dist/configure", *args
+      system "make", "install"
+
+      # use the standard docs location
+      doc.parent.mkpath
+      mv prefix+"docs", doc
+    end
+  end
+end
+
+__END__
+diff --git a/src/dbinc/atomic.h b/src/dbinc/atomic.h
+index 6a858f7..c0a0ee7 100644
+--- a/src/dbinc/atomic.h
++++ b/src/dbinc/atomic.h
+@@ -144,7 +144,7 @@ typedef LONG volatile *interlocked_val;
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@ static inline int __atomic_dec(db_atomic_t *p)
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;

--- a/Library/Formula/berkeley-db5.rb
+++ b/Library/Formula/berkeley-db5.rb
@@ -30,6 +30,19 @@ class BerkeleyDb5 < Formula
       mv prefix+"docs", doc
     end
   end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <db.h>
+
+      int main() {
+        db_version(NULL,NULL,NULL);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{prefix}/lib", "-ldb-5", "-o", "test"
+    system "./test"
+  end
 end
 
 __END__

--- a/Library/Formula/jack.rb
+++ b/Library/Formula/jack.rb
@@ -20,7 +20,7 @@ class Jack < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "berkeley-db"
+  depends_on "berkeley-db5"
   depends_on "libsndfile"
   depends_on "libsamplerate"
 


### PR DESCRIPTION
I want to resolve #46628 with these two commits, one being the creation of a new formula 'berkeley-db5', the other being a modification to the jack formula to use it as a dependency.