### PR TITLE
manpage: fix formatting of command list (plus minor tweak)

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -29,7 +29,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `list`:
     List all installed formulae.
 
-  * `search` <text> | `/`<text>`/`:
+  * `search` <text>|`/`<text>`/`:
     Perform a substring search of formula names for <text>. If <text> is
     surrounded with slashes, then it is interpreted as a regular expression.
     The search for <text> is extended online to some popular taps.

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -377,21 +377,21 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `switch` <name> <version>:
     Symlink all of the specific <version> of <name>'s install to Homebrew prefix.
 
+  * `tap`:
+    List all installed taps.
+
   * `tap` [`--full`] <user>`/`<repo> [<URL>]:
-    Tap a formula repository or list existing taps. This command can be invoked
-    in three ways.
+    Tap a formula repository.
 
-    + `tap` without arguments displays existing taps.
+    With <URL> unspecified, taps a formula repository from GitHub using HTTPS.
+    Since so many taps are hosted on GitHub, this command is a shortcut for
+    `tap <user>/<repo> https://github.com/<user>/homebrew-<repo>`.
 
-    + `tap` <user>`/`<repo> taps a formula repository from GitHub using HTTPS.
-      Since so many taps are hosted on GitHub, this command is a shortcut for
-      `tap <user>/<repo> https://github.com/<user>/homebrew-<repo>`.
-
-    + `tap` <user>`/`<repo> <URL> taps a formula repository from anywhere, using
-      any transport protocol that `git` handles. The one-argument form of `tap`
-      simplifies but also limits.  This two-argument command makes no
-      assumptions, so taps can be cloned from places other than GitHub and
-      using protocols other than HTTPS, e.g., SSH, GIT, HTTP, FTP(S), RSYNC.
+    With <URL> specified, taps a formula repository from anywhere, using
+    any transport protocol that `git` handles. The one-argument form of `tap`
+    simplifies but also limits. This two-argument command makes no
+    assumptions, so taps can be cloned from places other than GitHub and
+    using protocols other than HTTPS, e.g., SSH, GIT, HTTP, FTP(S), RSYNC.
 
     By default, the repository is cloned as a shallow copy (`--depth=1`), but
     if `--full` is passed, a full clone will be used.

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -34,9 +34,8 @@ If no search term is given, all locally available formulae are listed.</p></dd>
 
 <h2 id="COMMANDS">COMMANDS</h2>
 
-<ul>
-<li><p><code>audit</code> [<code>--strict</code>] [<code>--online</code>] [<var>formulae</var>]:
-Check <var>formulae</var> for Homebrew coding style violations. This should be
+<dl>
+<dt><code>audit</code> [<code>--strict</code>] [<code>--online</code>] [<var>formulae</var>]</dt><dd><p>Check <var>formulae</var> for Homebrew coding style violations. This should be
 run before submitting a new formula.</p>
 
 <p>If no <var>formulae</var> are provided, all of them are checked.</p>
@@ -48,11 +47,9 @@ when creating for new formulae.</p>
 connection are run. This should be used when creating for new formulae.</p>
 
 <p><code>audit</code> exits with a non-zero status if any errors are found. This is useful,
-for instance, for implementing pre-commit hooks.</p></li>
-<li><p><code>cat</code> <var>formula</var>:
-Display the source to <var>formula</var>.</p></li>
-<li><p><code>cleanup</code> [<code>--force</code>] [<code>--prune=</code><var>days</var>] [<code>-n</code>] [<code>-s</code>] [<var>formulae</var>]:
-For all installed or specific formulae, remove any older versions from the
+for instance, for implementing pre-commit hooks.</p></dd>
+<dt><code>cat</code> <var>formula</var></dt><dd><p>Display the source to <var>formula</var>.</p></dd>
+<dt><code>cleanup</code> [<code>--force</code>] [<code>--prune=</code><var>days</var>] [<code>-n</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
 cellar. By default, does not remove out-of-date keg-only brews, as other
 software may link directly to specific versions. In addition, old downloads from
 the Homebrew download-cache are deleted.</p>
@@ -65,20 +62,16 @@ the Homebrew download-cache are deleted.</p>
 
 <p>If <code>-s</code> is passed, scrubs the cache, removing downloads for even the latest
 versions of formulae. Note downloads for any installed formulae will still not be
-deleted. If you want to delete those too: <code>rm -rf $(brew --cache)</code></p></li>
-<li><p><code>command</code> <var>cmd</var>:
-Display the path to the file which is used when invoking <code>brew</code> <var>cmd</var>.</p></li>
-<li><p><code>commands</code> [<code>--quiet</code> [<code>--include-aliases</code>]]:
-Show a list of built-in and external commands.</p>
+deleted. If you want to delete those too: <code>rm -rf $(brew --cache)</code></p></dd>
+<dt><code>command</code> <var>cmd</var></dt><dd><p>Display the path to the file which is used when invoking <code>brew</code> <var>cmd</var>.</p></dd>
+<dt><code>commands</code> [<code>--quiet</code> [<code>--include-aliases</code>]]</dt><dd><p>Show a list of built-in and external commands.</p>
 
 <p>If <code>--quiet</code> is passed, list only the names of commands without the header.
-With <code>--include-aliases</code>, the aliases of internal commands will be included.</p></li>
-<li><p><code>config</code>:
-Show Homebrew and system configuration useful for debugging. If you file
+With <code>--include-aliases</code>, the aliases of internal commands will be included.</p></dd>
+<dt class="flush"><code>config</code></dt><dd><p>Show Homebrew and system configuration useful for debugging. If you file
 a bug report, you will likely be asked for this information if you do not
-provide it.</p></li>
-<li><p><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>]:
-Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
+provide it.</p></dd>
+<dt><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>]</dt><dd><p>Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
 Homebrew will attempt to automatically derive the formula name
 and version, but if it fails, you'll have to make your own template. The <code>wget</code>
 formula serves as a simple example. For the complete API have a look at</p>
@@ -92,9 +85,8 @@ If <code>--cmake</code> is passed, create a basic template for a CMake-style bui
 will thus not add the SHA256 to the formula for you.</p>
 
 <p>The options <code>--set-name</code> and <code>--set-version</code> each take an argument and allow
-you to explicitly set the name and version of the package you are creating.</p></li>
-<li><p><code>deps</code> [<code>--1</code>] [<code>-n</code>] [<code>--union</code>] [<code>--tree</code>] [<code>--all</code>] [<code>--installed</code>] [<code>--skip-build</code>] [<code>--skip-optional</code>] <var>formulae</var>:
-Show dependencies for <var>formulae</var>. When given multiple formula arguments,
+you to explicitly set the name and version of the package you are creating.</p></dd>
+<dt><code>deps</code> [<code>--1</code>] [<code>-n</code>] [<code>--union</code>] [<code>--tree</code>] [<code>--all</code>] [<code>--installed</code>] [<code>--skip-build</code>] [<code>--skip-optional</code>] <var>formulae</var></dt><dd><p>Show dependencies for <var>formulae</var>. When given multiple formula arguments,
 show the intersection of dependencies for <var>formulae</var>, except when passed
 <code>--tree</code>, <code>--all</code>, or <code>--installed</code>.</p>
 
@@ -114,33 +106,26 @@ instead of the intersection.</p>
 
 <p>By default, <code>deps</code> shows dependencies for <var>formulae</var>. To skip the <code>:build</code>
 type dependencies, pass <code>--skip-build</code>. Similarly, pass <code>--skip-optional</code>
-to skip <code>:optional</code> dependencies.</p></li>
-<li><p><code>desc</code> <var>formula</var>:
-Display <var>formula</var>'s name and one-line description.</p></li>
-<li><p><code>desc</code> [<code>-s</code>|<code>-n</code>|<code>-d</code>] <var>pattern</var>:
-Search both name and description (<code>-s</code>), just the names (<code>-n</code>), or just  the
+to skip <code>:optional</code> dependencies.</p></dd>
+<dt><code>desc</code> <var>formula</var></dt><dd><p>Display <var>formula</var>'s name and one-line description.</p></dd>
+<dt><code>desc</code> [<code>-s</code>|<code>-n</code>|<code>-d</code>] <var>pattern</var></dt><dd><p>Search both name and description (<code>-s</code>), just the names (<code>-n</code>), or just  the
 descriptions (<code>-d</code>) for <code>&lt;pattern></code>. <code>&lt;pattern></code> is by default interpreted
 as a literal string; if flanked by slashes, it is instead interpreted as a
 regular expression. Formula descriptions are cached; the cache is created on
-the first search, making that search slower than subsequent ones.</p></li>
-<li><p><code>diy</code> [<code>--name=</code><var>name</var>] [<code>--version=</code><var>version</var>]:
-Automatically determine the installation prefix for non-Homebrew software.</p>
+the first search, making that search slower than subsequent ones.</p></dd>
+<dt><code>diy</code> [<code>--name=</code><var>name</var>] [<code>--version=</code><var>version</var>]</dt><dd><p>Automatically determine the installation prefix for non-Homebrew software.</p>
 
 <p>Using the output from this command, you can install your own software into
 the Cellar and then link it into Homebrew's prefix with <code>brew link</code>.</p>
 
 <p>The options <code>--name=</code><var>name</var> and <code>--version=</code><var>version</var> each take an argument
 and allow you to explicitly set the name and version of the package you are
