### PR TITLE
clang-format 2016-01-05

### DIFF
--- a/Library/Formula/clang-format.rb
+++ b/Library/Formula/clang-format.rb
@@ -1,18 +1,20 @@
 class ClangFormat < Formula
   desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
   homepage "http://clang.llvm.org/docs/ClangFormat.html"
-  version "2015-09-01"
+  version "2016-01-05"
 
   stable do
-    url "http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_370/final/", :using => :svn
+    url "http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz"
+    sha256 "be7794ed0cec42d6c682ca8e3517535b54555a3defabec83554dbc74db545ad5"
 
     resource "clang" do
-      url "http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_370/final/", :using => :svn
+      url "http://llvm.org/releases/3.7.1/cfe-3.7.1.src.tar.xz"
+      sha256 "56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/releases/3.7.0/libcxx-3.7.0.src.tar.xz"
-      sha256 "c18f3c8333cd7e678c1424a57fe5e25efe740ca7caf62ac67152b4723f3ad08e"
+      url "http://llvm.org/releases/3.7.1/libcxx-3.7.1.src.tar.xz"
+      sha256 "357fbd4288ce99733ba06ae2bec6f503413d258aeebaab8b6a791201e6f7f144"
     end
   end
 
@@ -31,8 +33,8 @@ class ClangFormat < Formula
     end
 
     resource "libcxx" do
-      url "http://llvm.org/releases/3.6.2/libcxx-3.6.2.src.tar.xz"
-      sha256 "52f3d452f48209c9df1792158fdbd7f3e98ed9bca8ebb51fcd524f67437c8b81"
+      url "http://llvm.org/releases/3.7.1/libcxx-3.7.1.src.tar.xz"
+      sha256 "357fbd4288ce99733ba06ae2bec6f503413d258aeebaab8b6a791201e6f7f144"
     end
   end
 


### PR DESCRIPTION
Updated clang-format to 3.7.1 release (available since Jan 05, 2016).

While at it, I also changed the version field to reflect that it's not a development snapshot.