### PR TITLE
Revert "rakudo-star 2015.12"

### DIFF
--- a/Library/Formula/rakudo-star.rb
+++ b/Library/Formula/rakudo-star.rb
@@ -1,8 +1,8 @@
 class RakudoStar < Formula
   desc "Perl 6 compiler"
   homepage "http://rakudo.org/"
-  url "https://github.com/rakudo/rakudo/archive/2015.12.tar.gz"
-  sha256 "d7c4fd1c8bc525e16cefe2d28513dcd9642ecbed37775cd2a89b324a62278780"
+  url "http://rakudo.org/downloads/star/rakudo-star-2015.11.tar.gz"
+  sha256 "714aed706706f02efeadc0d7e4c7ad216de5ded80d4a1b2879c275d5d05beae7"
 
   bottle do
     sha256 "1dc08a7a33242131b827e7e266b8af9d3fb630dba738f9c22250de77a7088eb1" => :el_capitan
@@ -24,7 +24,7 @@ class RakudoStar < Formula
     ENV.remove "CPPFLAGS", "-I#{libffi.include}"
     ENV.prepend "CPPFLAGS", "-I#{libffi.lib}/libffi-#{libffi.version}/include"
 
-    ENV.j1 # An intermittent race condition causes random build failures.
+    ENV.j1  # An intermittent race condition causes random build failures.
 
     backends = ["moar"]
     generate = ["--gen-moar"]


### PR DESCRIPTION
This reverts commit 0a7d36bc3a5e74358a55100becec5441d4ecee9c.
There is not yet a rakudo-star release for the 2015.12 release of rakudo. This brew is for
Rakudo Star, not just the Rakudo compiler on its own.