-installing.</p></li>
-<li><p><code>doctor</code>:
-Check your system for potential problems. Doctor exits with a non-zero status
-if any problems are found.</p></li>
-<li><p><code>edit</code>:
-Open all of Homebrew for editing.</p></li>
-<li><p><code>edit</code> <var>formula</var>:
-Open <var>formula</var> in the editor.</p></li>
-<li><p><code>fetch</code> [<code>--force</code>] [<code>-v</code>] [<code>--devel</code>|<code>--HEAD</code>] [<code>--deps</code>] [<code>--build-from-source</code>|<code>--force-bottle</code>] <var>formulae</var>:
-Download the source packages for the given <var>formulae</var>.
+installing.</p></dd>
+<dt class="flush"><code>doctor</code></dt><dd><p>Check your system for potential problems. Doctor exits with a non-zero status
+if any problems are found.</p></dd>
+<dt class="flush"><code>edit</code></dt><dd><p>Open all of Homebrew for editing.</p></dd>
+<dt><code>edit</code> <var>formula</var></dt><dd><p>Open <var>formula</var> in the editor.</p></dd>
+<dt><code>fetch</code> [<code>--force</code>] [<code>-v</code>] [<code>--devel</code>|<code>--HEAD</code>] [<code>--deps</code>] [<code>--build-from-source</code>|<code>--force-bottle</code>] <var>formulae</var></dt><dd><p>Download the source packages for the given <var>formulae</var>.
 For tarballs, also print SHA-1 and SHA-256 checksums.</p>
 
 <p>If <code>--HEAD</code> or <code>--devel</code> is passed, fetch that version instead of the
@@ -157,28 +142,22 @@ This is useful for seeing if an existing VCS cache has been updated.</p>
 bottle.</p>
 
 <p>If <code>--force-bottle</code> is passed, download a bottle if it exists for the current
-version of OS X, even if it would not be used during installation.</p></li>
-<li><p><code>home</code>:
-Open Homebrew's own homepage in a browser.</p></li>
-<li><p><code>home</code> <var>formula</var>:
-Open <var>formula</var>'s homepage in a browser.</p></li>
-<li><p><code>info</code> <var>formula</var>:
-Display information about <var>formula</var>.</p></li>
-<li><p><code>info</code> <code>--github</code> <var>formula</var>:
-Open a browser to the GitHub History page for formula <var>formula</var>.</p>
+version of OS X, even if it would not be used during installation.</p></dd>
+<dt class="flush"><code>home</code></dt><dd><p>Open Homebrew's own homepage in a browser.</p></dd>
+<dt><code>home</code> <var>formula</var></dt><dd><p>Open <var>formula</var>'s homepage in a browser.</p></dd>
+<dt><code>info</code> <var>formula</var></dt><dd><p>Display information about <var>formula</var>.</p></dd>
+<dt><code>info</code> <code>--github</code> <var>formula</var></dt><dd><p>Open a browser to the GitHub History page for formula <var>formula</var>.</p>
 
-<p>To view formula history locally: <code>brew log -p &lt;formula></code>.</p></li>
-<li><p><code>info --json=</code><var>version</var> (<code>--all</code>|<code>--installed</code>|<var>formulae</var>):
-Print a JSON representation of <var>formulae</var>. Currently the only accepted value
+<p>To view formula history locally: <code>brew log -p &lt;formula></code>.</p></dd>
+<dt><code>info --json=</code><var>version</var> (<code>--all</code>|<code>--installed</code>|<var>formulae</var>)</dt><dd><p>Print a JSON representation of <var>formulae</var>. Currently the only accepted value
 for <var>version</var> is <code>v1</code>.</p>
 
 <p>Pass <code>--all</code> to get information on all formulae, or <code>--installed</code> to get
 information on all installed formulae.</p>
 
 <p>See the docs for examples of using the JSON:
-<a href="https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md" data-bare-link="true">https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md</a></p></li>
-<li><p><code>install</code> [<code>--debug</code>] [<code>--env=</code><var>std</var>|<var>super</var>] [<code>--ignore-dependencies</code>] [<code>--only-dependencies</code>] [<code>--cc=</code><var>compiler</var>] [<code>--build-from-source</code>|<code>--force-bottle</code>] [<code>--devel</code>|<code>--HEAD</code>] <var>formula</var>:
-Install <var>formula</var>.</p>
+<a href="https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md" data-bare-link="true">https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md</a></p></dd>
+<dt><code>install</code> [<code>--debug</code>] [<code>--env=</code><var>std</var>|<var>super</var>] [<code>--ignore-dependencies</code>] [<code>--only-dependencies</code>] [<code>--cc=</code><var>compiler</var>] [<code>--build-from-source</code>|<code>--force-bottle</code>] [<code>--devel</code>|<code>--HEAD</code>] <var>formula</var></dt><dd><p>Install <var>formula</var>.</p>
 
 <p><var>formula</var> is usually the name of the formula to install, but it can be specified
 several different ways. See <a href="#SPECIFYING-FORMULAE" title="SPECIFYING FORMULAE" data-bare-link="true">SPECIFYING FORMULAE</a>.</p>
@@ -215,22 +194,18 @@ for the current version of OS X, even if custom options are given.</p>
 aka master, trunk, unstable.</p>
 
 <p>To install a newer version of HEAD use
-<code>brew rm &lt;foo> &amp;&amp; brew install --HEAD &lt;foo></code>.</p></li>
-<li><p><code>install --interactive</code> [<code>--git</code>] <var>formula</var>:
-Download and patch <var>formula</var>, then open a shell. This allows the user to
+<code>brew rm &lt;foo> &amp;&amp; brew install --HEAD &lt;foo></code>.</p></dd>
+<dt><code>install --interactive</code> [<code>--git</code>] <var>formula</var></dt><dd><p>Download and patch <var>formula</var>, then open a shell. This allows the user to
 run <code>./configure --help</code> and otherwise determine how to turn the software
 package into a Homebrew formula.</p>
 
 <p>If <code>--git</code> is passed, Homebrew will create a Git repository, useful for
-creating patches to the software.</p></li>
-<li><p><code>irb</code> [<code>--examples</code>]:
-Enter the interactive Homebrew Ruby shell.</p>
+creating patches to the software.</p></dd>
+<dt><code>irb</code> [<code>--examples</code>]</dt><dd><p>Enter the interactive Homebrew Ruby shell.</p>
 
-<p>If <code>--examples</code> is passed, several examples will be shown.</p></li>
-<li><p><code>leaves</code>:
-Show installed formulae that are not dependencies of another installed formula.</p></li>
-<li><p><code>ln</code>, <code>link</code> [<code>--overwrite</code>] [<code>--dry-run</code>] [<code>--force</code>] <var>formula</var>:
-Symlink all of <var>formula</var>'s installed files into the Homebrew prefix. This
+<p>If <code>--examples</code> is passed, several examples will be shown.</p></dd>
+<dt class="flush"><code>leaves</code></dt><dd><p>Show installed formulae that are not dependencies of another installed formula.</p></dd>
+<dt><code>ln</code>, <code>link</code> [<code>--overwrite</code>] [<code>--dry-run</code>] [<code>--force</code>] <var>formula</var></dt><dd><p>Symlink all of <var>formula</var>'s installed files into the Homebrew prefix. This
 is done automatically when you install formulae but can be useful for DIY
 installations.</p>
 
@@ -241,23 +216,19 @@ the prefix while linking.</p>
 be linked or which would be deleted by <code>brew link --overwrite</code>, but will not
 actually link or delete any files.</p>
 
-<p>If <code>--force</code> is passed, Homebrew will allow keg-only formulae to be linked.</p></li>
-<li><p><code>linkapps</code> [<code>--local</code>] [<var>formulae</var>]:
-Find installed formulae that have compiled <code>.app</code>-style "application"
+<p>If <code>--force</code> is passed, Homebrew will allow keg-only formulae to be linked.</p></dd>
+<dt><code>linkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Find installed formulae that have compiled <code>.app</code>-style "application"
 packages for OS X, and symlink those apps into <code>/Applications</code>, allowing
 for easier access.</p>
 
 <p>If no <var>formulae</var> are provided, all of them will have their .apps symlinked.</p>
 
 <p>If provided, <code>--local</code> will move them into the user's <code>~/Applications</code>
-directory instead of the system directory. It may need to be created, first.</p></li>
-<li><p><code>ls</code>, <code>list</code> [<code>--full-name</code>]:
-List all installed formulae. If <code>--full-name</code> is passed, print formulae with
-full-qualified names.</p></li>
-<li><p><code>ls</code>, <code>list --unbrewed</code>:
-List all files in the Homebrew prefix not installed by Homebrew.</p></li>
-<li><p><code>ls</code>, <code>list</code> [<code>--versions</code> [<code>--multiple</code>]] [<code>--pinned</code>] [<var>formulae</var>]:
-List the installed files for <var>formulae</var>. Combined with <code>--verbose</code>, recursively
+directory instead of the system directory. It may need to be created, first.</p></dd>
+<dt><code>ls</code>, <code>list</code> [<code>--full-name</code>]</dt><dd><p>List all installed formulae. If <code>--full-name</code> is passed, print formulae with
+full-qualified names.</p></dd>
+<dt><code>ls</code>, <code>list --unbrewed</code></dt><dd><p>List all files in the Homebrew prefix not installed by Homebrew.</p></dd>
+<dt><code>ls</code>, <code>list</code> [<code>--versions</code> [<code>--multiple</code>]] [<code>--pinned</code>] [<var>formulae</var>]</dt><dd><p>List the installed files for <var>formulae</var>. Combined with <code>--verbose</code>, recursively
 list the contents of all subdirectories in each <var>formula</var>'s keg.</p>
 
 <p>If <code>--versions</code> is passed, show the version number for installed formulae,
