### PR TITLE
polipo: increase the maximum number of open files

### DIFF
--- a/Library/Formula/polipo.rb
+++ b/Library/Formula/polipo.rb
@@ -45,14 +45,14 @@ class Polipo < Formula
         <array>
           <string>#{opt_bin}/polipo</string>
         </array>
-        <!-- Set `ulimit -n 20480`. The default OS X limit is 256, that's
+        <!-- Set `ulimit -n 65536`. The default OS X limit is 256, that's
              not enough for Polipo (displays 'too many files open' errors).
              It seems like you have no reason to lower this limit
              (and unlikely will want to raise it). -->
         <key>SoftResourceLimits</key>
         <dict>
           <key>NumberOfFiles</key>
-          <integer>20480</integer>
+          <integer>65536</integer>
         </dict>
       </dict>
     </plist>


### PR DESCRIPTION
This avoid to reach the previous limit (20480) after few hours/days of use.

Sample errors:

```
polipo[3604]: Couldn't establish listening socket: Too many open files
polipo[3604]: Couldn't create pipe: Too many open files
polipo[3604]: dnssd_clientstub deliver_request: socketpair failed 24 (Too many open files)
polipo[3604]: Couldn't create disk file ~/.polipo-cache/init-p01st.push.apple.com/S5s7LMk8oj4eqjqILbosTQ==: Too many open files
```