### PR TITLE
All the formulas from the mpv-player tap

### DIFF
--- a/Library/Formula/mpv.rb
+++ b/Library/Formula/mpv.rb
@@ -1,0 +1,74 @@
+class Mpv < Formula
+  desc "Free, open source, and cross-platform media player"
+  homepage "https://mpv.io"
+  url "https://github.com/mpv-player/mpv/archive/v0.14.0.tar.gz"
+  sha256 "042937f483603f0c3d1dec11e8f0045e8c27f19eee46ea64d81a3cdf01e51233"
+  head "https://github.com/mpv-player/mpv.git"
+
+  option "with-shared", "Build libmpv shared library."
+  option "with-bundle", "Enable compilation of the .app bundle."
+
+  depends_on "pkg-config" => :build
+  depends_on :python3
+
+  depends_on "libass"
+  depends_on "ffmpeg"
+
+  depends_on "jpeg" => :recommended
+  depends_on "little-cms2" => :recommended
+  depends_on "lua" => :recommended
+  depends_on "youtube-dl" => :recommended
+
+  depends_on "libcaca" => :optional
+  depends_on "libdvdread" => :optional
+  depends_on "libdvdnav" => :optional
+  depends_on "libbluray" => :optional
+  depends_on "libaacs" => :optional
+  depends_on "vapoursynth" => :optional
+  depends_on :x11 => :optional
+
+  depends_on :macos => :mountain_lion
+
+  resource "waf" do
+    url "https://waf.io/waf-1.8.12"
+    sha256 "01bf2beab2106d1558800c8709bc2c8e496d3da4a2ca343fe091f22fca60c98b"
+  end
+
+  resource "docutils" do
+    url "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
+  end
+
+  def install
+    # LANG is unset by default on osx and causes issues when calling getlocale
+    # or getdefaultlocale in docutils. Force the default c/posix locale since
+    # that's good enough for building the manpage.
+    ENV["LC_ALL"] = "C"
+
+    version = Language::Python.major_minor_version("python3")
+    ENV.prepend_create_path "PKG_CONFIG_PATH", Pathname.new(`python3-config --prefix`.chomp)/"lib/pkgconfig"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+    ENV.prepend_create_path "PATH", libexec/"bin"
+    resource("docutils").stage do
+      system "python3", *Language::Python.setup_install_args(libexec)
+    end
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+
+    args = ["--prefix=#{prefix}", "--enable-gpl3", "--enable-zsh-comp"]
+    args << "--enable-libmpv-shared" if build.with? "shared"
+
+    waf = resource("waf")
+    buildpath.install waf.files("waf-#{waf.version}" => "waf")
+    system "python3", "waf", "configure", *args
+    system "python3", "waf", "install"
+
+    if build.with? "bundle"
+      system "python3", "TOOLS/osxbundle.py", "build/mpv"
+      prefix.install "build/mpv.app"
+    end
+  end
+
+  test do
+    system "#{bin}/mpv", "--ao=null", test_fixtures("test.wav")
+  end
+end

--- a/Library/Formula/mvtools.rb
+++ b/Library/Formula/mvtools.rb
@@ -1,0 +1,40 @@
+class Mvtools < Formula
+  desc "Filters for motion estimation and compensation"
+  homepage "https://github.com/dubhater/vapoursynth-mvtools"
+  url "https://github.com/dubhater/vapoursynth-mvtools/archive/v9.tar.gz"
+  sha256 "e417764cddcc2b24ee5a91c1136e95237ce1424f5d7f49ceb62ff092db18d907"
+  head "https://github.com/dubhater/vapoursynth-mvtools.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "yasm" => :build
+  depends_on "vapoursynth"
+  depends_on "fftw"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats
+    <<-EOS.undent
+      MVTools will not be autoloaded in your VapourSynth scripts. To use it
+      use the following code in your scripts:
+
+        core.std.LoadPlugin(path="#{HOMEBREW_PREFIX}/lib/libmvtools.dylib")
+    EOS
+  end
+
+  test do
+    script = <<-PYTHON.undent.split("\n").join(";")
+      import vapoursynth as vs
+      core = vs.get_core()
+      core.std.LoadPlugin(path="#{HOMEBREW_PREFIX}/lib/libmvtools.dylib")
+    PYTHON
+
+    system "python3", "-c", script
+  end
+end

