### PR TITLE
Add the dylib to the mediainfo formula

### DIFF
--- a/Library/Formula/media-info.rb
+++ b/Library/Formula/media-info.rb
@@ -28,6 +28,8 @@ class MediaInfo < Formula
       args = ["--disable-debug",
               "--disable-dependency-tracking",
               "--with-libcurl",
+              "--enable-static",
+              "--enable-shared",
               "--prefix=#{prefix}"]
       system "./configure", *args
       system "make", "install"


### PR DESCRIPTION
The media-info formula installs the CLI and libmediainfo.a. With this simple change, the libmediainfo.dylib is also installed.