### PR TITLE
python3: mark build failure on 10.7

### DIFF
--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -47,6 +47,11 @@ class Python3 < Formula
     sha256 "eaad353805c180a47545a256e6508835b65a8e830ba1093ed8162f19a50a530c"
   end
 
+  fails_with :clang do
+    build 425
+    cause "https://bugs.python.org/issue24844"
+  end
+
   # Homebrew's tcl-tk is built in a standard unix fashion (due to link errors)
   # so we have to stop python from searching for frameworks and linking against
   # X11.


### PR DESCRIPTION
Closes #45923.