### PR TITLE
enable static lib for pango

### DIFF
--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -47,6 +47,7 @@ class Pango < Formula
       --with-html-dir=#{share}/doc
       --enable-introspection=yes
       --without-xft
+      --enable-static
     ]
 
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
I am trying to statically link `librsvg` into my application but the static library for `pango` is missing.