### PR TITLE
duplicity fixes

### DIFF
--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -3,6 +3,7 @@ class Duplicity < Formula
   homepage "http://www.nongnu.org/duplicity/"
   url "https://code.launchpad.net/duplicity/0.7-series/0.7.06/+download/duplicity-0.7.06.tar.gz"
   sha256 "0075595edb894399cf00fae9154aae93a07eaadc031fede5df4cc595436c7f8c"
+  revision 1
 
   bottle do
     sha256 "36bfb11bd2f1fc81693e887c0b24e5af4b19579eac21af331c3e6eb9fd31c1e7" => :el_capitan

--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -15,6 +15,7 @@ class Duplicity < Formula
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "librsync"
   depends_on "openssl"
+  depends_on "par2" => :optional
   depends_on :gpg => :run
 
   # Generated with homebrew-pypi-poet from

--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -14,12 +14,14 @@ class Duplicity < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "librsync"
+  depends_on "openssl"
   depends_on :gpg => :run
 
-  # generated with homebrew-pypi-poet from
+  # Generated with homebrew-pypi-poet from
   # for i in boto pyrax dropbox mega.py paramiko pycrypto
   # lockfile python-swiftclient python-keystoneclient; do poet -r $i >>
   # resources; done
+  # Additional dependencies of requests[security] should also be installed.
 
   # MacOS versions prior to Yosemite need the latest setuptools in order to compile dependencies
   resource "setuptools" do
@@ -27,14 +29,15 @@ class Duplicity < Formula
     sha256 "32ebb08b72aee11fefa6907ddf5db5a81e0eef9cf62c7fa6b58d8e32da249960"
   end
 
-  resource "lockfile" do
-    url "https://pypi.python.org/packages/source/l/lockfile/lockfile-0.12.2.tar.gz"
-    sha256 "6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"
+  # must be installed before cryptography
+  resource "cffi" do
+    url "https://pypi.python.org/packages/source/c/cffi/cffi-1.4.2.tar.gz"
+    sha256 "8f1d177d364ea35900415ae24ca3e471be3d5334ed0419294068c49f45913998"
   end
 
-  resource "boto" do
-    url "https://pypi.python.org/packages/source/b/boto/boto-2.38.0.tar.gz"
-    sha256 "d9083f91e21df850c813b38358dc83df16d7f253180a1344ecfedce24213ecf2"
+  resource "Babel" do
+    url "https://pypi.python.org/packages/source/B/Babel/Babel-2.1.1.tar.gz"
+    sha256 "7fb6d50effe88a087feb2036cb972fd7a893bf338361516f1a55a820bf7b5248"
   end
 
   resource "PrettyTable" do
@@ -42,19 +45,89 @@ class Duplicity < Formula
     sha256 "853c116513625c738dc3ce1aee148b5b5757a86727e67eff6502c7ca59d43c36"
   end
 
-  resource "requests" do
-    url "https://pypi.python.org/packages/source/r/requests/requests-2.8.1.tar.gz"
-    sha256 "84fe8d5bf4dcdcc49002446c47a146d17ac10facf00d9086659064ac43b6c25b"
+  resource "boto" do
+    url "https://pypi.python.org/packages/source/b/boto/boto-2.38.0.tar.gz"
+    sha256 "d9083f91e21df850c813b38358dc83df16d7f253180a1344ecfedce24213ecf2"
   end
 
