### PR TITLE
cfitsio: enable reentrant by default

### DIFF
--- a/Library/Formula/cfitsio.rb
+++ b/Library/Formula/cfitsio.rb
@@ -22,7 +22,7 @@ class Cfitsio < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--enable-reentrant"
     system "make", "shared"
     system "make", "install"
 


### PR DESCRIPTION
The default configuration for cfitsio is not reentrant, which causes random errors when using it in a multi-threaded program. This PR adds an argument to `./configure` that makes the default configuration reentrant.