### PR TITLE
audit: check for more unused shorthand

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -855,6 +855,14 @@ class FormulaAuditor
       if line =~ /(require ["']formula["'])/
         problem "`#{$1}` is now unnecessary"
       end
+
+      if line =~ /#\{share\}\/#{formula.name}/
+        problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
+      end
+
+      if line =~ /share\/"#{formula.name}"/
+        problem "Use pkgshare instead of (share/\"#{formula.name}\")"
+      end
     end
   end
 


### PR DESCRIPTION
Adding a strict check for usage that should be using pkgshare.

Pulled onto two unique checks to provide a better problem message, with a clearer solution, but open to thoughts.

```
 * Use #{pkgshare} instead of #{share}/example
 * Use pkgshare instead of (share/"example")
```