### PR TITLE
Search also in Caskroom/versions Tap

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -84,7 +84,8 @@ module Homebrew
   end
 
   SEARCHABLE_TAPS = OFFICIAL_TAPS.map { |tap| ["Homebrew", tap] } + [
-    %w[Caskroom cask]
+    %w[Caskroom cask],
+    %w[Caskroom versions]
   ]
 
   def query_regexp(query)
@@ -104,7 +105,7 @@ module Homebrew
 
   def search_tap(user, repo, rx)
     if (HOMEBREW_LIBRARY/"Taps/#{user.downcase}/homebrew-#{repo.downcase}").directory? && \
-       "#{user}/#{repo}" != "Caskroom/cask"
+       user != "Caskroom"
       return []
     end
 

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -4,5 +4,5 @@ HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.]+)$}
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+)/([\w-]+)}
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
-# match the default brew-cask tap e.g. Caskroom/cask
-HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^(Caskroom)/(cask)/([\w+-.]+)$}
+# match the default and the versions brew-cask tap e.g. Caskroom/cask or Caskroom/versions
+HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^(Caskroom)/(cask|versions)/([\w+-.]+)$}


### PR DESCRIPTION
Extending the current search functionallity to search in
[Caskroom/versions](https://github.com/caskroom/homebrew-versions).

This repo contains many (alternate) versions of casks found in [Caskroom/cask](https://github.com/caskroom/homebrew-cask).

As an example search for `pycharm`:
```
$ brew search pycharm
Caskroom/cask/pycharm-edu                       Caskroom/cask/pycharm
Caskroom/versions/pycharm-ce-eap                Caskroom/versions/pycharm-ce
Caskroom/versions/pycharm-eap 
```

(In the light of https://github.com/caskroom/homebrew-cask/issues/14384)

@vitorgalvao What do you think?