### PR TITLE
libtorrent-rasterbar 1.0.7

### DIFF
--- a/Library/Formula/libtorrent-rasterbar.rb
+++ b/Library/Formula/libtorrent-rasterbar.rb
@@ -1,9 +1,9 @@
 class LibtorrentRasterbar < Formula
   desc "C++ bittorrent library by Rasterbar Software"
   homepage "http://www.libtorrent.org/"
-  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_0_6/libtorrent-rasterbar-1.0.6.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libt/libtorrent-rasterbar/libtorrent-rasterbar_1.0.6.orig.tar.gz"
-  sha256 "c97de804b77f44591801631aca3869567671df2d3e2afe7f5453d8db2478fd61"
+  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_0_7/libtorrent-rasterbar-1.0.7.tar.gz"
+  mirror "https://mirrors.kernel.org/debian/pool/main/libt/libtorrent-rasterbar/libtorrent-rasterbar_1.0.7.orig.tar.gz"
+  sha256 "3e16e024b175fefada17471c659fdbcfab235f9619d4f0913faa13cb02ca8d83"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Updates libtorrent-rasterbar to 1.0.7 - https://github.com/arvidn/libtorrent/releases/tag/libtorrent-1_0_7