### PR TITLE
bash-completion: fix file completion with spaces

### DIFF
--- a/Library/Formula/bash-completion.rb
+++ b/Library/Formula/bash-completion.rb
@@ -54,6 +54,15 @@ diff --git a/bash_completion b/bash_completion
 index 6601937..5184767 100644
 --- a/bash_completion
 +++ b/bash_completion
+@@ -640,7 +640,7 @@
+ 
+     _quote_readline_by_ref "$cur" quoted
+     toks=( ${toks[@]-} $(
+-        compgen -d -- "$quoted" | {
++        compgen -d -- "$cur" | {
+             while read -r tmp; do
+                 # TODO: I have removed a "[ -n $tmp ] &&" before 'printf ..',
+                 #       and everything works again. If this bug suddenly
 @@ -1334,7 +1334,7 @@ _known_hosts_real()
  
      # append any available aliases from config files


### PR DESCRIPTION
 * Attempting to complete a file name with a space in it with more than one
   possible completion was failing
 * This was fixed upstream after the 2.1 release, but not part of any official
   release yet
 * Redhat bug: https://bugzilla.redhat.com/show_bug.cgi?id=1171396
 * Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740971