### PR TITLE
Update doctor.rb check_access_uslr_local method

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -444,7 +444,8 @@ class Checks
     The /usr/local directory is not writable.
     Even if this directory was writable when you installed Homebrew, other
     software may change permissions on this directory. Some versions of the
-    "InstantOn" component of Airfoil or running Cocktail cleanup/optimizations are known to do this.
+    "InstantOn" component of Airfoil or running Cocktail cleanup/optimizations
+    are known to do this.
 
     You should probably change the ownership and permissions of /usr/local
     back to your user account.

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -444,7 +444,7 @@ class Checks
     The /usr/local directory is not writable.
     Even if this directory was writable when you installed Homebrew, other
     software may change permissions on this directory. Some versions of the
-    "InstantOn" component of Airfoil are known to do this.
+    "InstantOn" component of Airfoil or running Cocktail cleanup/optimizations are known to do this.
 
     You should probably change the ownership and permissions of /usr/local
     back to your user account.


### PR DESCRIPTION
Added mention to Cocktail app cleanup/repair/optimizations, that has some features that when run they restore the /usr/local directory to the original 'not writable' state in OS X 10.11 .

Cocktail app (http://www.maintain.se/cocktail/) is a popular application, even more than Airfoil.