### PR TITLE
Fix to execute embulk command as a shell script rather than jar (and upgrade to embulk 0.7.10)

### DIFF
--- a/Library/Formula/embulk.rb
+++ b/Library/Formula/embulk.rb
@@ -1,8 +1,8 @@
 class Embulk < Formula
   desc "Data transfer between various databases, file formats and services"
   homepage "http://www.embulk.org/"
-  url "https://bintray.com/artifact/download/embulk/maven/embulk-0.7.9.jar"
-  sha256 "72667956c37cebda7d3f03dd53c411465818a8fa12a1f5fb7402f7cde15e10a7"
+  url "https://bintray.com/artifact/download/embulk/maven/embulk-0.7.10.jar"
+  sha256 "0e0e8738b8b25ac9fe621fe677e918c4a39b9f78ef1df7e969efb06ee5f090e9"
 
   bottle :unneeded
 

--- a/Library/Formula/embulk.rb
+++ b/Library/Formula/embulk.rb
@@ -12,7 +12,8 @@ class Embulk < Formula
 
   def install
     (libexec/"bin").install "embulk-#{version}.jar" => "embulk"
-    bin.write_jar_script libexec/"bin/embulk", "embulk"
+    chmod 0755, libexec/"bin/embulk"
+    bin.write_exec_script libexec/"bin/embulk"
   end
 
   test do


### PR DESCRIPTION
bin/embulk is a polygot script, and it also works as a shell script.
bin/embulk supports serveral options as a shell script although jar
execution does not support. So, we should run embulk as a command.

cc: @frsyuki @cosmo0920