### PR TITLE
dependency: fix merging tags in 'merge_repeats'

### DIFF
--- a/Library/Homebrew/dependable.rb
+++ b/Library/Homebrew/dependable.rb
@@ -20,10 +20,16 @@ module Dependable
   end
 
   def required?
+    # FIXME: Should `required?` really imply `!build?`? And if so, why doesn't
+    #        any of `optional?` and `recommended?` equally imply `!build?`?
     !build? && !optional? && !recommended?
   end
 
+  def option_tags
+    tags - RESERVED_TAGS
+  end
+
   def options
-    Options.create(tags - RESERVED_TAGS)
+    Options.create(option_tags)
   end
 end

--- a/Library/Homebrew/test/test_dependency.rb
+++ b/Library/Homebrew/test/test_dependency.rb
@@ -48,7 +48,7 @@ class DependencyTests < Homebrew::TestCase
     assert_equal Dependency, merged.first.class
 
     foo_named_dep = merged.find {|d| d.name == "foo"}
-    assert_equal [:build, "bar"], foo_named_dep.tags
+    assert_equal ["bar"], foo_named_dep.tags
     assert_includes foo_named_dep.option_names, "foo"
     assert_includes foo_named_dep.option_names, "foo2"
 

--- a/Library/Homebrew/test/test_dependency_expansion.rb
+++ b/Library/Homebrew/test/test_dependency_expansion.rb
@@ -48,15 +48,15 @@ class DependencyExpansionTests < Homebrew::TestCase
   end
 
   def test_expand_skips_optionals_by_default
-    @foo.expects(:optional?).returns(true)
-    @f = stub(:deps => @deps, :build => stub(:with? => false), :name => "f")
-    assert_equal [@bar, @baz, @qux], Dependency.expand(@f)
+    deps = [build_dep(:foo, [:optional]), @bar, @baz, @qux]
+    f = stub(:deps => deps, :build => stub(:with? => false), :name => "f")
+    assert_equal [@bar, @baz, @qux], Dependency.expand(f)
   end
 
   def test_expand_keeps_recommendeds_by_default
-    @foo.expects(:recommended?).returns(true)
-    @f = stub(:deps => @deps, :build => stub(:with? => true), :name => "f")
-    assert_equal @deps, Dependency.expand(@f)
+    deps = [build_dep(:foo, [:recommended]), @bar, @baz, @qux]
+    f = stub(:deps => deps, :build => stub(:with? => true), :name => "f")
+    assert_equal deps, Dependency.expand(f)
   end
 
   def test_merges_repeated_deps_with_differing_options


### PR DESCRIPTION
While it may suffice to merge string and non-reserved tags by forming a union of all tags of dependencies of the same name, this approach fails to work for the reserved tags. These are now merged such that the most restrictive tag (meaning sometimes an empty tag) is preserved.

The previous behavior caused essential dependencies to be omitted and builds to fail in response. E.g., multiple `:fortran` dependencies with tags `[]`, `[:recommended]`, and `[:optional]` would have been expanded and merged to `"gcc"` with tags `[:recommended, :optional]`, causing it to be no longer seen as a required dependency.

To reproduce the issue fixed by this PR, start from a clean Homebrew installation and then execute:

```
$ brew tap homebrew/science
$ brew install -v petsc
==> Installing petsc from homebrew/science
==> Installing dependencies for homebrew/science/petsc: sphinx-doc, cmake, superlu43, metis, parmetis, superlu_dist, veclibfort, scalapack, mumps, hypre, sundials, szip, hdf5, pkg-config, hwloc, tbb, suite-sparse, netcdf, fftw
[…]
```

Notice how the list of dependencies to be installed neither contains `gcc` nor `open-mpi`, though [`petsc`](https://github.com/Homebrew/homebrew-science/blob/16c758b2298186330183520e4882dbc173528e3b/petsc.rb#L22-L23) has a mandatory dependency on both due to its `:fortran` and `:mpi` requirement. With this PR applied, the same invocation of `brew install` instead correctly yields:

```
==> Installing petsc from homebrew/science
==> Installing dependencies for homebrew/science/petsc: xz, gmp, mpfr, libmpc, isl, gcc, pkg-config, makedepend, openssl, libevent, open-mpi, sphinx-doc, cmake, superlu43, metis, parmetis, superlu_dist, veclibfort, scalapack, mumps, hypre, sundials, szip, hdf5, hwloc, tbb, suite-sparse, netcdf, fftw
[…]
```

**Notes:** I'm not particularly attached to any newly introduced names, I just couldn't come up with something better than “necessity” and “temporality”. I'd appreciate feedback for better naming. Please also scrutinize the merging logic and its representation in the tests.

(In some sense, this is a follow-up and extension of the fix in #46916.)