@@ -266,31 +237,26 @@ only show formulae with multiple versions installed.</p>
 
 <p>If <code>--pinned</code> is passed, show the versions of pinned formulae, or only the
 specified (pinned) formulae if <var>formulae</var> are given.
-See also <code>pin</code>, <code>unpin</code>.</p></li>
-<li><p><code>log</code> [<code>git-log-options</code>] <var>formula</var> ...:
-Show the git log for the given formulae. Options that <code>git-log</code>(1)
-recognizes can be passed before the formula list.</p></li>
-<li><p><code>missing</code> [<var>formulae</var>]:
-Check the given <var>formulae</var> for missing dependencies.</p>
+See also <code>pin</code>, <code>unpin</code>.</p></dd>
+<dt><code>log</code> [<code>git-log-options</code>] <var>formula</var> ...</dt><dd><p>Show the git log for the given formulae. Options that <code>git-log</code>(1)
+recognizes can be passed before the formula list.</p></dd>
+<dt><code>missing</code> [<var>formulae</var>]</dt><dd><p>Check the given <var>formulae</var> for missing dependencies.</p>
 
-<p>If no <var>formulae</var> are given, check all installed brews.</p></li>
-<li><p><code>migrate</code> [<code>--force</code>] <var>formulae</var>:
-Migrate renamed packages to new name, where <var>formulae</var> are old names of
+<p>If no <var>formulae</var> are given, check all installed brews.</p></dd>
+<dt><code>migrate</code> [<code>--force</code>] <var>formulae</var></dt><dd><p>Migrate renamed packages to new name, where <var>formulae</var> are old names of
 packages.</p>
 
 <p>If <code>--force</code> is passed, then treat installed <var>formulae</var> and passed <var>formulae</var>
-like if they are from same taps and migrate them anyway.</p></li>
-<li><p><code>options</code> [<code>--compact</code>] [<code>--all</code>] [<code>--installed</code>] <var>formula</var>:
-Display install options specific to <var>formula</var>.</p>
+like if they are from same taps and migrate them anyway.</p></dd>
+<dt><code>options</code> [<code>--compact</code>] [<code>--all</code>] [<code>--installed</code>] <var>formula</var></dt><dd><p>Display install options specific to <var>formula</var>.</p>
 
 <p>If <code>--compact</code> is passed, show all options on a single line separated by
 spaces.</p>
 
 <p>If <code>--all</code> is passed, show options for all formulae.</p>
 
-<p>If <code>--installed</code> is passed, show options for all installed formulae.</p></li>
-<li><p><code>outdated</code> [<code>--quiet</code>|<code>--verbose</code>|<code>--json=v1</code>]:
-Show formulae that have an updated version available.</p>
+<p>If <code>--installed</code> is passed, show options for all installed formulae.</p></dd>
+<dt><code>outdated</code> [<code>--quiet</code>|<code>--verbose</code>|<code>--json=v1</code>]</dt><dd><p>Show formulae that have an updated version available.</p>
 
 <p>By default, version information is displayed in interactive shells, and
 suppressed otherwise.</p>
@@ -301,79 +267,58 @@ precedence over <code>--verbose</code>).</p>
 <p>If <code>--verbose</code> is passed, display detailed version information.</p>
 
 <p>If <code>--json=</code><var>version</var> is passed, the output will be in JSON format. The only
-valid version is <code>v1</code>.</p></li>
-<li><p><code>pin</code> <var>formulae</var>:
-Pin the specified <var>formulae</var>, preventing them from being upgraded when
-issuing the <code>brew upgrade</code> command. See also <code>unpin</code>.</p></li>
-<li><p><code>prune</code>:
-Remove dead symlinks from the Homebrew prefix. This is generally not
-needed, but can be useful when doing DIY installations.</p></li>
-<li><p><code>reinstall</code> <var>formula</var>:
-Uninstall then install <var>formula</var></p></li>
-<li><p><code>rm</code>, <code>remove</code>, <code>uninstall</code> [<code>--force</code>] <var>formula</var>:
-Uninstall <var>formula</var>.</p>
+valid version is <code>v1</code>.</p></dd>
+<dt><code>pin</code> <var>formulae</var></dt><dd><p>Pin the specified <var>formulae</var>, preventing them from being upgraded when
+issuing the <code>brew upgrade</code> command. See also <code>unpin</code>.</p></dd>
+<dt class="flush"><code>prune</code></dt><dd><p>Remove dead symlinks from the Homebrew prefix. This is generally not
+needed, but can be useful when doing DIY installations.</p></dd>
+<dt><code>reinstall</code> <var>formula</var></dt><dd><p>Uninstall then install <var>formula</var></p></dd>
+<dt><code>rm</code>, <code>remove</code>, <code>uninstall</code> [<code>--force</code>] <var>formula</var></dt><dd><p>Uninstall <var>formula</var>.</p>
 
 <p>If <code>--force</code> is passed, and there are multiple versions of <var>formula</var>
-installed, delete all installed versions.</p></li>
-<li><p><code>search</code>, <code>-S</code>:
-Display all locally available formulae for brewing (including tapped ones).
-No online search is performed if called without arguments.</p></li>
-<li><p><code>search</code>, <code>-S</code> <var>text</var>|<code>/</code><var>text</var><code>/</code>:
-Perform a substring search of formula names for <var>text</var>. If <var>text</var> is
+installed, delete all installed versions.</p></dd>
+<dt><code>search</code>, <code>-S</code></dt><dd><p>Display all locally available formulae for brewing (including tapped ones).
+No online search is performed if called without arguments.</p></dd>
+<dt><code>search</code>, <code>-S</code> <var>text</var>|<code>/</code><var>text</var><code>/</code></dt><dd><p>Perform a substring search of formula names for <var>text</var>. If <var>text</var> is
 surrounded with slashes, then it is interpreted as a regular expression.
-The search for <var>text</var> is extended online to some popular taps.</p></li>
-<li><p><code>search --debian</code>|<code>--fedora</code>|<code>--fink</code>|<code>--macports</code>|<code>--opensuse</code>|<code>--ubuntu</code> <var>text</var>:
-Search for <var>text</var> in the given package manager's list.</p></li>
-<li><p><code>sh</code> [<code>--env=std</code>]:
-Instantiate a Homebrew build environment. Uses our years-battle-hardened
+The search for <var>text</var> is extended online to some popular taps.</p></dd>
+<dt><code>search --debian</code>|<code>--fedora</code>|<code>--fink</code>|<code>--macports</code>|<code>--opensuse</code>|<code>--ubuntu</code> <var>text</var></dt><dd><p>Search for <var>text</var> in the given package manager's list.</p></dd>
+<dt><code>sh</code> [<code>--env=std</code>]</dt><dd><p>Instantiate a Homebrew build environment. Uses our years-battle-hardened
 Homebrew build logic to help your <code>./configure &amp;&amp; make &amp;&amp; make install</code>
 or even your <code>gem install</code> succeed. Especially handy if you run Homebrew
 in an Xcode-only configuration since it adds tools like <code>make</code> to your <code>PATH</code>
-which otherwise build-systems would not find.</p></li>
-<li><p><code>switch</code> <var>name</var> <var>version</var>:
-Symlink all of the specific <var>version</var> of <var>name</var>'s install to Homebrew prefix.</p></li>
-<li><p><code>tap</code> [<code>--full</code>] <var>user</var><code>/</code><var>repo</var> [<var>URL</var>]:
-Tap a formula repository or list existing taps. This command can be invoked
-in three ways.</p>
+which otherwise build-systems would not find.</p></dd>
+<dt><code>switch</code> <var>name</var> <var>version</var></dt><dd><p>Symlink all of the specific <var>version</var> of <var>name</var>'s install to Homebrew prefix.</p></dd>
+<dt class="flush"><code>tap</code></dt><dd><p>List all installed taps.</p></dd>
+<dt><code>tap</code> [<code>--full</code>] <var>user</var><code>/</code><var>repo</var> [<var>URL</var>]</dt><dd><p>Tap a formula repository.</p>
 
-<ul>
-<li><p><code>tap</code> without arguments displays existing taps.</p></li>
-<li><p><code>tap</code> <var>user</var><code>/</code><var>repo</var> taps a formula repository from GitHub using HTTPS.
+<p>With <var>URL</var> unspecified, taps a formula repository from GitHub using HTTPS.
 Since so many taps are hosted on GitHub, this command is a shortcut for
-<code>tap &lt;user>/&lt;repo> https://github.com/&lt;user>/homebrew-&lt;repo></code>.</p></li>
-<li><p><code>tap</code> <var>user</var><code>/</code><var>repo</var> <var>URL</var> taps a formula repository from anywhere, using
-any transport protocol that <code>git</code> handles. The one-argument form of <code>tap</code>
-simplifies but also limits.  This two-argument command makes no
-assumptions, so taps can be cloned from places other than GitHub and
-using protocols other than HTTPS, e.g., SSH, GIT, HTTP, FTP(S), RSYNC.</p></li>
-</ul>
+<code>tap &lt;user>/&lt;repo> https://github.com/&lt;user>/homebrew-&lt;repo></code>.</p>
 
