### PR TITLE
 parallelized `update` + infrastructure for fast shell-based commands

### DIFF
--- a/Library/Homebrew/cmd/shellutils
+++ b/Library/Homebrew/cmd/shellutils
@@ -1,0 +1,300 @@
+#!/bin/sh ##==-- brew-shellutils - shell utility functions for homebrew --==##
+##===--------------------------------------------------------------------===##
+
+##===--------------------------------------------------------------------===##
+##===-- begin helper functions -- source this file or copy/paste below --===##
+##===--------------------------------------------------------------------===##
+
+# Convenience functions for verbose warnings and errors.
+
+note(){ echo "$(blue)$(bold) ➔  $(cclear)$(bold)$*$(cclear)" >&2   ;}
+warn(){ echo "$(yellow)$(bold) ⚠  $(cclear)$(bold)$*$(cclear)" >&2 ;}
+die(){ echo "$(red)$(bold) ⨷  $(magenta)$*$(cclear)" >&2; exit 1   ;}
+
+ohai(){ note "$*" ;}
+opoo(){ warn "$*" ;}
+odie(){ die "$*"  ;}
+
+##===--------------------------------------------------------------------===##
+
+# `/bin/echo` handles multibyte UTF-8 much better than builtins.
+
+echo(){   /bin/echo "$@"              ;}
+print(){  /bin/echo "$@"              ;}
+printf(){ /bin/echo "$@" | tr -d '\n' ;}
+
+##===--------------------------------------------------------------------===##
+
+# Use `tput` for safe terminal colors, so we don't have to hardcode escapes.
+# `tput` is a POSIX utility and outputs proper escapes based on terminfo.
+# This is much safer than hardcoding escape sequences.
+
+underline(){ tput smul    ;}
+cclear(){    tput sgr0    ;}
+bold(){      tput bold    ;}
+black(){     tput setaf 0 ;}
+red(){       tput setaf 1 ;}
+green(){     tput setaf 2 ;}
+yellow(){    tput setaf 3 ;}
+blue(){      tput setaf 4 ;}
+magenta(){   tput setaf 5 ;}
+cyan(){      tput setaf 6 ;}
+white(){     tput setaf 7 ;}
+
+##===--------------------------------------------------------------------===##
+
+# readlink(1), realpath(1) including GNU extensions like `readlink -f`.
+
+## A XSI/POSIX shell implementation of readlink(1), supporting GNU extensions.
+## Also realpath(1) [like the mksh builtin], but doesn't wrap realpath(3).
+## GNU *short* options are supported, just avoid the --longopt aliases;
+## Otherwise, the functionality should be identical.
+
+## One benefit of a using a pure shell implementation is that it can be used
+## *within a script* to canonicalize the path *of the script itself*.
+
+## Latest version should be somewhere around http://github.com/geoff-codes.
+## (c) 2015 Geoff Nixon. Public Domain; no warranty expressed or implied.
+
+readlink()
+{
+  readlink_exists=1
+  readlink_dirs_exist=1
+  readlink_print=echo
+  readlink_sep=''
+
+  readlink_usage()
+  {
+    echo "usage: "$(basename "$0")" [-efmnqsvz] [file ...]" >&2
+  }
+
+  OPTIND=1; while getopts "efhmnqsvz?" readlink_opt; do
+      case "$readlink_opt" in
+        e) readlink_realpath=1; readlink_dirs_exist=1; readlink_exists=1 ;;
+        f) readlink_realpath=1; readlink_dirs_exist=1; readlink_exists=  ;;
+        h) readlink_usage; exit 0                                        ;;
+        m) readlink_realpath=1; readlink_dirs_exist= ; readlink_exists=  ;;
+        n) readlink_print=printf                                         ;;
+      q|s) readlink_verbose=0                                            ;;
+        v) readlink_verbose=1                                            ;;
+        z) readlink_print=printf; readlink_sep='\0'                      ;;
+       \?) readlink_usage; exit 1                                        ;;
+      esac
+  done
+  shift $((OPTIND - 1))
+
+
+  readlink_readlink()
+  {
+    [ $(ls -ld "$@" | wc -l) -ne 1 ] &&
+      echo "Path contains newline!" >&2 && exit 1
+    readlink_readlink="$(ls -ld "$@" | sed 's|.* -> ||')"
+
+    [ $readlink_realpath- != - ] &&
+      [ "$(echo "$readlink_readlink" | cut -c1)" != "/" ] &&
+        readlink_readlink="$(pwd -P)/$readlink_readlink"
+
+    echo "$readlink_readlink"
+  }
+
+  readlink_canonicalize()
+  {
+    [ "$(basename "$@")"- = "."- ] || [ -"$(basename "$@")"- = -".."- ] &&
+      readlink_canon="$(cd "$(pwd -P)/$(basename "$@")"; pwd -P)" ||
+      readlink_canon="$(echo $(pwd -P)/$(basename "$@") | sed 's|//|/|g')"
+    readlink_canonical="$(echo "$readlink_canon" | sed 's|//|/|g')"
+
+    echo "$readlink_canonical"
+  }
+
+  readlink_no_dir()
+  {
+    [ $readlink_dirs_exist- = - ] &&
+      $readlink_print "$@$readlink_sep" && exit 0
+
+    [ $readlink_verbose- = - ] ||
+      echo "Directory $(dirname "$@") doesn't exist." >&2 && exit 1
+  }
+
+  readlink_no_target()
+  {
+     [ $readlink_exists- = - ] &&
+      $readlink_print "$(readlink_canonicalize "$@")$readlink_sep" && exit 0
+
+    [ $readlink_verbose- = - ] ||
+      echo "$@: No such file or directory." >&2 && exit 1
+  }
+
+  readlink_not_link()
+  {
+    [ $readlink_realpath- = - ]  && [ $readlink_verbose- = - ]  && exit 1 ||
+    [ $readlink_realpath- = - ]  && [ $readlink_verbose- != - ] &&
+      echo "$@ is not a link." >&2 && exit 1
+
+    [ $readlink_realpath- != - ]                           &&
+      readlink_canonical="$(readlink_canonicalize "$@")"   &&
+        $readlink_print "$readlink_canonical$readlink_sep" && exit 0
+
+    [ $readlink_verbose-  = - ] ||
+    { [ -f "$@" ] && readlink_file_type="regular file"                     ||
+        [ -d "$@" ] && readlink_file_type="directory"                      ||
+          [ -p "$@" ] && readlink_file_type="FIFO"                         ||
+            [ -b "$@" ] && readlink_file_type="block special file"         ||
+              [ -c "$@" ] && readlink_file_type="character special file"   ||
+                [ -S "$@" ] && readlink_file_type="socket"
+      echo "$(basename "$0"): "$@": is a $readlink_file_type." >&2; exit 1
+    }
+  }
+
+  readlink_try(){
+    readlink_cur_dir="$(dirname "$@")"
+    readlink_cur_base="$(basename "$@")"
+
+    cd "$readlink_cur_dir" 2>/dev/null || readlink_no_dir "$@"
+    [ -e "$readlink_cur_base" ]        || readlink_no_target "$(pwd -P)/$@"
+    [ -L "$readlink_cur_base" ]        || readlink_not_link "$@"
+
+    readlink_readlink="$(readlink_readlink "$readlink_cur_base")"
+
+    [ -$readlink_realpath- = -- ]                                 &&
+      $readlink_print "$readlink_readlink$readlink_sep" && exit 0 ||
+        readlink_try "$readlink_readlink"
+  }
+
+  for readlink_target; do :; done
+  [ "$readlink_target"- = ""- ] && readlink_usage && exit 1
+  readlink_try "$readlink_target"
+}
+
+realpath(){ readlink -f "$@" ;}
+
+##===--------------------------------------------------------------------===##
+
+## whence/which(1), written in POSIX shell and utilities.
+## Supports `which` options: -s (silent) and -a (all), and -v (verbose).
+## Does not support traditional ksh `whence` options.
+
+## (c) 2015 Geoff Nixon. Public Domain; no warranty expressed or implied.
+
+whence(){
+
+  whence_try=""
+  whence_result=""
+  whence_verbose=0
+  whence_silent=0
+  whence_next=break
+
+  whence_usage()
+  {
+    echo "usage: "$(basename "$0")" [-asv] program ..." >&2
+  }
+
+  whence_error()
+  {
+    [ -$whence_verbose- = -1- ] &&
+      echo "$(basename "$0"): no $whence_util in ($PATH)" >&2 ||:
+  }
+
+  OPTIND=1; while getopts "ahsv?" whence_opt; do
+      case "$whence_opt" in
+        a) whence_next=continue ;;
+        h) whence_usage; exit 0 ;;
+        s) whence_silent=1      ;;
+        v) whence_verbose=1     ;;
+       \?) whence_usage; exit 1 ;;
+      esac
+  done; shift $((OPTIND - 1))
+
+  whence_try()
+  {
+    echo "$PATH:." | tr ':' '\n' | while read whence_component; do
+
+      whence_try="$whence_component/$whence_util"
+      [ -e "$whence_try" ] && [ -x "$whence_try" ] &&
+        echo "$whence_try" && $whence_next || continue
+    done
+  }
+
+  for whence_util; do :; done
+  [ -"$whence_util"- = -""- ] && whence_usage && exit 1
+
+  whence_result="$(whence_try "$whence_util")"
+
+  [ -"$whence_result"- = -""- ] && whence_error && exit 1 ||
+    [ -$whence_silent- = -1- ] && exit 0 || echo "$whence_result" | uniq
+}
+
+which(){ whence "$@" ;}
+
+##===--------------------------------------------------------------------===##
+
+# Override TERM if not outputting to a TTY.
+
+brew_shellutils_term_init()
+{
+  [ -t 1 ] && [ -t 2 ] || { TERM=dumb; export TERM ;}
+}
+#===--------------------------------------------------------------------===##
+
+brew_shellutils_help(){
+
+  echo "
+  $(bold)Available in $(underline)brew-shellutils$(cclear) (source this file):
+
+  - $(bold)$(blue)realpath$(cclear)
+  - $(bold)$(blue)readlink$(cclear) [-efmnqsvz]
+
+    $(bold)Fully dereference symbolic links. Compatible with GNU readlink.
+    ($(cclear)brew shellutils is $(underline)$(realpath "$0")$(cclear)"\)."
+    $(cclear)$(bold)
+  - $(blue)whence$(cclear)$(bold)
+  - $(blue)which $(cclear)[-asv]
+
+    $(bold)Like /usr/bin/which. $(underline)Not a ksh \`whence\`$(cclear).
+    $(cclear)$(bold)
+  - $(blue)ohai$(cclear)$(bold)
+  - $(blue)note$(cclear)$(bold)
+       " >&2
+  note "Pretty-print a message to standard error."
+
+   echo "$(bold)
+  - $(blue)opoo$(cclear)$(bold)
+  - $(blue)warn$(cclear)$(bold)
+        " >&2
+
+  warn "$(yellow)Pretty-print a warning to standard error."
+
+  echo "$(bold)
+  - $(blue)odie$(cclear)$(bold)
+  - $(blue)die$(cclear)$(bold)
+       " >&2
+
+  echo " $(red)⨷  $(bold)Pretty-print an error to standard error, exit 1." >&2
+
+  echo "$(cclear)
+  - $(bold)$(red)red$(cclear)
+  - $(bold)$(yellow)yellow$(cclear)
+  - $(bold)$(magenta)magenta$(cclear)
+  - $(bold)$(cyan)cyan$(cclear)
+  - $(bold)$(green)green$(cclear)
+
+  $(bold) These use tput for $(underline)safe$(cclear)$(bold) terminal colors.
+  $(cclear)" >&2
+ cclear
+}
+
+##===--------------------------------------------------------------------===##
+
+# Intitialization and help.
+
+brew_shellutils_term_init
+brew_shellutils_main(){ brew_shellutils_help "$@" ;}
+
+##===--------------------------------------------------------------------===##
+##===--- end helper functions -------------------------------------------===##
+##===--------------------------------------------------------------------===##
+
+case $(basename "$0") in
+   *shellutils) brew_shellutils_main "$@" ;;
+   *|'') continue ;;
+esac

--- a/Library/Homebrew/cmd/shellutils
+++ b/Library/Homebrew/cmd/shellutils
@@ -9,7 +9,7 @@
 
 note(){ echo "$(blue)$(bold) ➔  $(cclear)$(bold)$*$(cclear)" >&2   ;}
 warn(){ echo "$(yellow)$(bold) ⚠  $(cclear)$(bold)$*$(cclear)" >&2 ;}
-die(){ echo "$(red)$(bold) ⨷  $(magenta)$*$(cclear)" >&2; exit 1   ;}
+die(){ echo "$(red)$(bold) ⨷  $*$(cclear)" >&2; exit 1   ;}
 
 ohai(){ note "$*" ;}
 opoo(){ warn "$*" ;}
@@ -234,12 +234,13 @@ brew_shellutils_term_init()
 {
   [ -t 1 ] && [ -t 2 ] || { TERM=dumb; export TERM ;}
 }
+
 #===--------------------------------------------------------------------===##
 
 brew_shellutils_help(){
 
   echo "
-  $(bold)Available in $(underline)brew-shellutils$(cclear) (source this file):
+  $(bold)Available in $(underline)brew shellutils$(cclear) (source this file):
 
   - $(bold)$(blue)realpath$(cclear)
   - $(bold)$(blue)readlink$(cclear) [-efmnqsvz]
@@ -287,8 +288,10 @@ brew_shellutils_help(){
 
 # Intitialization and help.
 
-brew_shellutils_term_init
-brew_shellutils_main(){ brew_shellutils_help "$@" ;}
+brew_shellutils_main(){
+ brew_shellutils_term_init
+ brew_shellutils_help "$@"
+}
 
 ##===--------------------------------------------------------------------===##
 ##===--- end helper functions -------------------------------------------===##

--- a/Library/Homebrew/cmd/update
+++ b/Library/Homebrew/cmd/update
@@ -1,0 +1,54 @@
+#!/bin/sh # brew-update.sh
+[ -n "$HOMEBREW_VERBOSE" ] && set -x
+
+trap_cleanup()
+{
+  for job in $(jobs -p); do
+    kill -s 2 $job >/dev/null 2>&1
+  done
+
+  for each in $HOMEBREW_PREFIX $(ls -1d $BREW_LIBRARY_DIRECTORY/Taps/*/* 2>/dev/null); do
+    cd "$each"
+    git config --remove-section brew >/dev/null 2>&1
+    git stash pop >/dev/null 2>&1
+  done
+}
+
+trap trap_cleanup HUP INT QUIT ABRT KILL TERM
+
+update_if_necessary()
+(
+  cd "$*"
+  trap trap_cleanup HUP INT QUIT ABRT KILL TERM
+
+  # Build the URI for the API call based on our remote and branch.
+  uri=$(git ls-remote --get-url | sed -e's|git://|https://|' -e's|\.git$||' \
+                                      -e's|github.com|api.github.com/repos|')
+  ref=$(git symbolic-ref HEAD)
+  api_uri=$(echo $uri | sed 's|$|/git|')/$ref
+
+  # We save a few milliseconds with a standard config avoiding the refs API.
+  [ "$ref" = "refs/heads/master" ] && api_uri="$uri/commits/master"
+
+  etag=$(git config brew.etag) # ETag gets cached in .git/config.
+  [ -z "$etag" ] && etag=xxx # On first run, set a fake ETag (for grep).
+
+  response=$(curl -isLH "If-None-Match: \"$etag\"" $api_uri)
+
+  # If the ETag matches, we can exit now.
+  echo "$response" | grep "ETag: \"$etag\"" >/dev/null 2>&1 && return 0 ||
+  {
+    { git stash save --include-untracked >/dev/null 2>&1 || :;} &&
+    { git pull --ff --no-rebase >/dev/null 2>&1 ;}              &&
+    { git stash pop >/dev/null 2>&1 || :;}
+
+    etag=$(echo "$response" | grep 'ETag:' | sed 's|.* "\(.*\)"|\1|')
+    git config brew.etag $(echo $etag | tr -d '\r') # Updated cached ETag
+  }
+)
+
+update_if_necessary "$HOMEBREW_PREFIX"
+
+for each in $(ls -1d $BREW_LIBRARY_DIRECTORY/Taps/*/* 2>/dev/null); do
+  update_if_necessary "$each" &
+done

--- a/bin/brew
+++ b/bin/brew
@@ -1,42 +1,79 @@
 #!/bin/sh
-chdir() {
-  cd "$@" >/dev/null
+
+realpath()
+# A fast, pared-down shell implementation of GNU `readlink -f`.
+# This is needed to fully dereference and canonicalize the relevant paths.
+# A full version of this is included in `brew shellutils`.
+{
+  rl_rl()
+  {
+    rl_rl="$(ls -ld "$*" | sed 's|.* -> ||')"
+    [ "$(echo "$rl_rl" | cut -c1)" != "/" ] && rl_rl="$(pwd -P)/$rl_rl"
+    echo "$rl_rl"
+  }
+
+  rl_canonicalize()
+  {
+    [ "$(basename "$*")"- = "."- ] || [ -"$(basename "$*")"- = -".."- ] &&
+      rl_canon=$(cd "$(pwd -P)/$(basename "$*")"; pwd -P) ||
+      rl_canon=$(echo $(pwd -P)/$(basename "$*") | sed 's|//|/|g')
+    rl_canonical=$(echo "$rl_canon" | sed 's|//|/|g')
+    echo "$rl_canonical"
+  }
+
+  rl_no_dir()
+  {
+    echo "$*" && return 0
+  }
+
+  rl_not_link()
+  {
+    rl_canonicalize "$*" && exit 0
+  }
+
+  rl_try(){
+    rl_cur_dir=$(dirname "$*")
+    rl_cur_base=$(basename "$*")
+
+    cd "$rl_cur_dir" 2>/dev/null || rl_no_dir "$*"
+    [ -e "$rl_cur_base" ] || rl_canonicalize "$(pwd -P)/$*"
+    [ -L "$rl_cur_base" ] || rl_not_link "$*"
+
+    rl_rl=$(rl_rl "$rl_cur_base")
+    rl_try "$rl_rl"
+  }
+
+  rl_try "$*"
 }
 
-BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
-HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"
+HOMEBREW_BREW_FILE=$(realpath "$0")
+BREW_FILE_DIRECTORY=$(dirname "$HOMEBREW_BREW_FILE")
+BREW_LIBRARY_DIRECTORY="$(cd "$BREW_FILE_DIRECTORY/../Library"; pwd -P)"
+HOMEBREW_PREFIX=$(dirname "$BREW_FILE_DIRECTORY")
 
-if [ -L "$HOMEBREW_BREW_FILE" ]
-then
-  BREW_SYMLINK="$(readlink "$HOMEBREW_BREW_FILE")"
-  BREW_SYMLINK_DIRECTORY="$(dirname "$BREW_SYMLINK")"
-  BREW_FILE_DIRECTORY="$(chdir "$BREW_FILE_DIRECTORY" &&
-                         chdir "$BREW_SYMLINK_DIRECTORY" && pwd -P)"
-fi
+export BREW_FILE_DIRECTORY
+export BREW_LIBRARY_DIRECTORY
+export HOMEBREW_PREFIX
+export HOMEBREW_BREW_FILE
 
-BREW_LIBRARY_DIRECTORY="$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)"
+case "$1" in
+      update) shift
+              exec "$BREW_LIBRARY_DIRECTORY/Homebrew/cmd/update"     "$@" ;;
+  shellutils) shift
+              exec "$BREW_LIBRARY_DIRECTORY/Homebrew/cmd/shellutils" "$@" ;;
 
-# Users may have these set, pointing the system Ruby
-# at non-system gem paths
+  ## This is where other commands which don't call any ruby would be handled.
+        ''|*) continue ;;
+esac
+
+# Users may have these set, pointing the system Ruby at non-system gem paths
 unset GEM_HOME
 unset GEM_PATH
 
-if [ -z "$HOMEBREW_DEVELOPER" ]
-then
-  unset HOMEBREW_RUBY_PATH
-fi
+[ -z "$HOMEBREW_DEVELOPER" ] && unset HOMEBREW_RUBY_PATH
+[ -z "$HOMEBREW_RUBY_PATH" ] && [ "$(uname)" = "Darwin" ] &&
+ HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby" || HOMEBREW_RUBY_PATH="$(which ruby)"
 
-if [ -z "$HOMEBREW_RUBY_PATH" ]
-then
-  if [ "$(uname -s)" = "Darwin" ]
-  then
-    HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
-  else
-    HOMEBREW_RUBY_PATH="$(which ruby)"
-  fi
-fi
-
-export HOMEBREW_BREW_FILE
 export HOMEBREW_RUBY_PATH
 
 exec "$HOMEBREW_RUBY_PATH" -W0 "$BREW_LIBRARY_DIRECTORY/brew.rb" "$@"

--- a/bin/brew
+++ b/bin/brew
@@ -57,12 +57,31 @@ export HOMEBREW_PREFIX
 export HOMEBREW_BREW_FILE
 
 case "$1" in
-      update) shift
+
+          update) shift
               exec "$BREW_LIBRARY_DIRECTORY/Homebrew/cmd/update"     "$@" ;;
-  shellutils) shift
+
+      shellutils) shift
               exec "$BREW_LIBRARY_DIRECTORY/Homebrew/cmd/shellutils" "$@" ;;
 
-  ## This is where other commands which don't call any ruby would be handled.
+        --prefix) shift
+              [ $# -eq 0 ] && echo $HOMEBREW_PREFIX && exit 0
+
+              for each in "$@"; do
+                incellar=$(ls -1d $HOMEBREW_PREFIX/Cellar/$each/* 2>/dev/null)
+                [ -z "$incellar" ] && echo "$HOMEBREW_PREFIX/opt/$each" ||
+                  echo "$cellar"
+                shift
+              done
+
+              exit 0 ;;
+
+           *) tapcommand=$(ls $HOMEBREW_PREFIX/*/*/*/*/*/brew-$1 2>/dev/null)
+              [ ! -z $tapcommand ] && shift && exec "$tapcommand" "$@"
+
+              externalcommand=$(which brew-$1) && shift &&
+                exec "$externalcommand" "$@" || continue ;;
+
         ''|*) continue ;;
 esac
 


### PR DESCRIPTION
Following up on discussion in #38818, this PR tracks a topic branch I've created for implementing a much faster `brew update` (the idea being that, once stable, it could/would run automatically).

I've still yet to implement the latest discussed changes in #38818, but part and parcel of this (and prerequisite to it) is some additional infrastructure for handling commands "outside" ruby.

At this time, this PR consists of:

- The new shell-based `update` command (WIP).

- Some necessary changes to the `bin/brew` shell script:
  - The script now fully dereferences its path(s). Previously, one level of symbolic links.
  - A switch to handle parsing and executing subcommands, **prior** to to the ruby `exec`
  - To illustrate and test, I've implemented `--prefix` in-line in the script, and the handling of both explicit (`update`) and implicit (i.e., from a tap, or elsewhere in one's path) subcommands.

- A small shell utility library, consisting of some helpful convenience functions I've written.
  `brew shellutils` both illustrates and documents its usage.

Additionally, I've put a couple of example commands in a tap, `geoff-codes/fastcommands`, to illustrate how all the above could be utilized.

I'll post some more benchmarks over the next couple of days, in addition to fleshing out the new update command. In the meantime, please feel free to kick the tires, give your thoughts or contribute!

:beers:
