### PR TITLE
update: make stashing local changes more robust

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -225,7 +225,9 @@ class Updater
         puts "Stashing uncommitted changes to #{repository}."
         system "git", "status", "--short", "--untracked-files=all"
       end
-      safe_system "git", "stash", "save", "--include-untracked", *@quiet_args
+      safe_system "git", "-c", "user.email=brew-update@localhost",
+                         "-c", "user.name=brew update",
+                         "stash", "save", "--include-untracked", *@quiet_args
       safe_system "git", "reset", "--hard", *@quiet_args
       @stashed = true
     end


### PR DESCRIPTION
Users with local changes and without a configured Git identity won't be able to update Homebrew via `brew update`, as the update will fail when trying to stash the local modifications with `git stash`. They will be unable to proceed until they follow Git's advice to configure their identity or they manage to revert their local changes (like in #46930).

This change always sets a commit e-mail and name, avoiding this issue. A nice bonus is that experienced Git users can see who created the stash commit (identifying `brew update` as the author).

Prior to this change, affected users will see their `brew update` runs fail with something like:

```
$ brew update

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got '(none)')
Cannot save the current index state
Error: Failure while executing: git stash save --include-untracked --quiet
```

cc @mikemcquaid