### PR TITLE
cgal 4.7

### DIFF
--- a/Library/Formula/cgal.rb
+++ b/Library/Formula/cgal.rb
@@ -1,8 +1,8 @@
 class Cgal < Formula
   desc "CGAL: Computational Geometry Algorithm Library"
   homepage "http://www.cgal.org/"
-  url "https://gforge.inria.fr/frs/download.php/file/35138/CGAL-4.6.3.tar.gz"
-  sha256 "f90fc9d319a0bdb66b09570a8a0399671c25caeb5db1dc8c555f876d795c74ff"
+  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.7/CGAL-4.7.tar.gz"
+  sha256 "1be058fe9fc4d8331b48daf8beb114a049fd4970220d8a570ff709b7789dacae"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Switched to the GitHub download URL since their [download page](http://www.cgal.org/download/macosx.html) redirects over there now.