### PR TITLE
ansible: bump revision

### DIFF
--- a/Library/Formula/ansible.rb
+++ b/Library/Formula/ansible.rb
@@ -342,6 +342,7 @@ class Ansible < Formula
     sha256 "f43f9f15b0b719de94cab2754dcf78ef63b40ee2a12cea296e7af788b28501bb"
   end
 
+  # also required by the htpasswd core module
   resource "passlib" do
     url "https://pypi.python.org/packages/source/p/passlib/passlib-1.6.5.tar.gz"
     sha256 "a83d34f53dc9b17aa42c9a35c3fbcc5120f3fcb07f7f8721ec45e6a27be347fc"

--- a/Library/Formula/ansible.rb
+++ b/Library/Formula/ansible.rb
@@ -3,6 +3,7 @@ class Ansible < Formula
   homepage "https://www.ansible.com/home"
   url "https://releases.ansible.com/ansible/ansible-1.9.4.tar.gz"
   sha256 "972c2face49f1577bd0ff7989440bfe2820e66fb10d7579915cc536bccfa6fe3"
+  revision 1
 
   head "https://github.com/ansible/ansible.git", :branch => "devel"
 


### PR DESCRIPTION
Rackspace support was broken and TLS support was potentially degraded before #47424, so go ahead and bump the revision.

I would have done this then except that I thought that I needed to fix passlib and apparently I don't.