### PR TITLE
[WIP] sandbox: disable network access.

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -141,8 +141,15 @@ class Sandbox
   class SandboxProfile
     SEATBELT_ERB = <<-EOS.undent
       (version 1)
+      (deny network-inbound)
+      (deny network-outbound)
       (debug deny) ; log all denied operations to /var/log/system.log
       <%= rules.join("\n") %>
+      (allow network-outbound
+        (subpath "/tmp")
+        (subpath "/private")
+        (subpath "#{HOMEBREW_TEMP}")
+        )
       (allow file-write*
           (literal "/dev/ptmx")
           (literal "/dev/dtracehelper")


### PR DESCRIPTION
Obviously this would need a lot more testing but thought I'd open it for some discussion. We could also disable file reads too.

On top of this MacPorts has a cool library hack that means you can, rather than making files fail to read, make files just show as missing (so it doesn't error out).

CC @xu-cheng particularly for thoughts.