### PR TITLE
rabbitmq 3.5.7

### DIFF
--- a/Library/Formula/rabbitmq.rb
+++ b/Library/Formula/rabbitmq.rb
@@ -1,8 +1,8 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.6/rabbitmq-server-mac-standalone-3.5.6.tar.gz"
-  sha256 "da35427cc9b153dc2158ca0b4b9f8ca334164a246943dad0cbe94e4de776dff4"
+  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.7/rabbitmq-server-mac-standalone-3.5.7.tar.gz"
+  sha256 "48a2acb30c1731f82303ef8fe3447a5f643ea7327bb8503e44149790ed7d5a7d"
 
   bottle :unneeded
 


### PR DESCRIPTION
Not sure if we should keep postponing building from source as is mentioned in the last couple of version upgrades (and in #33616), but for me this is the fastest way to get rabbitmq up to date on my dev machine so here it is.

