### PR TITLE
findutils: added creation of gnubin aliases that can be added to $PATH, like in coreutils

### DIFF
--- a/Library/Formula/findutils.rb
+++ b/Library/Formula/findutils.rb
@@ -47,6 +47,35 @@ class Findutils < Formula
       export LC_ALL='C'
       exec "#{libexec}/bin/#{updatedb}" "$@"
     EOS
+
+    if build.without? "default-names"
+      [[prefix, bin], [share, man/"*"]].each do |base, path|
+        Dir[path/"g*"].each do |p|
+          f = Pathname.new(p)
+          gnupath = "gnu" + f.relative_path_from(base).dirname
+          (libexec/gnupath).install_symlink f => f.basename.sub(/^g/, "")
+        end
+      end
+    end
+  end
+
+  def caveats
+    if build.without? "default-names"
+      <<-EOS.undent
+        All commands have been installed with the prefix 'g'.
+        If you do not want the prefix, install using the "with-default-names" option.
+
+        If you need to use these commands with their normal names, you
+        can add a "gnubin" directory to your PATH from your bashrc like:
+
+            PATH="#{opt_libexec}/gnubin:$PATH"
+
+        Additionally, you can access their man pages with normal names if you add
+        the "gnuman" directory to your MANPATH from your bashrc as well:
+
+            MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+      EOS
+    end
   end
 
   def post_install

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1204,8 +1204,9 @@ module Homebrew
       end
 
       def check_for_non_prefixed_findutils
+        gnubin = "#{Formulary.factory("findutils").prefix}/libexec/gnubin"
         default_names = Tab.for_name("findutils").with? "default-names"
-        if default_names then <<-EOS.undent
+        if paths.include?(gnubin) || default_names then <<-EOS.undent
           Putting non-prefixed findutils in your path can cause python builds to fail.
           EOS
         end


### PR DESCRIPTION
- added creation of gnubin aliases that can be added to `$PATH`, like in
  coreutils