### PR TITLE
Refactor SDK lookup, fix building software under Xcode 7 on 10.10

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -610,19 +610,6 @@ class Checks
     end
   end
 
-  # Xcode 7 lacking the 10.10 SDK is forcing sysroot to be declared
-  # nil on 10.10 & breaking compiles. CLT is workaround.
-  def check_sdk_path_not_nil_yosemite
-    if MacOS.version == :yosemite && !MacOS::CLT.installed? && MacOS::Xcode.installed? && MacOS.sdk_path.nil?
-      <<-EOS.undent
-      Xcode 7 lacks the 10.10 SDK which can cause some builds to fail.
-      We recommend installing the Command Line Tools with:
-        xcode-select --install
-      to resolve this issue.
-     EOS
-    end
-  end
-
   def check_user_path_1
     $seen_prefix_bin = false
     $seen_prefix_sbin = false

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -67,6 +67,11 @@ module Superenv
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
 
+    if MacOS::Xcode.without_clt?
+      self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
+      self["SDKROOT"] = MacOS.sdk_path
+    end
+
     # On 10.9, the tools in /usr/bin proxy to the active developer directory.
     # This means we can use them for any combination of CLT and Xcode.
     self["HOMEBREW_PREFER_CLT_PROXIES"] = "1" if MacOS.version >= "10.9"

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -89,6 +89,9 @@ module OS
       begin
         @locator.sdk_for v
       rescue SDKLocator::NoSDKError
+        sdk = @locator.latest_sdk
+        # don't return an SDK that's older than the OS version
+        sdk unless sdk.nil? || sdk.version < version
       end
     end
 

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -1,0 +1,59 @@
+require "os/mac/version"
+
+module OS
+  module Mac
+    class SDK
+      attr_reader :version, :path
+
+      def initialize(version, path)
+        @version = OS::Mac::Version.new version
+        @path = Pathname.new(path)
+      end
+    end
+
+    class SDKLocator
+      class NoSDKError < StandardError; end
+
+      def sdk_for(v)
+        path = sdk_paths[v]
+        raise NoSDKError if path.nil?
+
+        SDK.new v, path
+      end
+
+      def latest_sdk
+        return if sdk_paths.empty?
+
+        v, path = sdk_paths.max {|a, b| OS::Mac::Version.new(a[0]) <=> OS::Mac::Version.new(b[0])}
+        SDK.new v, path
+      end
+
+      private
+
+      def sdk_paths
+        @sdk_paths ||= begin
+          # Xcode.prefix is pretty smart, so let's look inside to find the sdk
+          sdk_prefix = "#{Xcode.prefix}/Platforms/MacOSX.platform/Developer/SDKs"
+          # Xcode < 4.3 style
+          sdk_prefix = "/Developer/SDKs" unless File.directory? sdk_prefix
+          # Finally query Xcode itself (this is slow, so check it last)
+          sdk_prefix = File.join(Utils.popen_read(OS::Mac.locate("xcrun"), "--show-sdk-platform-path").chomp, "Developer", "SDKs") unless File.directory? sdk_prefix
+
+          # Bail out if there is no SDK prefix at all
+          if !File.directory? sdk_prefix
+            {}
+          else
+            paths = {}
+
+            Dir[File.join(sdk_prefix, "MacOSX*.sdk")].each do |sdk_path|
+              version = sdk_path[/MacOSX(\d+\.\d+)u?.sdk$/, 1]
+              paths[version] = sdk_path unless version.nil?
+            end
+
+            paths
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
refs #46362; this fixes building software on OS X 10.10 using Xcode 7, and other possible future configurations where the SDK for the specific OS being used is not present.

This refactors the SDK lookup code, and sets a couple of additional environment variables to ensure that the SDK can be found properly.

The SDK lookup code in `MacOS.sdk_path` has been pulled into a new `MacOS::SDKLocator` class, which returns `MacOS::SDK` objects which track both the OS verison and the path of the located SDK. The SDKLocator still searches in the same paths as the old code, but only searches within a single SDK location (instead of, potentially, several). It offers instance methods to return both specific SDKs and the latest installed SDK.

A new `MacOS.sdk` method has been added to return a `MacOS::SDK` object for the requested OS version or, if not present, the latest SDK, and `MacOS.sdk_path` is a wrapper around that which returns only the path, as before.

More notes on the changes are in the commit messages.

cc @UniqMartin 