### PR TITLE
audit: don't check recursively unconditionally

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -440,7 +440,11 @@ module Homebrew
         formula_name
       end
 
-      test "brew", "uses", "--recursive", canonical_formula_name
+      if ENV["HOMEBREW_USES_RECURSIVE"]
+        test "brew", "uses", "--recursive", canonical_formula_name
+      else
+        test "brew", "uses", canonical_formula_name
+      end
 
       formula = Formulary.factory(canonical_formula_name)
 
@@ -539,7 +543,11 @@ module Homebrew
       build_dependencies = dependencies - runtime_dependencies
       unchanged_build_dependencies = build_dependencies - @formulae
 
-      dependents = Utils.popen_read("brew", "uses", "--recursive", "--skip-build", "--skip-optional", canonical_formula_name).split("\n")
+      if ENV["HOMEBREW_USES_RECURSIVE"]
+        dependents = Utils.popen_read("brew", "uses", "--recursive", "--skip-build", "--skip-optional", canonical_formula_name).split("\n")
+      else
+        dependents = Utils.popen_read("brew", "uses", "--skip-build", "--skip-optional", canonical_formula_name).split("\n")
+      end
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }
 


### PR DESCRIPTION
There's an issue with either brew or (seemingly more likely) Ruby that blocks this check from running successfully if you have more than a certain number or specific taps tapped.

The error is:
```
Error: stack level too deep
Please report this bug:
    https://git.io/brew-troubleshooting
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/pathname.rb:333
```

This has been killing builds off in the various taps. This isn't really a long-term solution but for now it at least allows builds to proceed whilst we spend some more time getting familiar with this problem.

I went down the `ENV` route because this bug reproduces locally against the core with taps present, so for example I cannot currently run any `brew test-bot` commands against core formulae without it hanging and then dying on that message. We can pass the ENV selectively to Travis and Jenkins in the core easily, so it seems like a nice compromise.

Ref: https://github.com/Homebrew/homebrew/commit/1d3b69dd54c69813d65e80f90ed4ca00de2fd3e6
CC @mikemcquaid @xu-cheng @dunn 