### PR TITLE
dependency: merge_repeats using option names.

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -24,21 +24,23 @@ class BuildOptions
   #   args << "--with-example1"
   # end</pre>
   def with?(val)
-    name = val.respond_to?(:option_name) ? val.option_name : val
+    option_names = val.respond_to?(:option_names) ? val.option_names : [val]
 
-    if option_defined? "with-#{name}"
-      include? "with-#{name}"
-    elsif option_defined? "without-#{name}"
-      !include? "without-#{name}"
-    else
-      false
+    option_names.any? do |name|
+      if option_defined? "with-#{name}"
+        include? "with-#{name}"
+      elsif option_defined? "without-#{name}"
+        !include? "without-#{name}"
+      else
+        false
+      end
     end
   end
 
   # True if a {Formula} is being built without a specific option.
   # <pre>args << "--no-spam-plz" if build.without? "spam"
-  def without?(name)
-    !with? name
+  def without?(val)
+    !with?(val)
   end
 
   # True if a {Formula} is being built as a bottle (i.e. binary package).

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -4,15 +4,15 @@ require "dependable"
 class Dependency
   include Dependable
 
-  attr_reader :name, :tags, :env_proc, :option_name
+  attr_reader :name, :tags, :env_proc, :option_names
 
   DEFAULT_ENV_PROC = proc {}
 
-  def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_name = name)
+  def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_names = [name])
     @name = name
     @tags = tags
     @env_proc = env_proc
-    @option_name = option_name
+    @option_names = option_names
   end
 
   def to_s
@@ -125,7 +125,8 @@ class Dependency
         deps = grouped.fetch(name)
         dep  = deps.first
         tags = deps.flat_map(&:tags).uniq
-        dep.class.new(name, tags, dep.env_proc)
+        option_names = deps.flat_map(&:option_names).uniq
+        dep.class.new(name, tags, dep.env_proc, option_names)
       end
     end
   end
@@ -134,9 +135,9 @@ end
 class TapDependency < Dependency
   attr_reader :tap
 
-  def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_name = name.split("/").last)
+  def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_names = [name.split("/").last])
     @tap = name.rpartition("/").first
-    super(name, tags, env_proc, option_name)
+    super(name, tags, env_proc, option_names)
   end
 
   def installed?

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -10,7 +10,6 @@ class Requirement
   include Dependable
 
   attr_reader :tags, :name, :cask, :download, :default_formula
-  alias_method :option_name, :name
 
   def initialize(tags = [])
     @default_formula = self.class.default_formula
@@ -24,6 +23,10 @@ class Requirement
     @tags = tags
     @tags << :build if self.class.build
     @name ||= infer_name
+  end
+
+  def option_names
+    [name]
   end
 
   # The message to show when the requirement is not met.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -185,12 +185,12 @@ class SoftwareSpec
   end
 
   def add_dep_option(dep)
-    name = dep.option_name
-
-    if dep.optional? && !option_defined?("with-#{name}")
-      options << Option.new("with-#{name}", "Build with #{name} support")
-    elsif dep.recommended? && !option_defined?("without-#{name}")
-      options << Option.new("without-#{name}", "Build without #{name} support")
+    dep.option_names.each do |name|
+      if dep.optional? && !option_defined?("with-#{name}")
+        options << Option.new("with-#{name}", "Build with #{name} support")
+      elsif dep.recommended? && !option_defined?("without-#{name}")
+        options << Option.new("without-#{name}", "Build without #{name} support")
+      end
     end
   end
 end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -147,12 +147,15 @@ class Tab < OpenStruct
   end
 
   def with?(val)
-    name = val.respond_to?(:option_name) ? val.option_name : val
-    include?("with-#{name}") || unused_options.include?("without-#{name}")
+    option_names = val.respond_to?(:option_names) ? val.option_names : [val]
+
+    option_names.any? do |name|
+      include?("with-#{name}") || unused_options.include?("without-#{name}")
+    end
   end
 
-  def without?(name)
-    !with? name
+  def without?(val)
+    !with?(val)
   end
 
   def include?(opt)

--- a/Library/Homebrew/test/test_build_options.rb
+++ b/Library/Homebrew/test/test_build_options.rb
@@ -20,6 +20,7 @@ class BuildOptionsTests < Homebrew::TestCase
     assert @build.with?("bar")
     assert @build.with?("baz")
     assert @build.without?("qux")
+    assert @build.without?("xyz")
   end
 
   def test_used_options

--- a/Library/Homebrew/test/test_dependency.rb
+++ b/Library/Homebrew/test/test_dependency.rb
@@ -49,13 +49,13 @@ class DependencyTests < Homebrew::TestCase
 
     foo_named_dep = merged.find {|d| d.name == "foo"}
     assert_equal [:build, "bar"], foo_named_dep.tags
