### PR TITLE
kubernetes-cli: install bash completion

### DIFF
--- a/Library/Formula/kubernetes-cli.rb
+++ b/Library/Formula/kubernetes-cli.rb
@@ -30,6 +30,7 @@ class KubernetesCli < Formula
 
     dir = "_output/local/bin/darwin/#{arch}"
     bin.install "#{dir}/kubectl"
+    bash_completion.install "contrib/completions/bash/kubectl"
   end
 
   test do

--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -140,6 +140,10 @@ module Homebrew
     erb.result(bottle.instance_eval { binding }).gsub(/^\s*$\n/, "")
   end
 
+  def most_recent_mtime(pathname)
+    pathname.to_enum(:find).select(&:exist?).map(&:mtime).max
+  end
+
   def bottle_formula(f)
     unless f.installed?
       return ofail "Formula not installed or up-to-date: #{f.full_name}"
@@ -187,7 +191,7 @@ module Homebrew
     skip_relocation = false
 
     formula_source_time = f.stable.stage do
-      Pathname.pwd.to_enum(:find).map(&:mtime).max
+      most_recent_mtime(Pathname.pwd)
     end
 
     keg.lock do

--- a/Library/Homebrew/test/resources/source-with-broken-symlink/broken-link
+++ b/Library/Homebrew/test/resources/source-with-broken-symlink/broken-link
@@ -1,0 +1,1 @@
+does-not-exist

--- a/Library/Homebrew/test/test_bottle.rb
+++ b/Library/Homebrew/test/test_bottle.rb
@@ -1,0 +1,8 @@
+require "testing_env"
+require "cmd/bottle"
+
+class BottleTests < Homebrew::TestCase
+  def test_most_recent_mtime_with_broken_symlink()
+    refute_nil Homebrew.most_recent_mtime(Pathname(File.join(TEST_DIRECTORY, 'resources/source-with-broken-symlink')))
+  end
+end


### PR DESCRIPTION
The Kubernetes distribution provides bash completion for kubectl
already; we just need to install it.