### PR TITLE
Improve dash separated version detection.

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -365,4 +365,8 @@ class VersionParsingTests < Homebrew::TestCase
   def test_waf_version
     assert_version_detected "1.8.12", "https://waf.io/waf-1.8.12"
   end
+
+  def test_dash_separated_version
+    assert_version_detected "6-20151227", "ftp://gcc.gnu.org/pub/gcc/snapshots/6-20151227/gcc-6-20151227.tar.bz2"
+  end
 end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -312,7 +312,7 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. lame-398-1
-    m = /-((?:\d)+-\d)/.match(stem)
+    m = /-((?:\d)+-\d+)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. foobar-4.5.1


### PR DESCRIPTION
Seems to make more sense this way.

Also I encountered a situation when packaging GCC 6 snapshots whose package is named `gcc-6-20151227.tar.bz2` but the version detected was `6-2`. This was not a problem when GCC versions include a minor version which were detected correctly, so I guess it should be made working now as well.