### PR TITLE
Tap: unify internally state from string to tap object

### DIFF
--- a/Library/Homebrew/bottles.rb
+++ b/Library/Homebrew/bottles.rb
@@ -47,10 +47,10 @@ def bottle_resolve_formula_names(bottle_file)
   name = receipt_file_path.split("/").first
   tap = Tab.from_file_content(receipt_file, "#{bottle_file}/#{receipt_file_path}").tap
 
-  if tap.nil? || tap == "Homebrew/homebrew"
+  if tap.nil? || tap.core_formula_repository?
     full_name = name
   else
-    full_name = "#{tap.sub("homebrew-", "")}/#{name}"
+    full_name = "#{tap}/#{name}"
   end
 
   [name, full_name]
@@ -66,8 +66,11 @@ class Bintray
   end
 
   def self.repository(tap = nil)
-    return "bottles" if tap.nil? || tap == "Homebrew/homebrew"
-    "bottles-#{tap.sub(%r{^homebrew/(homebrew-)?}i, "")}"
+    if tap.nil? || tap.core_formula_repository?
+      "bottles"
+    else
+      "bottles-#{tap.repo}"
+    end
   end
 end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -245,8 +245,8 @@ class FormulaAuditor
       return
     end
 
-    if FORMULA_RENAMES.key? name
-      problem "'#{name}' is reserved as the old name of #{FORMULA_RENAMES[name]}"
+    if oldname = CoreFormulaRepository.instance.formula_renames[name]
+      problem "'#{name}' is reserved as the old name of #{oldname}"
       return
     end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -235,7 +235,7 @@ class FormulaAuditor
   def audit_formula_name
     return unless @strict
     # skip for non-official taps
-    return if !formula.core_formula? && !formula.tap.to_s.start_with?("homebrew")
+    return unless formula.tap.official?
 
     name = formula.name
     full_name = formula.full_name

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -67,18 +67,9 @@ module Homebrew
   end
 
   def github_info(f)
-    if f.tap?
-      user, repo = f.tap.split("/", 2)
-      tap = Tap.fetch user, repo
-      if remote = tap.remote
-        path = f.path.relative_path_from(tap.path)
-        github_remote_path(remote, path)
-      else
-        f.path
-      end
-    elsif f.core_formula?
-      if remote = git_origin
-        path = f.path.relative_path_from(HOMEBREW_REPOSITORY)
+    if f.tap
+      if remote = f.tap.remote
+        path = f.path.relative_path_from(f.tap.path)
         github_remote_path(remote, path)
       else
         f.path

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -14,8 +14,8 @@ module Homebrew
     end
 
     ARGV.named.each do |name|
-      if !File.exist?(name) && (name !~ HOMEBREW_CORE_FORMULA_REGEX) \
-              && (name =~ HOMEBREW_TAP_FORMULA_REGEX || name =~ HOMEBREW_CASK_TAP_FORMULA_REGEX)
+      if !File.exist?(name) &&
+         (name =~ HOMEBREW_TAP_FORMULA_REGEX || name =~ HOMEBREW_CASK_TAP_FORMULA_REGEX)
         tap = Tap.fetch($1, $2)
         tap.install unless tap.installed?
       end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -46,7 +46,7 @@ module Homebrew
     if ARGV.named.empty?
       formulae = Formula.files
     else
-      tap = Tap.fetch(*tap_args)
+      tap = Tap.fetch(ARGV.named.first)
       raise TapUnavailableError, tap.name unless tap.installed?
       formulae = tap.formula_files
     end

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -1,4 +1,4 @@
-require "cmd/tap"
+require "tap"
 
 module Homebrew
   def tap_info
@@ -6,9 +6,11 @@ module Homebrew
       taps = Tap
     else
       taps = ARGV.named.map do |name|
-        Tap.fetch(*tap_args(name))
+        Tap.fetch(name)
       end
     end
+
+    raise "Homebrew/homebrew is not allowed" if taps.any?(&:core_formula_repository?)
 
     if ARGV.json == "v1"
       print_tap_json(taps)

--- a/Library/Homebrew/cmd/tap-pin.rb
+++ b/Library/Homebrew/cmd/tap-pin.rb
@@ -1,9 +1,10 @@
-require "cmd/tap"
+require "tap"
 
 module Homebrew
   def tap_pin
     ARGV.named.each do |name|
