### PR TITLE
Change LV2 plugin path to #{lib}/LV2

### DIFF
--- a/Library/Formula/lv2.rb
+++ b/Library/Formula/lv2.rb
@@ -12,7 +12,7 @@ class Lv2 < Formula
   end
 
   def install
-    system "./waf", "configure", "--prefix=#{prefix}", "--lv2dir=#{share}/lv2", "--no-plugins"
+    system "./waf", "configure", "--prefix=#{prefix}", "--no-plugins"
     system "./waf", "build"
     system "./waf", "install"
   end

--- a/Library/Formula/mda-lv2.rb
+++ b/Library/Formula/mda-lv2.rb
@@ -8,7 +8,7 @@ class MdaLv2 < Formula
   depends_on "lv2"
 
   def install
-    system "./waf", "configure", "--prefix=#{prefix}", "--lv2dir=#{share}/lv2"
+    system "./waf", "configure", "--prefix=#{prefix}"
     system "./waf"
     system "./waf", "install"
   end


### PR DESCRIPTION
This changes the default install path for LV2 plugins from `/usr/local/share/LV2` to `/usr/local/lib/LV2`

`/usr/local/lib/LV2` is defined in the LV2 specification to be searched by default (see http://lv2plug.in/pages/filesystem-hierarchy-standard.html). 

One could also make `/usr/local/share/LV2` working by modifying `LV2_PATH` but for GUI applications like [ardour](http://ardour.org) is way more comfortable to have it working by default.
