### PR TITLE
Add a echo-sd

### DIFF
--- a/Library/Formula/echo-sd.rb
+++ b/Library/Formula/echo-sd.rb
@@ -1,0 +1,10 @@
+class EchoSd < Formula
+  desc "Echo 'sudden death' message"
+  homepage "https://fumiyas.github.io/2013/12/25/echo-sd.sh-advent-calendar.html"
+  url "https://raw.githubusercontent.com/fumiyas/home-commands/master/echo-sd"
+  sha256 "42f333ec81642f3b6a3a5fb59ab35f526dd7c86b77cdb8a420ba73eaf3846652"
+
+  def install
+    bin.install "echo-sd"
+  end
+end


### PR DESCRIPTION
Added a command.
echo-sd is a command for Japanese joke generator.
Many people using this joke. I also frequently use this joke on Twitter :smile: 
Generated result:
<img width="322" alt="screenshot 2016-01-01 00 47 55" src="https://cloud.githubusercontent.com/assets/3052342/12065814/548d0d30-b021-11e5-9780-0962c1b35c7f.png">
Why image? because output is included Japanese fonts.