### PR TITLE
mu: two tweaks

### DIFF
--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -32,7 +32,8 @@ class Mu < Formula
 
     system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-lispdir=#{elisp}"
     system "make"
     system "make", "install"
   end

--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -1,3 +1,6 @@
+# Note that odd release numbers indicate unstable releases.
+# Please only submit PRs for [x.x.even] version numbers:
+# https://github.com/djcb/mu/commit/23f4a64bdcdee3f9956a39b9a5a4fd0c5c2370ba
 class Mu < Formula
   desc "Tool for searching e-mail messages stored in the maildir-format"
   homepage "http://www.djcbsoftware.nl/code/mu/"


### PR DESCRIPTION
- Add a note at the top about versioning
- Have elisp files installed into `site-lisp/mu` rather than `site-lisp/mu4e`.  