### PR TITLE
travis: avoid polluting path with Ruby 1.8 on 10.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
 install:
   - if [ "$HOMEBREW_RUBY" = "1.8.7" ]; then
       brew install homebrew/versions/ruby187;
-      export PATH="/usr/local/opt/ruby187/bin:$PATH";
       export HOMEBREW_RUBY_PATH="/usr/local/opt/ruby187/bin/ruby";
       brew untap homebrew/versions;
     fi

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -231,7 +231,12 @@ module Homebrew
 
   def self.install_gem_setup_path!(gem, version = nil, executable = gem)
     require "rubygems"
-    ENV["PATH"] = "#{Gem.user_dir}/bin:#{ENV["PATH"]}"
+
+    # Add Gem binary directory and (if missing) Ruby binary directory to PATH.
+    path = ENV["PATH"].split(File::PATH_SEPARATOR)
+    path.unshift(RUBY_BIN) if which("ruby") != RUBY_PATH
+    path.unshift("#{Gem.user_dir}/bin")
+    ENV["PATH"] = path.join(File::PATH_SEPARATOR)
 
     if Gem::Specification.find_all_by_name(gem, version).empty?
       ohai "Installing or updating '#{gem}' gem"


### PR DESCRIPTION
Putting the Ruby 1.8 we use to run tests on 10.9 into the PATH adversely affects formulae with a Ruby dependency (possibly other formulae, too). Remove this hack, as it is no longer needed.