-  resource "six" do
-    url "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz"
-    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  resource "cryptography" do
+    url "https://pypi.python.org/packages/source/c/cryptography/cryptography-1.1.2.tar.gz"
+    sha256 "7f51459f84d670444275e615839f4542c93547a12e938a0a4906dafe5f7de153"
+  end
+
+  resource "debtcollector" do
+    url "https://pypi.python.org/packages/source/d/debtcollector/debtcollector-1.1.0.tar.gz"
+    sha256 "87da37838bffbe61b7ba4986579e0ae06bc5f8eb2e197e89ef7419322655ae9b"
+  end
+
+  resource "dropbox" do
+    url "https://pypi.python.org/packages/source/d/dropbox/dropbox-4.0.tar.gz"
+    sha256 "95f766839247b4c8c714dc3af9bab7b2b149e9fb507c7f2ba44ee321a76a684a"
+  end
+
+  resource "ecdsa" do
+    url "https://pypi.python.org/packages/source/e/ecdsa/ecdsa-0.13.tar.gz"
+    sha256 "64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
+  end
+
+  resource "enum34" do
+    url "https://pypi.python.org/packages/source/e/enum34/enum34-1.1.2.tar.gz"
+    sha256 "2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7"
+  end
+
+  resource "funcsigs" do
+    url "https://pypi.python.org/packages/source/f/funcsigs/funcsigs-0.4.tar.gz"
+    sha256 "d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033"
+  end
+
+  resource "futures" do
+    url "https://pypi.python.org/packages/source/f/futures/futures-3.0.3.tar.gz"
+    sha256 "2fe2342bb4fe8b8e217f0d21b5921cbe5408bf966d9f92025e707e881b198bed"
+  end
+
+  resource "idna" do
+    url "https://pypi.python.org/packages/source/i/idna/idna-2.0.tar.gz"
+    sha256 "16199aad938b290f5be1057c0e1efc6546229391c23cea61ca940c115f7d3d3b"
+  end
+
+  resource "ip_associations_python_novaclient_ext" do
+    url "https://pypi.python.org/packages/source/i/ip_associations_python_novaclient_ext/ip_associations_python_novaclient_ext-0.1.tar.gz"
+    sha256 "a709b8804364afbbab81470b57e8df3f3ea11dff843c6cb4590bbc130cea94f7"
+  end
+
+  resource "ipaddress" do
+    url "https://pypi.python.org/packages/source/i/ipaddress/ipaddress-1.0.15.tar.gz"
+    sha256 "af6c85cfc9cdb12b861655e6b9f2f59618bf3088cbde858727b2c0a98e9f6636"
   end
 
   resource "iso8601" do
     url "https://pypi.python.org/packages/source/i/iso8601/iso8601-0.1.11.tar.gz"
     sha256 "e8fb52f78880ae063336c94eb5b87b181e6a0cc33a6c008511bac9a6e980ef30"
+  end
+
+  resource "keyring" do
+    url "https://pypi.python.org/packages/source/k/keyring/keyring-5.7.1.tar.gz"
+    sha256 "3df352616b856a3aebd699ab2e946d4a6e3b0219e696d5416bfc4c16530eeac0"
+  end
+
+  resource "keystoneauth1" do
+    url "https://pypi.python.org/packages/source/k/keystoneauth1/keystoneauth1-2.1.0.tar.gz"
+    sha256 "3990130416f85a252896fd36f895ab4d0b692b782801d7e4e522b862dbf84e69"
+  end
+
+  resource "lockfile" do
+    url "https://pypi.python.org/packages/source/l/lockfile/lockfile-0.12.2.tar.gz"
+    sha256 "6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"
+  end
+
+  resource "mega.py" do
+    url "https://pypi.python.org/packages/source/m/mega.py/mega.py-0.9.18.tar.gz"
+    sha256 "f3e15912ce2e5de18e31e7abef8a819a5546c184aa09586bfdaa42968cc827bf"
+  end
+
+  resource "mock" do
+    url "https://pypi.python.org/packages/source/m/mock/mock-1.3.0.tar.gz"
+    sha256 "1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6"
   end
 
   resource "monotonic" do
@@ -67,34 +140,9 @@ class Duplicity < Formula
     sha256 "bfcc581c9dbbf07cc2f951baf30c3249a57e20dcbd60f7e6ffc43ab3cc614794"
   end
 
