### PR TITLE
doctor: use respond_to? instead of NoMethodError

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -21,13 +21,13 @@ module Homebrew
 
     first_warning = true
     methods.each do |method|
-      begin
-        out = checks.send(method)
-      rescue NoMethodError
+      unless checks.respond_to?(method)
         Homebrew.failed = true
         puts "No check available by the name: #{method}"
         next
       end
+
+      out = checks.send(method)
       unless out.nil? || out.empty?
         if first_warning
           $stderr.puts <<-EOS.undent


### PR DESCRIPTION
I’m not sure why the code uses `NoMethodError` instead of `respond_to?`. If an existing check calls an unexisting function the current code says the check doesn’t exist even if it does.