### PR TITLE
duply: fix calling a bash script with python interpreter

### DIFF
--- a/Library/Formula/duply.rb
+++ b/Library/Formula/duply.rb
@@ -10,5 +10,8 @@ class Duply < Formula
 
   def install
     bin.install "duply"
+    # Homebrew uses env_script_all_files in the duplicity script, so calling it
+    # with the python interpreter doesn't work
+    inreplace "#{bin}/duply", "DEFAULT_PYTHON=\'python2\'", "DEFAULT_PYTHON=\'bash\'"
   end
 end


### PR DESCRIPTION
The latest version(s) of duply call duplicity with an explicit python interpreter, which doesn't work since duplicity in homebrew is a bash script, basically breaking duply.

This fix simply tells to use "bash" as a very special python interpreter. There might be more elegant fixes, before exploring those some input from others might be nice.