### PR TITLE
cd-discid: bump revision so recent patch actually gets used

### DIFF
--- a/Library/Formula/cd-discid.rb
+++ b/Library/Formula/cd-discid.rb
@@ -4,15 +4,17 @@ class CdDiscid < Formula
   url "http://linukz.org/download/cd-discid-1.4.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/c/cd-discid/cd-discid_1.4.orig.tar.gz"
   sha256 "ffd68cd406309e764be6af4d5cbcc309e132c13f3597c6a4570a1f218edd2c63"
+  revision 1
   head "https://github.com/taem/cd-discid.git"
 
-  # OS X fix; see ps://github.com/Homebrew/homebrew/issues/46267
-  # Already fixed in upstream head; remove when bumping version to >1.4
-  patch :DATA
+  stable do
+    # OS X fix; see ps://github.com/Homebrew/homebrew/issues/46267
+    # Already fixed in upstream head; remove when bumping version to >1.4
+    patch :DATA
+  end
 
   bottle do
     cellar :any_skip_relocation
-    revision 1
     sha256 "14cfc760d2cbd99750c84634b964a6950428ac014b8edce68a5262ed8b7605e2" => :el_capitan
     sha256 "b8b56556b0818b6d2dd1bfd389f317dd701abb4c74ebaa187edd2b13565e6851" => :yosemite
     sha256 "9231f27b586840defbdcca95084365c13c6ba85231da20d9bc199b735b9b0d66" => :mavericks


### PR DESCRIPTION
Fixes #46267.

The original fix for this issue, 3cc4985cabe0ecc7594c42e2e001094086b740d8, didn't increment the revision, so users who already have `cd-discid` installed (and those installing from bottles?) wouldn't actually pick up the new patch.