### PR TITLE
xcode: auto-select Xcode prefix more carefully

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -32,7 +32,11 @@ module Homebrew
       @xcode
     elsif MacOS::Xcode.installed?
       @xcode = MacOS::Xcode.version
-      @xcode += " => #{MacOS::Xcode.prefix}" unless MacOS::Xcode.default_prefix?
+      if MacOS::Xcode.auto_selected?
+        @xcode += " => #{MacOS::Xcode.prefix} (auto-selected)"
+      elsif !MacOS::Xcode.default_prefix?
+        @xcode += " => #{MacOS::Xcode.prefix}"
+      end
       @xcode
     end
   end


### PR DESCRIPTION
Addresses #47579 by no longer accepting the first Xcode found by Spotlight, but only one that is (on modern systems) inside `/Applications/Xcode.app`. (This only applies if the CLT are selected via `xcode-select` instead of some Xcode installation.)

This should avoid picking up arbitrary Xcode installations while still retaining some magic as to not break a typical user installation, where we have recommended to use the CLT in most cases. Also, `brew config` now reports whether Xcode was auto-selected by Homebrew or not.

The relevant lines of `brew config` for various scenarios now look like this:

```
$ sudo xcode-select -s /Library/Developer/CommandLineTools # no Xcode installed
Xcode: N/A
CLT: 7.2.0.0.1.1447826929

$ sudo xcode-select -s /Library/Developer/CommandLineTools # with Xcode installed
Xcode: 7.2 => /Applications/Xcode.app/Contents/Developer (auto-selected)
CLT: 7.2.0.0.1.1447826929

$ sudo xcode-select -s /Applications/Xcode.app
Xcode: 7.2
CLT: 7.2.0.0.1.1447826929

$ sudo xcode-select -s /Volumes/DeveloperStuff/Xcode/Xcode-7.0.1.app
Xcode: 7.0.1 => /Volumes/DeveloperStuff/Xcode/Xcode-7.0.1.app/Contents/Developer
CLT: 7.2.0.0.1.1447826929
```

cc @mistydemeo @mikemcquaid @apjanke 