### PR TITLE
formula_installer: allow pouring bottles without default_formula.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -286,7 +286,7 @@ class FormulaInstaller
 
   def install_requirement_default_formula?(req, dependent, build)
     return false unless req.default_formula?
-    return true unless req.satisfied?
+    return false if req.satisfied?
     return false if req.run?
     install_bottle_for?(dependent, build) || build_bottle?
   end


### PR DESCRIPTION
This was a change made long ago for safety, mostly around Python
packages. It’s now no longer needed and in most places it causes more
annoyance/confusion than it solves. If there’s interest: I can add a
DSL to `default_formula` to allow the requirement to decide when a
bottle should be used/not.

As far as I’m aware this is the main thing stopping us bottling e.g.
Vim and friends.