### PR TITLE
Bottle: allow creating with a specific tag

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -243,13 +243,13 @@ class Bottle
   def_delegators :resource, :url, :fetch, :verify_download_integrity
   def_delegators :resource, :cached_download, :clear_cache
 
-  def initialize(formula, spec)
+  def initialize(formula, spec, tag=bottle_tag)
     @name = formula.name
     @resource = Resource.new
     @resource.owner = formula
     @spec = spec
 
-    checksum, tag = spec.checksum_for(bottle_tag)
+    checksum, tag = spec.checksum_for(tag)
 
     filename = Filename.create(formula, tag, spec.revision)
     @resource.url(build_url(spec.root_url, filename))

--- a/Library/Homebrew/test/test_bottle.rb
+++ b/Library/Homebrew/test/test_bottle.rb
@@ -1,8 +1,22 @@
 require "testing_env"
 require "cmd/bottle"
+require "formula"
 
 class BottleTests < Homebrew::TestCase
   def test_most_recent_mtime_with_broken_symlink()
     refute_nil Homebrew.most_recent_mtime(Pathname(File.join(TEST_DIRECTORY, 'resources/source-with-broken-symlink')))
+  end
+
+  def test_initialize_with_tag
+    f = formula do
+      url "https://example.com/foo-1.0.tgz"
+
+      bottle do
+        sha256 TEST_SHA256 => :sometag
+      end
+    end
+
+    b = Bottle.new f, f.bottle_specification, :sometag
+    assert_match ".sometag.bottle.tar.gz", b.resource.url
   end
 end


### PR DESCRIPTION
The idea is to be able to get a bottle URL for different OS X version than the host one. Right now if I’m on El Capitan I can’t get e.g. the Mavericks URL for a given bottle without an hack like `gsub("el_capitan", "mavericks")`.