### PR TITLE
audit: don’t fail if there’s no tap

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -235,7 +235,7 @@ class FormulaAuditor
   def audit_formula_name
     return unless @strict
     # skip for non-official taps
-    return unless formula.tap.official?
+    return if formula.tap.nil? || !formula.tap.official?
 
     name = formula.name
     full_name = formula.full_name


### PR DESCRIPTION
`formula.tap` can be `nil` in some cases e.g. when it’s a file path or an URL:

```
$ brew audit --strict https://raw.githubusercontent.com/noahm/homebrew/lorem-0.7.4/Library/Formula/lorem.rb
######################################################################## 100,0%
==> brew style lorem

1 file inspected, no offenses detected
Error: undefined method `official?' for nil:NilClass
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/cmd/audit.rb:238:in `audit_formula_name'
/usr/local/Library/Homebrew/cmd/audit.rb:922:in `audit'
/usr/local/Library/Homebrew/cmd/audit.rb:58:in `block in audit'
/usr/local/Library/Homebrew/cmd/audit.rb:56:in `each'
/usr/local/Library/Homebrew/cmd/audit.rb:56:in `audit'
/usr/local/Library/brew.rb:143:in `<main>'
```

cc @xu-cheng