### PR TITLE
--with-sasl is displayed in brew options mongodb

### DIFF
--- a/Library/Formula/mongodb.rb
+++ b/Library/Formula/mongodb.rb
@@ -34,6 +34,7 @@ class Mongodb < Formula
   end
 
   option "with-boost", "Compile using installed boost, not the version shipped with mongodb"
+  option "with-sasl", "Compile with SASL support"
 
   needs :cxx11
 


### PR DESCRIPTION
This is related to pull request #46765.
This commit causes the --with-sasl option to be displayed when `brew options mongodb` is executed.
It also looks like it fixes a bug, as I (at least occasionally) had trouble getting brew to not use a bottle when --with-sasl was used (and using a bottle resulted in the switch being effectively ignored).