### PR TITLE
boost 1.60

### DIFF
--- a/Library/Formula/boost-bcp.rb
+++ b/Library/Formula/boost-bcp.rb
@@ -1,8 +1,8 @@
 class BoostBcp < Formula
   desc "Utility for extracting subsets of the Boost library"
   homepage "http://www.boost.org/doc/tools/bcp/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
-  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
+  sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
 
   head "https://github.com/boostorg/boost.git"
 

--- a/Library/Formula/boost-python.rb
+++ b/Library/Formula/boost-python.rb
@@ -1,8 +1,8 @@
 class BoostPython < Formula
   desc "C++ library for C++/Python interoperability"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
-  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
+  sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
   head "https://github.com/boostorg/boost.git"
 
   bottle do
@@ -32,14 +32,6 @@ class BoostPython < Formula
 
   def install
     ENV.universal_binary if build.universal?
-
-    if stable?
-      # fix make_setter regression
-      # https://github.com/boostorg/python/pull/40
-      inreplace "boost/python/data_members.hpp",
-                "# if BOOST_WORKAROUND(__EDG_VERSION__, <= 238)",
-                "# if !BOOST_WORKAROUND(__EDG_VERSION__, <= 238)"
-    end
 
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -1,8 +1,8 @@
 class Boost < Formula
   desc "Collection of portable C++ source libraries"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
-  sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
+  sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
 
   head "https://github.com/boostorg/boost.git"
 
@@ -31,24 +31,6 @@ class Boost < Formula
   else
     depends_on "icu4c" => :optional
     depends_on :mpi => [:cc, :cxx, :optional]
-  end
-
-  stable do
-    # Fixed compilation of operator<< into a record ostream, when
-    # the operator right hand argument is not directly supported by
-    # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549
-    # from https://github.com/boostorg/log/commit/7da193f.patch
-    patch do
-      url "https://gist.githubusercontent.com/tdsmith/bc76ddea1e2bdb2a3a18/raw/03d125b12a4b03c28ee011a2d6d42a8137061a3b/boost-log.patch"
-      sha256 "a49fd7461d9f3b478d2bddac19adca93fe0fabab71ee67e8f140cbd7d42d6870"
-    end
-
-    # Fixed missing symbols in libboost_log_setup (on mac/clang)
-    # from https://github.com/boostorg/log/commit/870284ed31792708a6139925d00a0aadf46bf09f
-    patch do
-      url "https://gist.githubusercontent.com/autosquid/a4974e112b754e03aad7/raw/985358f8909033eb7ad9aae8fbf60881ef70a275/boost-log_setup.patch"
-      sha256 "2c3a3bae1691df5f8fce8fbd4e5727d57bd4dd813748b70d7471c855c4f19d1c"
-    end
   end
 
   fails_with :llvm do

--- a/Library/Formula/folly.rb
+++ b/Library/Formula/folly.rb
@@ -3,6 +3,7 @@ class Folly < Formula
   homepage "https://github.com/facebook/folly"
   url "https://github.com/facebook/folly/archive/v0.48.0.tar.gz"
   sha256 "e0b6b3cd143b5d581e8cef470aea1b6f8aeaa4e7431522058872e245cac5c144"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/freeling.rb
+++ b/Library/Formula/freeling.rb
@@ -4,7 +4,7 @@ class Freeling < Formula
   url "http://devel.cpl.upc.edu/freeling/downloads/32"
   version "3.1"
   sha256 "e98471ceb3f58afbe70369584d8d316323d13fcc51d09b2fd7f431a3220982ba"
-  revision 6
+  revision 7
 
   bottle do
     cellar :any

--- a/Library/Formula/ledger.rb
+++ b/Library/Formula/ledger.rb
@@ -4,6 +4,7 @@ class Ledger < Formula
   url "https://github.com/ledger/ledger/archive/v3.1.1.tar.gz"
   sha256 "90f06561ab692b192d46d67bc106158da9c6c6813cc3848b503243a9dfd8548a"
   head "https://github.com/ledger/ledger.git"
+  revision 1
 
   bottle do
     sha256 "4aac92ddbafe1a02011bb69b1d57520e1fe566c08655a27111a7803a104fdde6" => :el_capitan

--- a/Library/Formula/libswiften.rb
+++ b/Library/Formula/libswiften.rb
@@ -1,7 +1,7 @@
 class Libswiften < Formula
   desc "C++ library for implementing XMPP applications"
   homepage "https://swift.im/swiften"