-  resource "pytz" do
-    url "https://pypi.python.org/packages/source/p/pytz/pytz-2015.7.tar.bz2"
-    sha256 "fbd26746772c24cb93c8b97cbdad5cb9e46c86bbdb1b9d8a743ee00e2fb1fc5d"
-  end
-
-  resource "Babel" do
-    url "https://pypi.python.org/packages/source/B/Babel/Babel-2.1.1.tar.gz"
-    sha256 "7fb6d50effe88a087feb2036cb972fd7a893bf338361516f1a55a820bf7b5248"
-  end
-
-  resource "debtcollector" do
-    url "https://pypi.python.org/packages/source/d/debtcollector/debtcollector-1.1.0.tar.gz"
-    sha256 "87da37838bffbe61b7ba4986579e0ae06bc5f8eb2e197e89ef7419322655ae9b"
-  end
-
-  resource "pbr" do
-    url "https://pypi.python.org/packages/source/p/pbr/pbr-1.8.1.tar.gz"
-    sha256 "e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649"
-  end
-
-  resource "simplejson" do
-    url "https://pypi.python.org/packages/source/s/simplejson/simplejson-3.8.1.tar.gz"
-    sha256 "428ac8f3219c78fb04ce05895d5dff9bd813c05a9a7922c53dc879cd32a12493"
-  end
-
-  resource "netifaces" do
-    url "https://pypi.python.org/packages/source/n/netifaces/netifaces-0.10.4.tar.gz"
-    sha256 "9656a169cb83da34d732b0eb72b39373d48774aee009a3d1272b7ea2ce109cde"
+  resource "ndg-httpsclient" do
+    url "https://pypi.python.org/packages/source/n/ndg-httpsclient/ndg_httpsclient-0.4.0.tar.gz"
+    sha256 "e8c155fdebd9c4bcb0810b4ed01ae1987554b1ee034dd7532d7b8fdae38a6274"
   end
 
   resource "netaddr" do
@@ -102,64 +150,9 @@ class Duplicity < Formula
     sha256 "a1f5c9fcf75ac2579b9995c843dade33009543c04f218ff7c007b3c81695bd19"
   end
 
-  resource "oslo.i18n" do
-    url "https://pypi.python.org/packages/source/o/oslo.i18n/oslo.i18n-3.1.0.tar.gz"
-    sha256 "1c82d9e3acd821015990fd111750fd949a5276ed6561a16e0a39d69e7145dbd8"
-  end
-
-  resource "oslo.utils" do
-    url "https://pypi.python.org/packages/source/o/oslo.utils/oslo.utils-3.2.0.tar.gz"
-    sha256 "c3d73a2c4556d88acd4b3b25786dbab83ee31aaea68c4c98cd4d1bfb9965f281"
-  end
-
-  resource "oslo.serialization" do
-    url "https://pypi.python.org/packages/source/o/oslo.serialization/oslo.serialization-2.1.0.tar.gz"
-    sha256 "8f8cb079e285a878dc176189edd7dced278d2419cc4d3e262f6669650f851643"
-  end
-
-  resource "stevedore" do
-    url "https://pypi.python.org/packages/source/s/stevedore/stevedore-1.10.0.tar.gz"
-    sha256 "f5d689ef38e0ca532d57a03d1ab95e89b17c57f97b58d10c92da94699973779f"
-  end
-
-  resource "wrapt" do
-    url "https://pypi.python.org/packages/source/w/wrapt/wrapt-1.10.6.tar.gz"
-    sha256 "9576869bb74a43cbb36ee39dc3584e6830b8e5c788e83edf0a397eba807734ab"
-  end
-
-  resource "oslo.config" do
-    url "https://pypi.python.org/packages/source/o/oslo.config/oslo.config-3.1.0.tar.gz"
-    sha256 "eeb79675d94963fa406d75c99ed7ac1110eef3134b1060670a3ebd67527edb2d"
-  end
-
-  resource "python-keystoneclient" do
-    url "https://pypi.python.org/packages/source/p/python-keystoneclient/python-keystoneclient-2.0.0.tar.gz"
-    sha256 "6c8895cc15c3ee42a7aea588da297b31e68eaf7af1dfd89eae9ed4c95da17500"
-  end
-
-  resource "python-novaclient" do
-    url "https://pypi.python.org/packages/source/p/python-novaclient/python-novaclient-2.35.0.tar.gz"
-    sha256 "370838b48f72ad00aeeb470b00fe18cc8bc359df06a915ac526c4ef0c09e2cbb"
-  end
-
-  resource "rackspace-auth-openstack" do
-    url "https://pypi.python.org/packages/source/r/rackspace-auth-openstack/rackspace-auth-openstack-1.3.tar.gz"
-    sha256 "c4c069eeb1924ea492c50144d8a4f5f1eb0ece945e0c0d60157cabcadff651cd"
-  end
-
-  resource "rax_default_network_flags_python_novaclient_ext" do
-    url "https://pypi.python.org/packages/source/r/rax_default_network_flags_python_novaclient_ext/rax_default_network_flags_python_novaclient_ext-0.3.2.tar.gz"
-    sha256 "bf18d534f6ab1ca1c82680a71d631babee285257c7d99321413a19d773790915"
-  end
-
-  resource "mock" do
-    url "https://pypi.python.org/packages/source/m/mock/mock-1.3.0.tar.gz"
-    sha256 "1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6"
-  end
-
-  resource "keyring" do
-    url "https://pypi.python.org/packages/source/k/keyring/keyring-5.7.1.tar.gz"
-    sha256 "3df352616b856a3aebd699ab2e946d4a6e3b0219e696d5416bfc4c16530eeac0"
+  resource "netifaces" do
+    url "https://pypi.python.org/packages/source/n/netifaces/netifaces-0.10.4.tar.gz"
+    sha256 "9656a169cb83da34d732b0eb72b39373d48774aee009a3d1272b7ea2ce109cde"
   end
 
   resource "os_diskconfig_python_novaclient_ext" do
