### PR TITLE
update: abbreviate hashes to at least 7 characters

### DIFF
--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -41,8 +41,8 @@ module Homebrew
     master_updater.pull!
     master_updated = master_updater.updated?
     if master_updated
-      initial_revision_short = shortenRevision(master_updater.initial_revision)
-      current_revision_short = shortenRevision(master_updater.current_revision)
+      initial_revision_short = shorten_revision(master_updater.initial_revision)
+      current_revision_short = shorten_revision(master_updater.current_revision)
       puts "Updated Homebrew from #{initial_revision_short} " \
            "to #{current_revision_short}."
     end
@@ -133,11 +133,11 @@ module Homebrew
     Descriptions.update_cache(report)
   end
 
-  def shortenRevision(revision)
+  private
+
+  def shorten_revision(revision)
     `git rev-parse --short #{revision}`.chomp
   end
-
-  private
 
   def git_init_if_necessary
     if Dir[".git/*"].empty?

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -41,8 +41,10 @@ module Homebrew
     master_updater.pull!
     master_updated = master_updater.updated?
     if master_updated
-      puts "Updated Homebrew from #{`git rev-parse --short #{master_updater.initial_revision}`.strip} " \
-           "to #{`git rev-parse --short #{master_updater.current_revision}`.strip}."
+      initial_revision_short = shortenRevision(master_updater.initial_revision)
+      current_revision_short = shortenRevision(master_updater.current_revision)
+      puts "Updated Homebrew from #{initial_revision_short} " \
+           "to #{current_revision_short}."
     end
     report.update(master_updater.report)
 
@@ -129,6 +131,10 @@ module Homebrew
       report.dump
     end
     Descriptions.update_cache(report)
+  end
+
+  def shortenRevision(revision)
+    `git rev-parse --short #{revision}`.chomp
   end
 
   private

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -41,8 +41,8 @@ module Homebrew
     master_updater.pull!
     master_updated = master_updater.updated?
     if master_updated
-      puts "Updated Homebrew from #{master_updater.initial_revision[0, 8]} " \
-           "to #{master_updater.current_revision[0, 8]}."
+      puts "Updated Homebrew from #{`git rev-parse --short #{master_updater.initial_revision}`.strip} " \
+           "to #{`git rev-parse --short #{master_updater.current_revision}`.strip}."
     end
     report.update(master_updater.report)
 

--- a/Library/Homebrew/cmd/update.rb
+++ b/Library/Homebrew/cmd/update.rb
@@ -41,10 +41,9 @@ module Homebrew
     master_updater.pull!
     master_updated = master_updater.updated?
     if master_updated
-      initial_revision_short = shorten_revision(master_updater.initial_revision)
-      current_revision_short = shorten_revision(master_updater.current_revision)
-      puts "Updated Homebrew from #{initial_revision_short} " \
-           "to #{current_revision_short}."
+      initial_short = shorten_revision(master_updater.initial_revision)
+      current_short = shorten_revision(master_updater.current_revision)
+      puts "Updated Homebrew from #{initial_short} to #{current_short}."
     end
     report.update(master_updater.report)
 


### PR DESCRIPTION
(see https://github.com/Homebrew/homebrew/pull/47746#issuecomment-169436995)

Abbreviations will be longer if needed to preserve uniqueness.

This makes it more consistent with `git rev-parse --short`,
https://github.com/Homebrew/homebrew/commits, etc

For example, instead of:

    Updated Homebrew from 40d1e9c2 to 90b9bdf4.

We see:

    Updated Homebrew from 40d1e9c to 90b9bdf.

See 0c48248 for the original introduction of eight-character
abbreviations.