### PR TITLE
mp3unicode: use pkg-config & fix error when building HEAD

### DIFF
--- a/Library/Formula/mp3unicode.rb
+++ b/Library/Formula/mp3unicode.rb
@@ -15,8 +15,15 @@ class Mp3unicode < Formula
   depends_on "pkg-config" => :build
   depends_on "taglib"
 
+  if build.head?
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
   def install
     ENV.append "ICONV_LIBS", "-liconv"
+
+    system "autoreconf", "-i" if build.head?
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Library/Formula/mp3unicode.rb
+++ b/Library/Formula/mp3unicode.rb
@@ -12,12 +12,10 @@ class Mp3unicode < Formula
     sha256 "10d647d04714f9e95d9bf3ab8dfd023fea3f22876dfe055c01211e527a2facd3" => :mavericks
   end
 
+  depends_on "pkg-config" => :build
   depends_on "taglib"
 
   def install
-    ENV.append "PKG_CONFIG", "true"
-    ENV.append "TAGLIB_CFLAGS", "-I#{Formula["taglib"].opt_include}/taglib"
-    ENV.append "TAGLIB_LIBS", "-L#{Formula["taglib"].opt_lib} -ltag"
     ENV.append "ICONV_LIBS", "-liconv"
 
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
In their git repo, `configure` does not exist. So we have to generate it from `configure.ac` before running `./configure`.