### PR TITLE
libevent: Fix source download URL

### DIFF
--- a/Library/Formula/libevent.rb
+++ b/Library/Formula/libevent.rb
@@ -1,7 +1,7 @@
 class Libevent < Formula
   desc "Asynchronous event library"
   homepage "http://libevent.org"
-  url "https://downloads.sourceforge.net/project/levent/libevent/libevent-2.0/libevent-2.0.22-stable.tar.gz"
+  url "https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz"
   sha256 "71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3"
 
   bottle do


### PR DESCRIPTION
The project moved from Sourceforge to GitHub: "As of 2015-10-07, this project may now be found at https://github.com/libevent/libevent."
Reference: http://sourceforge.net/projects/levent/

Also, the current URL results in a 404.