### PR TITLE
brew.rb: only print "Kernel.exit" on failures.

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -175,8 +175,9 @@ rescue KegUnspecifiedError
 rescue UsageError
   onoe "Invalid usage"
   abort ARGV.usage
-rescue SystemExit
-  puts "Kernel.exit" if ARGV.verbose?
+rescue SystemExit => e
+  onoe "Kernel.exit" if ARGV.verbose? && !e.success?
+  puts e.backtrace if ARGV.debug?
   raise
 rescue Interrupt => e
   puts # seemingly a newline is typical


### PR DESCRIPTION
CC @zmwangx

Closes #47099.