### PR TITLE
configuration file for rethinkdb

### DIFF
--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -32,6 +32,11 @@ class Rethinkdb < Formula
     system "make", "install-osx"
 
     (var/"log/rethinkdb").mkpath
+
+    inreplace "packaging/assets/config/default.conf.sample",
+              /^# directory=.*/, "directory=#{var}/rethinkdb"
+    cp "packaging/assets/config/default.conf.sample", "rethinkdb.conf"
+    etc.install "rethinkdb.conf"
   end
 
   def plist; <<-EOS.undent
@@ -44,8 +49,8 @@ class Rethinkdb < Formula
       <key>ProgramArguments</key>
       <array>
           <string>#{opt_bin}/rethinkdb</string>
-          <string>-d</string>
-          <string>#{var}/rethinkdb</string>
+          <string>--config-file</string>
+          <string>#{etc}/rethinkdb.conf</string>
       </array>
       <key>WorkingDirectory</key>
       <string>#{HOMEBREW_PREFIX}</string>

--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -35,8 +35,7 @@ class Rethinkdb < Formula
 
     inreplace "packaging/assets/config/default.conf.sample",
               /^# directory=.*/, "directory=#{var}/rethinkdb"
-    cp "packaging/assets/config/default.conf.sample", "rethinkdb.conf"
-    etc.install "rethinkdb.conf"
+    etc.install "packaging/assets/config/default.conf.sample" => "rethinkdb.conf"
   end
 
   def plist; <<-EOS.undent


### PR DESCRIPTION
Hi, new pull request because #46512 I merged with branch master ;)

Rethinkdb http admin console listens by default on port 8080, what can cause a conflict with other tools (like node-inspector) which are even not checking if port is already in use.
Right now port can be configured in plist file, but it would be easier and more transparent to have a configuration file with available config options.