### PR TITLE
plan9port add HEAD reference

### DIFF
--- a/Library/Formula/plan9port.rb
+++ b/Library/Formula/plan9port.rb
@@ -3,6 +3,7 @@ class Plan9port < Formula
   homepage "https://swtch.com/plan9port/"
   url "https://plan9port.googlecode.com/files/plan9port-20140306.tgz"
   sha256 "cbb826cde693abdaa2051c49e7ebf75119bf2a4791fe3b3229f1ac36a408eaeb"
+  head "https://github.com/9fans/plan9port.git"
 
   def install
     ENV["PLAN9_TARGET"] = libexec


### PR DESCRIPTION
This allows users to do `brew install --HEAD plan9port`. This is needed
because the latest release on https://code.google.com/p/plan9port/downloads/list
has broken GUI integration in OS X 10.11.