### PR TITLE
wxmac: follow up to #47226

### DIFF
--- a/Library/Formula/gnuradio.rb
+++ b/Library/Formula/gnuradio.rb
@@ -1,8 +1,8 @@
 class Gnuradio < Formula
   desc "SDK providing the signal processing runtime and processing blocks"
   homepage "http://gnuradio.squarespace.com/"
-  url "http://gnuradio.org/releases/gnuradio/gnuradio-3.7.8.tar.gz"
-  sha256 "fe19cb54b5d77fb76dde61d5cf184c6dee7066779b45c51676bae6e6d0cd4172"
+  url "http://gnuradio.org/releases/gnuradio/gnuradio-3.7.8.1.tar.gz"
+  sha256 "8406f49d085fdc2ef5d8ea90f3e19ad8782d2a2f5154bbe4f076591ddf7ae5aa"
 
   bottle do
     sha256 "5968cb5c61c7f44cb3b8c66c6ca418949d34c633f181ddcea78c5e1656b5a34a" => :yosemite
@@ -25,7 +25,6 @@ class Gnuradio < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "doxygen" => :build if build.with? "documentation"
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "boost"
@@ -41,6 +40,11 @@ class Gnuradio < Formula
     depends_on "qt"
     depends_on "qwt"
     depends_on "pyqt"
+  end
+
+  if build.with? "documentation"
+    depends_on "doxygen" => :build
+    depends_on "sphinx-doc" => :build
   end
 
   depends_on "uhd" => :recommended
@@ -70,76 +74,16 @@ class Gnuradio < Formula
     sha256 "062e6dbebcbe738eaa6e6298fe38b1ddf355dbe67a9f76c67a79fcef67468c5b"
   end
 
-  # sphinx starts here
-  resource "docutils" do
-    url "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
-    sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
-  end
-
-  resource "pygments" do
-    url "https://pypi.python.org/packages/source/P/Pygments/Pygments-2.0.2.tar.gz"
-    sha256 "7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51"
-  end
-
-  resource "jinja2" do
-    url "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.7.3.tar.gz"
-    sha256 "2e24ac5d004db5714976a04ac0e80c6df6e47e98c354cb2c0d82f8879d4f8fdb"
-  end
-
-  resource "markupsafe" do
-    url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
-    sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
-  end
-
-  resource "alabaster" do
-    url "https://pypi.python.org/packages/source/a/alabaster/alabaster-0.7.3.tar.gz"
-    sha256 "0703c1ea5a6af0bb6d0cec24708301334949d56ebc7f95c64028d9c66f9d8d5d"
-  end
-
-  resource "babel" do
-    url "https://pypi.python.org/packages/source/B/Babel/Babel-1.3.tar.gz"
-    sha256 "9f02d0357184de1f093c10012b52e7454a1008be6a5c185ab7a3307aceb1d12e"
-  end
-
-  resource "snowballstemmer" do
-    url "https://pypi.python.org/packages/source/s/snowballstemmer/snowballstemmer-1.2.0.tar.gz"
-    sha256 "6d54f350e7a0e48903a4e3b6b2cabd1b43e23765fbc975065402893692954191"
-  end
-
-  resource "six" do
-    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
-    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
-  end
-
-  resource "pytz" do
-    url "https://pypi.python.org/packages/source/p/pytz/pytz-2015.2.tar.bz2"
-    sha256 "3e15b416c9a2039c1a51208b2cd3bb4ffd796cd19e601b1d2657afcb77c3dc90"
-  end
-
-  resource "sphinx_rtd_theme" do
-    url "https://pypi.python.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.7.tar.gz"
-    sha256 "9a490c861f6cf96a0050c29a92d5d1e01eda02ae6f50760ad5c96a327cdf14e8"
-  end
-
-  resource "sphinx" do
-    url "https://pypi.python.org/packages/source/S/Sphinx/Sphinx-1.3.1.tar.gz"
-    sha256 "1a6e5130c2b42d2de301693c299f78cc4bd3501e78b610c08e45efc70e2b5114"
-  end
-  # sphinx ends here
-
   resource "cppzmq" do
-    url "https://github.com/zeromq/cppzmq/raw/34c8e4395c94d34a89bbeaaf2b8f9c94a8293c84/zmq.hpp"
-    sha256 "6cdd9d920f4a0f9f3a3257541321bef8369d9735c88b84ba8ae0e461f53e476c"
+    url "https://github.com/zeromq/cppzmq/raw/a4459abdd1d70fd980f9c166d73da71fe9762e0b/zmq.hpp"
+    sha256 "f042d4d66e2a58bd951a3eaf108303e862fad2975693bebf493931df9cd251a5"
   end
 
   def install
     ENV["CHEETAH_INSTALL_WITHOUT_SETUPTOOLS"] = "1"
-    ENV.prepend_path "PATH", libexec/"vendor/bin" if build.with? "documentation"
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
 
     res = %w[Markdown Cheetah lxml numpy]
