### PR TITLE
mg: 20160103

### DIFF
--- a/Library/Formula/mg.rb
+++ b/Library/Formula/mg.rb
@@ -1,24 +1,13 @@
 class Mg < Formula
   desc "Small Emacs-like editor"
-  homepage "http://homepage.boetes.org/software/mg/"
-  url "http://homepage.boetes.org/software/mg/mg-20131118.tar.gz"
-  sha256 "b99fe10cb8473e035ff43bf3fbf94a24035e4ebb89484d48e5b33075d22d79f3"
-
-  depends_on "clens"
+  homepage "http://devio.us/~bcallah/mg/"
+  url "http://devio.us/~bcallah/mg/mg-20160103.tar.gz"
+  sha256 "4abd059ba3e0d59626104a21812ae33a37ee1f6ddaafdb33511f38d21057fae6"
 
   conflicts_with "mg3a", :because => "both install `mg` binaries"
 
   def install
-    # makefile hardcodes include path to clens; since it's a
-    # nonstandard path, Homebrew's standard include paths won't
-    # fix this for people with nonstandard prefixes.
-    # Note mg also has a Makefile; but MacOS make uses GNUmakefile
-    inreplace "GNUmakefile", "$(includedir)/clens", "#{Formula["clens"].opt_include}/clens"
-
-    system "make"
-    bin.install "mg"
-    doc.install "tutorial"
-    man1.install "mg.1"
+    system "make", "install", "PREFIX=#{prefix}", "MANDIR=#{man}"
   end
 
   test do


### PR DESCRIPTION
⚠️ This is not a pure update!

This change switches mg to the most recent version from Brian Callahan.
This version of mg is actually portable (recent versions build on OS X)
and regularly synced with OpenBSD.

The removal of clens happened upstream to both distributions.