### PR TITLE
Fix pyenv formula

### DIFF
--- a/Library/Formula/pyenv.rb
+++ b/Library/Formula/pyenv.rb
@@ -9,34 +9,22 @@ class Pyenv < Formula
 
   depends_on "autoconf" => [:recommended, :run]
   depends_on "pkg-config" => [:recommended, :run]
+  depends_on "openssl" => :recommended
 
   def install
     inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX
-    prefix.install "bin", "completions", "libexec"
-    prefix.install "plugins" => "default-plugins"
-
+    prefix.install Dir["*"]
     %w[pyenv-install pyenv-uninstall python-build].each do |cmd|
-      bin.install_symlink "#{prefix}/default-plugins/python-build/bin/#{cmd}"
+      bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"
     end
-  end
-
-  def post_install
-    var_lib = HOMEBREW_PREFIX/"var/lib/pyenv"
-    %w[plugins versions].each do |dir|
-      var_dir = "#{var_lib}/#{dir}"
-      mkdir_p var_dir
-      ln_sf var_dir, "#{prefix}/#{dir}"
-    end
-
-    (var_lib/"plugins").install_symlink "#{prefix}/default-plugins/python-build"
   end
 
   def caveats; <<-EOS.undent
-    To enable shims and autocompletion add to your profile:
-      if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
-
     To use Homebrew's directories rather than ~/.pyenv add to your profile:
       export PYENV_ROOT=#{var}/pyenv
+
+    To enable shims and autocompletion add to your profile:
+      if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
     EOS
   end
 


### PR DESCRIPTION
pyenv is sharing many of lines from rbenv. I modified pyenv's formula to catch up changes in rbenv's and tweak a little to make it working with pyenv.

* Install all directories inside pyenv to install pyenv's default hook scripts inside `pyenv.d`
* Just install `python-build` as `plugins` in `pyenv`'s prefix. This should work without problem
  since `python-build` can find definition files from its installation path. It's okay if every
  `python-build`, `pyenv-install` and `pyenv-uninstall` are in shell's `$PATH`.
* Add `openssl` as a recommended formula

I believe this should solve pyenv's `post_install` problem Homebrew/homebrew#45871 (cc: @ryankask @xu-cheng)