### PR TITLE
cayley: fix audit error

### DIFF
--- a/Library/Formula/cayley.rb
+++ b/Library/Formula/cayley.rb
@@ -158,6 +158,6 @@ class Cayley < Formula
 
   test do
     result = pipe_output("#{bin}/cayley version")
-    assert result.include?("Cayley snapshot")
+    assert_match result, "Cayley snapshot\n"
   end
 end


### PR DESCRIPTION
This PR fixed error called `brew audit cayley`, It show message below.

```
$ brew audit cayley
cayley:
 * Use `assert_match` instead of `assert ...include?`

Error: 1 problem in 1 formula
```