### PR TITLE
superenv/cc: don't filter out `gdwarf-2`.

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -135,7 +135,7 @@ class Cmd
     args = []
 
     case arg
-    when /^-g\d?/, /^-gstabs\d+/, "-gstabs+", /^-ggdb\d?/, "-gdwarf-2",
+    when /^-g\d?$/, /^-gstabs\d+/, "-gstabs+", /^-ggdb\d?/,
       /^-march=.+/, /^-mtune=.+/, /^-mcpu=.+/,
       /^-O[0-9zs]?$/, "-fast", "-no-cpp-precomp",
       "-pedantic", "-pedantic-errors", "-Wno-long-double",

--- a/Library/Formula/corectl.rb
+++ b/Library/Formula/corectl.rb
@@ -28,15 +28,6 @@ class Corectl < Formula
     args = []
     args << "VERSION=#{version}" if build.stable?
 
-    # system "make", "corectl", *args
-    # busts with "cannot load DWARF output from ""...
-    # similar to https://github.com/jwaldrip/homebrew-utils/issues/1
-    # workaround ...
-    ["TheNewNormal/libxhyve", "TheNewNormal/corectl/uuid2ip",
-     "yeonsh/go-ps"].each do |repo|
-      system "godep", "go", "install", "github.com/#{repo}"
-    end
-
     system "make", "corectl", *args
     system "make", "documentation/man"
 

--- a/Library/Formula/nomad.rb
+++ b/Library/Formula/nomad.rb
@@ -33,13 +33,6 @@ class Nomad < Formula
 
     Language::Go.stage_deps resources, gopath/"src"
 
-    # explicit install of shirou/gopsutil/cpu to work around error message:
-    #   cannot load DWARF output from $WORK/github.com/shirou/gopsutil/cpu/_obj//_cgo_.o:
-    #   decoding dwarf section info at offset 0x0: too short
-    cd gopath/"src/github.com/shirou/gopsutil/cpu" do
-      system "go", "install"
-    end
-
     cd gopath/"src/github.com/hashicorp/nomad" do
       system "make", "bootstrap"
       system "make", "dev"


### PR DESCRIPTION
It's needed by `cgo` which is used by a lot of Go software.

Also, demonstrate it works by removing the `corectl` and `nomad` workarounds.

CC @mistydemeo @xu-cheng for review/thoughts.

Closes #45657 

