### PR TITLE
splint: audit fix

### DIFF
--- a/Library/Formula/splint.rb
+++ b/Library/Formula/splint.rb
@@ -29,9 +29,8 @@ class Splint < Formula
       }
     EOS
 
-    output = `#{bin}/splint #{path} 2>&1`
-    assert output.include?("5:18: Variable c used before definition")
-    assert_equal 1, $?.exitstatus
+    output = shell_output("#{bin}/splint #{path} 2>&1", 1)
+    assert_match "5:18: Variable c used before definition", output
   end
 end
 


### PR DESCRIPTION
fix audit from error message:

```
splint:
 * Use `assert_match` instead of `assert ...include?`

Error: 1 problem in 1 formula
```