-    res += %w[sphinx sphinx_rtd_theme alabaster babel docutils pygments
-              jinja2 markupsafe snowballstemmer six pytz] if build.with? "documentation"
     res.each do |r|
       resource(r).stage do
         system "python", *Language::Python.setup_install_args(libexec/"vendor")

--- a/Library/Formula/grass.rb
+++ b/Library/Formula/grass.rb
@@ -31,12 +31,12 @@ class Grass < Formula
   depends_on "libtiff"
   depends_on "unixodbc"
   depends_on "fftw"
-  depends_on "wxpython" => :recommended # prefer over OS X's version because of 64bit
-  depends_on :postgresql => :optional
-  depends_on :mysql => :optional
   depends_on "cairo"
   depends_on "freetype"
   depends_on :x11 # needs to find at least X11/include/GL/gl.h
+  depends_on "wxpython" => :recommended
+  depends_on :postgresql => :optional
+  depends_on :mysql => :optional
 
   fails_with :clang do
     cause "Multiple build failures while compiling GRASS tools."

--- a/Library/Formula/qwt.rb
+++ b/Library/Formula/qwt.rb
@@ -41,19 +41,28 @@ class Qwt < Formula
     system "qmake", *args
     system "make"
     system "make", "install"
+  end
 
-    # symlink Qt Designer plugin (note: not removed on qwt formula uninstall)
+  def post_install
+    # This is a dirty hack, but one we've been using since 2014 and may as well
+    # stick with until we decide how to handle the qt plugin problem UM is working on.
+    # Symlink Qt Designer plugin (note: not removed on qwt formula uninstall)
     ln_sf prefix/"plugins/designer/libqwt_designer_plugin.dylib",
           Formula["qt"].opt_prefix/"plugins/designer/" if build.with? "plugin"
   end
 
   def caveats
-    if build.with? "qwtmathml"; <<-EOS.undent
+    s = ""
+
+    if build.with? "qwtmathml"
+      s += <<-EOS.undent
         The qwtmathml library contains code of the MML Widget from the Qt solutions package.
         Beside the Qwt license you also have to take care of its license:
         #{opt_prefix}/qtmmlwidget-license
       EOS
     end
+
+    s
   end
 end
 

--- a/Library/Formula/wxmac.rb
+++ b/Library/Formula/wxmac.rb
@@ -3,6 +3,7 @@ class Wxmac < Formula
   homepage "https://www.wxwidgets.org"
   url "https://downloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.tar.bz2"
   sha256 "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,12 +14,13 @@ class Wxmac < Formula
     sha256 "59eb370bb7368a155ad3d6b7dba8536160d9d1ee6ebc67d240eb014f4a6d2dda" => :mountain_lion
   end
 
+  option :universal
+  option "with-stl", "use standard C++ classes for everything"
+  option "with-static", "build static libraries"
+
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-
-  option "with-stl", "use standard C++ classes for everything"
-  option "with-static", "build static libraries"
 
   # Various fixes related to Yosemite. Revisit in next stable release.
   # Please keep an eye on http://trac.wxwidgets.org/ticket/16329 as well
@@ -27,14 +29,6 @@ class Wxmac < Formula
 
   def install
     # need to set with-macosx-version-min to avoid configure defaulting to 10.5
-    # need to enable universal binary build in order to build all x86_64
-    # Jack - I don't believe this is the whole story, surely this can be fixed
-    # without building universal for users who don't need it.
-    # headers need to specify x86_64 and i386 or will try to build for ppc arch
-    # and fail on newer OSes
-    # DomT4 - MacPorts seems to have stopped building universal by default? Can we do the same?
-    # https://trac.macports.org/browser/trunk/dports/graphics/wxWidgets-3.0/Portfile#L210
-    ENV.universal_binary
     args = [
       "--disable-debug",
       "--prefix=#{prefix}",
@@ -63,12 +57,16 @@ class Wxmac < Formula
       "--enable-controls",
       "--enable-dataviewctrl",
       "--with-expat",
-      "--with-macosx-version-min=#{MacOS.version}",
-      "--enable-universal_binary=#{Hardware::CPU.universal_archs.join(",")}",
       "--disable-precomp-headers",
+      "--with-macosx-version-min=#{MacOS.version}",
       # This is the default option, but be explicit
-      "--disable-monolithic"
+      "--disable-monolithic",
     ]
+
+    if build.universal?
+      ENV.universal_binary
+      args << "--enable-universal_binary=#{Hardware::CPU.universal_archs.join(",")}"
+    end
 
     args << "--enable-stl" if build.with? "stl"
 
@@ -83,7 +81,7 @@ class Wxmac < Formula
   end
 
   test do
-    system "wx-config", "--libs"
+    system bin/"wx-config", "--libs"
   end
 end
 


### PR DESCRIPTION
Misty's PR fixed the `wxpython` issue (:bow:) but not the other issues such as `gnuradio` being broken for a handful of other reasons, `wxmac` enforcing universal builds on everyone, `qwt` breaching sandbox, etc so this is just an uncontroversial follow-up PR.

I say "uncontroversial" both optimistically and pleadingly.