### PR TITLE
docker-machine-parallels 1.1.1

### DIFF
--- a/Library/Formula/docker-machine-parallels.rb
+++ b/Library/Formula/docker-machine-parallels.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachineParallels < Formula
   desc "Docker Machine Parallels Driver"
   homepage "https://github.com/Parallels/docker-machine-parallels"
-  url "https://github.com/Parallels/docker-machine-parallels/archive/v1.1.0.tar.gz"
-  sha256 "0f2ccc1c470a71b40e81b548b4587cdcbc098f0ceeea6295ec8bebbb06aa9135"
+  url "https://github.com/Parallels/docker-machine-parallels/archive/v1.1.1.tar.gz"
+  sha256 "a085bbc8c231f4629d3404677f73b49bff2414f7002f0e9acf9aee8cdae15829"
   head "https://github.com/Parallels/docker-machine-parallels.git"
 
   bottle do
@@ -19,17 +19,19 @@ class DockerMachineParallels < Formula
   depends_on "docker-machine"
 
   go_resource "github.com/docker/docker" do
-    # Docker v1.9.1 release
-    url "https://github.com/docker/docker.git", :revision => "a34a1d598c6096ed8b5ce5219e77d68e5cd85462"
+    url "https://github.com/docker/docker.git", :tag => "v1.9.1", :revision => "a34a1d598c6096ed8b5ce5219e77d68e5cd85462"
   end
 
   go_resource "github.com/docker/machine" do
-    # Docker Machine v0.5.1 release
-    url "https://github.com/docker/machine.git", :revision => "7e8e38e1485187c0064e054029bb1cc68c87d39a"
+    url "https://github.com/docker/machine.git", :tag => "v0.5.5", :revision => "02c4254cb4c93a4bbb5dc4ca0467abeb12d72546"
   end
 
   go_resource "golang.org/x/crypto" do
-    url "https://go.googlesource.com/crypto.git", :revision => "beef0f4390813b96e8e68fd78570396d0f4751fc"
+    url "https://go.googlesource.com/crypto.git", :revision => "f18420efc3b4f8e9f3d51f6bd2476e92c46260e9"
+  end
+
+  go_resource "github.com/codegangsta/cli" do
+    url "https://github.com/codegangsta/cli.git", :tag => "v1.2.0", :revision => "565493f259bf868adb54d45d5f4c68d405117adf"
   end
 
   def install
@@ -39,7 +41,7 @@ class DockerMachineParallels < Formula
     ln_sf buildpath, buildpath/"src/github.com/Parallels/docker-machine-parallels"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    system "godep", "go", "build", "-i", "-o", "./bin/docker-machine-driver-parallels", "./bin"
+    system "godep", "go", "build", "-o", "./bin/docker-machine-driver-parallels", "./bin"
     bin.install "bin/docker-machine-driver-parallels"
   end
 


### PR DESCRIPTION
- Compatibility with Docker Machine v0.5.5+
- Add arguments --version and --help for plugin binary