### PR TITLE
sdl2_mixer: fix build with optional libmikmod

### DIFF
--- a/Library/Formula/sdl2_mixer.rb
+++ b/Library/Formula/sdl2_mixer.rb
@@ -29,8 +29,13 @@ class Sdl2Mixer < Formula
 
     ENV["SMPEG_CONFIG"] = "#{Formula["smpeg2"].bin}/smpeg2-config" if build.with? "smpeg2"
 
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking"
+    args = ["--prefix=#{prefix}",
+            "--disable-dependency-tracking",
+           ]
+
+    args << "--enable-music-mod-mikmod" if build.with? "libmikmod"
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
`libmikmod` isn't enabled by default in configure script. It requires `--enable-music-mod-mikmod` to be actually used.
This change was previously applied as a part of https://github.com/Homebrew/homebrew/pull/47350