### PR TITLE
crawl 0.17.1 (new formula)

### DIFF
--- a/Library/Formula/crawl.rb
+++ b/Library/Formula/crawl.rb
@@ -1,0 +1,30 @@
+class Crawl < Formula
+  desc "Dungeon Crawl: Stone Soup"
+  homepage "http://crawl.develz.org/"
+  url "https://github.com/crawl/crawl.git",
+    :tag => "0.17.1",
+    :revision => "942a3d2973debefdaddbf6291e4ebc890725b920"
+  head "https://github.com/crawl/crawl.git"
+
+  option "with-tiles", "Build with graphical tiles"
+
+  depends_on "cmake" => :build
+
+  def install
+    args = [
+      "APPLE_GCC=1",
+      "prefix=#{prefix}",
+      "DATADIR=#{prefix}",
+    ]
+
+    args << "NO_PKGCONFIG=y" << "CONTRIB_SDL=y" << "TILES=y" if build.with? "tiles"
+
+    cd "crawl-ref/source" do
+      system "make", "install", *args
+    end
+  end
+
+  test do
+    assert_match "Crawl version #{version}", shell_output("#{bin}/crawl -version")
+  end
+end


### PR DESCRIPTION
Adds a source formula for the game [Dungeon Crawl: Stone Soup](http://crawl.develz.org/), including options for the terminal or graphical tile mode.

Note that there are older Cask-based formulas here [dungeon-crawl-stone-soup-console](https://github.com/caskroom/homebrew-cask/blob/master/Casks/dungeon-crawl-stone-soup-console.rb) and here [dungeon-crawl-stone-soup-tiles](https://github.com/caskroom/homebrew-cask/blob/master/Casks/dungeon-crawl-stone-soup-tiles.rb)

However, those use pre-compiled binaries and the Cask console version is wrapped in an unusably small terminal, requiring tinkering to play "normally" on a terminal.

I believe this type of formula installation is preferred to the casks.