### PR TITLE
cayley: fix install failure

### DIFF
--- a/Library/Formula/cayley.rb
+++ b/Library/Formula/cayley.rb
@@ -92,7 +92,7 @@ class Cayley < Formula
     ln_s buildpath, "src/github.com/google/cayley"
 
     # Build
-    system "go", "build", "-o", "cayley"
+    system "go", "build", "-o", "cayley", "github.com/google/cayley"
 
     # Create sample configuration that uses the Homebrew-based directories
     inreplace "cayley.cfg.example", "/tmp/cayley_test", "#{var}/cayley"


### PR DESCRIPTION
fixed from error

```
==> go build -o cayley
package .
	imports github.com/google/cayley/internal: use of internal package not allowed
```