### PR TITLE
pretty_duration: fixed for int arguments

### DIFF
--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -48,6 +48,14 @@ class UtilTests < Homebrew::TestCase
     assert_predicate $?, :success?
   end
 
+  def test_pretty_duration
+    assert_equal "2 seconds", pretty_duration(1)
+    assert_equal "2 seconds", pretty_duration(2.5)
+    assert_equal "42 seconds", pretty_duration(42)
+    assert_equal "4.2 minutes", pretty_duration(252)
+    assert_equal "4.2 minutes", pretty_duration(252.45)
+  end
+
   def test_plural
     assert_equal "", plural(1)
     assert_equal "s", plural(0)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -140,7 +140,7 @@ end
 def pretty_duration(s)
   return "2 seconds" if s < 3 # avoids the plural problem ;)
   return "#{s.to_i} seconds" if s < 120
-  "%.1f minutes" % (s/60)
+  "%.1f minutes" % (s/60.0)
 end
 
 def plural(n, s = "s")


### PR DESCRIPTION
Without this the returned string is not as accurate if the method is called with an int larger than 120.