### PR TITLE
qscintilla2: make formula compatible with sandbox

### DIFF
--- a/Library/Formula/qscintilla2.rb
+++ b/Library/Formula/qscintilla2.rb
@@ -10,10 +10,10 @@ class Qscintilla2 < Formula
     sha256 "d487010da4ab0eee416ae7dcd1f22e2be2ed60984dda8da1b579094351e173f4" => :mountain_lion
   end
 
+  option "without-plugin", "Skip building the Qt Designer plugin"
+
   depends_on :python => :recommended
   depends_on :python3 => :optional
-
-  option "without-plugin", "Skip building the Qt Designer plugin"
 
   if build.with? "python3"
     depends_on "pyqt" => "with-python3"

--- a/Library/Formula/qscintilla2.rb
+++ b/Library/Formula/qscintilla2.rb
@@ -77,10 +77,21 @@ class Qscintilla2 < Formula
         system "make"
         system "make", "install"
       end
-      # symlink Qt Designer plugin (note: not removed on qscintilla2 formula uninstall)
-      ln_sf prefix/"plugins/designer/libqscintillaplugin.dylib",
-            Formula["qt"].opt_prefix/"plugins/designer/"
     end
+  end
+
+  def caveats
+    s = ""
+    s += <<-EOS.undent if build.with? "plugin"
+      QScintilla installed a Qt Designer plugin. Issue the following commands
+      to create a symbolic link that makes the plugin available to Qt Designer:
+
+        cd #{Formula["qt"].opt_prefix}/plugins/designer
+        ln -sf #{opt_prefix}/plugins/designer/libqscintillaplugin.dylib
+
+      The symbolic link needs to be recreated if Qt is upgraded or reinstalled.
+    EOS
+    s
   end
 
   test do


### PR DESCRIPTION
The `qscintilla2` formula previously tried to create a symlink in the `qt` formula prefix in order to make its Qt Designer plugin discoverable. It now prints equivalent instructions in its caveats for the (presumably) very few users interested in this feature. Also fixes a strict audit error.

~~The test in the **codequery** formula attempted to write to the formula's `share/test/` directory. Instead, it now symlinks the test data into temporary test directory and places its intermediate output there.~~