### PR TITLE
update: avoid unnecessarily recreating 'master'

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -245,7 +245,13 @@ class Updater
     end
 
     if @initial_branch != @upstream_branch && !@initial_branch.empty?
-      safe_system "git", "checkout", "--force", "-B", @upstream_branch, "origin/#{@upstream_branch}", *@quiet_args
+      # Recreate and check out `#{upstream_branch}` if unable to fast-forward
+      # it to `origin/#{@upstream_branch}`. Otherwise, just check it out.
+      if system("git", "merge-base", "--is-ancestor", @upstream_branch, "origin/#{@upstream_branch}")
+        safe_system "git", "checkout", "--force", @upstream_branch, *@quiet_args
+      else
+        safe_system "git", "checkout", "--force", "-B", @upstream_branch, "origin/#{@upstream_branch}", *@quiet_args
+      end
     end
 
     @initial_revision = read_current_revision


### PR DESCRIPTION
This only affects the behavior of `brew update` while being on a branch `feature` that doesn't track the upstream branch. For simplicity, the upstream branch is assumed to be called `master` (`@upstream_branch` in the code). Consider the following simplified commit history:

```
        master      origin/master (current state of remote)
        |           |
A---B---C---D---E---F
     \
      G---H---I
              |
              feature (HEAD)
```

If `origin/master` is equal to `master` and also points at commit `C`, then `brew update` will update both `master` and `origin/master` to `F` and report on the changes in the range `C..F`.

However, if `origin/master` is equal to `E` because some commits have been already fetched with `git fetch origin`, then `brew update` will recreate `master` from `origin/master` and then pull in the commits from the remote to update both to `F`. Because `master` gets recreated from a younger `origin/master`, the report will only contain changes from the range `E..F` (thus omitting the changes from `C..E`).

This commit adjusts the logic to not recreate `master` if it can be safely fast-forwarded to `origin/master` (the common case). This fixes the problem from the second scenario and again reports on the desired range `C..F`.

cc @mikemcquaid as that fixes a scenario I missed when testing #45825.