### PR TITLE
brew: cask is now a tap command.

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -162,21 +162,8 @@ begin
       Tap.fetch("Homebrew", "services")
     end
 
-    command_installed = false
-
     if possible_tap && !possible_tap.installed?
       possible_tap.install
-      command_installed = true
-    end
-
-    if cmd == "cask" && (brew_cask = Formulary.factory("brew-cask")) \
-       && !brew_cask.installed?
-      require "cmd/install"
-      Homebrew.install_formula(brew_cask)
-      command_installed = true
-    end
-
-    if command_installed
       exec HOMEBREW_BREW_FILE, cmd, *ARGV
     else
       onoe "Unknown command: #{cmd}"


### PR DESCRIPTION
So we can remove the formula installation from `brew.rb`.