### PR TITLE
ENV: avoid misleading Fortran setup warnings

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -203,6 +203,12 @@ module SharedEnvExtension
   end
 
   def fortran
+    # Ignore repeated calls to this function as it will misleadingly warn about
+    # building with an alternative Fortran compiler without optimization flags,
+    # despite it often being the Homebrew-provided one set up in the first call.
+    return if @fortran_setup_done
+    @fortran_setup_done = true
+
     flags = []
 
     if fc


### PR DESCRIPTION
For some formulae, particularly from homebrew/science, the output is just hilariously long and misleading. This happens with formulae that have a `:fortran` requirement, where some of the dependencies happen to also have a `:fortran` requirement. A prominent example is `petsc`:

```
$ brew install petsc
==> Installing petsc from homebrew/science
==> Using the sandbox
==> Using Homebrew-provided fortran compiler.
This may be changed by setting the FC environment variable.
==> Building with an alternative Fortran compiler
This is unsupported.
Warning: No Fortran optimization information was provided.  You may want to consider
setting FCFLAGS and FFLAGS or pass the `--default-fortran-flags` option to
`brew install` if your compiler is compatible with GCC.

If you like the default optimization level of your compiler, ignore this
warning.
==> Building with an alternative Fortran compiler
This is unsupported.
Warning: No Fortran optimization information was provided.  You may want to consider
setting FCFLAGS and FFLAGS or pass the `--default-fortran-flags` option to
`brew install` if your compiler is compatible with GCC.

If you like the default optimization level of your compiler, ignore this
warning.
[… snip … repeated another 5 times …]
==> Downloading http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.6.3.tar.gz
```

cc @dpo