### PR TITLE
Pass SDK path in std_cmake_args

### DIFF
--- a/Library/Formula/apngasm.rb
+++ b/Library/Formula/apngasm.rb
@@ -27,6 +27,6 @@ class Apngasm < Formula
   end
 
   test do
-    system "apngasm", "#{pkgshare}/test/samples/clock*.png"
+    system bin/"apngasm", "#{pkgshare}/test/samples/clock*.png"
   end
 end

--- a/Library/Formula/autopano-sift-c.rb
+++ b/Library/Formula/autopano-sift-c.rb
@@ -4,8 +4,8 @@ class AutopanoSiftC < Formula
   url "https://downloads.sourceforge.net/project/hugin/autopano-sift-C/autopano-sift-C-2.5.1/autopano-sift-C-2.5.1.tar.gz"
   sha256 "9a9029353f240b105a9c0e31e4053b37b0f9ef4bd9166dcb26be3e819c431337"
 
-  depends_on "libpano"
   depends_on "cmake" => :build
+  depends_on "libpano"
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -13,7 +13,6 @@ class AutopanoSiftC < Formula
   end
 
   test do
-    assert_match /Version #{Regexp.escape(version)}/,
-                 pipe_output("#{bin}/autopano-sift-c")
+    assert_match "Version #{version}", pipe_output("#{bin}/autopano-sift-c")
   end
 end

--- a/Library/Formula/avro-c.rb
+++ b/Library/Formula/avro-c.rb
@@ -8,7 +8,7 @@ class AvroC < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", *std_cmake_args
     system "make", "install"
   end
 end

--- a/Library/Formula/eigen.rb
+++ b/Library/Formula/eigen.rb
@@ -18,6 +18,7 @@ class Eigen < Formula
 
   def install
     ENV.universal_binary if build.universal?
+
     mkdir "eigen-build" do
       args = std_cmake_args
       args << "-Dpkg_config_libdir=#{lib}" << ".."
@@ -43,6 +44,6 @@ class Eigen < Formula
       }
     EOS
     system ENV.cxx, "test.cpp", "-I#{include}/eigen3", "-o", "test"
-    assert_equal `./test`.split, %w[3 -1 2.5 1.5]
+    assert_equal %w[3 -1 2.5 1.5], shell_output("./test").split
   end
 end

--- a/Library/Formula/vrpn.rb
+++ b/Library/Formula/vrpn.rb
@@ -27,7 +27,6 @@ class Vrpn < Formula
     ENV.libstdcxx
 
     args = std_cmake_args
-    args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}"
 
     if build.with? "clients"
       args << "-DVRPN_BUILD_CLIENTS:BOOL=ON"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1047,6 +1047,7 @@ class Formula
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_FIND_FRAMEWORK=LAST
       -DCMAKE_VERBOSE_MAKEFILE=ON
+      -DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}
       -Wno-dev
     ]
   end


### PR DESCRIPTION
Partially a follow-up to @mistydemeo's #46682. `cmake` is still problematic because it has an internal method for determining which SDK to point at, and that method isn't much more advanced than *"Which OS X version are we using, is there an SDK for that, if nope panic and break the build"*.

This hasn't been *massively* widely tested, but shouldn't be problematic. Should deal with things like #46362, https://github.com/Homebrew/homebrew/pull/47407#issuecomment-167381979 & *possibly* #29101.

If we agree this is roughly the right path to trundle down I'll likely chuck a few extra `cmake`-using builds into this PR to check it a bit more widely.