### PR TITLE
ncdc: remove unneeded option for dependency

### DIFF
--- a/Library/Formula/ncdc.rb
+++ b/Library/Formula/ncdc.rb
@@ -21,10 +21,10 @@ class Ncdc < Formula
 
   option "with-geoip", "Build with geoip support"
 
+  depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "sqlite"
-  depends_on "gnutls" => "with-p11-kit"
-  depends_on "pkg-config" => :build
+  depends_on "gnutls"
   depends_on "geoip" => :optional
 
   def install


### PR DESCRIPTION
* remove option 'with-p11-kit' for gnutls

remove the dependency option introduced in https://github.com/Homebrew/homebrew/commit/724eaa35c90ce29cffcbbc3f5fe554c05d217b51