### PR TITLE
Various

### DIFF
--- a/Library/Formula/bigdata.rb
+++ b/Library/Formula/bigdata.rb
@@ -1,9 +1,9 @@
 class Bigdata < Formula
   desc "Graph database supporting RDF data model, Sesame, and Blueprint APIs"
   homepage "https://www.blazegraph.com/bigdata"
-  url "https://downloads.sourceforge.net/project/bigdata/bigdata/1.5.1/bigdata-bundled.jar"
-  version "1.5.1"
-  sha256 "092ecfb1293de27ef40c02795a34ac410e30d175623a342b27271952f01c1f1a"
+  url "https://downloads.sourceforge.net/project/bigdata/bigdata/1.5.3/bigdata-bundled.jar"
+  version "1.5.3"
+  sha256 "d72a490a7e86ad96a85e26f52977675ac0f0621b8b02866ce29410796d70d552"
 
   bottle :unneeded
 
@@ -25,7 +25,7 @@ class Bigdata < Formula
         <key>Label</key>
         <string>#{plist_name}</string>
         <key>Program</key>
-        <string>#{bin}/bigdata</string>
+        <string>#{opt_bin}/bigdata</string>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>

--- a/Library/Formula/dynamodb-local.rb
+++ b/Library/Formula/dynamodb-local.rb
@@ -59,7 +59,7 @@ class DynamodbLocal < Formula
       <false/>
       <key>ProgramArguments</key>
       <array>
-        <string>#{bin}/dynamodb-local</string>
+        <string>#{opt_bin}/dynamodb-local</string>
       </array>
       <key>StandardErrorPath</key>
       <string>#{log_path}</string>

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -32,6 +32,9 @@ class Freeswitch < Formula
   depends_on "speex"
   depends_on "sqlite"
 
+  # https://github.com/Homebrew/homebrew/issues/42865
+  fails_with :gcc
+
   #----------------------- Begin sound file resources -------------------------
   sounds_url_base = "https://files.freeswitch.org/releases/sounds"
 

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -206,7 +206,7 @@ class Freeswitch < Formula
         <string>#{plist_name}</string>
       <key>ProgramArguments</key>
         <array>
-          <string>#{bin}/freeswitch</string>
+          <string>#{opt_bin}/freeswitch</string>
           <string>-nc</string>
           <string>-nonat</string>
         </array>

--- a/Library/Formula/redshift.rb
+++ b/Library/Formula/redshift.rb
@@ -1,5 +1,5 @@
 class Redshift < Formula
-  desc "Adjusts color temperature of your screen according to your surroundings"
+  desc "Adjust color temperature of your screen according to your surroundings"
   homepage "http://jonls.dk/redshift/"
   url "https://github.com/jonls/redshift/releases/download/v1.10/redshift-1.10.tar.xz"
   sha256 "5bc2e70aa414f42dafb45c6e06ea90157d7d4b298af48877144ff442639aeea6"
@@ -52,7 +52,7 @@ class Redshift < Formula
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
         <array>
-          <string>#{bin}/redshift</string>
+          <string>#{opt_bin}/redshift</string>
         </array>
         <key>KeepAlive</key>
         <true/>
@@ -70,7 +70,7 @@ class Redshift < Formula
   def caveats; <<-EOS.undent
     A .conf file has not been provided. If you want one, see:
       http://jonls.dk/redshift/
-    And place it in $HOME/.config
+    And place it in #{ENV["HOME"]}/.config
     EOS
   end
 


### PR DESCRIPTION
Eliminating more annoyances.

This time the use of `bin` in the `plist` rather than `opt_bin`, the latter meaning people can just unload/load the existing `plist` rather than having to copy across a new one every single update/revision/etc.