### PR TITLE
LanguageModuleRequirement: remove rbx support

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :ruby
+    :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :jruby, :lua, :perl, :python, :python3, :ruby
+    :lua, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :jruby, :lua, :ocaml, :perl, :python, :python3, :ruby
+    :jruby, :lua, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :lua, :perl, :python, :python3, :ruby
+    :lua, :lua51, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :ruby
+    :jruby, :lua, :ocaml, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,7 +18,7 @@ require "set"
 class DependencyCollector
   # Define the languages that we can handle as external dependencies.
   LANGUAGE_MODULES = Set[
-    :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :rbx, :ruby
+    :chicken, :jruby, :lua, :node, :ocaml, :perl, :python, :python3, :ruby
   ].freeze
 
   CACHE = {}

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -31,7 +31,6 @@ class LanguageModuleRequirement < Requirement
     when :python then %W[/usr/bin/env python -c import\ #{@import_name}]
     when :python3 then %W[/usr/bin/env python3 -c import\ #{@import_name}]
     when :ruby then %W[/usr/bin/env ruby -rubygems -e require\ '#{@import_name}']
-    when :rbx then %W[/usr/bin/env rbx -rubygems -e require\ '#{@import_name}']
     end
   end
 
@@ -46,7 +45,6 @@ class LanguageModuleRequirement < Requirement
     when :perl    then "cpan -i"
     when :python  then "pip install"
     when :python3 then "pip3 install"
-    when :rbx     then "rbx gem install"
     when :ruby    then "gem install"
     end
   end

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -24,7 +24,6 @@ class LanguageModuleRequirement < Requirement
     when :jruby then %W[/usr/bin/env jruby -rubygems -e require\ '#{@import_name}']
     when :lua then %W[/usr/bin/env luarocks-5.2 show #{@import_name}]
     when :lua51 then %W[/usr/bin/env luarocks-5.1 show #{@import_name}]
-    when :node then %W[/usr/bin/env node -e require('#{@import_name}');]
     when :ocaml then %W[/usr/bin/env opam list --installed #{@import_name}]
     when :perl then %W[/usr/bin/env perl -e use\ #{@import_name}]
     when :python then %W[/usr/bin/env python -c import\ #{@import_name}]
@@ -38,7 +37,6 @@ class LanguageModuleRequirement < Requirement
     when :jruby   then "jruby -S gem install"
     when :lua     then "luarocks-5.2 install"
     when :lua51   then "luarocks-5.1 install"
-    when :node    then "npm install"
     when :ocaml   then "opam install"
     when :perl    then "cpan -i"
     when :python  then "pip install"

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -21,7 +21,6 @@ class LanguageModuleRequirement < Requirement
 
   def the_test
     case @language
-    when :chicken then %W[/usr/bin/env csi -e (use\ #{@import_name})]
     when :jruby then %W[/usr/bin/env jruby -rubygems -e require\ '#{@import_name}']
     when :lua then %W[/usr/bin/env luarocks-5.2 show #{@import_name}]
     when :lua51 then %W[/usr/bin/env luarocks-5.1 show #{@import_name}]
@@ -36,7 +35,6 @@ class LanguageModuleRequirement < Requirement
 
   def command_line
     case @language
-    when :chicken then "chicken-install"
     when :jruby   then "jruby -S gem install"
     when :lua     then "luarocks-5.2 install"
     when :lua51   then "luarocks-5.1 install"

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -21,10 +21,8 @@ class LanguageModuleRequirement < Requirement
 
   def the_test
     case @language
-    when :jruby then %W[/usr/bin/env jruby -rubygems -e require\ '#{@import_name}']
     when :lua then %W[/usr/bin/env luarocks-5.2 show #{@import_name}]
     when :lua51 then %W[/usr/bin/env luarocks-5.1 show #{@import_name}]
-    when :ocaml then %W[/usr/bin/env opam list --installed #{@import_name}]
     when :perl then %W[/usr/bin/env perl -e use\ #{@import_name}]
     when :python then %W[/usr/bin/env python -c import\ #{@import_name}]
     when :python3 then %W[/usr/bin/env python3 -c import\ #{@import_name}]
@@ -34,10 +32,8 @@ class LanguageModuleRequirement < Requirement
 
   def command_line
     case @language
-    when :jruby   then "jruby -S gem install"
     when :lua     then "luarocks-5.2 install"
     when :lua51   then "luarocks-5.1 install"
-    when :ocaml   then "opam install"
     when :perl    then "cpan -i"
     when :python  then "pip install"
     when :python3 then "pip3 install"

--- a/Library/Homebrew/test/test_language_module_requirement.rb
+++ b/Library/Homebrew/test/test_language_module_requirement.rb
@@ -50,14 +50,4 @@ class LanguageModuleRequirementTests < Homebrew::TestCase
   def test_good_ruby_deps
     assert_deps_pass "date" => :ruby
   end
-
-  if which("node")
-    def test_bad_node_deps
-      assert_deps_fail "notapackage" => :node
-    end
-
-    def test_good_node_deps
-      assert_deps_pass "util" => :node
-    end
-  end
 end

--- a/Library/Homebrew/test/test_language_module_requirement.rb
+++ b/Library/Homebrew/test/test_language_module_requirement.rb
@@ -51,16 +51,6 @@ class LanguageModuleRequirementTests < Homebrew::TestCase
     assert_deps_pass "date" => :ruby
   end
 
-  if which("csc")
-    def test_bad_chicken_deps
-      assert_deps_fail "notapackage" => :chicken
-    end
-
-    def test_good_chicken_deps
-      assert_deps_pass "extras" => :chicken
-    end
-  end
-
   if which("node")
     def test_bad_node_deps
       assert_deps_fail "notapackage" => :node

--- a/Library/Homebrew/test/test_language_module_requirement.rb
+++ b/Library/Homebrew/test/test_language_module_requirement.rb
@@ -51,16 +51,6 @@ class LanguageModuleRequirementTests < Homebrew::TestCase
     assert_deps_pass "date" => :ruby
   end
 
-  if which("rbx")
-    def test_bad_rubinius_deps
-      assert_deps_fail "notapackage" => :rbx
-    end
-
-    def test_good_rubinius_deps
-      assert_deps_pass "date" => :rbx
-    end
-  end
-
   if which("csc")
     def test_bad_chicken_deps
       assert_deps_fail "notapackage" => :chicken


### PR DESCRIPTION
This test wasn't running by default, so we missed that it wasn't actually being executed - or that it was failing when running in the testing environment.

As far as I can tell this is not, and has not, been used either in core or in any tap, third party or otherwise, so just remove the feature and its test.