### PR TITLE
azure-cli: fix azure completion, so outputs script to stdout

### DIFF
--- a/Library/Formula/azure-cli.rb
+++ b/Library/Formula/azure-cli.rb
@@ -23,7 +23,7 @@ class AzureCli < Formula
     rm_rf "bin/windows"
     (prefix/"src").install Dir["lib", "node_modules", "package.json", "bin"]
     bin.install_symlink (prefix/"src/bin/azure")
-    (bash_completion/"azure").write system("#{bin}/azure", "--completion")
+    (bash_completion/"azure").write `#{bin}/azure --completion`
   end
 
   test do


### PR DESCRIPTION
azure-cli completion was broken due to stdout not returning (difference between backtics and system). This caused the write to bash_completion.d/azure to create an empty file rather than the script needed for auto completion.