### PR TITLE
gcc 5.3

### DIFF
--- a/Library/Formula/cloog.rb
+++ b/Library/Formula/cloog.rb
@@ -1,8 +1,8 @@
 class Cloog < Formula
   desc "Generate code for scanning Z-polyhedra"
   homepage "http://www.cloog.org/"
-  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.3.tar.gz"
-  sha256 "460c6c740acb8cdfbfbb387156b627cf731b3837605f2ec0001d079d89c69734"
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
+  sha256 "325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e"
 
   bottle do
     cellar :any

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -21,9 +21,9 @@ class Gcc < Formula
 
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org"
-  url "http://ftpmirror.gnu.org/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
-  sha256 "5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad"
+  url "http://ftpmirror.gnu.org/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+  sha256 "b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db"
 
   head "svn://gcc.gnu.org/svn/gcc/trunk"
 

--- a/Library/Formula/isl.rb
+++ b/Library/Formula/isl.rb
@@ -1,14 +1,15 @@
 class Isl < Formula
   desc "Integer Set Library for the polyhedral model"
-  homepage "http://freecode.com/projects/isl"
+  homepage "http://isl.gforge.inria.fr"
   # Note: Always use tarball instead of git tag for stable version.
   #
   # Currently isl detects its version using source code directory name
   # and update isl_version() function accordingly.  All other names will
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
-  url "http://isl.gforge.inria.fr/isl-0.14.1.tar.xz"
-  sha256 "8882c9e36549fc757efa267706a9af733bb8d7fe3905cbfde43e17a89eea4675"
+  url "http://isl.gforge.inria.fr/isl-0.15.tar.bz2"
+  mirror "ftp://gcc.gnu.org//pub/gcc/infrastructure/isl-0.15.tar.bz2"
+  sha256 "8ceebbf4d9a81afa2b4449113cee4b7cb14a687d7a549a963deb5e2a41458b6b"
 
   bottle do
     cellar :any
@@ -36,7 +37,6 @@ class Isl < Formula
                           "--prefix=#{prefix}",
                           "--with-gmp=system",
                           "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}"
-    system "make"
     system "make", "install"
     (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
   end


### PR DESCRIPTION
Updated formula for 5.3 release of GCC.

**N.B.**:
 1. As of writing this, the bzipped source files were not yet on gnumirror... just the normal GNU ftp server (listed as the `url` in the formula) but this shouldn't cause a problem since it can be downloaded from the `mirror` in the formula, until it is uploaded... Also the SHA256 checksum will ensure that the files are identical between `url` and `mirror`
 2. I cleaned up some warnings from `brew audit --strict` about commas and multi-line arrays
 3. The build took over 50 minutes on my machine, so I'm guessing Travis-CI will time out.


