### PR TITLE
qt: add shared 'plugins' path for use by formulae

### DIFF
--- a/Library/Formula/qscintilla2.rb
+++ b/Library/Formula/qscintilla2.rb
@@ -70,16 +70,13 @@ class Qscintilla2 < Formula
       mkpath prefix/"plugins/designer"
       cd "designer-Qt4Qt5" do
         inreplace "designer.pro" do |s|
-          s.sub! "$$[QT_INSTALL_PLUGINS]", "#{prefix}/plugins"
+          s.sub! "$$[QT_INSTALL_PLUGINS]", "#{lib}/qt4/plugins"
           s.sub! "$$[QT_INSTALL_LIBS]", "#{lib}"
         end
         system "qmake", "designer.pro", *args
         system "make"
         system "make", "install"
       end
-      # symlink Qt Designer plugin (note: not removed on qscintilla2 formula uninstall)
-      ln_sf prefix/"plugins/designer/libqscintillaplugin.dylib",
-            Formula["qt"].opt_prefix/"plugins/designer/"
     end
   end
 

--- a/Library/Formula/qscintilla2.rb
+++ b/Library/Formula/qscintilla2.rb
@@ -10,10 +10,10 @@ class Qscintilla2 < Formula
     sha256 "d487010da4ab0eee416ae7dcd1f22e2be2ed60984dda8da1b579094351e173f4" => :mountain_lion
   end
 
+  option "without-plugin", "Skip building the Qt Designer plugin"
+
   depends_on :python => :recommended
   depends_on :python3 => :optional
-
-  option "without-plugin", "Skip building the Qt Designer plugin"
 
   if build.with? "python3"
     depends_on "pyqt" => "with-python3"

--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -1,7 +1,7 @@
 class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  revision 1
+  revision 2
 
   head "https://code.qt.io/qt/qt.git", :branch => "4.8"
 
@@ -125,12 +125,22 @@ class Qt < Formula
       include.install_symlink path => path.parent.basename(".framework")
     end
 
+    # Make `HOMEBREW_PREFIX/lib/qt4/plugins` an additional plug-in search path
+    # for Qt Designer to support formulae that provide Qt Designer plug-ins.
+    system "/usr/libexec/PlistBuddy",
+            "-c", "Add :LSEnvironment:QT_PLUGIN_PATH string \"#{HOMEBREW_PREFIX}/lib/qt4/plugins\"",
+           "#{bin}/Designer.app/Contents/Info.plist"
+
     Pathname.glob("#{bin}/*.app") { |app| mv app, prefix }
   end
 
   def caveats; <<-EOS.undent
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
+
+    Qt Designer no longer picks up changes to the QT_PLUGIN_PATH environment
+    variable as it was tweaked to search for plug-ins provided by formulae in
+      #{HOMEBREW_PREFIX}/lib/qt4/plugins
     EOS
   end
 

--- a/Library/Formula/qwt.rb
+++ b/Library/Formula/qwt.rb
@@ -25,6 +25,10 @@ class Qwt < Formula
     inreplace "qwtconfig.pri" do |s|
       s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
       s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
+
+      # Install Qt plugin in `lib/qt4/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt4/\\2"
     end
 
     args = ["-config", "release", "-spec"]
@@ -43,14 +47,6 @@ class Qwt < Formula
     system "qmake", *args
     system "make"
     system "make", "install"
-  end
-
-  def post_install
-    # This is a dirty hack, but one we've been using since 2014 and may as well
-    # stick with until we decide how to handle the qt plugin problem UM is working on.
-    # Symlink Qt Designer plugin (note: not removed on qwt formula uninstall)
-    ln_sf prefix/"plugins/designer/libqwt_designer_plugin.dylib",
-          Formula["qt"].opt_prefix/"plugins/designer/" if build.with? "plugin"
   end
 
   def caveats

--- a/Library/Formula/qwtpolar.rb
+++ b/Library/Formula/qwtpolar.rb
@@ -30,6 +30,10 @@ class Qwtpolar < Formula
       s.sub! /\+(=\s*QwtPolarDesigner)/, "-\\1" if build.without? "plugin"
       # Don't build examples now, since linking flawed until qwtpolar installed
       s.sub! /\+(=\s*QwtPolarExamples)/, "-\\1"
+
+      # Install Qt plugin in `lib/qt4/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_POLAR_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt4/\\2"
     end
 
     args = %W[-config release -spec]
@@ -44,10 +48,6 @@ class Qwtpolar < Formula
     system "qmake", *args
     system "make"
     system "make", "install"
-
-    # symlink Qt Designer plugin (note: not removed on qwtpolar formula uninstall)
-    ln_sf prefix/"plugins/designer/libqwt_polar_designer_plugin.dylib",
-          Formula["qt"].opt_prefix/"plugins/designer/" if build.with? "plugin"
   end
 end
 


### PR DESCRIPTION
This path is located in `lib/qt4/plugins` in the Homebrew prefix, thus formulae wishing to make their plug-ins available to Qt Designer (and other Qt programs) can install them in `lib/qt4/plugins` inside their formula prefix. These will be later symlinked into the Homebrew prefix.

This new path is searched in addition to (and prior to) the path that contains the plug-ins distributed with Qt itself, but after any user-defined paths.

There are other ways to achieve a similar effect, but they are all more fragile than this (in my opinion) rather simple source code change, that just adds another default search path. Possible alternatives are:

- Set `QT_PLUGIN_PATH` environment variable to include the new directory. Difficult to find a good and reliable place where to set this.
- Rearrange stuff with crazy symlinking between Homebrew and `qt` prefix. Stops working as soon as the `qt` formula is unlinked or becomes keg-only.

This PR also fixes/adjusts formulae that provide Qt Designer plugins and replaces #47086.

cc @DomT4 @mikemcquaid 