### PR TITLE
Add sent

### DIFF
--- a/Library/Formula/sent.rb
+++ b/Library/Formula/sent.rb
@@ -1,0 +1,14 @@
+class Sent < Formula
+  desc "Simple plaintext presentation tool."
+  homepage "http://tools.suckless.org/sent/"
+  url "http://dl.suckless.org/tools/sent-0.2.tar.gz"
+  sha256 "53b961f9d92a277a6408df7025b4a6deae6b655a797383c93442290e45391076"
+
+  depends_on :x11 => :build
+
+  def install
+    system "make"
+    bin.install "sent"
+  end
+
+end


### PR DESCRIPTION
sent does not need latex, libreoffice or any other fancy file format, it uses plaintext files to describe the slides and can include images via farbfeld. Every paragraph represents a slide in the presentation. Especially for presentations using the Takahashi method this is very nice and allows you to write down the presentation for a quick lightning talk within a few minutes.