### PR TITLE
Handle Java sandboxed caching better

### DIFF
--- a/Library/Formula/ammonite-repl.rb
+++ b/Library/Formula/ammonite-repl.rb
@@ -15,13 +15,15 @@ class AmmoniteRepl < Formula
   depends_on "sbt" => :build
 
   def install
-    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{buildpath}"
+    ENV.java_cache
+
     system "sbt", "repl/assembly"
     bin.install "repl/target/scala-2.11/ammonite-repl-0.5.1-2.11.7" => "amm"
   end
 
   test do
-    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{testpath}"
+    ENV.java_cache
+
     assert_equal "hello world!", shell_output("#{bin}/amm -c 'print(\"hello world!\")'")
   end
 end

--- a/Library/Formula/gdub.rb
+++ b/Library/Formula/gdub.rb
@@ -13,9 +13,9 @@ class Gdub < Formula
   end
 
   test do
-    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{testpath}"
-    system "gradle", "init"
+    ENV.java_cache
 
+    system "gradle", "init"
     cd "gradle" do
       system bin/"gw", "tasks"
     end

--- a/Library/Formula/gosu.rb
+++ b/Library/Formula/gosu.rb
@@ -18,7 +18,9 @@ class Gosu < Formula
   skip_clean "libexec/ext"
 
   def install
-    system "mvn", "package", "-Duser.home=#{buildpath}"
+    ENV.java_cache
+
+    system "mvn", "package"
     libexec.install Dir["gosu/target/gosu-#{version}-full/gosu-#{version}/*"]
     (libexec/"ext").mkpath
     bin.install_symlink libexec/"bin/gosu"

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -62,6 +62,10 @@ module Homebrew
         cleanup_path(path) { path.unlink }
         next
       end
+      if path.basename.to_s == "java_cache" && path.directory?
+        cleanup_path(path) { FileUtils.rm_rf path }
+        next
+      end
       if prune?(path)
         if path.file?
           cleanup_path(path) { path.unlink }

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -240,6 +240,10 @@ module SharedEnvExtension
     set_cpu_flags(flags)
   end
 
+  def java_cache
+    append "_JAVA_OPTIONS", "-Duser.home=#{HOMEBREW_CACHE}/java_cache"
+  end
+
   # ld64 is a newer linker provided for Xcode 2.5
   # @private
   def ld64


### PR DESCRIPTION
We talked about this a while back, but for the benefit of new maintainers and/or curious contributors/users as part of the sandbox we've barred things from writing outside cache locations, the buildpath, testpath, etc during installation and tests.

Tim has an open PR to set this globally but at the moment there are an unknown number of formulae that break if you pass `_JAVA_OPTIONS` to them: https://github.com/Homebrew/homebrew/pull/44567. Consequently, we can't really set it globally until upstream move on it & we can do extensive testing in the core.

So far we've been setting some variation of `_JAVA_OPTIONS` in `def install` and `test do`, using one of the following as the variable:
* `ENV["HOME"]` - Pretty much means buildpath/testpath.
* `buildpath` or `testpath`
* `buildpath/".some_hidden_dir"`

The problem with all the above is that it kills off one of the useful features of cache directories in that once you've downloaded the required elements if the build fails you can re-do the build without having to download everything afresh. Some Java-using formulae are grabbing 100+ MB of files during installation, so we're taking liberties with user bandwidth at times under the present system.

The other significantly more minor problem is that using a bunch of different variable names leaves contributors confused as to which they should actually use, something we see pretty often. A single unified `java_cache` option is easier to communicate.

No direct sandbox changes are required because the current sandbox mechanism allows file/folder reading/writing in the cache directories during both install and test.

The `@private` tag in `formula.rb` is intended to mean "Don't use this outside of the core". I appreciate the downsides on that is that people may choose to ignore this. If necessary, rather than scrapping the option entirely once the time comes to make the `_JAVA_OPTIONS` variable global we could just do something like:

```ruby
old_java_options = ENV["_JAVA_OPTIONS"]
ENV.append "_JAVA_OPTIONS", "-Duser.home=#{java_cache}"
```
Which means we won't have to change in-formula code immediately *or* have the code break for people using the private DSL externally. If people prefer that over the shorthand simply being killed at a future date, I'll adjust the notations in `formula.rb` accordingly.

Let the brutal criticism commence! :wink: 