### PR TITLE
ruby: clean up

### DIFF
--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -46,7 +46,9 @@ class Ruby < Formula
     system "autoconf" if build.head?
 
     args = %W[
-      --prefix=#{prefix} --enable-shared --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-shared
+      --disable-silent-rules
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
@@ -56,7 +58,7 @@ class Ruby < Formula
       args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
     end
 
-    args << "--program-suffix=23" if build.with? "suffix"
+    args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--with-out-ext=tk" if build.without? "tcltk"
     args << "--disable-install-doc" if build.without? "doc"
     args << "--disable-dtrace" unless MacOS::CLT.installed?
@@ -106,12 +108,22 @@ class Ruby < Formula
     config_file.write rubygems_config
 
     # Create the sitedir and vendordir that were skipped during install
-    mkdir_p `#{bin}/ruby -e 'require "rbconfig"; print RbConfig::CONFIG["sitearchdir"]'`
-    mkdir_p `#{bin}/ruby -e 'require "rbconfig"; print RbConfig::CONFIG["vendorarchdir"]'`
+    ruby="#{bin}/ruby#{program_suffix}"
+    %w[sitearchdir vendorarchdir].each do |dir|
+      mkdir_p `#{ruby} -rrbconfig -e 'print RbConfig::CONFIG["#{dir}"]'`
+    end
   end
 
   def abi_version
     "2.3.0"
+  end
+
+  def program_suffix
+    build.with?("suffix") ? "23" : ""
+  end
+
+  def rubygems_bindir
+    "#{HOMEBREW_PREFIX}/bin"
   end
 
   def rubygems_config; <<-EOS.undent
@@ -169,18 +181,19 @@ class Ruby < Formula
       end
 
       def self.default_bindir
-        "#{HOMEBREW_PREFIX}/bin"
+        "#{rubygems_bindir}"
       end
 
       def self.ruby
-        "#{opt_bin}/ruby#{"23" if build.with? "suffix"}"
+        "#{opt_bin}/ruby#{program_suffix}"
       end
     end
     EOS
   end
 
   test do
-    output = shell_output("#{bin}/ruby -e \"puts 'hello'\"")
-    assert_match "hello\n", output
+    hello_text = shell_output("#{bin}/ruby#{program_suffix} -e 'puts :hello'")
+    assert_equal "hello\n", hello_text
+    system "#{bin}/gem#{program_suffix}", "list", "--local"
   end
 end


### PR DESCRIPTION
This PR carries over some changes/improvements that were already applied to the various Ruby formulae in `homebrew/versions`, namely:

- **(Removed)** ~~Gems are kept in a version-specific directory. Once a major version bump happens (like from 2.2.4 to 2.3.0), the binary wrappers for Gems that are placed in `HOMEBREW_PREFIX/bin` stop working, because matching Gems only exist in the old Gem directory (of the old Ruby). Rectify this by placing the wrappers in `HOMEBREW_PREFIX/lib/ruby/gems/ABI_VERSION/bin`.~~

- Fix `post_install` and `test` if option `--with-suffix` is specified.

- Reduce some code duplication by introducing `program_suffix` and `rubygems_bindir`. Also some minor stylistic adjustments and a slightly beefed up test.

**(Removed)** ~~I suspect the first change won't make everyone happy (and might require a `revision` bump, too). Hence, here are pros and cons (all paths relative to the Homebrew prefix):~~

- :heavy_plus_sign: ~~Gem binary wrappers are kept in a versioned directory, meaning they are next to the Gems they actually belong to. (If binaries are in `lib/ruby/gems/2.2.0/bin` this will create less of an impression that it makes sense to call them after an update to Ruby 2.3.0.)~~

- :heavy_minus_sign: ~~As explained in the added `caveats`, users will need to modify their `PATH` if they want convenient access to these wrappers. Furthermore, they will need to modify their `PATH` again after a major Ruby upgrade.~~

- :heavy_minus_sign: ~~(Not really a change, except it's actually easier to wipe old Gems and their wrappers.) After a major upgrade, e.g. from 2.2.4 to 2.3.0, the entire `lib/ruby/gems/2.2.0` directory becomes basically useless. In theory it could be taken over by a `ruby22` formula, but the binary wrappers will be broken because they continue to reference `opt/ruby/bin/ruby` in their shebang line.~~