@@ -177,44 +170,24 @@ class Duplicity < Formula
     sha256 "5171370e5cea447019cee5da22102b7eca4d4a7fb3f12875e2d7658d98462c0a"
   end
 
-  resource "rax_scheduled_images_python_novaclient_ext" do
-    url "https://pypi.python.org/packages/source/r/rax_scheduled_images_python_novaclient_ext/rax_scheduled_images_python_novaclient_ext-0.3.1.tar.gz"
-    sha256 "f170cf97b20bdc8a1784cc0b85b70df5eb9b88c3230dab8e68e1863bf3937cdb"
+  resource "oslo.config" do
+    url "https://pypi.python.org/packages/source/o/oslo.config/oslo.config-3.2.0.tar.gz"
+    sha256 "35d3de9145af1f8467d8c3062415b9a150dcc1a6453a8fc17ca48d14a7a001d3"
   end
 
-  resource "rackspace-novaclient" do
-    url "https://pypi.python.org/packages/source/r/rackspace-novaclient/rackspace-novaclient-1.5.tar.gz"
-    sha256 "0fcde7e22594d9710c65e850d11898bd342fa83849dc8ef32c2a94117f7132b1"
+  resource "oslo.i18n" do
+    url "https://pypi.python.org/packages/source/o/oslo.i18n/oslo.i18n-3.1.0.tar.gz"
+    sha256 "1c82d9e3acd821015990fd111750fd949a5276ed6561a16e0a39d69e7145dbd8"
   end
 
-  resource "pyrax" do
-    url "https://pypi.python.org/packages/source/p/pyrax/pyrax-1.9.5.tar.gz"
-    sha256 "59ac98ae0549beb1eb36cc1f4985d565f126adbfa596d7fa5aaccde5ef194c0e"
+  resource "oslo.serialization" do
+    url "https://pypi.python.org/packages/source/o/oslo.serialization/oslo.serialization-2.2.0.tar.gz"
+    sha256 "24320d26f6bc4850057aa9996e3a2431d4c4c5d0b670658e7e632007f31c4003"
   end
 
-  resource "urllib3" do
-    url "https://pypi.python.org/packages/source/u/urllib3/urllib3-1.12.tar.gz"
-    sha256 "0ea512776971fe4e76192600fe41e4e7ee96b4b9a5b15aefc1ac31d2a63872c6"
-  end
-
-  resource "dropbox" do
-    url "https://pypi.python.org/packages/source/d/dropbox/dropbox-4.0.tar.gz"
-    sha256 "95f766839247b4c8c714dc3af9bab7b2b149e9fb507c7f2ba44ee321a76a684a"
-  end
-
-  resource "pycrypto" do
-    url "https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz"
-    sha256 "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
-  end
-
-  resource "mega.py" do
-    url "https://pypi.python.org/packages/source/m/mega.py/mega.py-0.9.18.tar.gz"
-    sha256 "f3e15912ce2e5de18e31e7abef8a819a5546c184aa09586bfdaa42968cc827bf"
-  end
-
-  resource "ecdsa" do
-    url "https://pypi.python.org/packages/source/e/ecdsa/ecdsa-0.13.tar.gz"
-    sha256 "64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
+  resource "oslo.utils" do
+    url "https://pypi.python.org/packages/source/o/oslo.utils/oslo.utils-3.3.0.tar.gz"
+    sha256 "484f1025132756c065b5843ceb420b113a4fd262071887e85e5a2695f71bcabc"
   end
 
   resource "paramiko" do
