### PR TITLE
povray: fix build issue

### DIFF
--- a/Library/Formula/povray.rb
+++ b/Library/Formula/povray.rb
@@ -61,7 +61,7 @@ class Povray < Formula
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --mandir=#{man}"
+      --mandir=#{man}
     ]
 
     args << "--with-openexr=#{HOMEBREW_PREFIX}" if build.with? "openexr"


### PR DESCRIPTION
Fix issue #45317

Caused by extra " in args making it into the Makefile. Povray now builds correctly (tested on 10.10.5).