### PR TITLE
Update Google AppEngine releases to 1.9.30

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -1,8 +1,8 @@
 class AppEngineGo32 < Formula
   desc "Google App Engine SDK for Go!"
   homepage "https://cloud.google.com/appengine/docs/go/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.27.zip"
-  sha256 "90443fbcc24e3026b67d27241d7dfede7e380b9a0c6af737687360e7d9913d48"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.30.zip"
+  sha256 "15d7f5f378d6e765da22c5db7ff855dafee1c2f72c78347bc9a1e4426248f2e3"
 
   bottle :unneeded
 

--- a/Library/Formula/app-engine-java.rb
+++ b/Library/Formula/app-engine-java.rb
@@ -1,8 +1,8 @@
 class AppEngineJava < Formula
   desc "Google App Engine for Java"
   homepage "https://cloud.google.com/appengine/docs/java/gettingstarted/introduction"
-  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.27.zip"
-  sha256 "069fc498bd292af01577f941f1f7d950e0bfe427f83099a1e381f7382500f0b6"
+  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.30.zip"
+  sha256 "7571b8620f958ad7c6bd2ecb30bb1482faa4c2868fe99eade6a450488ada9054"
 
   bottle :unneeded
 

--- a/Library/Formula/app-engine-python.rb
+++ b/Library/Formula/app-engine-python.rb
@@ -1,9 +1,8 @@
 class AppEnginePython < Formula
   desc "Google App Engine"
   homepage "https://cloud.google.com/appengine/docs"
-  url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.27.zip"
-  sha256 "6192f295969dabf8659ce9a698450154f7c8c35b89c6e3cb52908c8f50d7c1f4"
-  revision 1
+  url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.30.zip"
+  sha256 "d908f031672f8a95da0cc9230253a9985cfd57f6721d89606ccea21c8e00b471"
 
   bottle :unneeded
 


### PR DESCRIPTION
(updates the go-32, java, and python platforms.  The go-64 platform is already at version 1.9.30)