### PR TITLE
openssl: restore Lion build support

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,5 +1,5 @@
 class Openssl < Formula
-  desc "OpenSSL SSL/TLS cryptography library"
+  desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
   url "https://www.openssl.org/source/openssl-1.0.2e.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2e.tar.gz"
@@ -12,6 +12,9 @@ class Openssl < Formula
     sha256 "1c41a5dbe6728f3037be5003583009334b18922e9bc6bd0bb1065676ee32940b" => :mavericks
   end
 
+  keg_only :provided_by_osx,
+    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
+
   option :universal
   option "without-test", "Skip build-time tests (not recommended)"
 
@@ -19,13 +22,21 @@ class Openssl < Formula
 
   depends_on "makedepend" => :build
 
-  keg_only :provided_by_osx,
-    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
+  # Xcode 7 Clang fix introduced regression which makes older Clang versions
+  # incorrectly declare suitable instructions.
+  # https://github.com/openssl/openssl/issues/494
+  # https://svn.macports.org/repository/macports/trunk/dports/devel/openssl/files/fix-Apple-clang-version-detection.patch
+  if MacOS.version <= :lion
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/312f6228/openssl/fix-Apple-clang-version-detection.patch"
+      sha256 "a3e0e13e6c70d85d916bb88cbddc134952794d6292fbab4f2740ac9a07759606"
+    end
+  end
 
   def arch_args
     {
       :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
-      :i386   => %w[darwin-i386-cc]
+      :i386   => %w[darwin-i386-cc],
     }
   end
 


### PR DESCRIPTION
Using patch from Clemens Lang, submitted upstream at https://github.com/openssl/openssl/issues/494.

Closes #46751.