### PR TITLE
graphicsmagick: set default quantum-depth to 16 (issue #46101 and #46248)

### DIFF
--- a/Library/Formula/graphicsmagick.rb
+++ b/Library/Formula/graphicsmagick.rb
@@ -25,10 +25,10 @@ class Graphicsmagick < Formula
 
   depends_on "jpeg" => :recommended
   depends_on "libpng" => :recommended
+  depends_on "libtiff" => :recommended
   depends_on "freetype" => :recommended
 
   depends_on :x11 => :optional
-  depends_on "libtiff" => :optional
   depends_on "little-cms2" => :optional
   depends_on "jasper" => :optional
   depends_on "libwmf" => :optional

--- a/Library/Formula/graphicsmagick.rb
+++ b/Library/Formula/graphicsmagick.rb
@@ -4,6 +4,7 @@ class Graphicsmagick < Formula
   url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.23/GraphicsMagick-1.3.23.tar.bz2"
   sha256 "6e14a9e9e42ec074239b2de4db37ebebb8268b0361332d5bc86d7c3fbfe5aabf"
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg
+  revision 1
 
   bottle do
     sha256 "96b2c3787f3c6c86d2a6b5088b51ee5c4e7c740ffc9e1c18a720c40414ff7fa0" => :el_capitan
@@ -12,7 +13,7 @@ class Graphicsmagick < Formula
   end
 
   option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
-  option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit"
+  option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit (default)"
   option "with-quantum-depth-32", "Compile with a quantum depth of 32 bit"
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-svg", "Compile without svg support"
@@ -58,15 +59,13 @@ class Graphicsmagick < Formula
     args << "--with-perl" if build.with? "perl"
     args << "--with-webp=yes" if build.with? "webp"
 
-    if build.with? "quantum-depth-32"
-      quantum_depth = 32
-    elsif build.with? "quantum-depth-16"
-      quantum_depth = 16
-    elsif build.with? "quantum-depth-8"
-      quantum_depth = 8
+    quantum_depth = [8, 16, 32].select {|n| build.with? "quantum-depth-#{n}"}
+    if quantum_depth.length > 1
+      odie "graphicsmagick: --with-quantum-depth-N options are mutually exclusive"
     end
+    quantum_depth = quantum_depth.first || 16 # user choice or default
 
-    args << "--with-quantum-depth=#{quantum_depth}" if quantum_depth
+    args << "--with-quantum-depth=#{quantum_depth}"
     args << "--without-x" if build.without? "x11"
     args << "--without-ttf" if build.without? "freetype"
     args << "--without-xml" if build.without? "svg"


### PR DESCRIPTION
This was originally discussed on issue #46101 which led to pull request #46248 . This was then discussed one more time and asked to reopen as new pull request with further changes (because the issue was closed, github does not update with more changes). This pull request addresses the following issues (in addition to the original issue of course):

* bumping revision number to force rebuild of dependants
* error out when incompatible options are passed (this issue already existed before)

but please see discussion on the originals reports. I will also open a bug report on `homebrew/science` and `homebrew/x11`.