### PR TITLE
acmetool 0.0.34 (new formula)

### DIFF
--- a/Library/Formula/acmetool.rb
+++ b/Library/Formula/acmetool.rb
@@ -8,9 +8,6 @@ class Acmetool < Formula
 
   depends_on "go" => :build
 
-  ###### Generated with homebrew-go-resources ######
-  # homebrew-go-resources github.com/hlandau/acme/cmd/acmetool
-
   go_resource "github.com/alecthomas/template" do
     url "https://github.com/alecthomas/template.git",
       :revision => "14fd436dd20c3cc65242a9f396b61bfc8a3926fc"
@@ -120,8 +117,6 @@ class Acmetool < Formula
     url "https://gopkg.in/yaml.v2.git",
       :revision => "53feefa2559fb8dfa8d81baad31be332c97d6c77"
   end
-
-  ################################################
 
   def install
     ENV["GOBIN"] = bin

--- a/Library/Formula/acmetool.rb
+++ b/Library/Formula/acmetool.rb
@@ -130,9 +130,9 @@ class Acmetool < Formula
     # https://github.com/hlandau/acme/blob/master/_doc/PACKAGING-PATHS.md
     builddate = `date -u "+%Y%m%d%H%M%S"`.strip
     ldflags = <<-LDFLAGS
-        -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acme
+        -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acmetool
         -X github.com/hlandau/acme/notify.DefaultHookPath=#{lib}/hooks
-        -X github.com/hlandau/acme/responder.StandardWebrootPath=#{var}/run/acme/acme-challenge
+        -X github.com/hlandau/acme/responder.StandardWebrootPath=#{var}/run/acmetool/acme-challenge
         -X github.com/hlandau/degoutils/buildinfo.BuildInfo=v#{version}-#{builddate}-Homebrew
     LDFLAGS
 
@@ -147,5 +147,10 @@ class Acmetool < Formula
 
   test do
     system "#{bin}/acmetool", "help"
+  end
+
+  def post_install
+    (var/"lib/acmetool").mkpath
+    (var/"run/acmetool").mkpath
   end
 end

--- a/Library/Formula/acmetool.rb
+++ b/Library/Formula/acmetool.rb
@@ -123,6 +123,9 @@ class Acmetool < Formula
     ENV["GOPATH"] = buildpath
     ENV["GOHOME"] = buildpath
 
+    ###########################################
+    # Ugly patch for Homebrew-compatible paths
+    # Issue: https://github.com/hlandau/acme/issues/64
     # git grep -l /etc/
     inreplace ["README.md",
                "cmd/acmetool/main.go",
@@ -131,7 +134,6 @@ class Acmetool < Formula
                "fdb/fdb.go"] do |s|
       s.gsub! "/etc", etc
     end
-
     # git grep -l /var/lib/
     inreplace ["README.md",
                "_doc/NOROOT.md",
@@ -140,14 +142,12 @@ class Acmetool < Formula
                "storage/storage.go"] do |s|
       s.gsub! "/var/lib/acme", var/"lib/acmetool"
     end
-
     # git grep -l /usr/lib
     inreplace ["_doc/NOROOT.md",
                "_doc/SCHEMA.md",
                "notify/notify.go"] do |s|
       s.gsub! "/usr/lib", lib
     end
-
     # git grep -l /var/run/
     inreplace ["_doc/NOROOT.md",
                "_doc/WSCONFIG.md",
@@ -157,6 +157,7 @@ class Acmetool < Formula
                "responder/http.go"] do |s|
       s.gsub! "/var/run/acme", var/"run/acmetool"
     end
+    ###########################################
 
     mkdir_p buildpath/"src/github.com/hlandau/"
     ln_sf buildpath, buildpath/"src/github.com/hlandau/acme"

--- a/Library/Formula/acmetool.rb
+++ b/Library/Formula/acmetool.rb
@@ -133,8 +133,6 @@ class Acmetool < Formula
     Language::Go.stage_deps resources, buildpath/"src"
 
     # https://github.com/hlandau/acme/blob/master/_doc/PACKAGING-PATHS.md
