### PR TITLE
zero-install: fix shasum mismatch and version redundant

### DIFF
--- a/Library/Formula/zero-install.rb
+++ b/Library/Formula/zero-install.rb
@@ -21,81 +21,68 @@ class ZeroInstall < Formula
 
   resource "easy-format" do # [required by yojson]
     url "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
-    version "1.0.2"
     sha256 "c2a04ab1084bc5ce1ec52a3aa320c825c22f8be527fb5f82d920a9d92a673cd3"
   end
 
   resource "biniou" do # [required by yojson]
     url "https://opam.ocaml.org/archives/biniou.1.0.9+opam.tar.gz"
-    version "1.0.9"
     sha256 "08e6a17a19fbe5e9da4c77d1e8c1bb05333f84ec8a634721a39c6c505ce51e0d"
   end
 
   resource "cppo" do # [required by yojson]
     url "https://opam.ocaml.org/archives/cppo.1.1.2+opam.tar.gz"
-    version "1.1.2"
-    sha256 "35c1caddb249293c5a24f095e0dea85c670056083e30010078124b65e557a2d8"
+    sha256 "8341d5a37d9e9351c1a46bf4d0843bff4fe1690b6329c28f8f41ca3dd189252a"
   end
 
   resource "yojson" do
     url "https://opam.ocaml.org/archives/yojson.1.1.8+opam.tar.gz"
-    version "1.1.8"
     sha256 "20ce2c2f752b49695468b0bf66f17cf20219d7bca5a0b71a3fb89af500fb52f1"
   end
 
   resource "xmlm" do
     url "https://opam.ocaml.org/archives/xmlm.1.2.0+opam.tar.gz"
-    version "1.2.0"
-    sha256 "518617e737730c89a04ca68ae927cb1510a027a9924df591df8575e386d810f0"
+    sha256 "a73af14cb2771247311e9130cbf7d10d66970f4725359db0923c92106ba94457"
   end
 
   resource "ounit" do
     url "https://opam.ocaml.org/archives/ounit.2.0.0+opam.tar.gz"
-    version "2.0.0"
-    sha256 "bc87d648a6186d7a708442a9dcb2197e9f0d5d8ba62f60daf18ae8b592b658ce"
+    sha256 "5a26c6404d9c8701f5a7510a985963f4eae003d58ae5fc3d9b7f1a862e91de71"
   end
 
   resource "react" do
     url "https://opam.ocaml.org/archives/react.1.2.0+opam.tar.gz"
-    version "1.2.0"
-    sha256 "690a1a7b18be21fa83876599639ddd3954c2a53d5cf1e13a76f2a140e1f9aa71"
+    sha256 "51cab5941511220cd3f51b04cbab58ed34409bf9ec78dfed7611ab169f294499"
   end
 
   resource "ppx_tools" do # [required by lwt]
     url "https://opam.ocaml.org/archives/ppx_tools.0.99.2+opam.tar.gz"
-    version "0.99.2"
     sha256 "0c5b9802de2005b55717ac78bffcead1ee11dd28f91fb32f7e3518a7d7d8c48a"
   end
 
   resource "lwt" do
     url "https://opam.ocaml.org/archives/lwt.2.4.6+opam.tar.gz"
-    version "2.4.6"
-    sha256 "297eda984412d6cd231bea548da4ef2d8b08db5f1a0bc295d47ac993243005b5"
+    sha256 "f0d814e04e4447322b592ee38b2bb634287bc6142c195381da39e28d4a0e9071"
   end
 
   resource "extlib" do
     url "https://opam.ocaml.org/archives/extlib.1.6.1+opam.tar.gz"
-    version "1.6.1"
     sha256 "c76176916c39d4ccae82a34c33e694652c0c55d79eec8830dfddadb580b53773"
   end
 
   resource "ocurl" do
     url "https://opam.ocaml.org/archives/ocurl.0.7.2+opam.tar.gz"
-    version "0.7.2"
     sha256 "669c5142b7f4002521468b75ee254b269f0094c9a22d3381e94a440a6aa2d400"
   end
 
   if build.with? "gtk+"
     resource "lablgtk" do
       url "https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz"
-      version "2.18.3"
       sha256 "f0b7ed0bd85f6cf4b4c5f81966f03763e76bb9f866f5172511ce48cf31fd433c"
     end
   end
 
   resource "sha" do
     url "https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz"
-    version "1.9"
     sha256 "d3cfda4cd6f79b01c6613219baa3e8548365c309952168b3539e0edce9370b40"
   end
 


### PR DESCRIPTION
Fixed #46657 