### PR TITLE
llvm: Remove --without-assertions

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -116,10 +116,8 @@ class Llvm < Formula
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build Python bindings against Homebrew Python"
   option "with-rtti", "Build with C++ RTTI"
-  option "without-assertions", "Speeds up LLVM, but provides less debug information"
 
   deprecated_option "rtti" => "with-rtti"
-  deprecated_option "disable-assertions" => "without-assertions"
 
   if MacOS.version <= :snow_leopard
     depends_on :python
@@ -191,10 +189,6 @@ class Llvm < Formula
     ]
 
     args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
-
-    if build.with? "assertions"
-      args << "-DLLVM_ENABLE_ASSERTIONS=On"
-    end
 
     if build.universal?
       ENV.permit_arch_flags


### PR DESCRIPTION
Homebrew passes -DNDEBUG by default, so assertions should not be enabled
by default. In addition, assertions would likely not be too helpful, as
this formula makes a Release build of LLVM, so debugging would likely be
somewhat difficult.