### PR TITLE
racket: make installing DrRacket much more straightforward

### DIFF
--- a/Library/Formula/racket.rb
+++ b/Library/Formula/racket.rb
@@ -58,16 +58,17 @@ class Racket < Formula
     assert_match /Hello Homebrew/, output
 
     # show that the config file isn't malformed
-    output = `'#{bin}/raco' pkg config`
+    output = shell_output("'#{bin}/raco' pkg config")
     assert $?.success?
-    assert_match Regexp.new("^name:
-  #{version}
-catalogs:
-  http://download.racket-lang.org/releases/#{version}/catalog/
-  http://pkgs.racket-lang.org
-  http://planet-compats.racket-lang.org
-default-scope:
-  installation
-"), output
+    assert_match Regexp.new(<<-EOS.undent), output
+      ^name:
+        #{version}
+      catalogs:
+        http://download.racket-lang.org/releases/#{version}/catalog/
+        http://pkgs.racket-lang.org
+        http://planet-compats.racket-lang.org
+      default-scope:
+        installation
+    EOS
   end
 end

--- a/Library/Formula/racket.rb
+++ b/Library/Formula/racket.rb
@@ -11,6 +11,9 @@ class Racket < Formula
     sha256 "474e72aee9d5e4a3b122caac9fe5429da912050bc9353f8c3a8687c4ff232b0d" => :mavericks
   end
 
+  # these two files are amended when (un)installing packages
+  skip_clean "lib/racket/launchers.rktd", "lib/racket/mans.rktd"
+
   def install
     cd "src" do
       args = %W[
@@ -28,17 +31,43 @@ class Racket < Formula
       system "make"
       system "make", "install"
     end
+
+    # configure racket's package tool (raco) to do the Right Thing
+    # see: http://docs.racket-lang.org/raco/config-file.html
+    inreplace etc/"racket/config.rktd" do |s|
+        s.gsub!(
+            /\(bin-dir\s+\.\s+"#{Regexp.quote(bin)}"\)/,
+            "(bin-dir . \"#{HOMEBREW_PREFIX}/bin\")",
+        )
+        s.gsub!(
+            /\n\)$/,
+            "\n      (default-scope . \"installation\")\n)",
+        )
+    end
   end
 
   def caveats; <<-EOS.undent
     This is a minimal Racket distribution.
-    If you want to use the DrRacket IDE, we recommend that you use
-    the PLT-provided packages from http://racket-lang.org/download/.
+    If you want to use the DrRacket IDE, you may run
+      raco pkg install --auto drracket
     EOS
   end
 
   test do
     output = shell_output("#{bin}/racket -e '(displayln \"Hello Homebrew\")'")
     assert_match /Hello Homebrew/, output
+
+    # show that the config file isn't malformed
+    output = `'#{bin}/raco' pkg config`
+    assert $?.success?
+    assert_match Regexp.new("^name:
+  #{version}
+catalogs:
+  http://download.racket-lang.org/releases/#{version}/catalog/
+  http://pkgs.racket-lang.org
+  http://planet-compats.racket-lang.org
+default-scope:
+  installation
+"), output
   end
 end


### PR DESCRIPTION
Installing DrRacket via racket's raco tool now Just Works as show in the updated caveat.

@tdsmith @mistydemeo We discussed this in IRC a bit.