### PR TITLE
libvpx: fix and remove options

### DIFF
--- a/Library/Formula/libvpx.rb
+++ b/Library/Formula/libvpx.rb
@@ -30,7 +30,7 @@ class Libvpx < Formula
 
     args << (build.with?("examples") ? "--enable-examples" : "--disable-examples")
     args << "--enable-gcov" if !ENV.compiler == :clang && build.with?("gcov")
-    args << "--enable-postproc-visualizer" if build.with? "visualizer"
+    args << "--enable-postproc" << "--enable-postproc-visualizer" if build.with? "visualizer"
 
     # configure misdetects 32-bit 10.6
     # https://code.google.com/p/webm/issues/detail?id=401

--- a/Library/Formula/libvpx.rb
+++ b/Library/Formula/libvpx.rb
@@ -12,12 +12,10 @@ class Libvpx < Formula
   end
 
   option "with-gcov", "Enable code coverage"
-  option "with-mem-tracker", "Enable tracking memory usage"
   option "with-visualizer", "Enable post processing visualizer"
   option "with-examples", "Build examples (vpxdec/vpxenc)"
 
   deprecated_option "gcov" => "with-gcov"
-  deprecated_option "mem-tracker" => "with-mem-tracker"
   deprecated_option "visualizer" => "with-visualizer"
 
   depends_on "yasm" => :build
@@ -32,7 +30,6 @@ class Libvpx < Formula
 
     args << (build.with?("examples") ? "--enable-examples" : "--disable-examples")
     args << "--enable-gcov" if !ENV.compiler == :clang && build.with?("gcov")
-    args << "--enable-mem-tracker" if build.with? "mem-tracker"
     args << "--enable-postproc-visualizer" if build.with? "visualizer"
 
     # configure misdetects 32-bit 10.6

--- a/Library/Formula/libvpx.rb
+++ b/Library/Formula/libvpx.rb
@@ -23,7 +23,12 @@ class Libvpx < Formula
   depends_on "yasm" => :build
 
   def install
-    args = %W[--prefix=#{prefix} --enable-pic --disable-unit-tests]
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --enable-pic
+      --disable-unit-tests
+    ]
 
     args << (build.with?("examples") ? "--enable-examples" : "--disable-examples")
     args << "--enable-gcov" if !ENV.compiler == :clang && build.with?("gcov")


### PR DESCRIPTION
The `--with-mem-tracker` option is no longer supported as of libvpx 1.5.0 (the corresponding functionality has been removed) and the `--with-visualizer` option was broken.