### PR TITLE
eina: disable bottles due to pkgconfig breakage

### DIFF
--- a/Library/Formula/eina.rb
+++ b/Library/Formula/eina.rb
@@ -1,14 +1,8 @@
 class Eina < Formula
-  desc "Eina is a core data structure and common utility library"
+  desc "Core data structure and common utility library for Enlightenment"
   homepage "https://docs.enlightenment.org/auto/eina/eina_main.html"
   url "https://download.enlightenment.org/releases/eina-1.7.10.tar.gz"
   sha256 "3f33ae45c927faedf8d342106136ef1269cf8dde6648c8165ce55e72341146e9"
-
-  bottle do
-    sha256 "4624c44c02ada4a1bc5a967efb13a2e5602cca01e61e83bfa03d389006bdb852" => :yosemite
-    sha256 "dbfcbd09d224c85aa1697d5892bfbe9e9aa03ba153a4aa2f4eb13625555dce68" => :mavericks
-    sha256 "6d3680d80b19884486c8379bf7cced4c141b9d7c7bc97c2044cd617343835ed0" => :mountain_lion
-  end
 
   head do
     url "https://git.enlightenment.org/legacy/eina.git/"
@@ -17,6 +11,8 @@ class Eina < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
+
+  bottle :disable, "Work around broken pkgconfig in bottle installation (#45293)"
 
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
The pkgconfig config file in the poured bottle is broken because its type is misdetected; see #45293