### PR TITLE
gitignore: reorder, cleanup and document.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,13 @@
+# First, ignore everything.
 /*
-!/.gitignore
-!/.travis.yml
-!/.yardopts
-!/Library/
-!/CODEOFCONDUCT.md
-!/CONTRIBUTING.md
-!/LICENSE.txt
-!/README.md
-!/SUPPORTERS.md
-!/bin
-/bin
-!/bin/brew
-!/share
-/share
-!/share/doc
-/share/doc
-!/share/doc/homebrew
-!/share/man/man1/brew.1
+
+# Explicitly ignore OS X Finder thumbnail files.
 .DS_Store
+
+# Unignore the contents of `Library` as that's where our code lives.
+!/Library/
+
+# Ignore generated files within `Library` (again).
 /Library/Homebrew/doc
 /Library/Homebrew/test/.bundle
 /Library/Homebrew/test/bin
@@ -26,5 +16,29 @@
 /Library/Homebrew/test/fs_leak_log
 /Library/LinkedKegs
 /Library/PinnedKegs
-/Library/Taps
 /Library/PinnedTaps
+/Library/Taps
+
+# Ignore `bin` contents (again).
+/bin
+
+# Unignore our `brew` script.
+!/bin/brew
+
+# Ignore `share` contents (again).
+/share
+/share/doc
+
+# Unignore our documentation.
+!/share/doc/homebrew
+!/share/man/man1/brew.1
+
+# Unignore our root-level metadata files.
+!/.gitignore
+!/.travis.yml
+!/.yardopts
+!/CODEOFCONDUCT.md
+!/CONTRIBUTING.md
+!/LICENSE.txt
+!/README.md
+!/SUPPORTERS.md


### PR DESCRIPTION
This new `.gitignore` format produces consistent/expected `git status` output with Git <2.7.0, Git >2.7.0 and libgit2 0.23.4.

Motivated by https://github.com/Homebrew/homebrew/issues/47710 and being annoyed that `libgit2` applications got very upset with our previous rules.