+<p>With <var>URL</var> specified, taps a formula repository from anywhere, using
+any transport protocol that <code>git</code> handles. The one-argument form of <code>tap</code>
+simplifies but also limits. This two-argument command makes no
+assumptions, so taps can be cloned from places other than GitHub and
+using protocols other than HTTPS, e.g., SSH, GIT, HTTP, FTP(S), RSYNC.</p>
 
 <p>By default, the repository is cloned as a shallow copy (<code>--depth=1</code>), but
-if <code>--full</code> is passed, a full clone will be used.</p></li>
-<li><p><code>tap --repair</code>:
-Migrate tapped formulae from symlink-based to directory-based structure.</p></li>
-<li><p><code>tap --list-official</code>:
-List all official taps.</p></li>
-<li><p><code>tap --list-pinned</code>:
-List all pinned taps.</p></li>
-<li><p><code>tap-info</code> <var>tap</var>:
-Display information about <var>tap</var>.</p></li>
-<li><p><code>tap-info</code> <code>--json=</code><var>version</var> (<code>--installed</code>|<var>taps</var>):
-Print a JSON representation of <var>taps</var>. Currently the only accepted value
+if <code>--full</code> is passed, a full clone will be used.</p></dd>
+<dt><code>tap --repair</code></dt><dd><p>Migrate tapped formulae from symlink-based to directory-based structure.</p></dd>
+<dt><code>tap --list-official</code></dt><dd><p>List all official taps.</p></dd>
+<dt><code>tap --list-pinned</code></dt><dd><p>List all pinned taps.</p></dd>
+<dt><code>tap-info</code> <var>tap</var></dt><dd><p>Display information about <var>tap</var>.</p></dd>
+<dt><code>tap-info</code> <code>--json=</code><var>version</var> (<code>--installed</code>|<var>taps</var>)</dt><dd><p>Print a JSON representation of <var>taps</var>. Currently the only accepted value
 for <var>version</var> is <code>v1</code>.</p>
 
 <p>Pass <code>--installed</code> to get information on installed taps.</p>
 
 <p>See the docs for examples of using the JSON:
-<a href="https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md" data-bare-link="true">https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md</a></p></li>
-<li><p><code>tap-pin</code> <var>tap</var>:
-Pin <var>tap</var>, prioritizing its formulae over core when formula names are supplied
-by the user. See also <code>tap-unpin</code>.</p></li>
-<li><p><code>tap-unpin</code> <var>tap</var>:
-Unpin <var>tap</var> so its formulae are no longer prioritized. See also <code>tap-pin</code>.</p></li>
-<li><p><code>test</code> [<code>--devel</code>|<code>--HEAD</code>] [<code>--debug</code>] <var>formula</var>:
-A few formulae provide a test method. <code>brew test</code> <var>formula</var> runs this
+<a href="https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md" data-bare-link="true">https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying-Brew.md</a></p></dd>
+<dt><code>tap-pin</code> <var>tap</var></dt><dd><p>Pin <var>tap</var>, prioritizing its formulae over core when formula names are supplied
+by the user. See also <code>tap-unpin</code>.</p></dd>
+<dt><code>tap-unpin</code> <var>tap</var></dt><dd><p>Unpin <var>tap</var> so its formulae are no longer prioritized. See also <code>tap-pin</code>.</p></dd>
+<dt><code>test</code> [<code>--devel</code>|<code>--HEAD</code>] [<code>--debug</code>] <var>formula</var></dt><dd><p>A few formulae provide a test method. <code>brew test</code> <var>formula</var> runs this
 test method. There is no standard output or return code, but it should
 generally indicate to the user if something is wrong with the installed
 formula.</p>
@@ -384,20 +329,17 @@ formula.</p>
 <p>If <code>--debug</code> is passed and the test fails, an interactive debugger will be
 launched with access to IRB or a shell inside the temporary test directory.</p>
 
-<p>Example: <code>brew install jruby &amp;&amp; brew test jruby</code></p></li>
-<li><p><code>unlink</code> [<code>--dry-run</code>] <var>formula</var>:
-Remove symlinks for <var>formula</var> from the Homebrew prefix. This can be useful
+<p>Example: <code>brew install jruby &amp;&amp; brew test jruby</code></p></dd>
+<dt><code>unlink</code> [<code>--dry-run</code>] <var>formula</var></dt><dd><p>Remove symlinks for <var>formula</var> from the Homebrew prefix. This can be useful
 for temporarily disabling a formula:
 <code>brew unlink foo &amp;&amp; commands &amp;&amp; brew link foo</code>.</p>
 
 <p>If <code>--dry-run</code> or <code>-n</code> is passed, Homebrew will list all files which would
-be unlinked, but will not actually unlink or delete any files.</p></li>
-<li><p><code>unlinkapps</code> [<code>--local</code>] [<var>formulae</var>]:
-Removes links created by <code>brew linkapps</code>.</p>
+be unlinked, but will not actually unlink or delete any files.</p></dd>
+<dt><code>unlinkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Removes links created by <code>brew linkapps</code>.</p>
 
-<p>If no <var>formulae</var> are provided, all linked app will be removed.</p></li>
-<li><p><code>unpack</code> [<code>--git</code>|<code>--patch</code>] [<code>--destdir=</code><var>path</var>] <var>formulae</var>:
-Unpack the source files for <var>formulae</var> into subdirectories of the current
+<p>If no <var>formulae</var> are provided, all linked app will be removed.</p></dd>
+<dt><code>unpack</code> [<code>--git</code>|<code>--patch</code>] [<code>--destdir=</code><var>path</var>] <var>formulae</var></dt><dd><p>Unpack the source files for <var>formulae</var> into subdirectories of the current
 working directory. If <code>--destdir=</code><var>path</var> is given, the subdirectories will
 be created in the directory named by <code>&lt;path></code> instead.</p>
 
@@ -405,28 +347,23 @@ be created in the directory named by <code>&lt;path></code> instead.</p>
 unpacked source.</p>
 
 <p>If <code>--git</code> is passed, a Git repository will be initalized in the unpacked
-source. This is useful for creating patches for the software.</p></li>
-<li><p><code>unpin</code> <var>formulae</var>:
-Unpin <var>formulae</var>, allowing them to be upgraded by <code>brew upgrade</code>. See also
-<code>pin</code>.</p></li>
-<li><p><code>untap</code> <var>tap</var>:
-Remove a tapped repository.</p></li>
-<li><p><code>update</code> [<code>--rebase</code>]:
-Fetch the newest version of Homebrew and all formulae from GitHub using
+source. This is useful for creating patches for the software.</p></dd>
+<dt><code>unpin</code> <var>formulae</var></dt><dd><p>Unpin <var>formulae</var>, allowing them to be upgraded by <code>brew upgrade</code>. See also
+<code>pin</code>.</p></dd>
+<dt><code>untap</code> <var>tap</var></dt><dd><p>Remove a tapped repository.</p></dd>
+<dt><code>update</code> [<code>--rebase</code>]</dt><dd><p>Fetch the newest version of Homebrew and all formulae from GitHub using
  <code>git</code>(1).</p>
 
-<p>If <code>--rebase</code> is specified then <code>git pull --rebase</code> is used.</p></li>
-<li><p><code>upgrade</code> [<var>install-options</var>] [<code>--cleanup</code>] [<var>formulae</var>]:
-Upgrade outdated, unpinned brews.</p>
+<p>If <code>--rebase</code> is specified then <code>git pull --rebase</code> is used.</p></dd>
+<dt><code>upgrade</code> [<var>install-options</var>] [<code>--cleanup</code>] [<var>formulae</var>]</dt><dd><p>Upgrade outdated, unpinned brews.</p>
 
 <p>Options for the <code>install</code> command are also valid here.</p>
 
 <p>If <code>--cleanup</code> is specified then remove previously installed <var>formula</var> version(s).</p>
 
 <p>If <var>formulae</var> are given, upgrade only the specified brews (but do so even
-if they are pinned; see <code>pin</code>, <code>unpin</code>).</p></li>
-<li><p><code>uses</code> [<code>--installed</code>] [<code>--recursive</code>] [<code>--skip-build</code>] [<code>--skip-optional</code>] [<code>--devel</code>|<code>--HEAD</code>] <var>formulae</var>:
-Show the formulae that specify <var>formulae</var> as a dependency. When given
+if they are pinned; see <code>pin</code>, <code>unpin</code>).</p></dd>
+<dt><code>uses</code> [<code>--installed</code>] [<code>--recursive</code>] [<code>--skip-build</code>] [<code>--skip-optional</code>] [<code>--devel</code>|<code>--HEAD</code>] <var>formulae</var></dt><dd><p>Show the formulae that specify <var>formulae</var> as a dependency. When given
 multiple formula arguments, show the intersection of formulae that use
 <var>formulae</var>.</p>
 
@@ -440,29 +377,20 @@ To skip the <code>:build</code> type dependencies, pass <code>--skip-build</code
 
 <p>By default, <code>uses</code> shows usages of <code>formula</code> by stable builds. To find
 cases where <code>formula</code> is used by development or HEAD build, pass
