### PR TITLE
macvim: Remove custom-icon cruft

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -23,10 +23,8 @@ class Macvim < Formula
 
   bottle :disable, "To use the user's Python."
 
-  option "with-custom-icons", "Try to generate custom document icons"
   option "with-override-system-vim", "Override system vim"
 
-  deprecated_option "custom-icons" => "with-custom-icons"
   deprecated_option "override-system-vim" => "with-override-system-vim"
 
   depends_on :xcode => :build
@@ -43,11 +41,6 @@ class Macvim < Formula
   def install
     # MacVim doesn't have and required any Python package, unset PYTHONPATH.
     ENV.delete("PYTHONPATH")
-
-    # Set ARCHFLAGS so the Python app (with C extension) that is
-    # used to create the custom icons will not try to compile in
-    # PPC support (which isn't needed in Homebrew-supported systems.)
-    ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
 
     # If building for 10.7 or up, make sure that CC is set to "clang".
     ENV.clang if MacOS.version >= :lion
@@ -105,16 +98,6 @@ class Macvim < Formula
     end
 
     system "./configure", *args
-
-    if build.with? "custom-icons"
-      # Get the custom font used by the icons
-      system "make", "-C", "src/MacVim/icons", "getenvy"
-    else
-      # Building custom icons fails for many users, so off by default.
-      inreplace "src/MacVim/icons/Makefile", "$(MAKE) -C makeicns", ""
-      inreplace "src/MacVim/icons/make_icons.py", "dont_create = False", "dont_create = True"
-    end
-
     system "make"
 
     prefix.install "src/MacVim/build/Release/MacVim.app"


### PR DESCRIPTION
MacVim stopped actually making custom icons a long time ago, and upstream is about to remove that code anyway: https://github.com/macvim-dev/macvim/pull/177