### PR TITLE
pandoc-citeproc 0.8.1.3

### DIFF
--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -5,8 +5,8 @@ class PandocCiteproc < Formula
 
   desc "Library and executable for using citeproc with pandoc"
   homepage "https://github.com/jgm/pandoc-citeproc"
-  url "https://hackage.haskell.org/package/pandoc-citeproc-0.8.1.1/pandoc-citeproc-0.8.1.1.tar.gz"
-  sha256 "0fc5f1f82ce6687f0bc63eb57543a86eecf56cbcd43cec2d0191e6868502b189"
+  url "https://github.com/jgm/pandoc-citeproc/archive/0.8.1.3.tar.gz"
+  sha256 "d1806c65b35851abb44faa90c0ba60e15a11656420713a5907dfa1563c32be5b"
 
   bottle do
     sha256 "007625243bcac2f5306caf8d80b620b6e75dc88d5f4a8130d5ab3713dcd3bce8" => :el_capitan
@@ -21,11 +21,7 @@ class PandocCiteproc < Formula
   setup_ghc_compilers
 
   def install
-    cabal_sandbox do
-      cabal_install "--only-dependencies"
-      cabal_install "--prefix=#{prefix}"
-    end
-    cabal_clean_lib
+    install_cabal_package
   end
 
   test do


### PR DESCRIPTION
Simplifies the use of Haskell language support.

Downloads from GitHub instead of Hackage.