-<code>--devel</code> or <code>--HEAD</code>.</p></li>
-<li><p><code>--cache</code>:
-Display Homebrew's download cache. See also <code>HOMEBREW_CACHE</code>.</p></li>
-<li><p><code>--cache</code> <var>formula</var>:
-Display the file or directory used to cache <var>formula</var>.</p></li>
-<li><p><code>--cellar</code>:
-Display Homebrew's Cellar path. <em>Default:</em> <code>$(brew --prefix)/Cellar</code>, or if
-that directory doesn't exist, <code>$(brew --repository)/Cellar</code>.</p></li>
-<li><p><code>--cellar</code> <var>formula</var>:
-Display the location in the cellar where <var>formula</var> would be installed,
-without any sort of versioned directory as the last path.</p></li>
-<li><p><code>--env</code>:
-Show a summary of the Homebrew build environment.</p></li>
-<li><p><code>--prefix</code>:
-Display Homebrew's install path. <em>Default:</em> <code>/usr/local</code></p></li>
-<li><p><code>--prefix</code> <var>formula</var>:
-Display the location in the cellar where <var>formula</var> is or would be installed.</p></li>
-<li><p><code>--repository</code>:
-Display where Homebrew's <code>.git</code> directory is located. For standard installs,
-the <code>prefix</code> and <code>repository</code> are the same directory.</p></li>
-<li><p><code>--version</code>:
-Print the version number of brew to standard error and exit.</p></li>
-</ul>
+<code>--devel</code> or <code>--HEAD</code>.</p></dd>
+<dt class="flush"><code>--cache</code></dt><dd><p>Display Homebrew's download cache. See also <code>HOMEBREW_CACHE</code>.</p></dd>
+<dt><code>--cache</code> <var>formula</var></dt><dd><p>Display the file or directory used to cache <var>formula</var>.</p></dd>
+<dt><code>--cellar</code></dt><dd><p>Display Homebrew's Cellar path. <em>Default:</em> <code>$(brew --prefix)/Cellar</code>, or if
+that directory doesn't exist, <code>$(brew --repository)/Cellar</code>.</p></dd>
+<dt><code>--cellar</code> <var>formula</var></dt><dd><p>Display the location in the cellar where <var>formula</var> would be installed,
+without any sort of versioned directory as the last path.</p></dd>
+<dt class="flush"><code>--env</code></dt><dd><p>Show a summary of the Homebrew build environment.</p></dd>
+<dt><code>--prefix</code></dt><dd><p>Display Homebrew's install path. <em>Default:</em> <code>/usr/local</code></p></dd>
+<dt><code>--prefix</code> <var>formula</var></dt><dd><p>Display the location in the cellar where <var>formula</var> is or would be installed.</p></dd>
+<dt><code>--repository</code></dt><dd><p>Display where Homebrew's <code>.git</code> directory is located. For standard installs,
+the <code>prefix</code> and <code>repository</code> are the same directory.</p></dd>
+<dt><code>--version</code></dt><dd><p>Print the version number of brew to standard error and exit.</p></dd>
+</dl>
 
 
 <h2 id="EXTERNAL-COMMANDS">EXTERNAL COMMANDS</h2>

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -25,7 +25,7 @@ didn't include with OS X.</p>
 <dt><code>remove</code> <var>formula</var></dt><dd><p>Uninstall <var>formula</var>.</p></dd>
 <dt class="flush"><code>update</code></dt><dd><p>Fetch the newest version of Homebrew from GitHub using <code>git</code>(1).</p></dd>
 <dt class="flush"><code>list</code></dt><dd><p>List all installed formulae.</p></dd>
-<dt><code>search</code> <var>text</var> | <code>/</code><var>text</var><code>/</code></dt><dd><p>Perform a substring search of formula names for <var>text</var>. If <var>text</var> is
+<dt><code>search</code> <var>text</var>|<code>/</code><var>text</var><code>/</code></dt><dd><p>Perform a substring search of formula names for <var>text</var>. If <var>text</var> is
 surrounded with slashes, then it is interpreted as a regular expression.
 The search for <var>text</var> is extended online to some popular taps.
 If no search term is given, all locally available formulae are listed.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -38,7 +38,7 @@ Fetch the newest version of Homebrew from GitHub using \fBgit\fR(1)\.
 List all installed formulae\.
 .
 .TP
-\fBsearch\fR \fItext\fR | \fB/\fR\fItext\fR\fB/\fR
+\fBsearch\fR \fItext\fR|\fB/\fR\fItext\fR\fB/\fR
 Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is surrounded with slashes, then it is interpreted as a regular expression\. The search for \fItext\fR is extended online to some popular taps\. If no search term is given, all locally available formulae are listed\.
 .
 .SH "COMMANDS"

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -43,8 +43,9 @@ Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is su
 .
 .SH "COMMANDS"
 .
-.IP "\(bu" 4
-\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-online\fR] [\fIformulae\fR]: Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
+.TP
+\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-online\fR] [\fIformulae\fR]
+Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
 .
 .IP
 If no \fIformulae\fR are provided, all of them are checked\.
@@ -58,11 +59,13 @@ If \fB\-\-online\fR is passed, additional slower checks that require a network c
 .IP
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.
 .
-.IP "\(bu" 4
-\fBcat\fR \fIformula\fR: Display the source to \fIformula\fR\.
+.TP
+\fBcat\fR \fIformula\fR
+Display the source to \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fBcleanup\fR [\fB\-\-force\fR] [\fB\-\-prune=\fR\fIdays\fR] [\fB\-n\fR] [\fB\-s\fR] [\fIformulae\fR]: For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only brews, as other software may link directly to specific versions\. In addition, old downloads from the Homebrew download\-cache are deleted\.
+.TP
+\fBcleanup\fR [\fB\-\-force\fR] [\fB\-\-prune=\fR\fIdays\fR] [\fB\-n\fR] [\fB\-s\fR] [\fIformulae\fR]
+For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only brews, as other software may link directly to specific versions\. In addition, old downloads from the Homebrew download\-cache are deleted\.
 .
 .IP
 If \fB\-\-force\fR is passed, remove out\-of\-date keg\-only brews as well\.
@@ -76,20 +79,24 @@ If \fB\-n\fR is passed, show what would be removed, but do not actually remove a
 .IP
 If \fB\-s\fR is passed, scrubs the cache, removing downloads for even the latest versions of formulae\. Note downloads for any installed formulae will still not be deleted\. If you want to delete those too: \fBrm \-rf $(brew \-\-cache)\fR
 .
-.IP "\(bu" 4
-\fBcommand\fR \fIcmd\fR: Display the path to the file which is used when invoking \fBbrew\fR \fIcmd\fR\.
+.TP
+\fBcommand\fR \fIcmd\fR
+Display the path to the file which is used when invoking \fBbrew\fR \fIcmd\fR\.
 .
-.IP "\(bu" 4
-\fBcommands\fR [\fB\-\-quiet\fR [\fB\-\-include\-aliases\fR]]: Show a list of built\-in and external commands\.
+.TP
+\fBcommands\fR [\fB\-\-quiet\fR [\fB\-\-include\-aliases\fR]]
+Show a list of built\-in and external commands\.
 .
 .IP
 If \fB\-\-quiet\fR is passed, list only the names of commands without the header\. With \fB\-\-include\-aliases\fR, the aliases of internal commands will be included\.
 .
-.IP "\(bu" 4
-\fBconfig\fR: Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
+.TP
+\fBconfig\fR
+Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
 .
-.IP "\(bu" 4
-\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR]: Generate a formula for the downloadable file at \fIURL\fR and open it in the editor\. Homebrew will attempt to automatically derive the formula name and version, but if it fails, you\'ll have to make your own template\. The \fBwget\fR formula serves as a simple example\. For the complete API have a look at
+.TP
+\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR]
+Generate a formula for the downloadable file at \fIURL\fR and open it in the editor\. Homebrew will attempt to automatically derive the formula name and version, but if it fails, you\'ll have to make your own template\. The \fBwget\fR formula serves as a simple example\. For the complete API have a look at
 .
 .IP
 \fIhttp://www\.rubydoc\.info/github/Homebrew/homebrew/master/Formula\fR
@@ -103,8 +110,9 @@ If \fB\-\-no\-fetch\fR is passed, Homebrew will not download \fIURL\fR to the ca
 .IP
 The options \fB\-\-set\-name\fR and \fB\-\-set\-version\fR each take an argument and allow you to explicitly set the name and version of the package you are creating\.
 .
-.IP "\(bu" 4
-\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-tree\fR] [\fB\-\-all\fR] [\fB\-\-installed\fR] [\fB\-\-skip\-build\fR] [\fB\-\-skip\-optional\fR] \fIformulae\fR: Show dependencies for \fIformulae\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformulae\fR, except when passed \fB\-\-tree\fR, \fB\-\-all\fR, or \fB\-\-installed\fR\.
+.TP
+\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-tree\fR] [\fB\-\-all\fR] [\fB\-\-installed\fR] [\fB\-\-skip\-build\fR] [\fB\-\-skip\-optional\fR] \fIformulae\fR
+Show dependencies for \fIformulae\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformulae\fR, except when passed \fB\-\-tree\fR, \fB\-\-all\fR, or \fB\-\-installed\fR\.
 .
 .IP
 If \fB\-\-1\fR is passed, only show dependencies one level down, instead of recursing\.
