### PR TITLE
Tap#issues_url added

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -235,8 +235,10 @@ class BuildError < RuntimeError
           puts "#{formula} was moved to homebrew-boneyard because it has unfixable issues."
           puts "Please do not file any issues about this. Sorry!"
         else
-          puts "If reporting this issue please do so at (not Homebrew/homebrew):"
-          puts "  https://github.com/#{formula.tap}/issues"
+          if issues_url = formula.tap.issues_url
+            puts "If reporting this issue please do so at (not Homebrew/homebrew):"
+            puts "  #{issues_url}"
+          end
         end
       end
     else

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -82,6 +82,14 @@ class Tap
     (path/".git").exist?
   end
 
+  # The issues URL of this {Tap}.
+  # e.g. `https://github.com/user/homebrew-repo/issues`
+  def issues_url
+    if official? || !custom_remote?
+      "https://github.com/#{user}/homebrew-#{repo}/issues"
+    end
+  end
+
   def to_s
     name
   end

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -67,6 +67,22 @@ class TapTest < Homebrew::TestCase
     refute_predicate @tap, :core_formula_repository?
   end
 
+  def test_issues_url
+    t = Tap.new("someone", "foo")
+    path = Tap::TAP_DIRECTORY/"someone/homebrew-foo"
+    path.mkpath
+    FileUtils.cd path do
+      shutup { system "git", "init" }
+      system "git", "remote", "add", "origin",
+        "https://github.com/someone/homebrew-foo"
+    end
+    assert_equal "https://github.com/someone/homebrew-foo/issues", t.issues_url
+    assert_equal "https://github.com/Homebrew/homebrew-foo/issues", @tap.issues_url
+
+    (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
+    assert_nil Tap.new("someone", "no-git").issues_url
+  end
+
   def test_files
     setup_tap_files
 


### PR DESCRIPTION
The goal is to fix the error message for official Homebrew taps. We might want to support more cases in the future.

Right now the error message displays a wrong URL because it strips the `homebrew-` prefix:
```
READ THIS: https://git.io/brew-troubleshooting
If reporting this issue please do so at (not Homebrew/homebrew):
https://github.com/homebrew/php/issues
```

cc @mikemcquaid @xu-cheng 