### PR TITLE
brew: tap missing tap as normal user

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -160,7 +160,13 @@ begin
     end
 
     if possible_tap && !possible_tap.installed?
-      possible_tap.install
+      brew_uid = File.stat(HOMEBREW_BREW_FILE).uid
+      tap_commands = []
+      if Process.uid.zero? && !brew_uid.zero?
+        tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]
+      end
+      tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
+      safe_system *tap_commands
       exec HOMEBREW_BREW_FILE, cmd, *ARGV
     else
       onoe "Unknown command: #{cmd}"


### PR DESCRIPTION
Before this, `sudo brew cask` will auto install Homebrew cask as root
user. This will cause permission problem for files in `Tap` directory.

Therefore, let's check process uid and switch to normal user for tap.
As result, `sudo brew cask` will work as the same before, except tap
files will have the correct permission attributes.