### PR TITLE
git-annex: force-enable "webapp" flag

### DIFF
--- a/Library/Formula/git-annex.rb
+++ b/Library/Formula/git-annex.rb
@@ -28,7 +28,7 @@ class GitAnnex < Formula
   depends_on "quvi"
 
   def install
-    install_cabal_package :using => ["alex", "happy", "c2hs"] do
+    install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["Webapp"] do
       # this can be made the default behavior again once git-union-merge builds properly when bottling
       if build.with? "git-union-merge"
         system "make", "git-union-merge", "PREFIX=#{prefix}"


### PR DESCRIPTION
To address issue #47346 (git-annex-webapp missing), we explicitly enable the "webapp" flag for git-annex. This should prevent git-annex from being built without the webapp and make the build fail if there is e.g. a dependency issue.

In order to set the build flags to git-annex correctly, we must (1) pass them to cabal install to resolve/install all the necessary dependencies correctly, and (2) pass them to cabal configure to make sure git-annex compiles with the flags we want. 

I originally wanted to enable S3 here too, but as noted in my comment on #47737 this would currently break the build because of a dependency/version conflict with aws 0.13.0. After a new version of aws is released on Hackage, it should be possible to add "S3" to `:flags` to re-enable and avoid accidentally dropping S3 support in the future. 