### PR TITLE
Upgrade Apache Storm to version 0.10.0

### DIFF
--- a/Library/Formula/storm.rb
+++ b/Library/Formula/storm.rb
@@ -1,8 +1,8 @@
 class Storm < Formula
   desc "Distributed realtime computation system to process data streams"
   homepage "https://storm.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz"
-  sha256 "2e8337126de8d1e180abe77fb81af7c971f8c4b2dad94e446ac86c0f02ba3fb2"
+  url "https://www.apache.org/dyn/closer.cgi?path=storm/apache-storm-0.10.0/apache-storm-0.10.0.tar.gz"
+  sha256 "066d1f5343333efd9187d7b850047cf9b3f63d885811e9fdd6e50f949b432f62"
 
   bottle :unneeded
 


### PR DESCRIPTION
See the following blog posts for information about this release:
- <http://storm.apache.org/2015/11/05/storm0100-released.html>
- <http://storm.apache.org/2015/06/15/storm0100-beta-released.html>