### PR TITLE
fix mplayer_1.2 and clean up formula

### DIFF
--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -22,21 +22,8 @@ class Mplayer < Formula
     patch :DATA
   end
 
-  option "without-osd", "Build without OSD"
-
   depends_on "yasm" => :build
   depends_on "libcaca" => :optional
-  depends_on :x11 => :optional
-
-  deprecated_option "with-x" => "with-x11"
-
-  if build.with?("osd") || build.with?("x11")
-    # These are required for the OSD. We can get them from X11, or we can
-    # build our own.
-    depends_on "fontconfig"
-    depends_on "freetype"
-    depends_on "libpng"
-  end
 
   fails_with :clang do
     build 211
@@ -51,18 +38,17 @@ class Mplayer < Formula
     ENV.O1 if ENV.compiler == :llvm
 
     # we disable cdparanoia because homebrew's version is hacked to work on OS X
-    # and mplayer doesn't expect the hacks we apply. So it chokes.
+    # and mplayer doesn't expect the hacks we apply. So it chokes. Only relevant
+    # if you have cdparanoia installed.
     # Specify our compiler to stop ffmpeg from defaulting to gcc.
     args = %W[
-      --prefix=#{prefix}
       --cc=#{ENV.cc}
       --host-cc=#{ENV.cc}
       --disable-cdparanoia
+      --prefix=#{prefix}
+      --disable-x11
     ]
 
-    args << "--enable-menu" if build.with? "osd"
-    args << "--disable-x11" if build.without? "x11"
-    args << "--enable-freetype" if build.with?("osd") || build.with?("x11")
     args << "--enable-caca" if build.with? "libcaca"
 
     system "./configure", *args


### PR DESCRIPTION
- remove --enable-freetype as it caused the bug where the window stayed black (try running mplayer somevideofile.mkv with the current formula...)
- completely remove osd options and x11 options as --enable-menu is no longer present in ./configure (As far as I can tell, I don't see it) and the new enable-gui requires gtk+
- also, I don't think we really need to care about 10.6 systems or leopard systems in the recipe itself anymore. I might be wrong, but it works on 10.11.1 (and I sadly can't test on more systems).
- if one wants to have a GUI (*not* to be confused by subtitles support and the white ovberlays that appear when one presses the arrow keys during playback), one needs to fiddle with x11 (probably one roadblock is https://github.com/Homebrew/homebrew/issues/46748), getting gtk+ AND a skin file according to https://www.mplayerhq.hu/DOCS/README
- also removed other old options. If they are needed for older systems, they can be brought back of course. I only tested on 10.11.1