### PR TITLE
ruby: revert upstream change to header path location

### DIFF
--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -20,6 +20,14 @@ class Ruby < Formula
   option "with-doc", "Install documentation"
   option "with-tcltk", "Install with Tcl/Tk support"
 
+  # Reverts an upstream commit which incorrectly tries to install headers
+  # into SDKROOT, if defined
+  # See https://bugs.ruby-lang.org/issues/11881
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/ba8cc6b88e6b7153ac37739e5a1a6bbbd8f43817/ruby/mkconfig.patch"
+    sha256 "929c618f74e89a5e42d899a962d7d2e4af75716523193af42626884eaba1d765"
+  end
+
   depends_on "pkg-config" => :build
   depends_on "readline" => :recommended
   depends_on "gdbm" => :optional


### PR DESCRIPTION
Fixes #47439.