### PR TITLE
audit: flag '--with{,out}-check' options

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -372,6 +372,10 @@ class FormulaAuditor
       if o.name !~ /with(out)?-/ && o.name != "c++11" && o.name != "universal" && o.name != "32-bit"
         problem "Options should begin with with/without. Migrate '--#{o.name}' with `deprecated_option`."
       end
+
+      if o.name =~ /with(out)?-check/
+        problem "Use '--with#{$1}-test' instead of '--with#{$1}-check'."
+      end
     end
   end
 


### PR DESCRIPTION
I didn’t check for `--with-tests` because [`mariadb.rb`](https://github.com/Homebrew/homebrew/blob/f27da993b90856c7d8dceea3953e03c16be1431f/Library/Formula/mariadb.rb#L14) uses it for a different purpose than running compile-time tests.