### PR TITLE
libgit2: build, install examples.

### DIFF
--- a/Library/Formula/libgit2.rb
+++ b/Library/Formula/libgit2.rb
@@ -21,6 +21,7 @@ class Libgit2 < Formula
 
   def install
     args = std_cmake_args
+    args << "-DBUILD_EXAMPLES=YES"
     args << "-DBUILD_CLAR=NO" # Don't build tests.
     args << "-DUSE_SSH=NO" if build.without? "libssh2"
 
@@ -32,6 +33,13 @@ class Libgit2 < Formula
     mkdir "build" do
       system "cmake", "..", *args
       system "make", "install"
+      cd "examples" do
+        (pkgshare/"examples").install "add", "blame", "cat-file", "cgit2",
+                                      "describe", "diff", "for-each-ref",
+                                      "general", "init", "log", "remote",
+                                      "rev-list", "rev-parse", "showindex",
+                                      "status", "tag"
+      end
     end
   end
 


### PR DESCRIPTION
These example programs can be useful for e.g. comparing `git status` behaviour between `git` and `libgit2`.