### PR TITLE
git: install Emacs Lisp files

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -127,6 +127,7 @@ class Git < Formula
       cp "#{bash_completion}/git-completion.bash", zsh_completion
     end
 
+    elisp.install Dir["contrib/emacs/*.el"]
     (share+"git-core").install "contrib"
 
     # We could build the manpages ourselves, but the build process depends


### PR DESCRIPTION
Could byte-compile them, but that would mean another option with `depends_on :emacs => [:optional]`