### PR TITLE
mupdf-tools: use stable URL

### DIFF
--- a/Library/Formula/mupdf-tools.rb
+++ b/Library/Formula/mupdf-tools.rb
@@ -1,7 +1,7 @@
 class MupdfTools < Formula
   desc "Lightweight PDF and XPS viewer"
   homepage "http://mupdf.com"
-  url "http://mupdf.com/downloads/mupdf-1.8-source.tar.gz"
+  url "http://mupdf.com/downloads/archive/mupdf-1.8-source.tar.gz"
   sha256 "a2a3c64d8b24920f87cf4ea9339a25abf7388496440f13b37482d1403c33c206"
   head "git://git.ghostscript.com/mupdf.git"
 


### PR DESCRIPTION
Use mupdf-tools archive urls, which stay valid after a new version is released.

New versions are also available from the /archive/ path, so this makes sure the formula can still be installed if a new version gets and has not yet been updated in homebrew.