### PR TITLE
enable static libs for gdk-pixbuf

### DIFF
--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -32,6 +32,7 @@ class GdkPixbuf < Formula
             "--prefix=#{prefix}",
             "--enable-introspection=yes",
             "--disable-Bsymbolic",
+            "--enable-static",
             "--without-gdiplus",]
 
     args << "--enable-relocations" if build.with?("relocations")


### PR DESCRIPTION
I am trying to statically link `librsvg` into my application but the static library for `gdk-pixbuf` is missing.