### PR TITLE
Fix installation of docker-machine bash completion

### DIFF
--- a/Library/Formula/docker-machine.rb
+++ b/Library/Formula/docker-machine.rb
@@ -35,9 +35,8 @@ class DockerMachine < Formula
     cd path do
       system "make", "build"
       bin.install Dir["bin/*"]
+      bash_completion.install Dir["contrib/completion/bash/*.bash"]
     end
-
-    bash_completion.install Dir["contrib/completion/bash/*.bash"]
   end
 
   test do


### PR DESCRIPTION
The recent upgrade to docker-machine 0.5.4 accidentally broke the
installation of the docker-machine bash completion scripts.