### PR TITLE
llvm: build static libraries for libclang, libcxx and libcxxabi

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -211,6 +211,11 @@ class Llvm < Formula
 
     args << "-DLINK_POLLY_INTO_TOOLS:Bool=ON" if build.with? "polly"
 
+    args << "-DLIBCLANG_BUILD_STATIC:Bool=ON" if build.with? "clang"
+
+    args << "-DLIBCXX_ENABLE_SHARED:Bool=OFF"    if build.with? "libcxx"
+    args << "-DLIBCXXABI_ENABLE_SHARED:Bool=OFF" if build.with? "libcxx"
+
     mktemp do
       system "cmake", "-G", "Unix Makefiles", buildpath, *(std_cmake_args + args)
       system "make"


### PR DESCRIPTION
#39882 avoid shared libraries for LLVM. However, if LLVM is built with clang, libcxx, it will still build shared libraries for libclang, libcxx, libcxxabi since it is default behavior.
The shared libraries of libclang, libcxx, libcxxabi also have similar run path problems as LLVM's shared libraries.
This PR adds flags to let cmake build static library for libclang, libcxx, libcxxabi if they are built.