### PR TITLE
Don't have any rbenv plugins depend on "rbenv" formula

### DIFF
--- a/Library/Formula/rbenv-aliases.rb
+++ b/Library/Formula/rbenv-aliases.rb
@@ -7,8 +7,6 @@ class RbenvAliases < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-binstubs.rb
+++ b/Library/Formula/rbenv-binstubs.rb
@@ -7,8 +7,6 @@ class RbenvBinstubs < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-bundle-exec.rb
+++ b/Library/Formula/rbenv-bundle-exec.rb
@@ -7,8 +7,6 @@ class RbenvBundleExec < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-bundler-ruby-version.rb
+++ b/Library/Formula/rbenv-bundler-ruby-version.rb
@@ -7,8 +7,6 @@ class RbenvBundlerRubyVersion < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-bundler.rb
+++ b/Library/Formula/rbenv-bundler.rb
@@ -7,8 +7,6 @@ class RbenvBundler < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-communal-gems.rb
+++ b/Library/Formula/rbenv-communal-gems.rb
@@ -6,8 +6,6 @@ class RbenvCommunalGems < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-ctags.rb
+++ b/Library/Formula/rbenv-ctags.rb
@@ -7,8 +7,7 @@ class RbenvCtags < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-  depends_on "ctags"
+  depends_on "ctags" => :optional
 
   def install
     prefix.install Dir["*"]

--- a/Library/Formula/rbenv-default-gems.rb
+++ b/Library/Formula/rbenv-default-gems.rb
@@ -8,9 +8,6 @@ class RbenvDefaultGems < Formula
 
   head "https://github.com/sstephenson/rbenv-default-gems.git"
 
-  depends_on "rbenv"
-  depends_on "ruby-build"
-
   # Upstream patch: https://github.com/sstephenson/rbenv-default-gems/pull/3
   patch do
     url "https://github.com/sstephenson/rbenv-default-gems/commit/ead67889c91c53ad967f85f5a89d986fdb98f6fb.diff"

--- a/Library/Formula/rbenv-gem-rehash.rb
+++ b/Library/Formula/rbenv-gem-rehash.rb
@@ -6,8 +6,6 @@ class RbenvGemRehash < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   # Fixes issues with Homebrew-managed git-etc alpha.
   patch do
     url "https://github.com/sstephenson/rbenv-gem-rehash/commit/0756890cfd9c7bbbdde38560fe81626a0c5769bd.diff"

--- a/Library/Formula/rbenv-gemset.rb
+++ b/Library/Formula/rbenv-gemset.rb
@@ -7,8 +7,6 @@ class RbenvGemset < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-readline.rb
+++ b/Library/Formula/rbenv-readline.rb
@@ -3,13 +3,10 @@ class RbenvReadline < Formula
   homepage "https://github.com/tpope/rbenv-readline"
   url "https://github.com/tpope/rbenv-readline/archive/v1.0.0.tar.gz"
   sha256 "8ce024f47ebcdf7a657412a69f1bc4355769ef1bdede96d88785c5bb69483b77"
+  head "https://github.com/tpope/rbenv-readline.git"
 
   bottle :unneeded
 
-  head "https://github.com/tpope/rbenv-readline.git"
-
-  depends_on "rbenv"
-  depends_on "ruby-build"
   depends_on "readline"
 
   def install

--- a/Library/Formula/rbenv-use.rb
+++ b/Library/Formula/rbenv-use.rb
@@ -3,6 +3,7 @@ class RbenvUse < Formula
   homepage "https://github.com/rkh/rbenv-use"
   url "https://github.com/rkh/rbenv-use/archive/v1.0.0.tar.gz"
   sha256 "f831dc9b8a43e30499e62928d13f5d354bf4c505b3f6b7fc1a1a9956ed9e538c"
+  head "https://github.com/rkh/rbenv-use.git"
 
   bottle :unneeded
 

--- a/Library/Formula/rbenv-use.rb
+++ b/Library/Formula/rbenv-use.rb
@@ -6,7 +6,6 @@ class RbenvUse < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
   depends_on "rbenv-whatis"
 
   def install

--- a/Library/Formula/rbenv-vars.rb
+++ b/Library/Formula/rbenv-vars.rb
@@ -7,8 +7,6 @@ class RbenvVars < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end

--- a/Library/Formula/rbenv-whatis.rb
+++ b/Library/Formula/rbenv-whatis.rb
@@ -3,6 +3,7 @@ class RbenvWhatis < Formula
   homepage "https://github.com/rkh/rbenv-whatis"
   url "https://github.com/rkh/rbenv-whatis/archive/v1.0.0.tar.gz"
   sha256 "1a09f824d1dcbca360565930fa66e93a9a2840c1bb45935e2ee989ce57d1f6e6"
+  head "https://github.com/rkh/rbenv-whatis.git"
 
   bottle :unneeded
 

--- a/Library/Formula/rbenv-whatis.rb
+++ b/Library/Formula/rbenv-whatis.rb
@@ -6,8 +6,6 @@ class RbenvWhatis < Formula
 
   bottle :unneeded
 
-  depends_on "rbenv"
-
   def install
     prefix.install Dir["*"]
   end


### PR DESCRIPTION
I could have rbenv installed from git under `~/.rbenv` (i.e. not installed via Homebrew) and may want to install these plugins from Homebrew. I will want plugin files to end up in `/usr/local/etc/rbenv.d/`, but I will **not** want a duplicate install of rbenv to happen as byproduct of installing these plugins.

Also, rbenv-ctags should not force installing "ctags" formula, because you may have chosen to install a better ctags implementation, such as universal-ctags from a tap.

Also, rbenv-readline should not depend on "ruby-build" formula, since ruby-build may have been manually installed from git directly into `~/.rbenv/plugins/`.

Overall theme of this PR is: trust that if a user is installing a `rbenv-*` plugin, they probably know what they're doing and most likely already have rbenv installed (otherwise their whole endeavor doesn't make any sense).

/cc @xu-cheng 