### PR TITLE
brew.rb: improve handling of --version/-v option

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -14,15 +14,12 @@ HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent.join("Homebrew")
 $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
-if ARGV.first == "--version"
-  puts Homebrew.homebrew_version_string
+if ARGV == %w[--version] || ARGV == %w[-v]
+  puts "Homebrew #{Homebrew.homebrew_version_string}"
   exit 0
 elsif ARGV.first == "-v"
-  puts "Homebrew #{Homebrew.homebrew_version_string}"
   # Shift the -v to the end of the parameter list
   ARGV << ARGV.shift
-  # If no other arguments, just quit here.
-  exit 0 if ARGV.length == 1
 end
 
 if OS.mac?


### PR DESCRIPTION
Make both `--version` and `-v` print the Homebrew version and exit, if provided as first and sole argument. `brew --version` no longer accepts additional arguments (they were previously ignored). Otherwise interpret `brew -v <arguments>` as if `brew <arguments> -v` was executed instead (no change here), but no longer print a line with the Homebrew version.

See #46387 for discussion leading to this PR.