### PR TITLE
postgrest: enable executable stripping on install

### DIFF
--- a/Library/Formula/postgrest.rb
+++ b/Library/Formula/postgrest.rb
@@ -22,7 +22,7 @@ class Postgrest < Formula
   setup_ghc_compilers
 
   def install
-    install_cabal_package
+    install_cabal_package "--enable-executable-stripping"
   end
 
   test do


### PR DESCRIPTION
Add the "--enable-executable-stripping" flag when calling
"install_cabal_package" to reduce the size of the binary.