### PR TITLE
Improve Haskell language support

### DIFF
--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -44,28 +44,20 @@ class Agda < Formula
   depends_on "gmp"
   depends_on :emacs => ["21.1", :recommended]
 
-  setup_ghc_compilers
-
   def install
     # install Agda core
-    cabal_sandbox do
-      cabal_install_tools "alex", "happy", "cpphs"
-      cabal_install "--only-dependencies"
-      cabal_install "--prefix=#{prefix}"
-    end
-    cabal_clean_lib
+    install_cabal_package :using => ["alex", "happy", "cpphs"]
 
     if build.with? "stdlib"
       resource("stdlib").stage lib/"agda"
 
       # generate the standard library's bytecode
       cd lib/"agda" do
-        cabal_sandbox do
+        cabal_sandbox :home => buildpath, :keep_lib => true do
           cabal_install "--only-dependencies"
           cabal_install
           system "GenerateEverything"
         end
-        rm_rf [".cabal", "dist"]
       end
 
       # install the standard library's FFI bindings for the MAlonzo backend
@@ -77,11 +69,10 @@ class Agda < Formula
         system "ghc-pkg", "--package-db=#{db_path}", "recache"
 
         cd lib/"agda"/"ffi" do
-          cabal_sandbox do
+          cabal_sandbox :home => buildpath, :keep_lib => true do
             system "cabal", "--ignore-sandbox", "install", "--package-db=#{db_path}",
               "--prefix=#{lib}/agda/ffi"
           end
-          rm_rf [".cabal", "dist"]
         end
       end
 

--- a/Library/Formula/arx.rb
+++ b/Library/Formula/arx.rb
@@ -17,8 +17,6 @@ class Arx < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     cabal_sandbox do
       cabal_install "--only-dependencies"
@@ -28,7 +26,6 @@ class Arx < Formula
       tag = `./bin/dist tag`.chomp
       bin.install "tmp/dist/arx-#{tag}/arx" => "arx"
     end
-    cabal_clean_lib
   end
 
   test do

--- a/Library/Formula/cgrep.rb
+++ b/Library/Formula/cgrep.rb
@@ -19,8 +19,6 @@ class Cgrep < Formula
   depends_on "cabal-install" => :build
   depends_on "pcre"
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/cless.rb
+++ b/Library/Formula/cless.rb
@@ -22,8 +22,6 @@ class Cless < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/cryptol.rb
+++ b/Library/Formula/cryptol.rb
@@ -20,8 +20,6 @@ class Cryptol < Formula
   depends_on "cabal-install" => :build
   depends_on "cvc4"
 
-  setup_ghc_compilers
-
   def install
     cabal_sandbox do
       system "make", "PREFIX=#{prefix}", "install"

--- a/Library/Formula/darcs.rb
+++ b/Library/Formula/darcs.rb
@@ -18,8 +18,6 @@ class Darcs < Formula
   depends_on "cabal-install" => :build
   depends_on "gmp"
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/elm.rb
+++ b/Library/Formula/elm.rb
@@ -60,8 +60,6 @@ class Elm < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     # elm-compiler needs to be staged in a subdirectory for the build process to succeed
     (buildpath/"elm-compiler").install Dir["*"]
@@ -73,7 +71,7 @@ class Elm < Formula
     end
 
     cabal_sandbox do
-      system "cabal", "sandbox", "add-source", "elm-compiler", *extras
+      cabal_sandbox_add_source "elm-compiler", *extras
       cabal_install "--only-dependencies", "elm-compiler", *extras
       cabal_install "--prefix=#{prefix}", "elm-compiler", *extras_no_reactor
 
@@ -82,7 +80,6 @@ class Elm < Formula
 
       cabal_install "--prefix=#{prefix}", "elm-reactor"
     end
-    cabal_clean_lib
   end
 
   test do

--- a/Library/Formula/git-annex.rb
+++ b/Library/Formula/git-annex.rb
@@ -25,14 +25,8 @@ class GitAnnex < Formula
   depends_on "gnutls"
   depends_on "quvi"
 
-  setup_ghc_compilers
-
   def install
-    cabal_sandbox do
-      cabal_install_tools "alex", "happy", "c2hs"
-      cabal_install "--only-dependencies"
-      cabal_install "--prefix=#{prefix}"
-
+    install_cabal_package :using => ["alex", "happy", "c2hs"] do
       # this can be made the default behavior again once git-union-merge builds properly when bottling
       if build.with? "git-union-merge"
         system "make", "git-union-merge", "PREFIX=#{prefix}"
@@ -41,7 +35,6 @@ class GitAnnex < Formula
       end
     end
     bin.install_symlink "git-annex" => "git-annex-shell"
-    cabal_clean_lib
   end
 
   test do

--- a/Library/Formula/haskell-stack.rb
+++ b/Library/Formula/haskell-stack.rb
@@ -19,8 +19,6 @@ class HaskellStack < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/highlighting-kate.rb
+++ b/Library/Formula/highlighting-kate.rb
@@ -19,8 +19,6 @@ class HighlightingKate < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package "-f executable"
   end

