### PR TITLE
tlcr 0.3.0 (new formula)

### DIFF
--- a/Library/Formula/tlcr.rb
+++ b/Library/Formula/tlcr.rb
@@ -1,0 +1,24 @@
+class Tlcr < Formula
+  desc "Simple terminal-based client for TLDR pages, written in Crystal"
+  homepage "https://github.com/porras/tlcr"
+  url "https://github.com/porras/tlcr/archive/0.3.0.tar.gz"
+  sha256 "d0f8be0b5d85fe0ed9587da4d32bdf7c8c401014bca83200aa8833f64d40b0c9"
+  head "https://github.com/porras/tlcr.git"
+
+  depends_on "crystal-lang" => :build
+  depends_on "openssl"
+  depends_on "libevent"
+  depends_on "libpcl"
+  depends_on "bdw-gc"
+
+  def install
+    system "shards"
+    system "crystal", "build", "--release", "tlcr.cr"
+    bin.install "tlcr"
+    doc.install "LICENSE"
+  end
+
+  test do
+    system "tlcr", "--version"
+  end
+end


### PR DESCRIPTION
[`tlcr`](http://github.com/porras/tlcr) is a simple terminal-based client for [TLDR pages](http://tldr-pages.github.io/), written in [Crystal](http://crystal-lang.org/). Once compiled, it is a single binary, dinamically linked to the libraries configured as dependencies.