### PR TITLE
Use Homebrew’s Erlang in RabbitMQ instead of a vendored Erlang.

### DIFF
--- a/Library/Formula/rabbitmq.rb
+++ b/Library/Formula/rabbitmq.rb
@@ -1,6 +1,3 @@
-# We'd really like this formula to be built from source so we can build
-# against a modern OpenSSL rather than the prehistoric system version.
-# Submit a PR if you're interested, Thanks!
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"

--- a/Library/Formula/rabbitmq.rb
+++ b/Library/Formula/rabbitmq.rb
@@ -4,11 +4,12 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.0/rabbitmq-server-mac-standalone-3.6.0.tar.xz"
-  sha256 "db10cb920cfc77f5714ca92275dcb5d4870301817debcc27c399041a4ed87ea8"
+  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.0/rabbitmq-server-generic-unix-3.6.0.tar.xz"
+  sha256 "f8b8e8cac8874d947c364350e215723309caf158b69ea265bac61a0f5e8d101b"
 
   bottle :unneeded
 
+  depends_on "erlang"
   depends_on "simplejson" => :python if MacOS.version <= :leopard
 
   def install
@@ -22,8 +23,9 @@ class Rabbitmq < Formula
     # Correct SYS_PREFIX for things like rabbitmq-plugins
     inreplace sbin/"rabbitmq-defaults" do |s|
       s.gsub! "SYS_PREFIX=${RABBITMQ_HOME}", "SYS_PREFIX=#{HOMEBREW_PREFIX}"
-      s.gsub! 'CLEAN_BOOT_FILE="${SYS_PREFIX}', "CLEAN_BOOT_FILE=\"#{prefix}"
-      s.gsub! 'SASL_BOOT_FILE="${SYS_PREFIX}', "SASL_BOOT_FILE=\"#{prefix}"
+      erlang = Formula["erlang"]
+      s.gsub! "CLEAN_BOOT_FILE=start_clean", "CLEAN_BOOT_FILE=#{erlang.opt_lib/"erlang/bin/start_clean"}"
+      s.gsub! "SASL_BOOT_FILE=start_sasl", "SASL_BOOT_FILE=#{erlang.opt_lib/"erlang/bin/start_clean"}"
     end
 
     # Set RABBITMQ_HOME in rabbitmq-env

--- a/Library/Formula/rabbitmq.rb
+++ b/Library/Formula/rabbitmq.rb
@@ -52,6 +52,13 @@ class Rabbitmq < Formula
     EOS
   end
 
+  test do
+    ENV["RABBITMQ_MNESIA_BASE"] = testpath/"var/lib/rabbitmq/mnesia"
+    system sbin/"rabbitmq-server", "-detached"
+    system sbin/"rabbitmqctl", "status"
+    system sbin/"rabbitmqctl", "stop"
+  end
+
   def rabbitmq_env; <<-EOS.undent
     CONFIG_FILE=#{etc}/rabbitmq/rabbitmq
     NODE_IP_ADDRESS=127.0.0.1


### PR DESCRIPTION
~~This PR probably isn't ready to merge yet, but I'd like to start gathering some feedback.~~

I think it's good to go!