### PR TITLE
diagnostic: warn on outdated OS X versions.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -311,7 +311,7 @@ module Homebrew
             We do not provide support for this pre-release version.
             You may encounter build failures or other breakages.
           EOS
-        elsif OS::Mac.version < :mavericks
+        elsif OS::Mac.outdated_release?
           <<-EOS.undent
             You are using OS X #{MacOS.version}.
             We (and Apple) do not provide support for this old version.

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -304,11 +304,19 @@ module Homebrew
       end
 
       def check_for_unsupported_osx
-        if !ARGV.homebrew_developer? && OS::Mac.prerelease? then <<-EOS.undent
-        You are using OS X #{MacOS.version}.
-        We do not provide support for this pre-release version.
-        You may encounter build failures or other breakages.
-        EOS
+        return if ARGV.homebrew_developer?
+        if OS::Mac.prerelease?
+          <<-EOS.undent
+            You are using OS X #{MacOS.version}.
+            We do not provide support for this pre-release version.
+            You may encounter build failures or other breakages.
+          EOS
+        elsif OS::Mac.version < :mavericks
+          <<-EOS.undent
+            You are using OS X #{MacOS.version}.
+            We (and Apple) do not provide support for this old version.
+            You may encounter build failures or other breakages.
+          EOS
         end
       end
 

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -28,6 +28,11 @@ module OS
       version >= "10.12"
     end
 
+    def outdated_release?
+      # TODO: bump version when new OS is released
+      version < "10.9"
+    end
+
     def cat
       version.to_sym
     end


### PR DESCRIPTION
We don't have CI or new bottles for them so they aren't supported well so we should warn users.