### PR TITLE
doctor: simplify handling of slow checks

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -1289,9 +1289,13 @@ module Homebrew
     inject_dump_stats(checks) if ARGV.switch? "D"
 
     if ARGV.named.empty?
-      methods = checks.all.sort
-      methods << "check_for_linked_keg_only_brews" << "check_for_outdated_homebrew"
-      methods = methods.reverse.uniq.reverse
+      slow_checks = %w[
+        check_for_broken_symlinks
+        check_missing_deps
+        check_for_outdated_homebrew
+        check_for_linked_keg_only_brews
+      ]
+      methods = (checks.all.sort - slow_checks) + slow_checks
     else
       methods = ARGV.named
     end


### PR DESCRIPTION
Some (rather slow) checks should run after all other checks. Make that more obvious by removing them from the sorted list of all checks and then re-appending them to the resulting list. (Should also be slightly more efficient than the `<array>.reverse.uniq.reverse` incantation, though that hardly matters given the cumulated run time of all the checks.)