### PR TITLE
cern-ndiff 5.02.08 (new formula)

### DIFF
--- a/Library/Formula/cern-ndiff.rb
+++ b/Library/Formula/cern-ndiff.rb
@@ -13,4 +13,11 @@ class CernNdiff < Formula
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end
+
+  test do
+    (testpath/"lhs.txt").write("0.0 2e-3 0.003")
+    (testpath/"rhs.txt").write("1e-7 0.002 0.003")
+    (testpath/"test.cfg").write("*   * abs=1e-6")
+    system "#{bin}/numdiff", "lhs.txt", "rhs.txt", "test.cfg"
+  end
 end

--- a/Library/Formula/cern-ndiff.rb
+++ b/Library/Formula/cern-ndiff.rb
@@ -1,4 +1,3 @@
-
 class CernNdiff < Formula
   desc "Numerical diff tool"
   # Note: ndiff is a sub-project of Mad-X at the moment..

--- a/Library/Formula/cern-ndiff.rb
+++ b/Library/Formula/cern-ndiff.rb
@@ -1,0 +1,16 @@
+
+class CernNdiff < Formula
+  desc "Numerical diff tool"
+  # Note: ndiff is a sub-project of Mad-X at the moment..
+  homepage "http://cern.ch/mad"
+  url "http://svn.cern.ch/guest/madx/tags/5.02.08/madX/tools/numdiff"
+  version "5.02.08"
+  head "http://svn.cern.ch/guest/madx/trunk/madX/tools/numdiff"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
The CERN ndiff tool is a specialiced diff tool
for comparing numerical differences in (large) text files.
There are no testing defined for the binary at the moment,
which is why the test is empty in this recipe.
The tool is primarily used for testing of the Mad-X software,
but generally useful for people that need to do advanced numerical
difference comparison.