--- a/Library/Formula/vapoursynth.rb
+++ b/Library/Formula/vapoursynth.rb
@@ -1,0 +1,64 @@
+class Vapoursynth < Formula
+  desc "Video processing framework with simplicity in mind"
+  homepage "http://www.vapoursynth.com"
+  url "https://github.com/vapoursynth/vapoursynth/archive/R29.tar.gz"
+  sha256 "5a2e37f3a9a5dc60f55a301b222df75a580ccf319b099a3e421e2334ef8cbde6"
+  head "https://github.com/vapoursynth/vapoursynth.git"
+
+  # issue with upstream: https://github.com/vapoursynth/vapoursynth/issues/201
+  patch :DATA
+
+  needs :cxx11
+  depends_on "pkg-config" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "yasm" => :build
+  depends_on :python3
+
+  depends_on "zimg"
+  depends_on "tesseract"
+  depends_on "libass"
+
+  resource "cython" do
+    url "https://pypi.python.org/packages/source/C/Cython/Cython-0.21.2.tar.gz"
+    sha256 "b01af23102143515e6138a4d5e185c2cfa588e0df61c0827de4257bac3393679"
+  end
+
+  def install
+    version = Language::Python.major_minor_version("python3")
+    ENV.prepend_create_path "PKG_CONFIG_PATH", Pathname.new(`python3-config --prefix`.chomp)/"lib/pkgconfig"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+    ENV.prepend_create_path "PATH", libexec/"bin"
+    resource("cython").stage do
+      system "python3", *Language::Python.setup_install_args(libexec)
+    end
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"vspipe", "--version"
+    system "python3", "-c", "import vapoursynth"
+  end
+end
+
+__END__
+diff --git a/Makefile.am b/Makefile.am
+index 88287a0..dfcaace 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -98,8 +98,8 @@ pyexec_LTLIBRARIES = vapoursynth.la
+
+ vapoursynth_la_SOURCES = src/cython/vapoursynth.pyx
+ vapoursynth_la_CPPFLAGS = $(PYTHON3_CFLAGS)
+-vapoursynth_la_LIBADD = $(PYTHON3_LIBS) libvapoursynth.la
+-vapoursynth_la_LDFLAGS = -no-undefined -avoid-version -module
++vapoursynth_la_LIBADD = libvapoursynth.la
++vapoursynth_la_LDFLAGS = -undefined dynamic_lookup -avoid-version -module
+ vapoursynth_la_LIBTOOLFLAGS = $(commonlibtoolflags)
+
+ MOSTLYCLEANFILES = src/cython/vapoursynth.c \

--- a/Library/Formula/zimg.rb
+++ b/Library/Formula/zimg.rb
@@ -1,0 +1,33 @@
+class Zimg < Formula
+  desc "Scaling, colorspace conversion, and dithering library"
+  homepage "https://github.com/sekrit-twc/zimg"
+  url "https://github.com/sekrit-twc/zimg/archive/release-2.0.2.tar.gz"
+  sha256 "b9c7bac9e6ad53dfa94215c28440167d72d41109df10278673789f8e531f2142"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <assert.h>
+      #include <zimg.h>
+
+      int main()
+      {
+        zimg_image_format format;
+        zimg_image_format_default(&format, ZIMG_API_VERSION);
+        assert(ZIMG_MATRIX_UNSPECIFIED == format.matrix_coefficients);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lzimg", "-o", "test"
+    system "./test"
+  end
+end

--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -361,4 +361,8 @@ class VersionParsingTests < Homebrew::TestCase
     assert_version_detected "1.0.2",
       "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
   end
+
+  def test_waf_version
+    assert_version_detected "1.8.12", "https://waf.io/waf-1.8.12"
+  end
 end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -307,6 +307,10 @@ class Version
     m = /[-_]((?:\d+\.)*\d\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
     return m.captures.first unless m.nil?
 
+    # URL with no extension e.g. https://waf.io/waf-1.8.12
+    m = /-((?:\d+\.)*\d+)$/.match(spec_s)
+    return m.captures.first unless m.nil?
+
     # e.g. lame-398-1
     m = /-((?:\d)+-\d)/.match(stem)
     return m.captures.first unless m.nil?


### PR DESCRIPTION
As mentioned in #46413 we are planning to close down [mpv's official tap](https://github.com/mpv-player/homebrew-mpv) when this gets merged. I addressed most of the comments in @mikemcquaid review of the earlier PR (#46413).

The only missing bit fix from the review is renaming the waf resource from `waf-1.8.12` to `waf` (here: https://github.com/Homebrew/homebrew/commit/ec9c416f680ed460730e255fa6a7d2c744afe872#diff-ee2f3e398ed3cc70f2a1bdc443032205R59). @mikemcquaid was suggesting to use a glob but I am not sure how that would work since the resource directory is not the cwd.

How should we handle closing the tap? Do I have to completely delete the repository, or should I empty it out from any formula?