### PR TITLE
Rbenv formula update in anticipation of 1.0 release

### DIFF
--- a/Library/Formula/rbenv.rb
+++ b/Library/Formula/rbenv.rb
@@ -1,8 +1,8 @@
 class Rbenv < Formula
   desc "Ruby version manager"
   homepage "https://github.com/rbenv/rbenv#readme"
-  url "https://github.com/rbenv/rbenv/archive/v0.4.0.tar.gz"
-  sha256 "d40fe637cc799b828498fc5793548fab70d9e2431efc6a3d3f4a671d670fa9ff"
+  url "https://github.com/rbenv/rbenv/archive/v1.0.0.tar.gz"
+  sha256 "4658f2d8604ef847b39cb8216bb0d8a8aa000f504b6d06b30e008f92e6fa5210"
   head "https://github.com/rbenv/rbenv.git"
 
   bottle :unneeded

--- a/Library/Formula/rbenv.rb
+++ b/Library/Formula/rbenv.rb
@@ -12,6 +12,9 @@ class Rbenv < Formula
   def install
     inreplace "libexec/rbenv" do |s|
       s.gsub!('"${BASH_SOURCE%/*}"/../libexec', libexec.to_s, false)
+      if HOMEBREW_PREFIX.to_s != "/usr/local"
+        s.gsub!(":/usr/local/etc/rbenv.d", ":#{HOMEBREW_PREFIX}/etc/rbenv.d\\0")
+      end
     end
 
     # Compile optional bash extension. Failure is not critical.

--- a/Library/Formula/rbenv.rb
+++ b/Library/Formula/rbenv.rb
@@ -1,6 +1,6 @@
 class Rbenv < Formula
-  desc "Ruby environment tool"
-  homepage "https://github.com/rbenv/rbenv"
+  desc "Ruby version manager"
+  homepage "https://github.com/rbenv/rbenv#readme"
   url "https://github.com/rbenv/rbenv/archive/v0.4.0.tar.gz"
   sha256 "d40fe637cc799b828498fc5793548fab70d9e2431efc6a3d3f4a671d670fa9ff"
   head "https://github.com/rbenv/rbenv.git"
@@ -15,11 +15,12 @@ class Rbenv < Formula
   end
 
   def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.rbenv add to your profile:
+    Rbenv stores data under `~/.rbenv' by default. If you absolutely need to instead
+    store everything under the Homebrew prefix, include this in your profile:
       export RBENV_ROOT=#{var}/rbenv
 
-    To enable shims and autocompletion add to your profile:
-      if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
+    To enable shims and autocompletion, run this and follow the instructions:
+      rbenv init
     EOS
   end
 


### PR DESCRIPTION
This adds compatibility with new rbenv features when `brew install rbenv --HEAD` was used.

Rbenv 1.0 was not tagged yet, but will soon. I will update the tag in a separate PR. This is a transitional change that's backwards compatible with both rbenv v0.4.0 stable and rbenv master.

<del>This intentionally undoes the change made in https://github.com/Homebrew/homebrew/pull/17778 because it was unwanted. Rbenv hardcodes RBENV_HOOK_PATH to include `/usr/local/etc/rbenv.d` and that shouldn't get overwritten.</del>