### PR TITLE
logcheck 1.3.17.1

### DIFF
--- a/Library/Formula/logcheck.rb
+++ b/Library/Formula/logcheck.rb
@@ -15,6 +15,7 @@ class Logcheck < Formula
 
   def install
     inreplace "Makefile", "$(DESTDIR)/$(CONFDIR)", "$(CONFDIR)"
+    inreplace "src/logcheck-test", "mktemp --tmpdir logcheck-test", "mktemp /tmp/logcheck-test"
 
     system "make", "install", "--always-make", "DESTDIR=#{prefix}",
                    "SBINDIR=sbin", "BINDIR=bin", "CONFDIR=#{etc}/logcheck"

--- a/Library/Formula/logcheck.rb
+++ b/Library/Formula/logcheck.rb
@@ -15,6 +15,8 @@ class Logcheck < Formula
 
   def install
     inreplace "Makefile", "$(DESTDIR)/$(CONFDIR)", "$(CONFDIR)"
+    # email sent to logcheck mailing list asking whether this patch can land upstream:
+    # http://lists.alioth.debian.org/pipermail/logcheck-users/2015-December/000328.html
     inreplace "src/logcheck-test", "mktemp --tmpdir logcheck-test", "mktemp /tmp/logcheck-test"
 
     system "make", "install", "--always-make", "DESTDIR=#{prefix}",


### PR DESCRIPTION
On OSX `mktemp` does not accept `--tmpdir` argument, causing the `logcheck-test` script to fail.
These changes do not contain a new upstream version of logcheck; in the homebrew docs I could not find the preferred to mark a packaging release, that's why I went with 1.3.17.1. 