@@ -127,14 +135,17 @@ If \fB\-\-installed\fR is passed, show dependencies for all installed formulae\.
 .IP
 By default, \fBdeps\fR shows dependencies for \fIformulae\fR\. To skip the \fB:build\fR type dependencies, pass \fB\-\-skip\-build\fR\. Similarly, pass \fB\-\-skip\-optional\fR to skip \fB:optional\fR dependencies\.
 .
-.IP "\(bu" 4
-\fBdesc\fR \fIformula\fR: Display \fIformula\fR\'s name and one\-line description\.
+.TP
+\fBdesc\fR \fIformula\fR
+Display \fIformula\fR\'s name and one\-line description\.
 .
-.IP "\(bu" 4
-\fBdesc\fR [\fB\-s\fR|\fB\-n\fR|\fB\-d\fR] \fIpattern\fR: Search both name and description (\fB\-s\fR), just the names (\fB\-n\fR), or just the descriptions (\fB\-d\fR) for \fB<pattern>\fR\. \fB<pattern>\fR is by default interpreted as a literal string; if flanked by slashes, it is instead interpreted as a regular expression\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.
+.TP
+\fBdesc\fR [\fB\-s\fR|\fB\-n\fR|\fB\-d\fR] \fIpattern\fR
+Search both name and description (\fB\-s\fR), just the names (\fB\-n\fR), or just the descriptions (\fB\-d\fR) for \fB<pattern>\fR\. \fB<pattern>\fR is by default interpreted as a literal string; if flanked by slashes, it is instead interpreted as a regular expression\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.
 .
-.IP "\(bu" 4
-\fBdiy\fR [\fB\-\-name=\fR\fIname\fR] [\fB\-\-version=\fR\fIversion\fR]: Automatically determine the installation prefix for non\-Homebrew software\.
+.TP
+\fBdiy\fR [\fB\-\-name=\fR\fIname\fR] [\fB\-\-version=\fR\fIversion\fR]
+Automatically determine the installation prefix for non\-Homebrew software\.
 .
 .IP
 Using the output from this command, you can install your own software into the Cellar and then link it into Homebrew\'s prefix with \fBbrew link\fR\.
@@ -142,17 +153,21 @@ Using the output from this command, you can install your own software into the C
 .IP
 The options \fB\-\-name=\fR\fIname\fR and \fB\-\-version=\fR\fIversion\fR each take an argument and allow you to explicitly set the name and version of the package you are installing\.
 .
-.IP "\(bu" 4
-\fBdoctor\fR: Check your system for potential problems\. Doctor exits with a non\-zero status if any problems are found\.
+.TP
+\fBdoctor\fR
+Check your system for potential problems\. Doctor exits with a non\-zero status if any problems are found\.
 .
-.IP "\(bu" 4
-\fBedit\fR: Open all of Homebrew for editing\.
+.TP
+\fBedit\fR
+Open all of Homebrew for editing\.
 .
-.IP "\(bu" 4
-\fBedit\fR \fIformula\fR: Open \fIformula\fR in the editor\.
+.TP
+\fBedit\fR \fIformula\fR
+Open \fIformula\fR in the editor\.
 .
-.IP "\(bu" 4
-\fBfetch\fR [\fB\-\-force\fR] [\fB\-v\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-deps\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] \fIformulae\fR: Download the source packages for the given \fIformulae\fR\. For tarballs, also print SHA\-1 and SHA\-256 checksums\.
+.TP
+\fBfetch\fR [\fB\-\-force\fR] [\fB\-v\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-deps\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] \fIformulae\fR
+Download the source packages for the given \fIformulae\fR\. For tarballs, also print SHA\-1 and SHA\-256 checksums\.
 .
 .IP
 If \fB\-\-HEAD\fR or \fB\-\-devel\fR is passed, fetch that version instead of the stable version\.
@@ -172,23 +187,28 @@ If \fB\-\-build\-from\-source\fR is passed, download the source rather than a bo
 .IP
 If \fB\-\-force\-bottle\fR is passed, download a bottle if it exists for the current version of OS X, even if it would not be used during installation\.
 .
-.IP "\(bu" 4
-\fBhome\fR: Open Homebrew\'s own homepage in a browser\.
+.TP
+\fBhome\fR
+Open Homebrew\'s own homepage in a browser\.
 .
-.IP "\(bu" 4
-\fBhome\fR \fIformula\fR: Open \fIformula\fR\'s homepage in a browser\.
+.TP
+\fBhome\fR \fIformula\fR
+Open \fIformula\fR\'s homepage in a browser\.
 .
-.IP "\(bu" 4
-\fBinfo\fR \fIformula\fR: Display information about \fIformula\fR\.
+.TP
+\fBinfo\fR \fIformula\fR
+Display information about \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fBinfo\fR \fB\-\-github\fR \fIformula\fR: Open a browser to the GitHub History page for formula \fIformula\fR\.
+.TP
+\fBinfo\fR \fB\-\-github\fR \fIformula\fR
+Open a browser to the GitHub History page for formula \fIformula\fR\.
 .
 .IP
 To view formula history locally: \fBbrew log \-p <formula>\fR\.
 .
-.IP "\(bu" 4
-\fBinfo \-\-json=\fR\fIversion\fR (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR): Print a JSON representation of \fIformulae\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
+.TP
+\fBinfo \-\-json=\fR\fIversion\fR (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
+Print a JSON representation of \fIformulae\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
 .
 .IP
 Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to get information on all installed formulae\.
@@ -196,8 +216,9 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 .IP
 See the docs for examples of using the JSON: \fIhttps://github\.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying\-Brew\.md\fR
 .
-.IP "\(bu" 4
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR\fIstd\fR|\fIsuper\fR] [\fB\-\-ignore\-dependencies\fR] [\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformula\fR: Install \fIformula\fR\.
+.TP
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR\fIstd\fR|\fIsuper\fR] [\fB\-\-ignore\-dependencies\fR] [\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformula\fR
+Install \fIformula\fR\.
 .
 .IP
 \fIformula\fR is usually the name of the formula to install, but it can be specified several different ways\. See \fISPECIFYING FORMULAE\fR\.
@@ -235,23 +256,27 @@ If \fB\-\-HEAD\fR is passed, and \fIformula\fR defines it, install the HEAD vers
 .IP
 To install a newer version of HEAD use \fBbrew rm <foo> && brew install \-\-HEAD <foo>\fR\.
 .
-.IP "\(bu" 4
-\fBinstall \-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR: Download and patch \fIformula\fR, then open a shell\. This allows the user to run \fB\./configure \-\-help\fR and otherwise determine how to turn the software package into a Homebrew formula\.
+.TP
+\fBinstall \-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR
+Download and patch \fIformula\fR, then open a shell\. This allows the user to run \fB\./configure \-\-help\fR and otherwise determine how to turn the software package into a Homebrew formula\.
 .
 .IP
 If \fB\-\-git\fR is passed, Homebrew will create a Git repository, useful for creating patches to the software\.
 .
-.IP "\(bu" 4
-\fBirb\fR [\fB\-\-examples\fR]: Enter the interactive Homebrew Ruby shell\.
+.TP
+\fBirb\fR [\fB\-\-examples\fR]
+Enter the interactive Homebrew Ruby shell\.
 .
 .IP
 If \fB\-\-examples\fR is passed, several examples will be shown\.
 .
-.IP "\(bu" 4
-\fBleaves\fR: Show installed formulae that are not dependencies of another installed formula\.
+.TP
+\fBleaves\fR
+Show installed formulae that are not dependencies of another installed formula\.
 .
-.IP "\(bu" 4
-\fBln\fR, \fBlink\fR [\fB\-\-overwrite\fR] [\fB\-\-dry\-run\fR] [\fB\-\-force\fR] \fIformula\fR: Symlink all of \fIformula\fR\'s installed files into the Homebrew prefix\. This is done automatically when you install formulae but can be useful for DIY installations\.
+.TP
+\fBln\fR, \fBlink\fR [\fB\-\-overwrite\fR] [\fB\-\-dry\-run\fR] [\fB\-\-force\fR] \fIformula\fR
+Symlink all of \fIformula\fR\'s installed files into the Homebrew prefix\. This is done automatically when you install formulae but can be useful for DIY installations\.
 .
 .IP
 If \fB\-\-overwrite\fR is passed, Homebrew will delete files which already exist in the prefix while linking\.
@@ -262,8 +287,9 @@ If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which
 .IP
 If \fB\-\-force\fR is passed, Homebrew will allow keg\-only formulae to be linked\.
 .
-.IP "\(bu" 4
-\fBlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]: Find installed formulae that have compiled \fB\.app\fR\-style "application" packages for OS X, and symlink those apps into \fB/Applications\fR, allowing for easier access\.
+.TP
+\fBlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]
+Find installed formulae that have compiled \fB\.app\fR\-style "application" packages for OS X, and symlink those apps into \fB/Applications\fR, allowing for easier access\.
 .
 .IP
 If no \fIformulae\fR are provided, all of them will have their \.apps symlinked\.
@@ -271,14 +297,17 @@ If no \fIformulae\fR are provided, all of them will have their \.apps symlinked\
 .IP
 If provided, \fB\-\-local\fR will move them into the user\'s \fB~/Applications\fR directory instead of the system directory\. It may need to be created, first\.
 .
