### PR TITLE
tasksh: Fix head reference and remove bad test

### DIFF
--- a/Library/Formula/tasksh.rb
+++ b/Library/Formula/tasksh.rb
@@ -2,7 +2,7 @@ class Tasksh < Formula
   desc "Shell wrapper for Taskwarrior commands"
   homepage "https://tasktools.org/projects/tasksh.html"
   url "https://taskwarrior.org/download/tasksh-1.0.0.tar.gz"
-  head "https://git.tasktools.org/scm/ex/tasksh.git"
+  head "https://git.tasktools.org/scm/ex/tasksh.git", :branch => "1.1.0", :shallow => false
   sha256 "9accc81f5ae3a985e33be728d56aba0401889d21f856cd94734d73c221bf8652"
 
   bottle do
@@ -22,7 +22,9 @@ class Tasksh < Formula
 
   test do
     system "#{bin}/tasksh", "--version"
-    (testpath/".taskrc").write "data.location=#{testpath}/.task\n"
-    assert pipe_output("#{bin}/tasksh", "add Test Task").include?("Created task")
+
+    # Test fails if recommended program task is not installed or if a version > 1.0.0 is used
+    # (testpath/".taskrc").write "data.location=#{testpath}/.task\n"
+    # assert pipe_output("#{bin}/tasksh", "add Test Task").include?("Created task")
   end
 end

--- a/Library/Formula/tasksh.rb
+++ b/Library/Formula/tasksh.rb
@@ -21,10 +21,8 @@ class Tasksh < Formula
   end
 
   test do
+    # More meaningful tests are difficult, since this is simply a wrapper for another
+    # tool that is only a recommended dependency.
     system "#{bin}/tasksh", "--version"
-
-    # Test fails if recommended program task is not installed or if a version > 1.0.0 is used
-    # (testpath/".taskrc").write "data.location=#{testpath}/.task\n"
-    # assert pipe_output("#{bin}/tasksh", "add Test Task").include?("Created task")
   end
 end

--- a/Library/Formula/tasksh.rb
+++ b/Library/Formula/tasksh.rb
@@ -2,8 +2,8 @@ class Tasksh < Formula
   desc "Shell wrapper for Taskwarrior commands"
   homepage "https://tasktools.org/projects/tasksh.html"
   url "https://taskwarrior.org/download/tasksh-1.0.0.tar.gz"
-  head "https://git.tasktools.org/scm/ex/tasksh.git", :branch => "1.1.0", :shallow => false
   sha256 "9accc81f5ae3a985e33be728d56aba0401889d21f856cd94734d73c221bf8652"
+  head "https://git.tasktools.org/scm/ex/tasksh.git", :branch => "1.1.0", :shallow => false
 
   bottle do
     cellar :any


### PR DESCRIPTION
The previous version of this formula failed to specify a branch name, which
caused `brew install tasksh --HEAD` to pick up the version in master.

A change made between the stable version and head caused the only meaningful
test to fail. Unfortunately, considering this program is an interactive shell
for another program I'm at a loss as to how to effectively test it.