### PR TITLE
pinentry: fix for bug #48020 (Pinentry formula: Wrong configure parameter)

### DIFF
--- a/Library/Formula/pinentry.rb
+++ b/Library/Formula/pinentry.rb
@@ -19,7 +19,7 @@ class Pinentry < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--disable-pinentry-qt4",
+                          "--disable-pinentry-qt",
                           "--disable-pinentry-gtk2",
                           "--disable-pinentry-gnome3"
     system "make", "install"


### PR DESCRIPTION
This is a fix for this bug: https://github.com/Homebrew/homebrew/issues/48020