### PR TITLE
Add support for SASL client for MongoDB

### DIFF
--- a/Library/Formula/mongodb.rb
+++ b/Library/Formula/mongodb.rb
@@ -84,6 +84,7 @@ class Mongodb < Formula
       args << "CXX=#{ENV.cxx}"
     end
 
+    args << "--use-sasl-client" if build.with? "sasl"
     args << "--use-system-boost" if build.with? "boost"
     args << "--use-new-tools"
     args << "--disable-warnings-as-errors" if MacOS.version >= :yosemite


### PR DESCRIPTION
Add support for SASL client to allow shell to use SASL auth (e.g. Kerberos) to MongoDB Enterprise