### PR TITLE
caddy 0.8.0

### DIFF
--- a/Library/Formula/caddy.rb
+++ b/Library/Formula/caddy.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Caddy < Formula
   desc "Alternative general-purpose HTTP/2 web server"
   homepage "https://caddyserver.com/"
-  url "https://github.com/mholt/caddy/archive/v0.7.5.tar.gz"
-  sha256 "3e322497466f1706c85a214095e645b2d4340ce83961ebd370178fbf840253bd"
+  url "https://github.com/mholt/caddy/archive/v0.8.0.tar.gz"
+  sha256 "c7650e8772b8b19cbe5aca1c51898c053c9df397237e54f671cee8780f21d741"
   head "https://github.com/mholt/caddy.git"
 
   bottle do
@@ -27,7 +27,11 @@ class Caddy < Formula
   end
 
   go_resource "golang.org/x/net" do
-    url "https://go.googlesource.com/net.git", :revision => "e0403b4e005737430c05a57aac078479844f919c"
+    url "https://go.googlesource.com/net.git", :revision => "943b8c241accc9aa2b2a91735b28aea7f26765cb"
+  end
+
+  go_resource "golang.org/x/crypto" do
+    url "https://go.googlesource.com/crypto.git", :revision => "7b85b097bf7527677d54d3220065e966a0e3b613"
   end
 
   go_resource "github.com/bradfitz/http2" do
@@ -52,6 +56,26 @@ class Caddy < Formula
 
   go_resource "github.com/hashicorp/go-syslog" do
     url "https://github.com/hashicorp/go-syslog.git", :revision => "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
+  end
+
+  go_resource "github.com/gorilla/websocket" do
+    url "https://github.com/gorilla/websocket.git", :revision => "844dd6d40e1a9215ef4c8a204bfc839fcf5dd5dd"
+  end
+
+  go_resource "github.com/jimstudt/http-authentication" do
+    url "https://github.com/jimstudt/http-authentication.git", :revision => "3eca13d6893afd7ecabe15f4445f5d2872a1b012"
+  end
+
+  go_resource "github.com/xenolf/lego" do
+    url "https://github.com/xenolf/lego.git", :revision => "bf740fa2cafb7d6deb0911792a13f37ef5995a03"
+  end
+
+  go_resource "gopkg.in/natefinch/lumberjack.v2" do
+    url "https://github.com/natefinch/lumberjack.git", :revision => "600ceb4523e5b7ff745f91083c8a023c2bf73af5"
+  end
+
+  go_resource "github.com/square/go-jose" do
+    url "https://github.com/square/go-jose.git", :revision => "37934a899dd03635373fd1e143936d32cfe48d31"
   end
 
   def install


### PR DESCRIPTION
1. Updating caddy from `0.7.5` to `0.8.0`
2. Adding necessary `go_resources` to account for changes in latest version

```
nande9 local nicholasa $ date && brew test -vv caddy && date
Mon Dec 14 18:56:26 PST 2015
Testing caddy
==> Using the sandbox
/usr/bin/sandbox-exec -f /tmp/homebrew20151214-23670-1t54efg.sb /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -I /usr/local/Library/Homebrew -- /usr/local/Library/Homebrew/test.rb /usr/local/Library/Formula/caddy.rb -vv
Mon Dec 14 18:56:33 PST 2015
nande9 local nicholasa $
```

```
nande9 local nicholasa $ brew audit --strict caddy
==> brew style caddy
==> Installing or updating 'rubocop' gem
Fetching: rainbow-2.0.0.gem (100%)
Successfully installed rainbow-2.0.0
Fetching: ast-2.1.0.gem (100%)
Successfully installed ast-2.1.0
Fetching: parser-2.2.3.0.gem (100%)
Successfully installed parser-2.2.3.0
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: astrolabe-1.3.1.gem (100%)
Successfully installed astrolabe-1.3.1
Fetching: ruby-progressbar-1.7.5.gem (100%)
Successfully installed ruby-progressbar-1.7.5
Fetching: tins-1.6.0.gem (100%)
Successfully installed tins-1.6.0
Fetching: rubocop-0.35.1.gem (100%)
Successfully installed rubocop-0.35.1
8 gems installed

1 file inspected, no offenses detected
```

I'm not sure if adding in go_resources is modifying the bottle itself but without adding in the necessary go dependencies, caddy failed to install via `brew upgrade caddy`.