-  revision 1
+  revision 2
 
   stable do
     url "https://swift.im/downloads/releases/swift-2.0/swift-2.0.tar.gz"

--- a/Library/Formula/mal4s.rb
+++ b/Library/Formula/mal4s.rb
@@ -3,7 +3,7 @@ class Mal4s < Formula
   homepage "https://github.com/secure411dotorg/mal4s/"
   url "https://service.dissectcyber.com/mal4s/mal4s-1.2.8.tar.gz"
   sha256 "1c40ca9d11d113278c4fbd5c7ec9ce0edc78d6c8bd1aa7d85fb6b9473e60f0f1"
-  revision 3
+  revision 4
 
   head "https://github.com/secure411dotorg/mal4s.git"
 

--- a/Library/Formula/metaproxy.rb
+++ b/Library/Formula/metaproxy.rb
@@ -3,6 +3,7 @@ class Metaproxy < Formula
   homepage "https://www.indexdata.com/metaproxy"
   url "http://ftp.indexdata.dk/pub/metaproxy/metaproxy-1.10.0.tar.gz"
   sha256 "83a282a9aefa71fd073adc2ef1c474e8b594c921da0c2c4b977821bfc3cf5a5e"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/mkvtoolnix.rb
+++ b/Library/Formula/mkvtoolnix.rb
@@ -3,6 +3,7 @@ class Mkvtoolnix < Formula
   homepage "https://www.bunkus.org/videotools/mkvtoolnix/"
   url "https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-8.8.0.tar.xz"
   sha256 "912de8148d21f38c9100de61dfcac0041d1114d1a50462700b94f3bc8cd3a19c"
+  revision 1
 
   bottle do
     sha256 "356062c44481c649964bcbaeed19af1b3660548978a1fdd63e257221743bffde" => :el_capitan

--- a/Library/Formula/ncmpcpp.rb
+++ b/Library/Formula/ncmpcpp.rb
@@ -3,7 +3,7 @@ class Ncmpcpp < Formula
   homepage "http://rybczak.net/ncmpcpp/"
   url "http://rybczak.net/ncmpcpp/stable/ncmpcpp-0.6.7.tar.bz2"
   sha256 "08807dc515b4e093154a6e91cdd17ba64ebedcfcd7aa34d0d6eb4d4cc28a217b"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/pdal.rb
+++ b/Library/Formula/pdal.rb
@@ -4,7 +4,7 @@ class Pdal < Formula
   url "https://github.com/PDAL/PDAL/archive/0.9.9.tar.gz"
   sha256 "d4f91478ca55b6b775980c5c2e4c23f43b6bb4e1908ae739b1605a30b57b8a83"
   head "https://github.com/PDAL/PDAL.git"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "67a6dc161a09be18f5b71aee0b80a193edd5be777a2cb328d4e0766fc998b715" => :el_capitan

--- a/Library/Formula/rcssserver.rb
+++ b/Library/Formula/rcssserver.rb
@@ -3,7 +3,7 @@ class Rcssserver < Formula
   homepage "http://sserver.sourceforge.net/"
   url "https://downloads.sourceforge.net/sserver/rcssserver/15.2.2/rcssserver-15.2.2.tar.gz"
   sha256 "329b3008689dac16d1f39ad8f5c8341aef283ef3750d137dcf299d1fbc30355a"
-  revision 1
+  revision 2
 
   bottle do
     revision 2

--- a/Library/Formula/uhd.rb
+++ b/Library/Formula/uhd.rb
@@ -4,7 +4,7 @@ class Uhd < Formula
   url "https://github.com/EttusResearch/uhd/archive/release_003_009_001.tar.gz"
   sha256 "e2059c34bea2aaca31eb8d3501ce7b535b559775d3050ed5c30946c34146a92e"
   head "https://github.com/EttusResearch/uhd.git"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "47de60fe5be8c80bc7d471ee782db3055a4b69b0677884a3dd24105097bed177" => :el_capitan


### PR DESCRIPTION
boost: Drop patches for 1.59, which are included in the 1.60 release.
boost-python: Drop patching of boost/python/data_members.hpp, which has been merged upstream.

Require rebuild against the new boost:
- folly
- freeling
- ledger
- libswiften
- mal4s
- metaproxy
- mkvtoolnix
- ncmpcpp
- pdal
- rcssserver
- uhd
