### PR TITLE
update: abbreviate commit hashes to 7 characters

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -41,8 +41,8 @@ module Homebrew
     master_updater.pull!
     master_updated = master_updater.updated?
     if master_updated
-      puts "Updated Homebrew from #{master_updater.initial_revision[0, 8]} " \
-           "to #{master_updater.current_revision[0, 8]}."
+      puts "Updated Homebrew from #{master_updater.initial_revision[0, 7]} " \
+           "to #{master_updater.current_revision[0, 7]}."
     end
     report.update(master_updater.report)
 


### PR DESCRIPTION
This makes it consistent with `git rev-parse --short`,
https://github.com/Homebrew/homebrew/commits, etc

For example, instead of:

    Updated Homebrew from 40d1e9c2 to 90b9bdf4.

We see:

    Updated Homebrew from 40d1e9c to 90b9bdf.

See 0c48248 for the original introduction of eight-character
abbreviations.