-      tap = Tap.fetch(*tap_args(name))
+      tap = Tap.fetch(name)
+      raise "Homebrew/homebrew is not allowed" if tap.core_formula_repository?
       tap.pin
       ohai "Pinned #{tap.name}"
     end

--- a/Library/Homebrew/cmd/tap-unpin.rb
+++ b/Library/Homebrew/cmd/tap-unpin.rb
@@ -1,9 +1,10 @@
-require "cmd/tap"
+require "tap"
 
 module Homebrew
   def tap_unpin
     ARGV.named.each do |name|
-      tap = Tap.fetch(*tap_args(name))
+      tap = Tap.fetch(name)
+      raise "Homebrew/homebrew is not allowed" if tap.core_formula_repository?
       tap.unpin
       ohai "Unpinned #{tap.name}"
     end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -12,8 +12,7 @@ module Homebrew
     elsif ARGV.first == "--list-pinned"
       puts Tap.select(&:pinned?).map(&:name)
     else
-      user, repo = tap_args
-      tap = Tap.fetch(user, repo)
+      tap = Tap.fetch(ARGV.named[0])
       begin
         tap.install(:clone_target => ARGV.named[1],
                     :full_clone   => ARGV.include?("--full"))
@@ -42,13 +41,5 @@ module Homebrew
     return unless ignore.exist? || options.fetch(:force, false)
     (HOMEBREW_LIBRARY/"Formula").children.each { |c| c.unlink if c.symlink? }
     ignore.unlink if ignore.exist?
-  end
-
-  private
-
-  def tap_args(tap_name = ARGV.named.first)
-    tap_name =~ HOMEBREW_TAP_ARGS_REGEX
-    raise "Invalid tap name" unless $1 && $3
-    [$1, $3]
   end
 end

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -37,20 +37,29 @@ module Homebrew
 
   def resolve_test_tap
     tap = ARGV.value("tap")
-    return Tap.fetch(*tap_args(tap)) if tap
+    if tap
+      tap = Tap.fetch(tap)
+      return tap unless tap.core_formula_repository?
+    end
 
     if ENV["UPSTREAM_BOT_PARAMS"]
       bot_argv = ENV["UPSTREAM_BOT_PARAMS"].split " "
       bot_argv.extend HomebrewArgvExtension
       tap = bot_argv.value("tap")
