### PR TITLE
digitemp 3.7.1 (new formula)

### DIFF
--- a/Library/Formula/digitemp.rb
+++ b/Library/Formula/digitemp.rb
@@ -1,0 +1,34 @@
+class Digitemp < Formula
+  desc "Read temperature sensors in a 1-Wire net"
+  homepage "https://www.digitemp.com/"
+  url "https://github.com/bcl/digitemp/archive/v3.7.1.tar.gz"
+  sha256 "6fa4d965350d5501b6ca73ee8a09276ca4f65b6d85dae62f0a796239bae5000e"
+  head "https://github.com/bcl/digitemp.git"
+
+  depends_on "libusb-compat"
+
+  def install
+    mkdir_p "build-serial/src"
+    mkdir_p "build-serial/userial/ds9097"
+    mkdir_p "build-serial/userial/ds9097u"
+    mkdir_p "build-usb/src"
+    mkdir_p "build-usb/userial/ds2490"
+    system "make", "-C", "build-serial", "-f", "../Makefile", "SRCDIR=..", "ds9097", "ds9097u"
+    system "make", "-C", "build-usb", "-f", "../Makefile", "SRCDIR=..", "ds2490"
+    bin.install "build-serial/digitemp_DS9097"
+    bin.install "build-serial/digitemp_DS9097U"
+    bin.install "build-usb/digitemp_DS2490"
+    man1.install "digitemp.1"
+    man1.install_symlink "digitemp.1" => "digitemp_DS9097.1"
+    man1.install_symlink "digitemp.1" => "digitemp_DS9097U.1"
+    man1.install_symlink "digitemp.1" => "digitemp_DS2490.1"
+  end
+
+  # digitemp has no self-tests and does nothing without a 1-wire device,
+  # so at least check the individual binaries compiled to what we expect.
+  test do
+    assert_match "Compiled for DS2490", shell_output("#{bin}/digitemp_DS2490 2>&1", 255)
+    assert_match "Compiled for DS9097", shell_output("#{bin}/digitemp_DS9097 2>&1", 255)
+    assert_match "Compiled for DS9097U", shell_output("#{bin}/digitemp_DS9097U 2>&1", 255)
+  end
+end


### PR DESCRIPTION
Digitemp is a program that reads data coming from a 1-Wire network using
a passive adapter (DS9097) or the newer active adapter (DS9097U),
connected to a serial port. It also supports reading from USB adaptors
like the DS2490. Basically it reads temperature sensors, but others are
supported, like a humidity sensor.

Digitemp also supports branched networks using DS2409 couplers.

Sample output / verification:
```
ryan@ndnd:~$ digitemp_DS9097U -s/dev/tty.usbserial-A800bZvc -i
DigiTemp v3.7.1 Copyright 1996-2015 by Brian C. Lane
GNU General Public License v2.0 - http://www.digitemp.com
Turning off all DS2409 Couplers
...
Searching the 1-Wire LAN
28D1483C0200002F : DS18B20 Temperature Sensor
28E9393C020000C3 : DS18B20 Temperature Sensor
ROM #0 : 28D1483C0200002F
ROM #1 : 28E9393C020000C3
Wrote .digitemprc
ryan@ndnd:~$ digitemp_DS9097U -w
DigiTemp v3.7.1 Copyright 1996-2015 by Brian C. Lane
GNU General Public License v2.0 - http://www.digitemp.com
Turning off all DS2409 Couplers
..
Devices on the Main LAN
28D1483C0200002F : DS18B20 Temperature Sensor
28E9393C020000C3 : DS18B20 Temperature Sensor
010EBED512000046 : DS2401/DS1990A Serial Number iButton

ryan@ndnd:~$ digitemp_DS9097U -a
DigiTemp v3.7.1 Copyright 1996-2015 by Brian C. Lane
GNU General Public License v2.0 - http://www.digitemp.com
Dec 21 17:14:30 Sensor 0 C: 23.30 F: 73.94
Dec 21 17:14:32 Sensor 1 C: 24.16 F: 75.49
```
