### PR TITLE
truncate 0.9: truncate a file to a given size

### DIFF
--- a/Library/Formula/truncate.rb
+++ b/Library/Formula/truncate.rb
@@ -1,10 +1,10 @@
 class Truncate < Formula
   desc "truncates a file to a given size"
   homepage "http://www.vanheusden.com/truncate"
-  url "http://www.vanheusden.com/truncate/truncate-0.8.tgz"
-  sha256 "165914d643351324d69096427d3ce5d3ab13aed3f7c990a71ba3bd0c6f278f00"
-
-  patch :DATA # remove missing file; rename syscalls for OSX which are natively 64bit
+  url "https://github.com/flok99/truncate/archive/fc30a29dab789249f0c5f6863fdc5c8d4c9c3f69.zip"
+  version "0.9"
+  sha256 "f63a767555aa2edae2f340bf349465b98c636e54d211e00dd6501b702fa1837d"
+  head "https://github.com/flok99/truncate.git"
 
   def install
     system "make"
@@ -16,24 +16,3 @@ class Truncate < Formula
     system "#{bin}/truncate", "-s", "1k", "testfile"
   end
 end
-__END__
-diff -Naur truncate-0.8/truncate.c truncate/truncate.c
---- truncate-0.8/truncate.c	2009-04-03 14:39:56 +0800
-+++ truncate/truncate.c	2016-01-09 12:26:28 +0800
-@@ -9,7 +9,15 @@
- #include <sys/stat.h>
- #include <fcntl.h>
-
--#include "error.h"
-+//#include "error.h"
-+void error_exit(char *format, ...);
-+
-+#ifdef __APPLE__
-+#define off64_t off_t
-+#define stat64 stat
-+#define ftruncate64 ftruncate
-+#define fstat64 fstat
-+#endif
-
- off64_t get_file_size(char *file_name)
- {

--- a/Library/Formula/truncate.rb
+++ b/Library/Formula/truncate.rb
@@ -17,20 +17,23 @@ class Truncate < Formula
   end
 end
 __END__
-diff --git a/truncate.c b/truncate.c
-index 3dcb0d0..53cb190 100644
---- a/truncate.c
-+++ b/truncate.c
-@@ -9,79,11 @@
+diff -Naur truncate-0.8/truncate.c truncate/truncate.c
+--- truncate-0.8/truncate.c	2009-04-03 14:39:56 +0800
++++ truncate/truncate.c	2016-01-09 12:26:28 +0800
+@@ -9,7 +9,15 @@
  #include <sys/stat.h>
  #include <fcntl.h>
- 
+
 -#include "error.h"
++//#include "error.h"
++void error_exit(char *format, ...);
++
 +#ifdef __APPLE__
 +#define off64_t off_t
 +#define stat64 stat
 +#define ftruncate64 ftruncate
++#define fstat64 fstat
 +#endif
- 
+
  off64_t get_file_size(char *file_name)
  {

--- a/Library/Formula/truncate.rb
+++ b/Library/Formula/truncate.rb
@@ -1,9 +1,8 @@
 class Truncate < Formula
   desc "truncates a file to a given size"
   homepage "http://www.vanheusden.com/truncate"
-  url "https://github.com/flok99/truncate/archive/fc30a29dab789249f0c5f6863fdc5c8d4c9c3f69.zip"
-  version "0.9"
-  sha256 "f63a767555aa2edae2f340bf349465b98c636e54d211e00dd6501b702fa1837d"
+  url "https://github.com/flok99/truncate/archive/0.9.tar.gz"
+  sha256 "a959d50cf01a67ed1038fc7814be3c9a74b26071315349bac65e02ca23891507"
   head "https://github.com/flok99/truncate.git"
 
   def install

--- a/Library/Formula/truncate.rb
+++ b/Library/Formula/truncate.rb
@@ -1,0 +1,36 @@
+class Truncate < Formula
+  desc "truncates a file to a given size"
+  homepage "http://www.vanheusden.com/truncate"
+  url "http://www.vanheusden.com/truncate/truncate-0.8.tgz"
+  sha256 "165914d643351324d69096427d3ce5d3ab13aed3f7c990a71ba3bd0c6f278f00"
+
+  patch :DATA # remove missing file; rename syscalls for OSX which are natively 64bit
+
+  def install
+    system "make"
+    bin.install "truncate"
+    man1.install "truncate.1"
+  end
+
+  test do
+    system "#{bin}/truncate", "-s", "1k", "testfile"
+  end
+end
+__END__
+diff --git a/truncate.c b/truncate.c
+index 3dcb0d0..53cb190 100644
+--- a/truncate.c
++++ b/truncate.c
+@@ -9,79,11 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ 
+-#include "error.h"
++#ifdef __APPLE__
++#define off64_t off_t
++#define stat64 stat
++#define ftruncate64 ftruncate
++#endif
+ 
+ off64_t get_file_size(char *file_name)
+ {


### PR DESCRIPTION
I find #44738 is closed by the author. However, I do think this tool is useful.

Found this on MacPorts. Took the latest version by artw.

~~Patch modified by me to get rid of all warnings.~~

Now use the author's github repo as source. All patches have been merged to upstream.

Since the source has been patched and is different from v0.8, I tag it as v0.9 now.