### PR TITLE
Libvoikko 4.0

### DIFF
--- a/Library/Formula/foma.rb
+++ b/Library/Formula/foma.rb
@@ -1,0 +1,32 @@
+class Foma < Formula
+  desc "Finite-state compiler and C library"
+  homepage "https://code.google.com/p/foma/"
+  url "https://bitbucket.org/mhulden/foma/downloads/foma-0.9.18.tar.gz"
+  sha256 "cb380f43e86fc7b3d4e43186db3e7cff8f2417e18ea69cc991e466a3907d8cbd"
+
+  def install
+    system "make"
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    # Source: https://code.google.com/p/foma/wiki/ExampleScripts
+    (testpath/"toysyllabify.script").write <<-EOS.undent
+      define V [a|e|i|o|u];
+      define Gli [w|y];
+      define Liq [r|l];
+      define Nas [m|n];
+      define Obs [p|t|k|b|d|g|f|v|s|z];
+
+      define Onset (Obs) (Nas) (Liq) (Gli); # Each element is optional.
+      define Coda  Onset.r;                 # Is mirror image of onset.
+
+      define Syllable Onset V Coda;
+      regex Syllable @> ... "." || _ Syllable;
+
+      apply down> abrakadabra
+    EOS
+
+    system "#{bin}/foma", "-f", "toysyllabify.script"
+  end
+end

--- a/Library/Formula/hfstospell.rb
+++ b/Library/Formula/hfstospell.rb
@@ -1,0 +1,23 @@
+class Hfstospell < Formula
+  desc "Helsinki Finite-State Technology ospell"
+  homepage "http://www.ling.helsinki.fi/kieliteknologia/tutkimus/hfst/"
+  url "https://downloads.sourceforge.net/project/hfst/hfst/archive/hfstospell-0.3.0.tar.gz"
+  sha256 "07b5b368882cac2399edb1bb6e2dd91450b56f732c25413a19fcfe194342d70c"
+
+  depends_on "pkg-config" => :build
+  depends_on "libarchive"
+  needs :cxx11
+
+  def install
+    ENV.cxx11
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/hfst-ospell", "--version"
+  end
+end

--- a/Library/Formula/libvoikko.rb
+++ b/Library/Formula/libvoikko.rb
@@ -1,8 +1,13 @@
 class Libvoikko < Formula
-  desc "Linguistic software for Finnish"
+  desc "Linguistic software for Finnish and other languages and Finnish dictionary"
   homepage "http://voikko.puimula.org/"
-  url "http://www.puimula.org/voikko-sources/libvoikko/libvoikko-3.8.tar.gz"
-  sha256 "1df2f4a47217d1de5978e1586c1bbf61a1454cef6aadadbda6aec45738e69cff"
+  url "http://www.puimula.org/voikko-sources/libvoikko/libvoikko-4.0.tar.gz"
+  sha256 "24c6e3625eb5a8550512f7ad2f708c5392b9a0b164c04fb3659592048555e291"
+
+  resource "voikko-fi" do
+    url "http://www.puimula.org/voikko-sources/voikko-fi/voikko-fi-2.0.tar.gz"
+    sha256 "02f7595dd7e3cee188184417d6a7365f9dc653b020913f5ad75d1f14b548fafd"
+  end
 
   bottle do
     cellar :any
@@ -12,7 +17,9 @@ class Libvoikko < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "suomi-malaga-voikko"
+  depends_on :python3 => :build
+  depends_on "foma" => :build
+  depends_on "hfstospell"
 
   def install
     system "./configure", "--disable-debug",
@@ -21,5 +28,16 @@ class Libvoikko < Formula
                           "--prefix=#{prefix}",
                           "--with-dictionary-path=#{HOMEBREW_PREFIX}/lib/voikko"
     system "make", "install"
+
+    resource("voikko-fi").stage do
+      ENV.append_path "PATH", "#{bin}"
+      system "make", "vvfst"
+      system "make", "vvfst-install", "DESTDIR=#{lib}/voikko"
+      lib.install_symlink "voikko"
+    end
+  end
+
+  test do
+    pipe_output("#{bin}/voikkospell -m", "onkohan\n")
   end
 end


### PR DESCRIPTION
This PR libvoikko to 4.0, adds dependencies and removes the package malaga that is not a dependency to Voikko any more and seems to be abandoned by upstream.

The dependency relations change in this version so that libvoikko doesn't pull Finnish dictionary as a dependency any more. Instead, the users need to install the package voikko-fi, which depends on Voikko and provides the dictionary. Should there be a printed message to users to notify about them, or are they supposed to read the release notes?