### PR TITLE
Add mysql option to libgda

### DIFF
--- a/Library/Formula/libgda.rb
+++ b/Library/Formula/libgda.rb
@@ -22,6 +22,8 @@ class Libgda < Formula
   depends_on "libgcrypt"
   depends_on "sqlite"
   depends_on "openssl"
+  depends_on "mysql" => :optional
+  depends_on "mysql56" => :optional
 
   def install
     ENV.libxml2


### PR DESCRIPTION
libgda can use mysql as a parser provider, however we need to
./configure it with mysql installed.
This will make sure mysql dependency is there and will not use the
bottle which doesnt have mysql on it.

review @mikemcquaid 