### PR TITLE
python-markdown 2.6.5 (new formula)

### DIFF
--- a/Library/Formula/python-markdown.rb
+++ b/Library/Formula/python-markdown.rb
@@ -1,0 +1,20 @@
+class PythonMarkdown < Formula
+  desc "Python implementation of Markdown"
+  homepage "https://pypi.python.org/pypi/Markdown"
+  url "https://pypi.python.org/packages/source/M/Markdown/Markdown-2.6.5.tar.gz"
+  sha256 "8d94cf6273606f76753fcb1324623792b3738c7612c2b180c85cc5e88642e560"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    (testpath/"test.md").write("# Hello World!")
+    assert_equal "<h1>Hello World!</h1>", shell_output(bin/"markdown_py test.md").strip
+  end
+end


### PR DESCRIPTION
Add the Python "markdown" package, including the "markdown_py" binary.

Name the formular "python-markdown" to follow the Debian naming scheme:
<https://packages.debian.org/search?searchon=contents&keywords=markdown_py>

Signed-off-by: Alexander Barton <alex@barton.de>