-    # degoutils buildinfo depends on this being a git checkout, but it's a tarball.
-    # rawbuildinfo = `#{buildpath}/src/github.com/hlandau/degoutils/buildinfo/gen github.com/hlandau/acme/cmd/acmetool`
     builddate = `date -u "+%Y%m%d%H%M%S"`.strip
     ldflags = <<-LDFLAGS
         -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acme

--- a/Library/Formula/acmetool.rb
+++ b/Library/Formula/acmetool.rb
@@ -1,0 +1,176 @@
+require "language/go"
+
+class Acmetool < Formula
+  desc "Automatic certificate acquisition tool for ACME (Let's Encrypt)"
+  homepage "https://github.com/hlandau/acme"
+  url "https://github.com/hlandau/acme/archive/v0.0.32.tar.gz"
+  sha256 "e82cde69e10b37c1ba1ca0c10e9668d3ba8461f946133d0d07fc48da9ce6a888"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/alecthomas/template" do
+    url "https://github.com/alecthomas/template.git",
+      :revision => "14fd436dd20c3cc65242a9f396b61bfc8a3926fc"
+  end
+
+  go_resource "github.com/alecthomas/units" do
+    url "https://github.com/alecthomas/units.git",
+      :revision => "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
+  end
+
+  go_resource "github.com/coreos/go-systemd" do
+    url "https://github.com/coreos/go-systemd.git",
+      :revision => "4f14f6deef2da87e4aa59e6c1c1f3e02ba44c5e1"
+  end
+
+  go_resource "github.com/hlandau/degoutils" do
+    url "https://github.com/hlandau/degoutils.git",
+      :revision => "506416d2acb230b3227a5cc2c4f19dd5f376b2bd"
+  end
+
+  go_resource "github.com/hlandau/xlog" do
+    url "https://github.com/hlandau/xlog.git",
+      :revision => "c37f75515760879c01260fdb842000f8af5c665c"
+  end
+
+  go_resource "github.com/hlandauf/gspt" do
+    url "https://github.com/hlandauf/gspt.git",
+      :revision => "25f3bd3f5948489aa5f31c949310ae9f2b0e956c"
+  end
+
+  go_resource "github.com/hlandauf/pb" do
+    url "https://github.com/hlandauf/pb.git",
+      :revision => "0c1cdefd84b3b1937c4e54309f3a817d9c683bab"
+  end
+
+  go_resource "github.com/mattn/go-isatty" do
+    url "https://github.com/mattn/go-isatty.git",
+      :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
+  end
+
+  go_resource "github.com/ogier/pflag" do
+    url "https://github.com/ogier/pflag.git",
+      :revision => "6f7159c3154e7cd4ab30f6cc9c58fa3fd0f22325"
+  end
+
+  go_resource "github.com/peterhellberg/link" do
+    url "https://github.com/peterhellberg/link.git",
+      :revision => "1053d3b2893eeebd482fce32550ec24bebed308c"
+  end
+
+  go_resource "github.com/satori/go.uuid" do
+    url "https://github.com/satori/go.uuid.git",
+      :revision => "d41af8bb6a7704f00bc3b7cba9355ae6a5a80048"
+  end
+
+  go_resource "github.com/shiena/ansicolor" do
+    url "https://github.com/shiena/ansicolor.git",
+      :revision => "a422bbe96644373c5753384a59d678f7d261ff10"
+  end
+
+  go_resource "github.com/square/go-jose" do
+    url "https://github.com/square/go-jose.git",
+      :revision => "37934a899dd03635373fd1e143936d32cfe48d31"
+  end
+
+  go_resource "golang.org/x/crypto" do
+    url "https://go.googlesource.com/crypto.git",
+      :revision => "f23ba3a5ee43012fcb4b92e1a2a405a92554f4f2"
+  end
+
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+      :revision => "f1d3149ecb40ffadf4a28d39a30f9a125fe57bdf"
+  end
+
+  go_resource "gopkg.in/alecthomas/kingpin.v2" do
+    url "https://gopkg.in/alecthomas/kingpin.v2.git",
+      :revision => "8852570bd3865e9c4d4cb7cf5001c4295b07cad5"
+  end
+
+  go_resource "gopkg.in/hlandau/configurable.v1" do
+    url "https://gopkg.in/hlandau/configurable.v1.git",
+      :revision => "41496864a1fe3e0fef2973f22372b755d2897402"
+  end
+
+  go_resource "gopkg.in/hlandau/easyconfig.v1" do
+    url "https://gopkg.in/hlandau/easyconfig.v1.git",
+      :revision => "c54c1752c0585f34484ae2f218366984d2234ede"
+  end
+
+  go_resource "gopkg.in/hlandau/service.v2" do
+    url "https://gopkg.in/hlandau/service.v2.git",
+      :revision => "88289e1ff32ad5b17c5b19d3d9680af98b036d0d"
+  end
+
+  go_resource "gopkg.in/hlandau/svcutils.v1" do
+    url "https://gopkg.in/hlandau/svcutils.v1.git",
+      :revision => "71059456e8e64b0913a61a46dd1898853222905e"
+  end
+
+  go_resource "gopkg.in/tylerb/graceful.v1" do
+    url "https://gopkg.in/tylerb/graceful.v1.git",
+      :revision => "48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e"
+  end
+
+  go_resource "gopkg.in/yaml.v2" do
+    url "https://gopkg.in/yaml.v2.git",
+      :revision => "53feefa2559fb8dfa8d81baad31be332c97d6c77"
+  end
+
+  def install
+    ENV["GOBIN"] = bin
+    ENV["GOPATH"] = buildpath
+    ENV["GOHOME"] = buildpath
+
+    # git grep -l /etc/
+    inreplace ["README.md",
+               "cmd/acmetool/main.go",
+               "cmd/acmetool/quickstart-linux.go",
+               "cmd/acmetool/quickstart.go",
+               "fdb/fdb.go"] do |s|
+      s.gsub! "/etc", etc
+    end
+
+    # git grep -l /var/lib/
+    inreplace ["README.md",
+               "_doc/NOROOT.md",
+               "_doc/SCHEMA.md",
+               "cmd/acmetool/doc.go",
+               "storage/storage.go"] do |s|
+      s.gsub! "/var/lib/acme", var/"lib/acmetool"
+    end
+
+    # git grep -l /usr/lib
+    inreplace ["_doc/NOROOT.md",
+               "_doc/SCHEMA.md",
+               "notify/notify.go"] do |s|
+      s.gsub! "/usr/lib", lib
+    end
+
+    # git grep -l /var/run/
+    inreplace ["_doc/NOROOT.md",
+               "_doc/WSCONFIG.md",
+               "cmd/acmetool/main.go",
+               "cmd/acmetool/main_test.go",
+               "redirector/redirector.go",
+               "responder/http.go"] do |s|
+      s.gsub! "/var/run/acme", var/"run/acmetool"
+    end
+
+    mkdir_p buildpath/"src/github.com/hlandau/"
+    ln_sf buildpath, buildpath/"src/github.com/hlandau/acme"
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    system "go", "build", "-o", bin/"acmetool", "github.com/hlandau/acme/cmd/acmetool"
+
+    system "#{bin}/acmetool --help-man >> acmetool.8"
+    man8.install "acmetool.8"
+
+    doc.install "README.md", Dir["_doc/*"]
+  end
+
+  test do
+    system "#{bin}/acmetool", "help"
+  end
+end


### PR DESCRIPTION
Adding acmetool (Go) by @hlandau. This is possibly the best featured Let's Encrypt client at the moment. See [Acmetool Feature comparison](https://github.com/hlandau/acme#comparison-list-of-client-implementations). Unfortunately name "acme" is already used, and even if it wasn't, I would go with acmetool because ACME is also the name of the protocol and this is a specific implementation.

I saw this comment for Python reference Let's encrypt client https://github.com/Homebrew/homebrew/pull/47467#issuecomment-168531294 by @tdsmith. I wonder if others find this LE client useful for Homebrew users? I have not attempted to test this with Homebrew nginx or apache. Hook scripts in particular should be checked.