### PR TITLE
dependency: don't recursive infinitely.

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -71,25 +71,30 @@ class Dependency
     # The default filter, which is applied when a block is not given, omits
     # optionals and recommendeds based on what the dependent has asked for.
     def expand(dependent, deps = dependent.deps, &block)
+      @expand_stack ||= []
+      @expand_stack.push dependent
+
       expanded_deps = []
 
       deps.each do |dep|
-        # FIXME: don't hide cyclic dependencies
         next if dependent.name == dep.name
 
         case action(dependent, dep, &block)
         when :prune
           next
         when :skip
+          next if @expand_stack.include? dep
           expanded_deps.concat(expand(dep.to_formula, &block))
         when :keep_but_prune_recursive_deps
           expanded_deps << dep
         else
+          next if @expand_stack.include? dep
           expanded_deps.concat(expand(dep.to_formula, &block))
           expanded_deps << dep
         end
       end
 
+      @expand_stack.pop
       merge_repeats(expanded_deps)
     end
 


### PR DESCRIPTION
If we have a dependency cycle ensure that infinite recursion does not result by storing state in a stack which we push/pop from for each level of recursion and verify that we haven’t been through this dependency already.