### PR TITLE
cdiff: fix missing `conflict` with `colordiff`

### DIFF
--- a/Library/Formula/cdiff.rb
+++ b/Library/Formula/cdiff.rb
@@ -8,6 +8,7 @@ class Cdiff < Formula
 
   bottle :unneeded
 
+  conflicts_with "colordiff", :because => "both install `cdiff` binaries"
   depends_on :python if MacOS.version <= :snow_leopard
 
   def install


### PR DESCRIPTION
Both `cdiff` and `colordiff` want to install a `cdiff` executable.