### PR TITLE
formula_installer: improve empty installation detection

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -8,6 +8,7 @@ require "caveats"
 require "cleaner"
 require "formula_cellar_checks"
 require "install_renamed"
+require "cmd/audit"
 require "cmd/postinstall"
 require "hooks/bottles"
 require "debrew"
@@ -572,7 +573,11 @@ class FormulaInstaller
       end
     end
 
-    raise "Empty installation" if Dir["#{formula.prefix}/*"].empty?
+    auditor = FormulaAuditor.new(formula)
+    auditor.audit_prefix_has_contents
+    unless formula.prefix.exist? && auditor.problems.empty?
+      raise "Empty installation"
+    end
 
   rescue Exception
     ignore_interrupts do


### PR DESCRIPTION
Per discussion in #47647, empty installation check should be more robust, which is especially important for `--interactive` install or reinstall.

Use the logic of `audit_prefix_has_contents` from `audit.rb`. In particular, directories, copyright files, `.DS_Store` and `INSTALL_RECEIPT.json` should not count toward nonemptiness.