--- a/Library/Formula/idris.rb
+++ b/Library/Formula/idris.rb
@@ -22,13 +22,11 @@ class Idris < Formula
   depends_on "libffi" => :recommended
   depends_on "pkg-config" => :build if build.with? "libffi"
 
-  setup_ghc_compilers
-
   def install
-    flags = []
-    flags << "-f FFI" if build.with? "libffi"
-    flags << "-f release" if build.stable?
-    install_cabal_package flags
+    args = []
+    args << "-f FFI" if build.with? "libffi"
+    args << "-f release" if build.stable?
+    install_cabal_package *args
   end
 
   test do

--- a/Library/Formula/mighttpd2.rb
+++ b/Library/Formula/mighttpd2.rb
@@ -17,8 +17,6 @@ class Mighttpd2 < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -18,8 +18,6 @@ class PandocCiteproc < Formula
   depends_on "cabal-install" => :build
   depends_on "pandoc"
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/pandoc.rb
+++ b/Library/Formula/pandoc.rb
@@ -20,8 +20,6 @@ class Pandoc < Formula
   depends_on "cabal-install" => :build
   depends_on "gmp"
 
-  setup_ghc_compilers
-
   def install
     args = []
     args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion

--- a/Library/Formula/postgrest.rb
+++ b/Library/Formula/postgrest.rb
@@ -19,8 +19,6 @@ class Postgrest < Formula
   depends_on "cabal-install" => :build
   depends_on "postgresql"
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
   end

--- a/Library/Formula/purescript.rb
+++ b/Library/Formula/purescript.rb
@@ -17,15 +17,8 @@ class Purescript < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
-    cabal_sandbox do
-      cabal_install_tools "alex", "happy"
-      cabal_install "--only-dependencies"
-      cabal_install "--prefix=#{prefix}"
-    end
-    cabal_clean_lib
+    install_cabal_package :using => ["alex", "happy"]
   end
 
   test do

--- a/Library/Formula/shellcheck.rb
+++ b/Library/Formula/shellcheck.rb
@@ -19,8 +19,6 @@ class Shellcheck < Formula
   depends_on "cabal-install" => :build
   depends_on "pandoc" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package
     system "pandoc", "-s", "-t", "man", "shellcheck.1.md", "-o", "shellcheck.1"

--- a/Library/Formula/texmath.rb
+++ b/Library/Formula/texmath.rb
@@ -17,8 +17,6 @@ class Texmath < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
 
-  setup_ghc_compilers
-
   def install
     install_cabal_package "-f executable"
   end

--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -2,13 +2,7 @@ module Language
   module Haskell
 
     module Cabal
-      module ClassMethods # TODO: Remove
-        def setup_ghc_compilers
-        end
-      end
-
       def self.included(base)
-        base.extend ClassMethods # TODO: Remove
         # use llvm-gcc on Lion or below, as when building GHC)
         fails_with(:clang) if MacOS.version <= :lion
       end
@@ -62,9 +56,6 @@ module Language
         # unregister packages installed as dependencies for the tools, so
         # that they can't cause dependency conflicts for the main package
         rm_rf Dir[".cabal-sandbox/*packages.conf.d/"]
-      end
-
-      def cabal_clean_lib # TODO: Remove
       end
 
       def install_cabal_package(*args)

--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -1,79 +1,86 @@
 module Language
   module Haskell
-    # module for formulae using cabal-install as build tool
+
     module Cabal
-      module ClassMethods
+      module ClassMethods # TODO: Remove
         def setup_ghc_compilers
-          # Use llvm-gcc on Lion or below (same compiler used when building GHC).
-          fails_with(:clang) if MacOS.version <= :lion
         end
       end
 
       def self.included(base)
-        base.extend ClassMethods
+        base.extend ClassMethods # TODO: Remove
+        # use llvm-gcc on Lion or below, as when building GHC)
+        fails_with(:clang) if MacOS.version <= :lion
       end
 
-      def cabal_sandbox
+      def cabal_sandbox(options = {})
         pwd = Pathname.pwd
-        # force cabal to put its stuff here instead of the home directory by
-        # pretending the home is here. This also avoid to deal with many options
-        # to configure cabal. Note this is also useful with cabal sandbox to
-        # avoid touching ~/.cabal
-        home = ENV["HOME"]
-        ENV["HOME"] = pwd
+        home = options[:home] || pwd
 
