### PR TITLE
man: modernize and reduce code duplication

### DIFF
--- a/Library/Homebrew/cmd/man.rb
+++ b/Library/Homebrew/cmd/man.rb
@@ -25,15 +25,12 @@ module Homebrew
       puts "Writing HTML fragments to #{DOC_PATH}"
       puts "Writing manpages to #{TARGET_PATH}"
 
-      target_file = nil
       Dir["#{SOURCE_PATH}/*.md"].each do |source_file|
         target_html = DOC_PATH/"#{File.basename(source_file, ".md")}.html"
         safe_system "ronn --fragment --pipe --organization='Homebrew' --manual='brew' #{source_file} > #{target_html}"
         target_man = TARGET_PATH/File.basename(source_file, ".md")
         safe_system "ronn --roff --pipe --organization='Homebrew' --manual='brew' #{source_file} > #{target_man}"
       end
-
-      system "man", target_file if ARGV.flag? "--verbose"
     end
   end
 end

--- a/Library/Homebrew/cmd/man.rb
+++ b/Library/Homebrew/cmd/man.rb
@@ -26,10 +26,19 @@ module Homebrew
       puts "Writing manpages to #{TARGET_PATH}"
 
       Dir["#{SOURCE_PATH}/*.md"].each do |source_file|
-        target_html = DOC_PATH/"#{File.basename(source_file, ".md")}.html"
-        safe_system "ronn --fragment --pipe --organization='Homebrew' --manual='brew' #{source_file} > #{target_html}"
-        target_man = TARGET_PATH/File.basename(source_file, ".md")
-        safe_system "ronn --roff --pipe --organization='Homebrew' --manual='brew' #{source_file} > #{target_man}"
+        args = %W[
+          --pipe
+          --organization=Homebrew
+          --manual=brew
+          #{source_file}
+        ]
+        page = File.basename(source_file, ".md")
+
+        target_html = DOC_PATH/"#{page}.html"
+        target_html.atomic_write Utils.popen_read("ronn", "--fragment", *args)
+
+        target_man = TARGET_PATH/page
+        target_man.atomic_write Utils.popen_read("ronn", "--roff", *args)
       end
     end
   end


### PR DESCRIPTION
**Somewhat related question:** Why are we invoking `ronn` with the `--fragment` option to generate the HTML code (that is supposed to be embedded; has no `head`, `body`, etc.) instead of the `--html` option that would generate a full-blown HTML file? Are we actually embedding `brew.1.html` somewhere?