### PR TITLE
Add -DNDEBUG to std_cmake_args

### DIFF
--- a/Library/Formula/gflags.rb
+++ b/Library/Formula/gflags.rb
@@ -19,7 +19,6 @@ class Gflags < Formula
   depends_on "cmake" => :build
 
   def install
-    ENV.append_to_cflags "-DNDEBUG" if build.without? "debug"
     args = std_cmake_args
     if build.with? "static"
       args << "-DBUILD_SHARED_LIBS=OFF"

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -200,8 +200,6 @@ class Llvm < Formula
 
     if build.with? "assertions"
       args << "-DLLVM_ENABLE_ASSERTIONS=On"
-    else
-      args << "-DCMAKE_CXX_FLAGS_RELEASE='-DNDEBUG'"
     end
 
     if build.universal?

--- a/Library/Formula/taglib.rb
+++ b/Library/Formula/taglib.rb
@@ -21,7 +21,6 @@ class Taglib < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    ENV.append "CXXFLAGS", "-DNDEBUG=1"
     system "cmake", "-DWITH_MP4=ON", "-DWITH_ASF=ON", *std_cmake_args
     system "make"
     system "make", "install"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1041,8 +1041,8 @@ class Formula
   # less consistent and the standard parameters are more memorable.
   def std_cmake_args
     %W[
-      -DCMAKE_C_FLAGS_RELEASE=
-      -DCMAKE_CXX_FLAGS_RELEASE=
+      -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
+      -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_FIND_FRAMEWORK=LAST


### PR DESCRIPTION
CMake has -DNDEBUG and -O3 as its default flags for Release builds.
Homebrew clears out the default CMake flags, which is fine for
optimization because Homebrew passes its own optimization flag(s).
-DNDEBUG wasn't added back in, though.

This ensures -DNDEBUG is passed to CMake release builds by default,
instead of individual formulas having to add it explicitly.