-        # use cabal's sandbox feature if available
-        cabal_version = `cabal --version`[/[0-9.]+/].split(".").collect(&:to_i)
-        if (cabal_version <=> [1, 20]) > -1
-          system "cabal", "sandbox", "init"
-          cabal_sandbox_bin = pwd/".cabal-sandbox/bin"
-        else
-          # no or broken sandbox feature - just use the HOME trick
-          cabal_sandbox_bin = pwd/".cabal/bin"
-        end
-        # cabal may build useful tools that should be found in the PATH
-        mkdir_p cabal_sandbox_bin
-        path = ENV["PATH"]
-        ENV.prepend_path "PATH", cabal_sandbox_bin
-        # update cabal package database
-        system "cabal", "update"
-        yield
-        # restore the environment
-        if (cabal_version <=> [1, 20]) > -1
-          system "cabal", "sandbox", "delete"
-        end
+        # pretend HOME is elsewhere, so that ~/.cabal is kept as untouched
+        # as possible (except for ~/.cabal/setup-exe-cache)
+        # https://github.com/haskell/cabal/issues/1234
+        saved_home = ENV["HOME"]
         ENV["HOME"] = home
-        ENV["PATH"] = path
+
+        system "cabal", "sandbox", "init"
+        cabal_sandbox_bin = pwd/".cabal-sandbox"/"bin"
+        mkdir_p cabal_sandbox_bin
+
+        # make available any tools that will be installed in the sandbox
+        saved_path = ENV["PATH"]
+        ENV.prepend_path "PATH", cabal_sandbox_bin
+
+        # avoid updating the cabal package database more than once
+        system "cabal", "update" unless (home/".cabal"/"packages").exist?
+
+        yield
+
+        # remove the sandbox and all build products
+        rm_rf [".cabal-sandbox", "cabal.sandbox.config", "dist"]
+
+        # avoid installing any Haskell libraries, as a matter of policy
+        rm_rf lib unless options[:keep_lib]
+
+        # restore the environment
+        ENV["HOME"] = saved_home
+        ENV["PATH"] = saved_path
       end
 
-      def cabal_install(*opts)
-        system "cabal", "install", "--jobs=#{ENV.make_jobs}", *opts
+      def cabal_sandbox_add_source(*args)
+        system "cabal", "sandbox", "add-source", *args
       end
 
-      # install the tools passed in parameter and remove the packages that where
-      # used so they won't be in the way of the dependency solver for the main
-      # package. The tools are installed sequentially in order to make possible
-      # to install several tools that depends on each other
-      def cabal_install_tools(*opts)
-        opts.each { |t| cabal_install t }
-        rm_rf Dir[".cabal*/*packages.conf.d/"]
+      def cabal_install(*args)
+        system "cabal", "install", "--jobs=#{ENV.make_jobs}", *args
       end
 
-      # remove the development files from the lib directory. cabal-install should
-      # be used instead to install haskell packages
-      def cabal_clean_lib
-        # a better approach may be needed here
-        rm_rf lib
+      def cabal_install_tools(*tools)
+        # install tools sequentially, as some tools can depend on other tools
+        tools.each { |tool| cabal_install tool }
+
+        # unregister packages installed as dependencies for the tools, so
+        # that they can't cause dependency conflicts for the main package
+        rm_rf Dir[".cabal-sandbox/*packages.conf.d/"]
       end
 
-      def install_cabal_package(args = [])
+      def cabal_clean_lib # TODO: Remove
+      end
+
+      def install_cabal_package(*args)
+        options = if args[-1].kind_of?(Hash) then args.pop else {} end
+
         cabal_sandbox do
-          # the dependencies are built first and installed locally, and only the
-          # current package is actually installed in the destination dir
+          cabal_install_tools *options[:using] if options[:using]
+
+          # install dependencies in the sandbox
           cabal_install "--only-dependencies", *args
+
+          # install the main package in the destination dir
           cabal_install "--prefix=#{prefix}", *args
+
+          yield if block_given?
         end
-        cabal_clean_lib
       end
     end
   end


### PR DESCRIPTION
Removes the need to call `setup_ghc_compilers` in every Haskell language formula, by automatically calling `fails_with`.

Adds a `:home` option to the `cabal_sandbox` method.  This option allows a specific temporary `HOME` to be used instead of the current working directory, and in turn allows a single Cabal package database to be reused between multiple calls to this method.

Avoids updating the Cabal package database more than once if `cabal_sandbox` is called multiple times.

Removes the need to call `cabal_clean_lib` whenever `cabal_sandbox` is called, by automatically cleaning the `lib` directory.

Adds a `:keep_lib` option to the `cabal_sandbox` method.  This option allows opting out of the automatic cleaning.

Ensures build products are always removed from the current working directory.

Removes a workaround for versions of `cabal-install` older than [1.20.0.0](https://github.com/haskell/cabal/releases/tag/cabal-install-v1.20.0.0).

Adds a `cabal_sandbox_add_source` method.

Adds a `:using` option to the `install_cabal_package` method.  This option allows specifying the Haskell language tools that are required to install a particular formula, and in turn allows formulae to be simplified by replacing calls to multiple methods with a single call to this method.

Allows customizing the call to `install_cabal_package` by giving a block.

Applies the newly enabled simplifications to all Haskell language formulae.