### PR TITLE
gnu-units: Fix Python 2 path for units_cur

### DIFF
--- a/Library/Formula/gnu-units.rb
+++ b/Library/Formula/gnu-units.rb
@@ -28,6 +28,11 @@ class GnuUnits < Formula
   patch :DATA
 
   def install
+    # OSX doesn't provide 'python2', but on some Linux distributions
+    # 'python' is an alias for python3 so this won't be changed
+    # upstream
+    inreplace "units_cur", "#!/usr/bin/python2", "#!/usr/bin/env python"
+
     args = ["--prefix=#{prefix}"]
     args << "--program-prefix=g" if build.without? "default-names"
 

--- a/Library/Formula/gnu-units.rb
+++ b/Library/Formula/gnu-units.rb
@@ -28,9 +28,7 @@ class GnuUnits < Formula
   patch :DATA
 
   def install
-    # OSX doesn't provide 'python2', but on some Linux distributions
-    # 'python' is an alias for python3 so this won't be changed
-    # upstream
+    # OS X does not provide a `python2` executable
     inreplace "units_cur", "#!/usr/bin/python2", "#!/usr/bin/env python"
 
     args = ["--prefix=#{prefix}"]


### PR DESCRIPTION
Fixes #46527. The `gunits_cur` script still errors for me, but that seems to be an upstream issue.