### PR TITLE
Improve `brew` script robustness

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 chdir() {
   cd "$@" >/dev/null

--- a/bin/brew
+++ b/bin/brew
@@ -5,7 +5,7 @@ chdir() {
 }
 
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
-if [ "$(locale charmap 2> /dev/null)" != "UTF-8" ]
+if [[ "$(locale charmap 2> /dev/null)" != "UTF-8" ]]
 then
   export LC_ALL="en_US.UTF-8"
 fi
@@ -13,7 +13,7 @@ fi
 BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
 HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"
 
-if [ -L "$HOMEBREW_BREW_FILE" ]
+if [[ -L "$HOMEBREW_BREW_FILE" ]]
 then
   BREW_SYMLINK="$(readlink "$HOMEBREW_BREW_FILE")"
   BREW_SYMLINK_DIRECTORY="$(dirname "$BREW_SYMLINK")"
@@ -28,14 +28,14 @@ BREW_LIBRARY_DIRECTORY="$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)"
 unset GEM_HOME
 unset GEM_PATH
 
-if [ -z "$HOMEBREW_DEVELOPER" ]
+if [[ -z "$HOMEBREW_DEVELOPER" ]]
 then
   unset HOMEBREW_RUBY_PATH
 fi
 
-if [ -z "$HOMEBREW_RUBY_PATH" ]
+if [[ -z "$HOMEBREW_RUBY_PATH" ]]
 then
-  if [ "$(uname -s)" = "Darwin" ]
+  if [[ "$(uname -s)" = "Darwin" ]]
   then
     HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
   else


### PR DESCRIPTION
##### [Update script hashbang to a more robust version](https://github.com/Homebrew/homebrew/commit/4a745d10c247579abb10d1a0d2a819225f1a8c69)

Given the variety of operating systems and configurations, there's not any good certainty about where `bash` is installed. That's why this use the `env` program to find it, resulting in a bit more robust script. A great explanation via [Bash.academy](http://guide.bash.academy/02.commands.html).

##### [Update obsolete test expression syntax \[ to \[\[](https://github.com/Homebrew/homebrew/commit/4a745d10c247579abb10d1a0d2a819225f1a8c69)
`[[` is an improved version of `[`, and it's a keyword, not a program. Besides, it's easier to use, more powerful, and maintains consistency with other scripts in the repo such as [brew_bash_completion.sh](https://github.com/Homebrew/homebrew/blob/master/Library/Contributions/brew_bash_completion.sh). More details via [Bash Hacker](http://wiki.bash-hackers.org/scripting/obsolete).