### PR TITLE
gkrellm 2.3.5 (return from boneyard)

### DIFF
--- a/Library/Formula/gkrellm.rb
+++ b/Library/Formula/gkrellm.rb
@@ -1,0 +1,55 @@
+class Gkrellm < Formula
+  desc "Extensible GTK system monitoring application"
+  homepage "https://billw2.github.io/gkrellm/gkrellm.html"
+  head "http://git.srcbox.net/gkrellm", :using => :git
+
+  stable do
+    url "https://billw2.github.io/gkrellm/gkrellm-2.3.5.tar.bz2"
+    sha256 "702b5b0e9c040eb3af8e157453f38dd6f53e1dcd8b1272d20266cda3d4372c8b"
+
+    # http://git.srcbox.net/gkrellm/commit/?id=207a0519ac73290ba65b6e5f7446549a2a66f5d2
+    # Resolves a NULL value crash. Fixed upstream already but unreleased in stable.
+    patch :p0 do
+      url "https://raw.githubusercontent.com/Homebrew/patches/8040a52382/gkrellm/nullpointer.patch"
+      sha256 "d005e7ad9b4c46d4930ccb4391481716b72c9a68454b8d8f4dfd2b597bfd77cc"
+    end
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "atk"
+  depends_on "cairo"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "gdk-pixbuf"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gtk+"
+  depends_on "pango"
+  depends_on "gobject-introspection"
+  depends_on "openssl"
+
+  def install
+    # Fixes broken pkg-config call. Without this compile fails on linking errors.
+    # Already fixed upstream but unreleased.
+    if build.stable?
+      inreplace "src/Makefile", "gtk+-2.0 gthread-2.0", "gtk+-2.0 gthread-2.0 gmodule-2.0"
+    end
+
+    system "make", "INSTALLROOT=#{prefix}", "macosx"
+    system "make", "INSTALLROOT=#{prefix}", "install"
+  end
+
+  test do
+    pid = fork do
+      exec "#{bin}/gkrellmd --pidfile #{testpath}/test.pid"
+    end
+    sleep 2
+
+    begin
+      assert File.exist?("test.pid")
+    ensure
+      Process.kill "SIGINT", pid
+      Process.wait pid
+    end
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -81,7 +81,6 @@ TAP_MIGRATIONS = {
   "git-flow-clone" => "homebrew/boneyard",
   "git-latexdiff" => "homebrew/tex",
   "gitfs" => "homebrew/fuse",
-  "gkrellm" => "homebrew/boneyard",
   "glade" => "homebrew/x11",
   "gle" => "homebrew/x11",
   "gnumeric" => "homebrew/x11",


### PR DESCRIPTION
We [boneyarded this](https://github.com/Homebrew/homebrew-x11/pull/83) when the X11 backend was removed from the GTK+ family, but it turns out it'll build against the Quartz backend fine. Upstream have labelled the Quartz backend experimental but I was able to build and run this without issue against that backend.

Two minor patches are required, one as an `inreplace`, both have been merged upstream. There hasn't been an upstream release for 5 years but it it still being actively developed and a second release candidate for the next version was tagged at Christmas.

One executable is GUI client-orientated but there's also a separate server-providing CLI executable which is which is why I've homed it here rather than the GUI tap.