### PR TITLE
Mongodb 2.6.10 (stable mongodb 2.6)

### DIFF
--- a/Library/Formula/mongodb26.rb
+++ b/Library/Formula/mongodb26.rb
@@ -1,0 +1,119 @@
+class Mongodb26 < Formula
+  homepage "https://www.mongodb.org/"
+  url "https://fastdl.mongodb.org/src/mongodb-src-r2.6.10.tar.gz"
+  sha256 "74228a22aaf99570e706ecde20658165e3983ee8a9f327e80974f82a4e819476"
+
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles-versions"
+    cellar :any
+    revision 1
+    sha256 "eb8e16df2c97b154eec8b748a1939e1f8848fe63ff884dc38342ac650d9f8aa9" => :yosemite
+    sha256 "c1e07199ff333e8bb5a74ce9f546418540cccba044dae88ec792a1d19b8e0ae3" => :mavericks
+    sha256 "db314adf23ea2406a98a88c3872ab76f8879ef23cff1b56997446d02664fa663" => :mountain_lion
+  end
+
+  option "with-boost", "Compile using installed boost, not the version shipped with mongodb"
+
+  depends_on "boost" => :optional
+  depends_on :macos => :snow_leopard
+  depends_on "scons" => :build
+  depends_on "openssl" => :optional
+
+  # Review this patch with each release.
+  # This modifies the SConstruct file to include 10.10 as an accepted build option.
+  if MacOS.version == :yosemite
+    patch do
+      url "https://raw.githubusercontent.com/DomT4/scripts/fbc0cda/Homebrew_Resources/Mongodb/mongoyosemite.diff"
+      sha1 "f4824e93962154aad375eb29527b3137d07f358c"
+    end
+  end
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      -j#{ENV.make_jobs}
+      --cc=#{ENV.cc}
+      --cxx=#{ENV.cxx}
+      --osx-version-min=#{MacOS.version}
+    ]
+
+    # --full installs development headers and client library, not just binaries
+    # (only supported pre-2.7)
+    args << "--full" if build.stable?
+    args << "--use-system-boost" if build.with? "boost"
+    args << "--64" if MacOS.prefer_64_bit?
+
+    # Pass the --disable-warnings-as-errors flag to Scons when on Yosemite
+    # or later, otherwise 2.6.x won't build from source due to a Clang 3.5+
+    # error - https://github.com/mongodb/mongo/pull/956#issuecomment-94545753
+    args << "--disable-warnings-as-errors" if MacOS.version >= :yosemite
+
+    if build.with? "openssl"
+      args << "--ssl" << "--extrapath=#{Formula["openssl"].opt_prefix}"
+    end
+
+    scons "install", *args
+
+    (buildpath+"mongod.conf").write mongodb_conf
+    etc.install "mongod.conf"
+
+    (var+"mongodb").mkpath
+    (var+"log/mongodb").mkpath
+  end
+
+  def mongodb_conf; <<-EOS.undent
+    systemLog:
+      destination: file
+      path: #{var}/log/mongodb/mongo.log
+      logAppend: true
+    storage:
+      dbPath: #{var}/mongodb
+    net:
+      bindIp: 127.0.0.1
+    EOS
+  end
+
+  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/mongod</string>
+        <string>--config</string>
+        <string>#{etc}/mongod.conf</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <false/>
+      <key>WorkingDirectory</key>
+      <string>#{HOMEBREW_PREFIX}</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/mongodb/output.log</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/mongodb/output.log</string>
+      <key>HardResourceLimits</key>
+      <dict>
+        <key>NumberOfFiles</key>
+        <integer>1024</integer>
+      </dict>
+      <key>SoftResourceLimits</key>
+      <dict>
+        <key>NumberOfFiles</key>
+        <integer>1024</integer>
+      </dict>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/mongod", "--sysinfo"
+  end
+end


### PR DESCRIPTION
Add mongodb 2.6.10 formulae for future references, this specific patch of mongodb fixes some issues regarding sub contained queries like $nin $neq