### PR TITLE
cleanup: consistently document --dry-run option

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -55,7 +55,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `cat` <formula>:
     Display the source to <formula>.
 
-  * `cleanup` [`--force`] [`--prune=`<days>] [`-n`] [`-s`] [<formulae>]:
+  * `cleanup` [`--force`] [`--prune=`<days>] [`--dry-run`] [`-s`] [<formulae>]:
     For all installed or specific formulae, remove any older versions from the
     cellar. By default, does not remove out-of-date keg-only brews, as other
     software may link directly to specific versions. In addition, old downloads from
@@ -65,7 +65,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--prune=`<days> is specified, remove all cache files older than <days>.
 
-    If `-n` is passed, show what would be removed, but do not actually remove anything.
+    If `--dry-run` or `-n` is passed, show what would be removed, but do not
+    actually remove anything.
 
     If `-s` is passed, scrubs the cache, removing downloads for even the latest
     versions of formulae. Note downloads for any installed formulae will still not be

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -49,7 +49,7 @@ connection are run. This should be used when creating for new formulae.</p>
 <p><code>audit</code> exits with a non-zero status if any errors are found. This is useful,
 for instance, for implementing pre-commit hooks.</p></dd>
 <dt><code>cat</code> <var>formula</var></dt><dd><p>Display the source to <var>formula</var>.</p></dd>
-<dt><code>cleanup</code> [<code>--force</code>] [<code>--prune=</code><var>days</var>] [<code>-n</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
+<dt><code>cleanup</code> [<code>--force</code>] [<code>--prune=</code><var>days</var>] [<code>--dry-run</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
 cellar. By default, does not remove out-of-date keg-only brews, as other
 software may link directly to specific versions. In addition, old downloads from
 the Homebrew download-cache are deleted.</p>
@@ -58,7 +58,8 @@ the Homebrew download-cache are deleted.</p>
 
 <p>If <code>--prune=</code><var>days</var> is specified, remove all cache files older than <var>days</var>.</p>
 
-<p>If <code>-n</code> is passed, show what would be removed, but do not actually remove anything.</p>
+<p>If <code>--dry-run</code> or <code>-n</code> is passed, show what would be removed, but do not
+actually remove anything.</p>
 
 <p>If <code>-s</code> is passed, scrubs the cache, removing downloads for even the latest
 versions of formulae. Note downloads for any installed formulae will still not be

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -64,7 +64,7 @@ If \fB\-\-online\fR is passed, additional slower checks that require a network c
 Display the source to \fIformula\fR\.
 .
 .TP
-\fBcleanup\fR [\fB\-\-force\fR] [\fB\-\-prune=\fR\fIdays\fR] [\fB\-n\fR] [\fB\-s\fR] [\fIformulae\fR]
+\fBcleanup\fR [\fB\-\-force\fR] [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [\fIformulae\fR]
 For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only brews, as other software may link directly to specific versions\. In addition, old downloads from the Homebrew download\-cache are deleted\.
 .
 .IP
@@ -74,7 +74,7 @@ If \fB\-\-force\fR is passed, remove out\-of\-date keg\-only brews as well\.
 If \fB\-\-prune=\fR\fIdays\fR is specified, remove all cache files older than \fIdays\fR\.
 .
 .IP
-If \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
+If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
 .
 .IP
 If \fB\-s\fR is passed, scrubs the cache, removing downloads for even the latest versions of formulae\. Note downloads for any installed formulae will still not be deleted\. If you want to delete those too: \fBrm \-rf $(brew \-\-cache)\fR


### PR DESCRIPTION
All other commands document both `--dry-run` and `-n` in the option description and mention only `--dry-run` in the command summary. Let's do the same for `cleanup`.