@@ -222,9 +195,44 @@ class Duplicity < Formula
     sha256 "3297ebd3cd072f573772f7c7426939a443c62c458d54bb632ff30fd6ecf96892"
   end
 
-  resource "futures" do
-    url "https://pypi.python.org/packages/source/f/futures/futures-3.0.3.tar.gz"
-    sha256 "2fe2342bb4fe8b8e217f0d21b5921cbe5408bf966d9f92025e707e881b198bed"
+  resource "pbr" do
+    url "https://pypi.python.org/packages/source/p/pbr/pbr-1.8.1.tar.gz"
+    sha256 "e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649"
+  end
+
+  resource "pyOpenSSL" do
+    url "https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.15.1.tar.gz"
+    sha256 "f0a26070d6db0881de8bcc7846934b7c3c930d8f9c79d45883ee48984bc0d672"
+  end
+
+  resource "pyasn1" do
+    url "https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.9.tar.gz"
+    sha256 "853cacd96d1f701ddd67aa03ecc05f51890135b7262e922710112f12a2ed2a7f"
+  end
+
+  resource "pycparser" do
+    url "https://pypi.python.org/packages/source/p/pycparser/pycparser-2.14.tar.gz"
+    sha256 "7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73"
+  end
+
+  resource "pycrypto" do
+    url "https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz"
+    sha256 "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
+  end
+
+  resource "pyrax" do
+    url "https://pypi.python.org/packages/source/p/pyrax/pyrax-1.9.6.tar.gz"
+    sha256 "a06b0ae9d0aac091c4287bf65debc64ecd85089c1ac765adbeea26204133a0ea"
+  end
+
+  resource "python-keystoneclient" do
+    url "https://pypi.python.org/packages/source/p/python-keystoneclient/python-keystoneclient-2.0.0.tar.gz"
+    sha256 "6c8895cc15c3ee42a7aea588da297b31e68eaf7af1dfd89eae9ed4c95da17500"
+  end
+
+  resource "python-novaclient" do
+    url "https://pypi.python.org/packages/source/p/python-novaclient/python-novaclient-2.27.0.tar.gz"
+    sha256 "d1279d5c2857cf8c56cb953639b36225bc1fec7fa30ee632940823506a7638ef"
   end
 
   resource "python-swiftclient" do
@@ -232,9 +240,59 @@ class Duplicity < Formula
     sha256 "013f3d8296f5b4342341e086e95c4a1fc85a24caa22a9bcc7de6716b20de2a55"
   end
 