-      return Tap.fetch(*tap_args(tap)) if tap
+      if tap
+        tap = Tap.fetch(tap)
+        return tap unless tap.core_formula_repository?
+      end
     end
 
     if git_url = ENV["UPSTREAM_GIT_URL"] || ENV["GIT_URL"]
       # Also can get tap from Jenkins GIT_URL.
       url_path = git_url.sub(%r{^https?://github\.com/}, "").chomp("/")
-      HOMEBREW_TAP_ARGS_REGEX =~ url_path
-      return Tap.fetch($1, $3) if $1 && $3 && $3 != "homebrew"
+      begin
+        tap = Tap.fetch(tap)
+        return tap unless tap.core_formula_repository?
+      rescue
+      end
     end
 
     # return nil means we are testing core repo.

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -1,11 +1,12 @@
-require "cmd/tap" # for tap_args
+require "tap"
 
 module Homebrew
   def untap
     raise "Usage is `brew untap <tap-name>`" if ARGV.empty?
 
     ARGV.named.each do |tapname|
-      tap = Tap.fetch(*tap_args(tapname))
+      tap = Tap.fetch(tapname)
+      raise "Homebrew/homebrew is not allowed" if tap.core_formula_repository?
       tap.uninstall
     end
   end

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -422,7 +422,7 @@ class Report
         next unless newname = Tap.fetch($1, $2).formula_renames[oldname]
       else
         oldname = path.basename(".rb").to_s
-        next unless newname = FORMULA_RENAMES[oldname]
+        next unless newname = CoreFormulaRepository.instance.formula_renames[oldname]
       end
 
       if fetch(:A, []).include?(newpath = path.dirname.join("#{newname}.rb"))

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -230,8 +230,8 @@ class BuildError < RuntimeError
       puts
       puts "#{Tty.red}READ THIS#{Tty.reset}: #{Tty.em}#{OS::ISSUES_URL}#{Tty.reset}"
       if formula.tap?
-        case formula.tap
-        when "homebrew/homebrew-boneyard"
+        case formula.tap.name
+        when "homebrew/boneyard"
           puts "#{formula} was moved to homebrew-boneyard because it has unfixable issues."
           puts "Please do not file any issues about this. Sorry!"
         else

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1051,13 +1051,13 @@ class Formula
   # an array of all core {Formula} names
   # @private
   def self.core_names
-    @core_names ||= core_files.map { |f| f.basename(".rb").to_s }.sort
+    CoreFormulaRepository.instance.formula_names
   end
 
   # an array of all core {Formula} files
   # @private
   def self.core_files
-    @core_files ||= Pathname.glob("#{HOMEBREW_LIBRARY}/Formula/*.rb")
+    CoreFormulaRepository.instance.formula_files
   end
 
   # an array of all tap {Formula} names
@@ -1130,13 +1130,13 @@ class Formula
   # an array of all alias files of core {Formula}
   # @private
   def self.core_alias_files
-    @core_alias_files ||= Pathname.glob("#{HOMEBREW_LIBRARY}/Aliases/*")
+    CoreFormulaRepository.instance.alias_files
   end
 
   # an array of all core aliases
   # @private
   def self.core_aliases
-    @core_aliases ||= core_alias_files.map { |f| f.basename.to_s }.sort
+    CoreFormulaRepository.instance.aliases
   end
 
   # an array of all tap aliases
@@ -1160,24 +1160,13 @@ class Formula
   # a table mapping core alias to formula name
   # @private
   def self.core_alias_table
-    return @core_alias_table if @core_alias_table
-    @core_alias_table = Hash.new
-    core_alias_files.each do |alias_file|
-      @core_alias_table[alias_file.basename.to_s] = alias_file.resolved_path.basename(".rb").to_s
-    end
-    @core_alias_table
+    CoreFormulaRepository.instance.alias_table
   end
 
   # a table mapping core formula name to aliases
   # @private
   def self.core_alias_reverse_table
-    return @core_alias_reverse_table if @core_alias_reverse_table
-    @core_alias_reverse_table = Hash.new
-    core_alias_table.each do |alias_name, formula_name|
-      @core_alias_reverse_table[formula_name] ||= []
-      @core_alias_reverse_table[formula_name] << alias_name
-    end
-    @core_alias_reverse_table
+    CoreFormulaRepository.instance.alias_reverse_table
   end
 
   def self.[](name)

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -12,7 +12,7 @@ class FormulaVersions
   def initialize(formula)
     @name = formula.name
     @path = formula.path
-    @repository = formula.tap? ? HOMEBREW_LIBRARY.join("Taps", formula.tap) : HOMEBREW_REPOSITORY
+    @repository = formula.tap.path
     @entry_name = @path.relative_path_from(repository).to_s
   end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -262,14 +262,6 @@ class Formulary
       return FromUrlLoader.new(ref)
     when Pathname::BOTTLE_EXTNAME_RX
       return BottleLoader.new(ref)
-    when HOMEBREW_CORE_FORMULA_REGEX
-      name = $1
-      formula_with_that_name = core_path(name)
-      if (newname = FORMULA_RENAMES[name]) && !formula_with_that_name.file?
-        return FormulaLoader.new(newname, core_path(newname))
-      else
-        return FormulaLoader.new(name, formula_with_that_name)
-      end
     when HOMEBREW_TAP_FORMULA_REGEX
       return TapLoader.new(ref)
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -150,7 +150,7 @@ class Formulary
       path = @tap.formula_files.detect { |file| file.basename(".rb").to_s == name }
 
       unless path
-        if (possible_alias = @tap.path/"Aliases/#{name}").file?
+        if (possible_alias = @tap.alias_dir/name).file?
           path = possible_alias.resolved_path
           name = path.basename(".rb").to_s
         else

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -326,7 +326,7 @@ class Formulary
   end
 
   def self.core_path(name)
-    Pathname.new("#{HOMEBREW_LIBRARY}/Formula/#{name.downcase}.rb")
+    CoreFormulaRepository.instance.formula_dir/"#{name.downcase}.rb"
   end
 
   def self.tap_paths(name, taps = Dir["#{HOMEBREW_LIBRARY}/Taps/*/*/"])

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -289,7 +289,7 @@ class Formulary
       return FormulaLoader.new(name, path)
     end
 
-    if newref = FORMULA_RENAMES[ref]
+    if newref = CoreFormulaRepository.instance.formula_renames[ref]
       formula_with_that_oldname = core_path(newref)
       if formula_with_that_oldname.file?
         return FormulaLoader.new(newref, formula_with_that_oldname)

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -31,7 +31,7 @@ class Migrator
       msg = if tap == "Homebrew/homebrew"
         "Please try to use #{formula.oldname} to refer the formula.\n"
       elsif tap
-        "Please try to use fully-qualified #{Tap.fetch(*tap.split("/"))}/#{formula.oldname} to refer the formula.\n"
+        "Please try to use fully-qualified #{tap}/#{formula.oldname} to refer the formula.\n"
       end
 
       super <<-EOS.undent
@@ -117,7 +117,7 @@ class Migrator
   # Fix INSTALL_RECEIPTS for tap-migrated formula.
   def fix_tabs
     old_tabs.each do |tab|
-      tab.source["tap"] = formula.tap
+      tab.tap = formula.tap
       tab.write
     end
   end
@@ -132,10 +132,10 @@ class Migrator
     # newname's tap is the same as tap to which oldname migrated, then we
     # can perform migrations and the taps for oldname and newname are the same.
     elsif TAP_MIGRATIONS && (rec = TAP_MIGRATIONS[formula.oldname]) \
-        && rec == formula.tap.sub("homebrew-", "") && old_tap == "Homebrew/homebrew"
+        && formula.tap == rec && old_tap == "Homebrew/homebrew"
       fix_tabs
       true
-    elsif formula.tap
+    else
       false
     end
   end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -28,7 +28,7 @@ class Tab < OpenStruct
       "stdlib" => stdlib,
       "source" => {
         "path" => formula.path.to_s,
-        "tap" => formula.tap,
+        "tap" => formula.tap ? formula.tap.name : nil,
         "spec" => formula.active_spec_sym.to_s
       }
     }
@@ -116,7 +116,11 @@ class Tab < OpenStruct
     else
       tab = empty
       tab.unused_options = f.options.as_flags
-      tab.source = { "path" => f.path.to_s, "tap" => f.tap, "spec" => f.active_spec_sym.to_s }
+      tab.source = {
+        "path" => f.path.to_s,
+        "tap" => f.tap ? f.tap.name : f.tap,
+        "spec" => f.active_spec_sym.to_s,
+      }
     end
 
     tab
@@ -194,11 +198,13 @@ class Tab < OpenStruct
   end
 
   def tap
-    source["tap"]
+    tap_name = source["tap"]
+    Tap.fetch(tap_name) if tap_name
   end
 
   def tap=(tap)
-    source["tap"] = tap
+    tap_name = tap.respond_to?(:name) ? tap.name : tap
+    source["tap"] = tap_name
   end
 
   def spec

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -152,10 +152,15 @@ class Tap
     remote.casecmp("https://github.com/#{user}/homebrew-#{repo}") != 0
   end
 
+  # path to the directory of all {Formula} files for this {Tap}.
+  def formula_dir
+    @formula_dir ||= [path/"Formula", path/"HomebrewFormula", path].detect(&:directory?)
+  end
+
   # an array of all {Formula} files of this {Tap}.
   def formula_files
-    @formula_files ||= if dir = [path/"Formula", path/"HomebrewFormula", path].detect(&:directory?)
-      dir.children.select { |p| p.extname == ".rb" }
+    @formula_files ||= if formula_dir
+      formula_dir.children.select { |p| p.extname == ".rb" }
     else
       []
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -108,6 +108,11 @@ class Tap
     path.directory?
   end
 
+  # @private
+  def core_formula_repository?
+    false
+  end
+
   # install this {Tap}.
   #
   # @param [Hash] options
@@ -363,6 +368,11 @@ class CoreFormulaRepository < Tap
   # @private
   def custom_remote?
     remote != "https://github.com/#{user}/#{repo}.git"
+  end
+
+  # @private
+  def core_formula_repository?
+    true
   end
 
   # @private

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -297,6 +297,11 @@ class Tap
     end
   end
 
+  def ==(other)
+    other = Tap.fetch(other) if other.is_a?(String)
+    self.class == other.class && self.name == other.name
+  end
+
   def self.each
     return unless TAP_DIRECTORY.directory?
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -171,10 +171,16 @@ class Tap
     @formula_names ||= formula_files.map { |f| "#{name}/#{f.basename(".rb")}" }
   end
 
+  # path to the directory of all alias files for this {Tap}.
+  # @private
+  def alias_dir
+    path/"Aliases"
+  end
+
   # an array of all alias files of this {Tap}.
   # @private
   def alias_files
-    @alias_files ||= Pathname.glob("#{path}/Aliases/*").select(&:file?)
+    @alias_files ||= Pathname.glob("#{alias_dir}/*").select(&:file?)
   end
 
   # an array of all aliases of this {Tap}.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -168,7 +168,7 @@ class Tap
 
   # an array of all {Formula} names of this {Tap}.
   def formula_names
-    @formula_names ||= formula_files.map { |f| "#{name}/#{f.basename(".rb")}" }
+    @formula_names ||= formula_files.map { |f| formula_file_to_name(f) }
   end
 
   # path to the directory of all alias files for this {Tap}.
@@ -186,7 +186,7 @@ class Tap
   # an array of all aliases of this {Tap}.
   # @private
   def aliases
-    @aliases ||= alias_files.map { |f| "#{name}/#{f.basename}" }
+    @aliases ||= alias_files.map { |f| alias_file_to_name(f) }
   end
 
   # a table mapping alias to formula name
@@ -195,7 +195,7 @@ class Tap
     return @alias_table if @alias_table
     @alias_table = Hash.new
     alias_files.each do |alias_file|
-      @alias_table["#{name}/#{alias_file.basename}"] = "#{name}/#{alias_file.resolved_path.basename(".rb")}"
+      @alias_table[alias_file_to_name(alias_file)] = formula_file_to_name(alias_file.resolved_path)
     end
     @alias_table
   end
@@ -290,5 +290,15 @@ class Tap
   # an array of all installed {Tap} names.
   def self.names
     map(&:name)
+  end
+
+  private
+
+  def formula_file_to_name(file)
+    "#{name}/#{file.basename(".rb")}"
+  end
+
+  def alias_file_to_name(file)
+    "#{name}/#{file.basename}"
   end
 end

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,7 +1,5 @@
 # match taps' formulae, e.g. someuser/sometap/someformula
 HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.]+)$}
