### PR TITLE
formula_installer: don't install build dep if dependent is installed

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -334,7 +334,7 @@ class FormulaInstaller
 
       if (dep.optional? || dep.recommended?) && build.without?(dep)
         Dependency.prune
-      elsif dep.build? && install_bottle_for?(dependent, build)
+      elsif dep.build? && (install_bottle_for?(dependent, build) || dependent.installed?)
         Dependency.prune
       elsif dep.satisfied?(options)
         Dependency.skip


### PR DESCRIPTION
**Important Note** The fix may be incorrect. See https://github.com/Homebrew/homebrew/pull/47816#issuecomment-169686926