### PR TITLE
itstool: fix runtime libxml2 breakage

### DIFF
--- a/Library/Formula/itstool.rb
+++ b/Library/Formula/itstool.rb
@@ -3,7 +3,7 @@ class Itstool < Formula
   homepage "http://itstool.org/"
   url "http://files.itstool.org/itstool/itstool-2.0.2.tar.bz2"
   sha256 "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -24,8 +24,22 @@ class Itstool < Formula
 
   def install
     ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python2.7/site-packages"
+
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{libexec}"
     system "make", "install"
+
+    bin.install Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    pkgshare.install_symlink libexec/"share/itstool/its"
+    man1.install_symlink libexec/"share/man/man1/itstool.1"
+  end
+
+  test do
+    (testpath/"test.xml").write <<-EOS.undent
+      <tag>Homebrew</tag>
+    EOS
+    system bin/"itstool", "-o", "test.pot", "test.xml"
+    assert_match "msgid \"Homebrew\"", File.read("test.pot")
   end
 end


### PR DESCRIPTION
The lack of test here means we've been missing this for a while, apparently.

Closes #47667.