### PR TITLE
formula_installed: tweak source build behaviour.

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -42,9 +42,15 @@ module Homebrew
   end
 
   def fetch_bottle?(f)
-    return true if ARGV.force_bottle? && f.bottle
-    return false unless f.bottle && f.pour_bottle?
-    return false if ARGV.build_from_source? || ARGV.build_bottle?
+    return false unless f.bottle
+    return true if ARGV.force_bottle?
+    return false unless f.pour_bottle?
+    # We want to behave different with `--build-from-source` and
+    # ENV["HOMEBREW_BUILD_FROM_SOURCE"] because the latter implies you want
+    # everything built from source and the prior that you want just the
+    # formulae you've requested built from source.
+    return false if ENV["HOMEBREW_BUILD_FROM_SOURCE"]
+    return false if ARGV.build_bottle?
     return false unless f.bottle.compatible_cellar?
     true
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -98,8 +98,13 @@ class FormulaInstaller
 
   def install_bottle_for?(dep, build)
     return pour_bottle? if dep == formula
-    return false if build_from_source?
-    return false unless dep.bottle && dep.pour_bottle?
+    # We want to behave different with `--build-from-source` and
+    # ENV["HOMEBREW_BUILD_FROM_SOURCE"] because the latter implies you want
+    # everything built from source and the prior that you want just the
+    # formulae you've requested built from source.
+    return false if ENV["HOMEBREW_BUILD_FROM_SOURCE"]
+    return false unless dep.bottle
+    return false unless dep.pour_bottle?
     return false unless build.used_options.empty?
     return false unless dep.bottle.compatible_cellar?
     true


### PR DESCRIPTION
Currently `brew install —build-from-source wget` builds all the
dependencies also from source. I can see people wanting to do this when
`HOMEBREW_BUILD_FROM_SOURCE` is set by passing it on the command-line
is mostly just annoying; it means you have to use `—build-bottle` and
deal with the CFLAGS and `post_install` changes if you want to build
from source. Tweak `formula_installer` so this behaviour is more
intuitive.