-  resource "pexpect" do
-    url "https://pypi.python.org/packages/source/p/pexpect/pexpect-4.0.1.tar.gz"
-    sha256 "232795ebcaaf2e120396dbbaa3a129eda51757eeaae1911558f4ef8ee414fc6c"
+  resource "pytz" do
+    url "https://pypi.python.org/packages/source/p/pytz/pytz-2015.7.tar.bz2"
+    sha256 "fbd26746772c24cb93c8b97cbdad5cb9e46c86bbdb1b9d8a743ee00e2fb1fc5d"
+  end
+
+  resource "rackspace-auth-openstack" do
+    url "https://pypi.python.org/packages/source/r/rackspace-auth-openstack/rackspace-auth-openstack-1.3.tar.gz"
+    sha256 "c4c069eeb1924ea492c50144d8a4f5f1eb0ece945e0c0d60157cabcadff651cd"
+  end
+
+  resource "rackspace-novaclient" do
+    url "https://pypi.python.org/packages/source/r/rackspace-novaclient/rackspace-novaclient-1.5.tar.gz"
+    sha256 "0fcde7e22594d9710c65e850d11898bd342fa83849dc8ef32c2a94117f7132b1"
+  end
+
+  resource "rax_default_network_flags_python_novaclient_ext" do
+    url "https://pypi.python.org/packages/source/r/rax_default_network_flags_python_novaclient_ext/rax_default_network_flags_python_novaclient_ext-0.3.2.tar.gz"
+    sha256 "bf18d534f6ab1ca1c82680a71d631babee285257c7d99321413a19d773790915"
+  end
+
+  resource "rax_scheduled_images_python_novaclient_ext" do
+    url "https://pypi.python.org/packages/source/r/rax_scheduled_images_python_novaclient_ext/rax_scheduled_images_python_novaclient_ext-0.3.1.tar.gz"
+    sha256 "f170cf97b20bdc8a1784cc0b85b70df5eb9b88c3230dab8e68e1863bf3937cdb"
+  end
+
+  resource "requests" do
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.9.1.tar.gz"
+    sha256 "c577815dd00f1394203fc44eb979724b098f88264a9ef898ee45b8e5e9cf587f"
+  end
+
+  resource "simplejson" do
+    url "https://pypi.python.org/packages/source/s/simplejson/simplejson-3.8.1.tar.gz"
+    sha256 "428ac8f3219c78fb04ce05895d5dff9bd813c05a9a7922c53dc879cd32a12493"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  resource "stevedore" do
+    url "https://pypi.python.org/packages/source/s/stevedore/stevedore-1.10.0.tar.gz"
+    sha256 "f5d689ef38e0ca532d57a03d1ab95e89b17c57f97b58d10c92da94699973779f"
+  end
+
+  resource "urllib3" do
+    url "https://pypi.python.org/packages/source/u/urllib3/urllib3-1.13.1.tar.gz"
+    sha256 "6eba1d713f8552e37ac4081c6bdf7be9f5a79f58447aed762bf24cc34c5e3983"
+  end
+
+  resource "wrapt" do
+    url "https://pypi.python.org/packages/source/w/wrapt/wrapt-1.10.6.tar.gz"
+    sha256 "9576869bb74a43cbb36ee39dc3584e6830b8e5c788e83edf0a397eba807734ab"
   end
 
   def install
@@ -242,10 +300,14 @@ class Duplicity < Formula
 
     ENV.universal_binary if build.universal?
 
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    vendor_site_packages = libexec/"vendor/lib/python2.7/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", vendor_site_packages
     resources.each do |r|
       r.stage { system "python", *Language::Python.setup_install_args(libexec/"vendor") }
     end
+
+    # ndg is a namespace package
+    touch vendor_site_packages/"ndg/__init__.py"
 
     system "python", *Language::Python.setup_install_args(libexec)
 

--- a/Library/Formula/duplicity.rb
+++ b/Library/Formula/duplicity.rb
@@ -19,7 +19,7 @@ class Duplicity < Formula
   depends_on :gpg => :run
 
   # Generated with homebrew-pypi-poet from
-  # for i in boto pyrax dropbox mega.py paramiko pycrypto
+  # for i in boto pyrax dropbox mega.py paramiko pexpect pycrypto
   # lockfile python-swiftclient python-keystoneclient; do poet -r $i >>
   # resources; done
   # Additional dependencies of requests[security] should also be installed.
@@ -199,6 +199,16 @@ class Duplicity < Formula
   resource "pbr" do
     url "https://pypi.python.org/packages/source/p/pbr/pbr-1.8.1.tar.gz"
     sha256 "e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649"
+  end
+
+  resource "pexpect" do
+    url "https://pypi.python.org/packages/source/p/pexpect/pexpect-4.0.1.tar.gz"
+    sha256 "232795ebcaaf2e120396dbbaa3a129eda51757eeaae1911558f4ef8ee414fc6c"
+  end
+
+  resource "ptyprocess" do
+    url "https://pypi.python.org/packages/source/p/ptyprocess/ptyprocess-0.5.tar.gz"
+    sha256 "dcb78fb2197b49ca1b7b2f37b047bc89c0da7a90f90bd5bc17c3ce388bb6ef59"
   end
 
   resource "pyOpenSSL" do


### PR DESCRIPTION
Changes:
ea5bcd2 (Bruno Sutic, 3 months ago)
    duplicity: add 'par2' optional dependency
    Closes #44043.

83ed94e (Tim D. Smith, 16 minutes ago)
   duplicity: fix pyrax resources

   Resolves a problem where Rackspace containers are not usable because pyrax
   was not importable. Additionally provide requests[security] and
   dependencies for better TLS handling.

   Fixes #34162.

   Fixes #42512 because oslo is no longer a namespace package.