### PR TITLE
mplayer: added some stuff to make OSD menu work via X11

### DIFF
--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -23,6 +23,9 @@ class Mplayer < Formula
     patch :DATA
   end
 
+  option "with-x11OSD", "Enable x11 for freefont/freetype menu support"
+
+  depends_on :x11 => :optional
   depends_on "yasm" => :build
   depends_on "libcaca" => :optional
 
@@ -47,10 +50,14 @@ class Mplayer < Formula
       --host-cc=#{ENV.cc}
       --disable-cdparanoia
       --prefix=#{prefix}
-      --disable-x11
     ]
 
     args << "--enable-caca" if build.with? "libcaca"
+
+    args << "--enable-x11" if build.with? "x11OSD"
+    args << "--extra-libs=-lX11" if build.with? "x11OSD"
+    args << "--extra-libs-mplayer=-lXext" if build.with? "x11OSD"
+    args << "--enable-menu" if build.with? "x11OSD"
 
     system "./configure", *args
     system "make"

--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -23,7 +23,7 @@ class Mplayer < Formula
     patch :DATA
   end
 
-  option "with-x11OSD", "Enable x11 for freefont/freetype menu support"
+  option "with-x11", "Enable x11 for freefont/freetype menu support (OSD)"
 
   depends_on :x11 => :optional
   depends_on "yasm" => :build
@@ -54,10 +54,13 @@ class Mplayer < Formula
 
     args << "--enable-caca" if build.with? "libcaca"
 
-    args << "--enable-x11" if build.with? "x11OSD"
-    args << "--extra-libs=-lX11" if build.with? "x11OSD"
-    args << "--extra-libs-mplayer=-lXext" if build.with? "x11OSD"
-    args << "--enable-menu" if build.with? "x11OSD"
+    # to get OSD to work on El Capitan we seen to need x11
+    if build.with? "x11"
+      args << "--enable-x11" 
+      args << "--extra-libs=-lX11"
+      args << "--extra-libs-mplayer=-lXext"
+      args << "--enable-menu"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
OSX El Capitan appears to have broken the non-X11 OSD. Several people are commenting on this online. I went into the Formula for mplayer, added back the x11 dependencies to enable x11 and turn on menu. This worked for me with XQuartz.

I put in a -with-x11OSD option to turn this on. I tried to follow the logic of how other people do things. 

mplayer uses a home-made configure which is *not* entirely normal, and needed multiple libraries passed in to the link phase. I used two flags to do this because the quoting to pass -lX11 -lXext didn't work on one line via the Formula. Thats a hack, but it worked for me.