### PR TITLE
integration tests: fix failing test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -119,7 +119,7 @@ class IntegrationCommandTests < Homebrew::TestCase
   ensure
     cmd("uninstall", "--force", "testball")
     cmd("cleanup", "--force", "--prune=all")
-    formula_file.unlink
+    formula_file.unlink unless formula_file.nil?
   end
 
   def test_uninstall


### PR DESCRIPTION
If the test fails above `formula_file`’s definition this line fails because `formula_file` is `nil`.