### PR TITLE
De-SSL homepage protocol for haskellstack.org formula

### DIFF
--- a/Library/Formula/haskell-stack.rb
+++ b/Library/Formula/haskell-stack.rb
@@ -4,7 +4,7 @@ class HaskellStack < Formula
   include Language::Haskell::Cabal
 
   desc "The Haskell Tool Stack"
-  homepage "https://haskellstack.org"
+  homepage "http://haskellstack.org"
   url "https://hackage.haskell.org/package/stack-0.1.10.0/stack-0.1.10.0.tar.gz"
   sha256 "9b730c2b4b7bb87fc70ccbf0bab0e2fe6f0775644b36972b4dea9088cbcab979"
 


### PR DESCRIPTION
The `homepage` for haskellstack.org does not currently listen to https:// connections; I've changed the protocol to http://haskellstack.org

:ok_hand: :point_right: http://haskellstack.org
:cry: :point_right: https://haskellstack.org