### PR TITLE
docker-machine 0.5.4

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachine < Formula
   desc "Create Docker hosts locally and on cloud providers"
   homepage "https://docs.docker.com/machine"
-  url "https://github.com/docker/machine/archive/v0.5.1.tar.gz"
-  sha256 "cd515d9b2d14edb9ce3429865cb9cdadc81d7c4ba685422fbd1ee10025987460"
+  url "https://github.com/docker/machine/archive/v0.5.4.tar.gz"
+  sha256 "050640764c9f55e76b9475b04ebd9d6069e63cf7e2b54c2d07eda9254722d90e"
   head "https://github.com/docker/machine.git"
 
   bottle do

--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -17,13 +17,25 @@ class DockerMachine < Formula
   depends_on "go" => :build
   depends_on "automake" => :build
 
-  def install
-    ENV["GOPATH"] = buildpath
-    mkdir_p buildpath/"src/github.com/docker/"
-    ln_sf buildpath, buildpath/"src/github.com/docker/machine"
+  go_resource "github.com/codegangsta/cli" do
+    url "https://github.com/codegangsta/cli.git",
+      :revision => "bca61c476e3c752594983e4c9bcd5f62fb09f157"
+  end
 
-    system "make", "build"
-    bin.install Dir["bin/*"]
+  def install
+    ENV["GOBIN"] = bin
+    ENV["GOPATH"] = buildpath
+    ENV["GOHOME"] = buildpath
+
+    path = buildpath/"src/github.com/docker/machine"
+    path.install Dir["*"]
+
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd path do
+      system "make", "build"
+      bin.install Dir["bin/*"]
+    end
 
     bash_completion.install Dir["contrib/completion/bash/*.bash"]
   end


### PR DESCRIPTION
Seems like a lot of issues discussed in the [0.5.2 upgrade](https://github.com/Homebrew/homebrew/pull/46598) are still happening, so let's try jumping straight to 0.5.4 and modifying the build to behave more like a `go`-based project, using `go_resources` so we can install the one missing dependency.

There's [an actual fix](https://github.com/docker/machine/commit/42b6249a8c9e314afe116b0bb375647cea8db7f6) coming soon, but no idea when it's going to be released.