-.IP "\(bu" 4
-\fBls\fR, \fBlist\fR [\fB\-\-full\-name\fR]: List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with full\-qualified names\.
+.TP
+\fBls\fR, \fBlist\fR [\fB\-\-full\-name\fR]
+List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with full\-qualified names\.
 .
-.IP "\(bu" 4
-\fBls\fR, \fBlist \-\-unbrewed\fR: List all files in the Homebrew prefix not installed by Homebrew\.
+.TP
+\fBls\fR, \fBlist \-\-unbrewed\fR
+List all files in the Homebrew prefix not installed by Homebrew\.
 .
-.IP "\(bu" 4
-\fBls\fR, \fBlist\fR [\fB\-\-versions\fR [\fB\-\-multiple\fR]] [\fB\-\-pinned\fR] [\fIformulae\fR]: List the installed files for \fIformulae\fR\. Combined with \fB\-\-verbose\fR, recursively list the contents of all subdirectories in each \fIformula\fR\'s keg\.
+.TP
+\fBls\fR, \fBlist\fR [\fB\-\-versions\fR [\fB\-\-multiple\fR]] [\fB\-\-pinned\fR] [\fIformulae\fR]
+List the installed files for \fIformulae\fR\. Combined with \fB\-\-verbose\fR, recursively list the contents of all subdirectories in each \fIformula\fR\'s keg\.
 .
 .IP
 If \fB\-\-versions\fR is passed, show the version number for installed formulae, or only the specified formulae if \fIformulae\fR are given\. With \fB\-\-multiple\fR, only show formulae with multiple versions installed\.
@@ -286,23 +315,27 @@ If \fB\-\-versions\fR is passed, show the version number for installed formulae,
 .IP
 If \fB\-\-pinned\fR is passed, show the versions of pinned formulae, or only the specified (pinned) formulae if \fIformulae\fR are given\. See also \fBpin\fR, \fBunpin\fR\.
 .
-.IP "\(bu" 4
-\fBlog\fR [\fBgit\-log\-options\fR] \fIformula\fR \.\.\.: Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recognizes can be passed before the formula list\.
+.TP
+\fBlog\fR [\fBgit\-log\-options\fR] \fIformula\fR \.\.\.
+Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recognizes can be passed before the formula list\.
 .
-.IP "\(bu" 4
-\fBmissing\fR [\fIformulae\fR]: Check the given \fIformulae\fR for missing dependencies\.
+.TP
+\fBmissing\fR [\fIformulae\fR]
+Check the given \fIformulae\fR for missing dependencies\.
 .
 .IP
 If no \fIformulae\fR are given, check all installed brews\.
 .
-.IP "\(bu" 4
-\fBmigrate\fR [\fB\-\-force\fR] \fIformulae\fR: Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
+.TP
+\fBmigrate\fR [\fB\-\-force\fR] \fIformulae\fR
+Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
 .
 .IP
 If \fB\-\-force\fR is passed, then treat installed \fIformulae\fR and passed \fIformulae\fR like if they are from same taps and migrate them anyway\.
 .
-.IP "\(bu" 4
-\fBoptions\fR [\fB\-\-compact\fR] [\fB\-\-all\fR] [\fB\-\-installed\fR] \fIformula\fR: Display install options specific to \fIformula\fR\.
+.TP
+\fBoptions\fR [\fB\-\-compact\fR] [\fB\-\-all\fR] [\fB\-\-installed\fR] \fIformula\fR
+Display install options specific to \fIformula\fR\.
 .
 .IP
 If \fB\-\-compact\fR is passed, show all options on a single line separated by spaces\.
@@ -313,8 +346,9 @@ If \fB\-\-all\fR is passed, show options for all formulae\.
 .IP
 If \fB\-\-installed\fR is passed, show options for all installed formulae\.
 .
-.IP "\(bu" 4
-\fBoutdated\fR [\fB\-\-quiet\fR|\fB\-\-verbose\fR|\fB\-\-json=v1\fR]: Show formulae that have an updated version available\.
+.TP
+\fBoutdated\fR [\fB\-\-quiet\fR|\fB\-\-verbose\fR|\fB\-\-json=v1\fR]
+Show formulae that have an updated version available\.
 .
 .IP
 By default, version information is displayed in interactive shells, and suppressed otherwise\.
@@ -328,67 +362,81 @@ If \fB\-\-verbose\fR is passed, display detailed version information\.
 .IP
 If \fB\-\-json=\fR\fIversion\fR is passed, the output will be in JSON format\. The only valid version is \fBv1\fR\.
 .
-.IP "\(bu" 4
-\fBpin\fR \fIformulae\fR: Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR command\. See also \fBunpin\fR\.
+.TP
+\fBpin\fR \fIformulae\fR
+Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR command\. See also \fBunpin\fR\.
 .
-.IP "\(bu" 4
-\fBprune\fR: Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
+.TP
+\fBprune\fR
+Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
 .
-.IP "\(bu" 4
-\fBreinstall\fR \fIformula\fR: Uninstall then install \fIformula\fR
+.TP
+\fBreinstall\fR \fIformula\fR
+Uninstall then install \fIformula\fR
 .
-.IP "\(bu" 4
-\fBrm\fR, \fBremove\fR, \fBuninstall\fR [\fB\-\-force\fR] \fIformula\fR: Uninstall \fIformula\fR\.
+.TP
+\fBrm\fR, \fBremove\fR, \fBuninstall\fR [\fB\-\-force\fR] \fIformula\fR
+Uninstall \fIformula\fR\.
 .
 .IP
 If \fB\-\-force\fR is passed, and there are multiple versions of \fIformula\fR installed, delete all installed versions\.
 .
-.IP "\(bu" 4
-\fBsearch\fR, \fB\-S\fR: Display all locally available formulae for brewing (including tapped ones)\. No online search is performed if called without arguments\.
+.TP
+\fBsearch\fR, \fB\-S\fR
+Display all locally available formulae for brewing (including tapped ones)\. No online search is performed if called without arguments\.
 .
-.IP "\(bu" 4
-\fBsearch\fR, \fB\-S\fR \fItext\fR|\fB/\fR\fItext\fR\fB/\fR: Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is surrounded with slashes, then it is interpreted as a regular expression\. The search for \fItext\fR is extended online to some popular taps\.
+.TP
+\fBsearch\fR, \fB\-S\fR \fItext\fR|\fB/\fR\fItext\fR\fB/\fR
+Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is surrounded with slashes, then it is interpreted as a regular expression\. The search for \fItext\fR is extended online to some popular taps\.
 .
-.IP "\(bu" 4
-\fBsearch \-\-debian\fR|\fB\-\-fedora\fR|\fB\-\-fink\fR|\fB\-\-macports\fR|\fB\-\-opensuse\fR|\fB\-\-ubuntu\fR \fItext\fR: Search for \fItext\fR in the given package manager\'s list\.
+.TP
+\fBsearch \-\-debian\fR|\fB\-\-fedora\fR|\fB\-\-fink\fR|\fB\-\-macports\fR|\fB\-\-opensuse\fR|\fB\-\-ubuntu\fR \fItext\fR
+Search for \fItext\fR in the given package manager\'s list\.
 .
-.IP "\(bu" 4
-\fBsh\fR [\fB\-\-env=std\fR]: Instantiate a Homebrew build environment\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeed\. Especially handy if you run Homebrew in an Xcode\-only configuration since it adds tools like \fBmake\fR to your \fBPATH\fR which otherwise build\-systems would not find\.
+.TP
+\fBsh\fR [\fB\-\-env=std\fR]
+Instantiate a Homebrew build environment\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeed\. Especially handy if you run Homebrew in an Xcode\-only configuration since it adds tools like \fBmake\fR to your \fBPATH\fR which otherwise build\-systems would not find\.
 .
-.IP "\(bu" 4
-\fBswitch\fR \fIname\fR \fIversion\fR: Symlink all of the specific \fIversion\fR of \fIname\fR\'s install to Homebrew prefix\.
+.TP
+\fBswitch\fR \fIname\fR \fIversion\fR
+Symlink all of the specific \fIversion\fR of \fIname\fR\'s install to Homebrew prefix\.
 .
-.IP "\(bu" 4
-\fBtap\fR [\fB\-\-full\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]: Tap a formula repository or list existing taps\. This command can be invoked in three ways\.
+.TP
+\fBtap\fR
+List all installed taps\.
 .
-.IP "\(bu" 4
-\fBtap\fR without arguments displays existing taps\.
+.TP
+\fBtap\fR [\fB\-\-full\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]
+Tap a formula repository\.
 .
-.IP "\(bu" 4
-\fBtap\fR \fIuser\fR\fB/\fR\fIrepo\fR taps a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBtap <user>/<repo> https://github\.com/<user>/homebrew\-<repo>\fR\.
+.IP
+With \fIURL\fR unspecified, taps a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBtap <user>/<repo> https://github\.com/<user>/homebrew\-<repo>\fR\.
 .
-.IP "\(bu" 4
-\fBtap\fR \fIuser\fR\fB/\fR\fIrepo\fR \fIURL\fR taps a formula repository from anywhere, using any transport protocol that \fBgit\fR handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\., SSH, GIT, HTTP, FTP(S), RSYNC\.
-.
-.IP "" 0
+.IP
+With \fIURL\fR specified, taps a formula repository from anywhere, using any transport protocol that \fBgit\fR handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\., SSH, GIT, HTTP, FTP(S), RSYNC\.
 .
 .IP
 By default, the repository is cloned as a shallow copy (\fB\-\-depth=1\fR), but if \fB\-\-full\fR is passed, a full clone will be used\.
 .