-    assert_includes foo_named_dep.option_name, "foo"
-    assert_includes foo_named_dep.option_name, "foo2"
+    assert_includes foo_named_dep.option_names, "foo"
+    assert_includes foo_named_dep.option_names, "foo2"
 
     xyz_named_dep = merged.find {|d| d.name == "xyz"}
     assert_equal ["abc"], xyz_named_dep.tags
-    assert_includes xyz_named_dep.option_name, "foo"
-    refute_includes xyz_named_dep.option_name, "foo2"
+    assert_includes xyz_named_dep.option_names, "foo"
+    refute_includes xyz_named_dep.option_names, "foo2"
   end
 
   def test_equality
@@ -73,8 +73,8 @@ class DependencyTests < Homebrew::TestCase
 end
 
 class TapDependencyTests < Homebrew::TestCase
-  def test_option_name
+  def test_option_names
     dep = TapDependency.new("foo/bar/dog")
-    assert_equal "dog", dep.option_name
+    assert_equal %w[dog], dep.option_names
   end
 end

--- a/Library/Homebrew/test/test_dependency.rb
+++ b/Library/Homebrew/test/test_dependency.rb
@@ -52,3 +52,10 @@ class DependencyTests < Homebrew::TestCase
     refute_eql foo1, foo3
   end
 end
+
+class TapDependencyTests < Homebrew::TestCase
+  def test_option_name
+    dep = TapDependency.new("foo/bar/dog")
+    assert_equal "dog", dep.option_name
+  end
+end

--- a/Library/Homebrew/test/test_dependency.rb
+++ b/Library/Homebrew/test/test_dependency.rb
@@ -39,6 +39,25 @@ class DependencyTests < Homebrew::TestCase
     assert_equal [:build, "bar"], dep.tags
   end
 
+  def test_merge_repeats
+    dep = Dependency.new("foo", [:build], nil, "foo")
+    dep2 = Dependency.new("foo", ["bar"], nil, "foo2")
+    dep3 = Dependency.new("xyz", ["abc"], nil, "foo")
+    merged = Dependency.merge_repeats([dep, dep2, dep3])
+    assert_equal 2, merged.length
+    assert_equal Dependency, merged.first.class
+
+    foo_named_dep = merged.find {|d| d.name == "foo"}
+    assert_equal [:build, "bar"], foo_named_dep.tags
+    assert_includes foo_named_dep.option_name, "foo"
+    assert_includes foo_named_dep.option_name, "foo2"
+
+    xyz_named_dep = merged.find {|d| d.name == "xyz"}
+    assert_equal ["abc"], xyz_named_dep.tags
+    assert_includes xyz_named_dep.option_name, "foo"
+    refute_includes xyz_named_dep.option_name, "foo2"
+  end
+
   def test_equality
     foo1 = Dependency.new("foo")
     foo2 = Dependency.new("foo")

--- a/Library/Homebrew/test/test_requirement.rb
+++ b/Library/Homebrew/test/test_requirement.rb
@@ -14,9 +14,9 @@ class RequirementTests < Homebrew::TestCase
     assert_equal %w[bar baz].sort, dep.tags.sort
   end
 
-  def test_option_name
+  def test_option_names
     dep = TestRequirement.new
-    assert_equal "test", dep.option_name
+    assert_equal %w[test], dep.option_names
   end
 
   def test_preserves_symbol_tags

--- a/Library/Homebrew/test/test_requirement.rb
+++ b/Library/Homebrew/test/test_requirement.rb
@@ -2,6 +2,8 @@ require "testing_env"
 require "requirement"
 
 class RequirementTests < Homebrew::TestCase
+  class TestRequirement < Requirement; end
+
   def test_accepts_single_tag
     dep = Requirement.new(%w[bar])
     assert_equal %w[bar], dep.tags
@@ -10,6 +12,11 @@ class RequirementTests < Homebrew::TestCase
   def test_accepts_multiple_tags
     dep = Requirement.new(%w[bar baz])
     assert_equal %w[bar baz].sort, dep.tags.sort
+  end
+
+  def test_option_name
+    dep = TestRequirement.new
+    assert_equal "test", dep.option_name
   end
 
   def test_preserves_symbol_tags


### PR DESCRIPTION
You cannot assume that a name is sufficient for a dependency to be unique. For example, a `default_formula` expansion of `gcc` for a `:fortran` `Requirement` does needs to retain the correct option name so that, if there's both a `gcc` dependency and a `:fortran` requirement they are treated as separate dependencies and both `with-gcc` and `with-fortran` have the expected effects.

This fixes the issue described in https://github.com/Homebrew/homebrew/pull/45730#issuecomment-159948546 which was a regression introduced in https://github.com/Homebrew/homebrew/issues/45420.

CC @apjanke and @xu-cheng for thoughts and review