### PR TITLE
update ruby-build and rbenv URLs

### DIFF
--- a/Library/Formula/rbenv.rb
+++ b/Library/Formula/rbenv.rb
@@ -1,9 +1,9 @@
 class Rbenv < Formula
   desc "Ruby environment tool"
-  homepage "https://github.com/sstephenson/rbenv"
-  url "https://github.com/sstephenson/rbenv/archive/v0.4.0.tar.gz"
+  homepage "https://github.com/rbenv/rbenv"
+  url "https://github.com/rbenv/rbenv/archive/v0.4.0.tar.gz"
   sha256 "d40fe637cc799b828498fc5793548fab70d9e2431efc6a3d3f4a671d670fa9ff"
-  head "https://github.com/sstephenson/rbenv.git"
+  head "https://github.com/rbenv/rbenv.git"
 
   bottle :unneeded
 

--- a/Library/Formula/ruby-build.rb
+++ b/Library/Formula/ruby-build.rb
@@ -1,12 +1,12 @@
 class RubyBuild < Formula
   desc "Install various Ruby versions and implementations"
-  homepage "https://github.com/sstephenson/ruby-build"
-  url "https://github.com/sstephenson/ruby-build/archive/v20151028.tar.gz"
+  homepage "https://github.com/rbenv/ruby-build"
+  url "https://github.com/rbenv/ruby-build/archive/v20151028.tar.gz"
   sha256 "3c83ae35c48869404884603b784927a8bd1d3e041c555996afb1286fc20aa708"
 
   bottle :unneeded
 
-  head "https://github.com/sstephenson/ruby-build.git"
+  head "https://github.com/rbenv/ruby-build.git"
 
   depends_on "autoconf" => [:recommended, :run]
   depends_on "pkg-config" => [:recommended, :run]


### PR DESCRIPTION
I updated homepage and download url for rbenv and ruby-build. 
rbenv and ruby-build are provided following URLs now.

* rbenv
 * https://github.com/rbenv/rbenv/
* ruby-build
 * https://github.com/rbenv/ruby-build