### PR TITLE
Don't recommend `source` on nvm info, it's not POSIX-compliant

### DIFF
--- a/Library/Formula/nvm.rb
+++ b/Library/Formula/nvm.rb
@@ -25,7 +25,7 @@ class Nvm < Formula
     configuration file:
 
       export NVM_DIR=~/.nvm
-      source $(brew --prefix nvm)/nvm.sh
+      . $(brew --prefix nvm)/nvm.sh
 
     You can set $NVM_DIR to any location, but leaving it unchanged from
     #{prefix} will destroy any nvm-installed Node installations


### PR DESCRIPTION
`source` is a bash-specific built-in which actually isn't even supported by Ruby 
itself: https://github.com/ruby/ruby/blob/a8fb40db8cea8ea998a569989168837e1c33c482/process.c#L2060-L2089

It's probably best not to assume people are using bash.

Alternatively, the nvm docs themselves encourage using `.`: 
https://github.com/creationix/nvm#manual-install