### PR TITLE
elasticsearch: disable launchctl keepalive

### DIFF
--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -89,7 +89,7 @@ class Elasticsearch < Formula
       <plist version="1.0">
         <dict>
           <key>KeepAlive</key>
-          <true/>
+          <false/>
           <key>Label</key>
           <string>#{plist_name}</string>
           <key>ProgramArguments</key>


### PR DESCRIPTION
The keepalive option in launchctl plists means that launchctl will
restart your process on successful zero-status exit code. This means
that you can never actually stop the service, even by doing
`launchctl stop <name>`.

This change sets keepalive to false, which is the same behavior nginx
and other launchctl runnable services on homebrew use.

**Question:** This PR doesn't actually change the package version, because it's not a change to do with a new version of elasticsearch, it's just fixing the launchctl configuration. What's the protocol in regards to these kind of updates? I couldn't see information about it in the documentation.