### PR TITLE
Fix boost dependency for mysql

### DIFF
--- a/Library/Formula/mysql.rb
+++ b/Library/Formula/mysql.rb
@@ -27,7 +27,7 @@ class Mysql < Formula
   depends_on "cmake" => :build
   depends_on "pidof" unless MacOS.version >= :mountain_lion
   depends_on "openssl"
-  depends_on "boost"
+  depends_on "boost" => :build
 
   conflicts_with "mysql-cluster", "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."


### PR DESCRIPTION
According to the mysql release notes, Boost.Geometry is required to build MySQL (see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-5.html).  However, Boost.Geometry is a header-only library, and only need to actually *build* MySQL...it is not needed as a runtime dependency.  This patch just changes the dependency on boost for MySQL to be build-time only.

See conversation at https://github.com/Homebrew/homebrew/commit/df384ee28529b4822b3fe222a7c5d4f523812338 for details and discussion that lead to this PR