### PR TITLE
quantlib 1.7

### DIFF
--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -24,6 +24,7 @@ class Quantlib < Formula
 
   # fix for quantlib 1.7 linking conflicts with the boost thread library
   # this patch must be removed when quantlib 1.8 is released, because quantlib maintainers fixed the bug
+  # (see https://github.com/lballabio/QuantLib/commit/d1909593d9f36c6703966460fb48773792facd7e)
   patch :p0 do
     url "https://gist.githubusercontent.com/enricodetoma/7d7b137b69726815f070/raw/aa952c28854df8bf3e95069ba1beb3ec76924644/patch-FRA"
     sha256 "cd5814785b3850bfd88559e94331ac3ae907868c36bfa23dbba41e2ef87cd9d9"

--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -22,6 +22,13 @@ class Quantlib < Formula
 
   option :cxx11
 
+  # fix for quantlib 1.7 linking conflicts with the boost thread library
+  # this patch must be removed when quantlib 1.8 is released, because quantlib maintainers fixed the bug
+  patch :p0 do
+    url "https://gist.githubusercontent.com/enricodetoma/7d7b137b69726815f070/raw/aa952c28854df8bf3e95069ba1beb3ec76924644/patch-FRA"
+    sha256 "cd5814785b3850bfd88559e94331ac3ae907868c36bfa23dbba41e2ef87cd9d9"
+  end
+
   if build.cxx11?
     depends_on "boost" => "c++11"
   else

--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -1,9 +1,9 @@
 class Quantlib < Formula
   desc "Library for quantitative finance"
   homepage "http://quantlib.org/"
-  url "https://downloads.sourceforge.net/project/quantlib/QuantLib/1.6.1/QuantLib-1.6.1.tar.gz"
-  mirror "https://distfiles.macports.org/QuantLib/QuantLib-1.6.1.tar.gz"
-  sha256 "4f90994671173ef20d2bfd34cefc79f753370d79eccafaec926db8c4b6c37870"
+  url "https://downloads.sourceforge.net/project/quantlib/QuantLib/1.7/QuantLib-1.7.tar.gz"
+  mirror "https://distfiles.macports.org/QuantLib/QuantLib-1.7.tar.gz"
+  sha256 "4b6f595bcac4fa319f0dc1211ab93df461a6266c70b2fc479aaccc746eb18c9b"
 
   head do
     url "https://github.com/lballabio/quantlib.git"


### PR DESCRIPTION
QuantLib 1.6.1 doesn't compile correctly with Boost 1.59, so this is a necessary update.