### PR TITLE
openssl: fix headers for universal build

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -81,6 +81,7 @@ class Openssl < Formula
       end
 
       if build.universal?
+        cp "include/openssl/opensslconf.h", dir
         cp Dir["*.?.?.?.dylib", "*.a", "apps/openssl"], dir
         cp Dir["engines/**/*.dylib"], "#{dir}/engines"
       end
@@ -108,6 +109,15 @@ class Openssl < Formula
       system "lipo", "-create", "#{dirs.first}/openssl",
                                 "#{dirs.last}/openssl",
                      "-output", "#{bin}/openssl"
+
+      confs = archs.map do |arch|
+        <<-EOS.undent
+          #ifdef __#{arch}__
+          #{(buildpath/"build-#{arch}/opensslconf.h").read}
+          #endif
+          EOS
+      end
+      (include/"openssl/opensslconf.h").atomic_write confs.join("\n")
     end
   end
 


### PR DESCRIPTION
opensslconf.h is different depending on the architecture for which it is
built. Previously, universal builds installed only one version of the
header, which was wrong for one of the architectures. This uses #ifdef
magic to make sure that the correct version of the header is used for
the target against which client software is building.

https://langui.sh/2016/01/03/universal-libraries-but-not-headers/
illustrates this bug causing problems in the wild.

This should be pulled at the same time as #47650 so that it lands on an openssl bump. CI won't be informative here but it looks correct locally.

Ping @reaperhulk per conversation!