### PR TITLE
formula_installer: build formula options better.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -349,6 +349,7 @@ class FormulaInstaller
     args  = dependent.build.used_options
     args |= dependent == formula ? options : inherited_options
     args |= Tab.for_formula(dependent).used_options
+    args &= dependent.options
     BuildOptions.new(args, dependent.options)
   end
 


### PR DESCRIPTION
Previously we got all the options based on the build, any inherited
options, any passed options and the tab. We want to make sure that these
then exclude any options that don't exist as, otherwise, passing an
option that doesn't exist (or has been deleted) is enough to stop a
bottle being poured. This was particularly nasty on upgrades where we
deleted options and one left in the tab would stop the bottle being
poured.

CC @DomT4 