### PR TITLE
ruby: Only apply patch to non-HEAD builds

### DIFF
--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -21,12 +21,16 @@ class Ruby < Formula
   option "with-doc", "Install documentation"
   option "with-tcltk", "Install with Tcl/Tk support"
 
-  # Reverts an upstream commit which incorrectly tries to install headers
-  # into SDKROOT, if defined
-  # See https://bugs.ruby-lang.org/issues/11881
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/ba8cc6b88e6b7153ac37739e5a1a6bbbd8f43817/ruby/mkconfig.patch"
-    sha256 "929c618f74e89a5e42d899a962d7d2e4af75716523193af42626884eaba1d765"
+  unless head?
+    # Reverts an upstream commit which incorrectly tries to install headers
+    # into SDKROOT, if defined
+    # See https://bugs.ruby-lang.org/issues/11881
+    # The issue has been fixed on HEAD as of 1 Jan 2016, but there has not been
+    # a release since then, so the patch is still required for release builds
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/ba8cc6b88e6b7153ac37739e5a1a6bbbd8f43817/ruby/mkconfig.patch"
+      sha256 "929c618f74e89a5e42d899a962d7d2e4af75716523193af42626884eaba1d765"
+    end
   end
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -21,7 +21,7 @@ class Ruby < Formula
   option "with-doc", "Install documentation"
   option "with-tcltk", "Install with Tcl/Tk support"
 
-  unless head?
+  stable do
     # Reverts an upstream commit which incorrectly tries to install headers
     # into SDKROOT, if defined
     # See https://bugs.ruby-lang.org/issues/11881


### PR DESCRIPTION
PR #47907, take 2. Github didn't let me reopen the last one because
I force pushed to this branch...

The issue that the patch fixes has been fixed in upstream's HEAD, but
hasn't made it to a stable release yet. Trying to apply the patch for a
--HEAD build results in a patch application error which fails the build,
so now the patch is only applied for non-HEAD builds.