### PR TITLE
lsyncd: use MACOS_FULL_VERSION

### DIFF
--- a/Library/Formula/lsyncd.rb
+++ b/Library/Formula/lsyncd.rb
@@ -44,6 +44,8 @@ class Lsyncd < Formula
     "10.10.4"  => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
     "10.10.5"  => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
     "10.11"    => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
+    "10.11.1"  => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
+    "10.11.2"  => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
   }
 
   if xnu_headers.key? MACOS_FULL_VERSION

--- a/Library/Formula/lsyncd.rb
+++ b/Library/Formula/lsyncd.rb
@@ -46,8 +46,8 @@ class Lsyncd < Formula
     "10.11"    => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
   }
 
-  if xnu_headers.key? MacOS.full_version
-    tarball, checksum = xnu_headers.fetch(MacOS.full_version)
+  if xnu_headers.key? MACOS_FULL_VERSION
+    tarball, checksum = xnu_headers.fetch(MACOS_FULL_VERSION)
     resource "xnu" do
       url "https://opensource.apple.com/tarballs/xnu/#{tarball}"
       sha256 checksum

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -790,9 +790,10 @@ class FormulaAuditor
       problem "Use MacOS.version instead of MACOS_VERSION"
     end
 
-    if line =~ /MACOS_FULL_VERSION/
-      problem "Use MacOS.full_version instead of MACOS_FULL_VERSION"
-    end
+    # TODO: comment out this after core code and formulae separation.
+    # if line =~ /MACOS_FULL_VERSION/
+    #   problem "Use MacOS.full_version instead of MACOS_FULL_VERSION"
+    # end
 
     cats = %w[leopard snow_leopard lion mountain_lion].join("|")
     if line =~ /MacOS\.(?:#{cats})\?/


### PR DESCRIPTION
This commit partial reverts beed39e46fa021dd1c133c2c8eaaa81b524e68c7.

For users whose local brew is at around 2015-06-02 to 2015-06-11,
running `brew update` will emit following error:

  Error: undefined method 'full_version' for OS::Mac:Module

This is caused by the same bug described in #42553.

Let's use `MACOS_FULL_VERSION` for now to restore `brew update` compatibility
for these users.

TODO: revert this commit after core code and formulae separation.