### PR TITLE
Core nits

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -60,7 +60,11 @@ module Homebrew
   def describe_path(path)
     return "N/A" if path.nil?
     realpath = path.realpath
-    if realpath == path then path else "#{path} => #{realpath}" end
+    if realpath == path
+      path
+    else
+      "#{path} => #{realpath}"
+    end
   end
 
   def describe_x11

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -6,7 +6,7 @@ module CompilerConstants
     "gcc-4.0"  => :gcc_4_0,
     "gcc-4.2"  => :gcc,
     "llvm-gcc" => :llvm,
-    "clang"    => :clang
+    "clang"    => :clang,
   }
 
   COMPILERS = COMPILER_SYMBOL_MAP.values +
@@ -67,12 +67,12 @@ class CompilerFailure
       create(:gcc => "4.3"),
       create(:gcc => "4.4"),
       create(:gcc => "4.5"),
-      create(:gcc => "4.6")
+      create(:gcc => "4.6"),
     ],
     :openmp => [
       create(:clang),
-      create(:llvm)
-    ]
+      create(:llvm),
+    ],
   }
 end
 
@@ -85,7 +85,7 @@ class CompilerSelector
     :clang   => [:clang, :gcc, :llvm, :gnu, :gcc_4_0],
     :gcc     => [:gcc, :llvm, :gnu, :clang, :gcc_4_0],
     :llvm    => [:llvm, :gcc, :gnu, :clang, :gcc_4_0],
-    :gcc_4_0 => [:gcc_4_0, :gcc, :llvm, :gnu, :clang]
+    :gcc_4_0 => [:gcc_4_0, :gcc, :llvm, :gnu, :clang],
   }
 
   def self.select_for(formula, compilers = self.compilers)

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -26,10 +26,10 @@ module DiskUsageExtension
   private
 
   def compute_disk_usage
-    if self.directory?
+    if directory?
       @file_count = 0
       @disk_usage = 0
-      self.find do |f|
+      find do |f|
         if !f.directory? && !f.symlink? && f.basename.to_s != ".DS_Store"
           @file_count += 1
           @disk_usage += f.size
@@ -37,7 +37,7 @@ module DiskUsageExtension
       end
     else
       @file_count = 1
-      @disk_usage = self.size
+      @disk_usage = size
     end
   end
 end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -177,7 +177,6 @@ class Pathname
   end
   private :default_stat
 
-
   # @private
   def cp_path_sub(pattern, replacement)
     raise "#{self} does not exist" unless self.exist?
@@ -229,7 +228,6 @@ class Pathname
   rescue Errno::EACCES, Errno::ENOENT
     false
   end
-
 
   # @private
   def version

--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -62,7 +62,7 @@ module Language
         options = if args[-1].kind_of?(Hash) then args.pop else {} end
 
         cabal_sandbox do
-          cabal_install_tools *options[:using] if options[:using]
+          cabal_install_tools(*options[:using]) if options[:using]
 
           # install dependencies in the sandbox
           cabal_install "--only-dependencies", *args

--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -1,6 +1,5 @@
 module Language
   module Haskell
-
     module Cabal
       def self.included(base)
         # use llvm-gcc on Lion or below, as when building GHC)
@@ -18,7 +17,7 @@ module Language
         ENV["HOME"] = home
 
         system "cabal", "sandbox", "init"
-        cabal_sandbox_bin = pwd/".cabal-sandbox"/"bin"
+        cabal_sandbox_bin = pwd/".cabal-sandbox/bin"
         mkdir_p cabal_sandbox_bin
 
         # make available any tools that will be installed in the sandbox
@@ -26,7 +25,7 @@ module Language
         ENV.prepend_path "PATH", cabal_sandbox_bin
 
         # avoid updating the cabal package database more than once
-        system "cabal", "update" unless (home/".cabal"/"packages").exist?
+        system "cabal", "update" unless (home/".cabal/packages").exist?
 
         yield
 

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -109,7 +109,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     formula_file = CoreFormulaRepository.new.formula_dir/"testball.rb"
     formula_file.write <<-EOS.undent
       class Testball < Formula
-        url "https://example.com/testabll-0.1.tar.gz"
+        url "https://example.com/testball-0.1.tar.gz"
       end
     EOS
     HOMEBREW_CACHE.cd do

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -113,8 +113,8 @@ class IntegrationCommandTests < Homebrew::TestCase
       end
     EOS
     HOMEBREW_CACHE.cd do
-      assert_match /testball-0\.1.*\.bottle\.tar\.gz/,
-                   cmd_output("bottle", "--no-revision", "testball")
+      assert_match(/testball-0\.1.*\.bottle\.tar\.gz/,
+                   cmd_output("bottle", "--no-revision", "testball"))
     end
   ensure
     cmd("uninstall", "--force", "testball")


### PR DESCRIPTION
Blame Mike for the encouragement :stuck_out_tongue_winking_eye:. Pretty minor changes, but minimises the risk of borking the core.

Tested all this locally with `brew readall --syntax --aliases` against both Ruby 2.x and 1.8, and Rubocop, and tested the Haskell tweaks by installing `purescript` from source.