-.IP "\(bu" 4
-\fBtap \-\-repair\fR: Migrate tapped formulae from symlink\-based to directory\-based structure\.
+.TP
+\fBtap \-\-repair\fR
+Migrate tapped formulae from symlink\-based to directory\-based structure\.
 .
-.IP "\(bu" 4
-\fBtap \-\-list\-official\fR: List all official taps\.
+.TP
+\fBtap \-\-list\-official\fR
+List all official taps\.
 .
-.IP "\(bu" 4
-\fBtap \-\-list\-pinned\fR: List all pinned taps\.
+.TP
+\fBtap \-\-list\-pinned\fR
+List all pinned taps\.
 .
-.IP "\(bu" 4
-\fBtap\-info\fR \fItap\fR: Display information about \fItap\fR\.
+.TP
+\fBtap\-info\fR \fItap\fR
+Display information about \fItap\fR\.
 .
-.IP "\(bu" 4
-\fBtap\-info\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-installed\fR|\fItaps\fR): Print a JSON representation of \fItaps\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
+.TP
+\fBtap\-info\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-installed\fR|\fItaps\fR)
+Print a JSON representation of \fItaps\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
 .
 .IP
 Pass \fB\-\-installed\fR to get information on installed taps\.
@@ -396,14 +444,17 @@ Pass \fB\-\-installed\fR to get information on installed taps\.
 .IP
 See the docs for examples of using the JSON: \fIhttps://github\.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Querying\-Brew\.md\fR
 .
-.IP "\(bu" 4
-\fBtap\-pin\fR \fItap\fR: Pin \fItap\fR, prioritizing its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.
+.TP
+\fBtap\-pin\fR \fItap\fR
+Pin \fItap\fR, prioritizing its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.
 .
-.IP "\(bu" 4
-\fBtap\-unpin\fR \fItap\fR: Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
+.TP
+\fBtap\-unpin\fR \fItap\fR
+Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
 .
-.IP "\(bu" 4
-\fBtest\fR [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-debug\fR] \fIformula\fR: A few formulae provide a test method\. \fBbrew test\fR \fIformula\fR runs this test method\. There is no standard output or return code, but it should generally indicate to the user if something is wrong with the installed formula\.
+.TP
+\fBtest\fR [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-debug\fR] \fIformula\fR
+A few formulae provide a test method\. \fBbrew test\fR \fIformula\fR runs this test method\. There is no standard output or return code, but it should generally indicate to the user if something is wrong with the installed formula\.
 .
 .IP
 To test the development or head version of a formula, use \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
@@ -414,20 +465,23 @@ If \fB\-\-debug\fR is passed and the test fails, an interactive debugger will be
 .IP
 Example: \fBbrew install jruby && brew test jruby\fR
 .
-.IP "\(bu" 4
-\fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR: Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink foo && commands && brew link foo\fR\.
+.TP
+\fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR
+Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink foo && commands && brew link foo\fR\.
 .
 .IP
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which would be unlinked, but will not actually unlink or delete any files\.
 .
-.IP "\(bu" 4
-\fBunlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]: Removes links created by \fBbrew linkapps\fR\.
+.TP
+\fBunlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]
+Removes links created by \fBbrew linkapps\fR\.
 .
 .IP
 If no \fIformulae\fR are provided, all linked app will be removed\.
 .
-.IP "\(bu" 4
-\fBunpack\fR [\fB\-\-git\fR|\fB\-\-patch\fR] [\fB\-\-destdir=\fR\fIpath\fR] \fIformulae\fR: Unpack the source files for \fIformulae\fR into subdirectories of the current working directory\. If \fB\-\-destdir=\fR\fIpath\fR is given, the subdirectories will be created in the directory named by \fB<path>\fR instead\.
+.TP
+\fBunpack\fR [\fB\-\-git\fR|\fB\-\-patch\fR] [\fB\-\-destdir=\fR\fIpath\fR] \fIformulae\fR
+Unpack the source files for \fIformulae\fR into subdirectories of the current working directory\. If \fB\-\-destdir=\fR\fIpath\fR is given, the subdirectories will be created in the directory named by \fB<path>\fR instead\.
 .
 .IP
 If \fB\-\-patch\fR is passed, patches for \fIformulae\fR will be applied to the unpacked source\.
@@ -435,20 +489,24 @@ If \fB\-\-patch\fR is passed, patches for \fIformulae\fR will be applied to the 
 .IP
 If \fB\-\-git\fR is passed, a Git repository will be initalized in the unpacked source\. This is useful for creating patches for the software\.
 .
-.IP "\(bu" 4
-\fBunpin\fR \fIformulae\fR: Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade\fR\. See also \fBpin\fR\.
+.TP
+\fBunpin\fR \fIformulae\fR
+Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade\fR\. See also \fBpin\fR\.
 .
-.IP "\(bu" 4
-\fBuntap\fR \fItap\fR: Remove a tapped repository\.
+.TP
+\fBuntap\fR \fItap\fR
+Remove a tapped repository\.
 .
-.IP "\(bu" 4
-\fBupdate\fR [\fB\-\-rebase\fR]: Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1)\.
+.TP
+\fBupdate\fR [\fB\-\-rebase\fR]
+Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1)\.
 .
 .IP
 If \fB\-\-rebase\fR is specified then \fBgit pull \-\-rebase\fR is used\.
 .
-.IP "\(bu" 4
-\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fIformulae\fR]: Upgrade outdated, unpinned brews\.
+.TP
+\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fIformulae\fR]
+Upgrade outdated, unpinned brews\.
 .
 .IP
 Options for the \fBinstall\fR command are also valid here\.
@@ -459,8 +517,9 @@ If \fB\-\-cleanup\fR is specified then remove previously installed \fIformula\fR
 .IP
 If \fIformulae\fR are given, upgrade only the specified brews (but do so even if they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
-.IP "\(bu" 4
-\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-skip\-build\fR] [\fB\-\-skip\-optional\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR: Show the formulae that specify \fIformulae\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformulae\fR\.
+.TP
+\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-skip\-build\fR] [\fB\-\-skip\-optional\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR
+Show the formulae that specify \fIformulae\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformulae\fR\.
 .
 .IP
 Use \fB\-\-recursive\fR to resolve more than one level of dependencies\.
@@ -474,34 +533,41 @@ By default, \fBuses\fR shows all formulae that specify \fIformulae\fR as a depen
 .IP
 By default, \fBuses\fR shows usages of \fBformula\fR by stable builds\. To find cases where \fBformula\fR is used by development or HEAD build, pass \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cache\fR: Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
+.TP
+\fB\-\-cache\fR
+Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cache\fR \fIformula\fR: Display the file or directory used to cache \fIformula\fR\.
+.TP
+\fB\-\-cache\fR \fIformula\fR
+Display the file or directory used to cache \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cellar\fR: Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
+.TP
+\fB\-\-cellar\fR
+Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cellar\fR \fIformula\fR: Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
+.TP
+\fB\-\-cellar\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
 .
-.IP "\(bu" 4
-\fB\-\-env\fR: Show a summary of the Homebrew build environment\.
+.TP
+\fB\-\-env\fR
+Show a summary of the Homebrew build environment\.
 .
-.IP "\(bu" 4
-\fB\-\-prefix\fR: Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR
+.TP
+\fB\-\-prefix\fR
+Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR
 .
-.IP "\(bu" 4
-\fB\-\-prefix\fR \fIformula\fR: Display the location in the cellar where \fIformula\fR is or would be installed\.
+.TP
+\fB\-\-prefix\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR is or would be installed\.
 .
-.IP "\(bu" 4
-\fB\-\-repository\fR: Display where Homebrew\'s \fB\.git\fR directory is located\. For standard installs, the \fBprefix\fR and \fBrepository\fR are the same directory\.
+.TP
+\fB\-\-repository\fR
+Display where Homebrew\'s \fB\.git\fR directory is located\. For standard installs, the \fBprefix\fR and \fBrepository\fR are the same directory\.
 .
-.IP "\(bu" 4
-\fB\-\-version\fR: Print the version number of brew to standard error and exit\.
-.
-.IP "" 0
+.TP
+\fB\-\-version\fR
+Print the version number of brew to standard error and exit\.
 .
 .SH "EXTERNAL COMMANDS"
 Homebrew, like \fBgit\fR(1), supports external commands\. These are executable scripts that reside somewhere in the \fBPATH\fR, named \fBbrew\-\fR\fIcmdname\fR or \fBbrew\-\fR\fIcmdname\fR\fB\.rb\fR, which can be invoked like \fBbrew\fR \fIcmdname\fR\. This allows you to create your own commands without modifying Homebrew\'s internals\.


### PR DESCRIPTION
This fixes a major formatting glitch in the man page, where the list in the `COMMANDS` section was rendered as an unordered list instead of a definition list. (With this fix, it is also consistent with the `ESSENTIAL COMMANDS` section.)

Before:

<img width="850" alt="before fix" src="https://cloud.githubusercontent.com/assets/11892150/11678054/8e053e5a-9e44-11e5-9178-f196d882b643.png">

After:

<img width="850" alt="after fix" src="https://cloud.githubusercontent.com/assets/11892150/11678057/97ecc2f8-9e44-11e5-996f-cf1ceaf89b08.png">