### PR TITLE
Recommend Homebrew'd curl on 10.8 and below.

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -677,9 +677,10 @@ class Checks
   end
 
   def check_for_bad_curl
-    if MacOS.version <= "10.6" && !Formula["curl"].installed? then <<-EOS.undent
-      The system curl on 10.6 and below is often incapable of supporting
+    if MacOS.version <= "10.8" && !Formula["curl"].installed? then <<-EOS.undent
+      The system curl on 10.8 and below is often incapable of supporting
       modern secure connections & will fail on fetching formulae.
+
       We recommend you:
         brew install curl
       EOS

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -293,7 +293,7 @@ end
 
 def curl(*args)
   brewed_curl = HOMEBREW_PREFIX/"opt/curl/bin/curl"
-  curl = if MacOS.version <= "10.6" && brewed_curl.exist?
+  curl = if MacOS.version <= "10.8" && brewed_curl.exist?
     brewed_curl
   else
     Pathname.new "/usr/bin/curl"


### PR DESCRIPTION
Extends the 10.6 check another couple OS X versions up.

OS X 10.8 `curl` can only handle SSLv3 handshakes and TLSv1 connections, and many newly-configured servers vomit if you try to touch them with SSLv3. The issue is only going to get worse over time as people update their server configurations and SSLv3 dies off more and more, which it is, just far too slowly.

Longer-term we are going to run into other issues with SSL/TLS `curl` connections on older OS X versions as discussed in chat, but this workaround should hold for a fair length of time until we decide on a more drastic path of action.