### PR TITLE
aws-apigateway-importer 1.0.1 (new formula)

### DIFF
--- a/Library/Formula/aws-apigateway-importer.rb
+++ b/Library/Formula/aws-apigateway-importer.rb
@@ -1,0 +1,20 @@
+class AwsApigatewayImporter < Formula
+  desc "AWS API Gateway Importer"
+  homepage "https://github.com/awslabs/aws-apigateway-importer"
+  url "https://github.com/awslabs/aws-apigateway-importer/archive/aws-apigateway-importer-1.0.1.tar.gz"
+  sha256 "1aecfd348135c2e364ce5e105d91d5750472ac4cb8848679d774a2ac00024d26"
+
+  depends_on :java => "1.7+"
+  depends_on "maven" => :build
+
+  def install
+    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{buildpath}"
+    system "mvn", "assembly:assembly"
+    libexec.install "target/aws-apigateway-importer-1.0.1-jar-with-dependencies.jar"
+    bin.write_jar_script libexec/"aws-apigateway-importer-1.0.1-jar-with-dependencies.jar", "aws-api-import"
+  end
+
+  test do
+    assert_match(/^Usage:\s+aws-api-import/, shell_output("#{bin}/aws-api-import --help"))
+  end
+end


### PR DESCRIPTION
New formula for the AWS API Gateway Importer: https://github.com/awslabs/aws-apigateway-importer