### PR TITLE
Update sngrep to 1.2.0

### DIFF
--- a/Library/Formula/sngrep.rb
+++ b/Library/Formula/sngrep.rb
@@ -1,14 +1,12 @@
 class Sngrep < Formula
   desc "Command-line tool for displaying SIP calls message flows"
   homepage "https://github.com/irontec/sngrep"
-  url "https://github.com/irontec/sngrep/archive/v0.2.2.tar.gz"
-  sha256 "06e3478dfc1d85ba54dd3aabbfb61690ce85fde8cb8153f5ed871f4f5f31fb8f"
+  url "https://github.com/irontec/sngrep/archive/v1.2.0.tar.gz"
+  sha256 "f7f9a05b4be9542ad0651d1deac3bb4cf40c9b1ebc40cfaa922d75a6997f1a7a"
 
   bottle do
-    cellar :any
-    sha256 "23b07b96e2aba627f3929c6d92ff9b1390e1a4fda71b56841d329c955b6d8407" => :yosemite
-    sha256 "73b228cd5e6cf2d8d2114375d4399b0b6cc847d1c07e00a146706c99e4cc73bc" => :mavericks
-    sha256 "d1527802672ba74c6aa5872fb6a9077b6b6f56f08f512f2de1678c317e0d39a3" => :mountain_lion
+    cellar :any_skip_relocation
+    sha256 "86d7cdf06db7e971539120b69bf94e6e21af83a31b15662484ba6dafb32d0aba" => :el_capitan
   end
 
   depends_on "autoconf" => :build

--- a/Library/Formula/sngrep.rb
+++ b/Library/Formula/sngrep.rb
@@ -5,8 +5,10 @@ class Sngrep < Formula
   sha256 "f7f9a05b4be9542ad0651d1deac3bb4cf40c9b1ebc40cfaa922d75a6997f1a7a"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "86d7cdf06db7e971539120b69bf94e6e21af83a31b15662484ba6dafb32d0aba" => :el_capitan
+    cellar :any
+    sha256 "23b07b96e2aba627f3929c6d92ff9b1390e1a4fda71b56841d329c955b6d8407" => :yosemite
+    sha256 "73b228cd5e6cf2d8d2114375d4399b0b6cc847d1c07e00a146706c99e4cc73bc" => :mavericks
+    sha256 "d1527802672ba74c6aa5872fb6a9077b6b6f56f08f512f2de1678c317e0d39a3" => :mountain_lion
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
This patch will update `sngrep` from current revision `0.2.2` to `1.2.0`.

I was only able to generate bottle for `El-Capitan` as I don't have access to the previous OS X revisions. If there's a way to generate bottles for older OS X revisions on `El-Capitan`, please share the instructions. I will re-generate the bottle section and submit another pull-request.

Thank you.
