### PR TITLE
reinstall: add --interactive and --git options

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -25,6 +25,8 @@ module Homebrew
     fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
     fi.build_from_source   = ARGV.build_from_source?
     fi.force_bottle        = ARGV.force_bottle?
+    fi.interactive         = ARGV.interactive?
+    fi.git                 = ARGV.git?
     fi.verbose             = ARGV.verbose?
     fi.debug               = ARGV.debug?
     fi.prelude


### PR DESCRIPTION
From #47622:

> ... [Speaking of `reinstall`] `--interactive` (and by extension, `--git`, which I personally never used but must be useful in certain cases) is sorely missed when developing a new formula with options, or revising an existing formula for major changes that break things.

@mikemcquaid replied

> It's excluded because `reinstall` does more than just `uninstall`; `install`. Often `--interactive` will write e.g. just metadata files which would mean the backup is destroyed.

I agree, but I would counter that by arguing that `--interactive`—I suppose—should only be used by users (mostly formula authors) who know what they're doing and are prepared to face the consequences. Worst case scenario: even if the interactive session turns out to be a flop, one could always issue a `false` before leaving the shell, which would lead to a restore of the backup.