-# match core's formulae, e.g. homebrew/homebrew/someformula
-HOMEBREW_CORE_FORMULA_REGEX = %r{^homebrew/homebrew/([\w+-.]+)$}i
 # match taps' directory paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+)/([\w-]+)}
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,5 +1,3 @@
-# match expressions when taps are given as ARGS, e.g. someuser/sometap
-HOMEBREW_TAP_ARGS_REGEX = %r{^([\w-]+)/(homebrew-)?([\w-]+)$}
 # match taps' formulae, e.g. someuser/sometap/someformula
 HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.]+)$}
 # match core's formulae, e.g. homebrew/homebrew/someformula

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -59,7 +59,7 @@ class TabTests < Homebrew::TestCase
 
   def test_other_attributes
     assert_equal TEST_SHA1, @tab.HEAD
-    assert_equal "Homebrew/homebrew", @tab.tap
+    assert_equal "Homebrew/homebrew", @tab.tap.name
     assert_nil @tab.time
     refute_predicate @tab, :built_as_bottle
     assert_predicate @tab, :poured_from_bottle
@@ -73,7 +73,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
-    assert_equal "Homebrew/homebrew", tab.tap
+    assert_equal "Homebrew/homebrew", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD
@@ -89,7 +89,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
-    assert_equal "Homebrew/homebrew", tab.tap
+    assert_equal "Homebrew/homebrew", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD


### PR DESCRIPTION
* introduce CoreTap singleton class.
* avoid duplicated logic shared by core formulae and tap formulae.
* make `Formula#tap` and `Tab#tap` return tap object or nil.
* Tap#==: allow compare with string. This along with `Tap#to_s` should help to keep backward compatibility.

Test and feedback is required due to the change magnitude.

As bonus, this will help future core code and formulae separation. 
As second bonus, this fixes #42553 once for all.
