### PR TITLE
tests: missing requires added

### DIFF
--- a/Library/Homebrew/test/test_caveats.rb
+++ b/Library/Homebrew/test/test_caveats.rb
@@ -1,4 +1,6 @@
 require "testing_env"
+require "formula"
+require "caveats"
 
 class CaveatsTests < Homebrew::TestCase
   def setup

--- a/Library/Homebrew/test/test_checksum_verification.rb
+++ b/Library/Homebrew/test/test_checksum_verification.rb
@@ -1,4 +1,5 @@
 require "testing_env"
+require "formula"
 
 class ChecksumVerificationTests < Homebrew::TestCase
   def assert_checksum_good

--- a/Library/Homebrew/test/test_formula_support.rb
+++ b/Library/Homebrew/test/test_formula_support.rb
@@ -1,4 +1,5 @@
 require "testing_env"
+require "formula_support"
 
 class KegOnlyReasonTests < Homebrew::TestCase
   def test_to_s_explanation

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -1,4 +1,7 @@
 require "testing_env"
+require "formula"
+require "formula_installer"
+require "bottles"
 
 class FormularyTest < Homebrew::TestCase
   def test_class_naming

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -3,6 +3,7 @@ $:.unshift File.expand_path("../lib", __FILE__)
 
 require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
 require "global"
+require "formulary"
 
 # Test environment setup
 %w[ENV Formula].each { |d| HOMEBREW_LIBRARY.join(d).mkpath }


### PR DESCRIPTION
Fixes #47861.

Some files are not `require`d if you run a specific test file with e.g. `brew tests TEST=test_formulary.rb`. This PR fixes that.