### PR TITLE
Cairo  1.15.2

### DIFF
--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -1,9 +1,8 @@
 class Cairo < Formula
   desc "Vector graphics library with cross-device output support"
   homepage "http://cairographics.org/"
-  url "http://cairographics.org/releases/cairo-1.14.6.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/cairo-1.14.6.tar.xz"
-  sha256 "613cb38447b76a93ff7235e17acd55a78b52ea84a9df128c3f2257f8eaa7b252"
+  url "http://cairographics.org/snapshots/cairo-1.15.2.tar.xz"
+  sha256 "268cc265a7f807403582f440643064bf52896556766890c8df7bad02d230f6c9"
 
   bottle do
     sha256 "0b6d60becf48ba6971ee9103e33ee8b9c96b394463483947657c9e45be28c566" => :el_capitan


### PR DESCRIPTION
Note, however, that, once a source tarball is available from the NetBSD mirror, this formula's `mirror` URL statement will have to be added back in.  