### PR TITLE
CMake 3.4.1

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -1,8 +1,8 @@
 class Cmake < Formula
   desc "Cross-platform make"
   homepage "https://www.cmake.org/"
-  url "https://cmake.org/files/v3.4/cmake-3.4.0.tar.gz"
-  sha256 "a5b82bf6ace6c481cdb911fd5d372a302740cbefd387e05297cb37f7468d1cea"
+  url "https://cmake.org/files/v3.4/cmake-3.4.1.tar.gz"
+  sha256 "d41462bdd80dc37f0d5608167b354bb3af8c068eee640be04c907154c5c113e2"
   head "https://cmake.org/cmake.git"
 
   bottle do


### PR DESCRIPTION
This commit updates Homebrew's CMake formula in order to reflect the fact that Kitware has released CMake v3.4.1 to the public.  
<hr />
Something weird seemed to happen with CMake's dependencies during my build attempt, though, so I'm not sure if this is ready to merge or not.  I forgot to log my installation run, though, so I can't provide you guys with any specifics (I _think_ I saw ICU4C and one other thing in the list of problem dependencies, but it all flashed by so fast that I'm not entirely sure…)  