### PR TITLE
fix chibi-scheme; previously it would fail test

### DIFF
--- a/Library/Formula/chibi-scheme.rb
+++ b/Library/Formula/chibi-scheme.rb
@@ -20,7 +20,7 @@ class ChibiScheme < Formula
     ENV.deparallelize
 
     # "make" and "make install" must be done separately
-    system "make"
+    system "make", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
Before:

```
$ brew test chibi-scheme
Testing chibi-scheme
ERROR: couldn't find file in module path: "init-7.scm"
Error: chibi-scheme: failed
<"0123456789"> expected but was
<"">.
```

After:

```
$ brew test chibi-scheme
Testing chibi-scheme
(success)
```