### PR TITLE
travis: use Xcode 7.2 on OS X 10.11 and Xcode 7.1.1 on OS X 10.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ matrix:
   include:
     - env: OSX=10.11
       os: osx
-      osx_image: osx10.11
+      osx_image: xcode7.2
       rvm: system
     - env: OSX=10.10
       os: osx
-      osx_image: xcode7
+      osx_image: xcode7.1
       rvm: system
     - env: OSX=10.9 HOMEBREW_RUBY=1.8.7
       os: osx


### PR DESCRIPTION
Should make the builds more comparable with Jenkins and lets us use more up-to-date developer tools. If we are lucky, the updated OS X 10.10 image also fixes the horribly slow builds seen there compared to the 10.9 and 10.11 builds.

I picked the latest available images per OS X release as seen in the [Travis CI documentation](https://docs.travis-ci.com/user/languages/objective-c).