### PR TITLE
bin/brew: enforce UTF-8 locale

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,7 +1,14 @@
 #!/bin/sh
+
 chdir() {
   cd "$@" >/dev/null
 }
+
+# Force UTF-8 to avoid encoding issues for users with broken locale settings.
+if [ "$(locale charmap 2> /dev/null)" != "UTF-8" ]
+then
+  export LC_ALL="en_US.UTF-8"
+fi
 
 BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
 HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"


### PR DESCRIPTION
Everyone should be using a UTF-8 locale nowadays. Not using one causes issues like `brew doctor` failing while checking symbolic links that point at file names with non-ASCII characters, since OS X always uses Unicode for the file system.

~~Be careful not to override the user's preference, if it is valid, and take into account relationship between `LC_ALL` (highest precedence), `LC_CTYPE`, and `LANG` (lowest precedence). The code only checks if the user has selected a locale ending in `.UTF-8` and doesn't handle the rather unlikely case of an invalid locale.~~

Rely on `locale charmap` to detect the currently selected encoding and if that's not UTF-8, override the user's choice (if any) by setting `LC_ALL` to `en_US.UTF-8`, the assumption being that every system has a usable `en_US.UTF-8` locale installed.

cc @apjanke @mikemcquaid