### PR TITLE
bottle: read mtime from tabfile

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -130,7 +130,7 @@ class Build
         formula.install
 
         stdlibs = detect_stdlibs(ENV.compiler)
-        Tab.create(formula, ENV.compiler, stdlibs.first, formula.build).write
+        Tab.create(formula, ENV.compiler, stdlibs.first, formula.build, formula.source_modified_time).write
 
         # Find and link metafiles
         formula.prefix.install_metafiles Pathname.pwd

--- a/Library/Homebrew/cmd/unpack.rb
+++ b/Library/Homebrew/cmd/unpack.rb
@@ -28,7 +28,7 @@ module Homebrew
       ENV["VERBOSE"] = "1" # show messages about tar
       f.brew do
         f.patch if ARGV.flag?("--patch")
-        cp_r getwd, stage_dir
+        cp_r getwd, stage_dir, :preserve => true
       end
       ENV["VERBOSE"] = nil
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -26,6 +26,12 @@ class AbstractDownloadStrategy
   def cached_location
   end
 
+  # @!attribute [r]
+  # return most recent modified time for all files in the current working directory after stage.
+  def source_modified_time
+    Pathname.pwd.to_enum(:find).select(&:file?).map(&:mtime).max
+  end
+
   # Remove {#cached_location} and any other files associated with the resource
   # from the cache.
   def clear_cache
@@ -553,6 +559,10 @@ class GitDownloadStrategy < VCSDownloadStrategy
   def stage
     super
     cp_r File.join(cached_location, "."), Dir.pwd
+  end
+
+  def source_modified_time
+    Time.parse Utils.popen_read("git", "--git-dir", git_dir, "show", "-s", "--format=%cD")
   end
 
   private

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -78,7 +78,6 @@ class Formula
   # This contains all the attributes (e.g. URL, checksum) that apply to the
   # stable version of this formula.
   # @private
-
   attr_reader :stable
 
   # The development {SoftwareSpec} for this {Formula}.
@@ -107,6 +106,10 @@ class Formula
   # @see #active_spec
   # @private
   attr_reader :active_spec_sym
+
+  # most recent modified time for source files
+  # @private
+  attr_reader :source_modified_time
 
   # Used for creating new Homebrew versions of software without new upstream
   # versions.
@@ -1550,6 +1553,7 @@ class Formula
 
   def stage
     active_spec.stage do
+      @source_modified_time = active_spec.source_modified_time
       @buildpath = Pathname.pwd
       env_home = buildpath/".brew_home"
       mkdir_p env_home

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -8,7 +8,7 @@ require "version"
 class Resource
   include FileUtils
 
-  attr_reader :mirrors, :specs, :using
+  attr_reader :mirrors, :specs, :using, :source_modified_time
   attr_writer :version
   attr_accessor :download_strategy, :checksum
 
@@ -87,6 +87,7 @@ class Resource
   def unpack(target = nil)
     mktemp(download_name) do
       downloader.stage
+      @source_modified_time = downloader.source_modified_time
       if block_given?
         yield self
       elsif target

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -25,7 +25,7 @@ class SoftwareSpec
   attr_reader :bottle_specification
   attr_reader :compiler_failures
 
-  def_delegators :@resource, :stage, :fetch, :verify_download_integrity
+  def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time
   def_delegators :@resource, :cached_download, :clear_cache
   def_delegators :@resource, :checksum, :mirrors, :specs, :using
   def_delegators :@resource, :version, :mirror, *Checksum::TYPES

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -15,7 +15,7 @@ class Tab < OpenStruct
     CACHE.clear
   end
 
-  def self.create(formula, compiler, stdlib, build)
+  def self.create(formula, compiler, stdlib, build, source_modified_time)
     attributes = {
       "used_options" => build.used_options.as_flags,
       "unused_options" => build.unused_options.as_flags,
@@ -23,6 +23,7 @@ class Tab < OpenStruct
       "built_as_bottle" => build.bottle?,
       "poured_from_bottle" => false,
       "time" => Time.now.to_i,
+      "source_modified_time" => source_modified_time.to_i,
       "HEAD" => Homebrew.git_head,
       "compiler" => compiler,
       "stdlib" => stdlib,
@@ -43,6 +44,7 @@ class Tab < OpenStruct
   def self.from_file_content(content, path)
     attributes = Utils::JSON.load(content)
     attributes["tabfile"] = path
+    attributes["source_modified_time"] ||= 0
     attributes["source"] ||= {}
 
     tapped_from = attributes["tapped_from"]
@@ -133,6 +135,7 @@ class Tab < OpenStruct
       "built_as_bottle" => false,
       "poured_from_bottle" => false,
       "time" => nil,
+      "source_modified_time" => 0,
       "HEAD" => nil,
       "stdlib" => nil,
       "compiler" => "clang",
@@ -214,6 +217,10 @@ class Tab < OpenStruct
     source["spec"].to_sym
   end
 
+  def source_modified_time
+    Time.at(super)
+  end
+
   def to_json
     attributes = {
       "used_options" => used_options.as_flags,
@@ -221,6 +228,7 @@ class Tab < OpenStruct
       "built_as_bottle" => built_as_bottle,
       "poured_from_bottle" => poured_from_bottle,
       "time" => time,
+      "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),

--- a/Library/Homebrew/test/resources/source-with-broken-symlink/broken-link
+++ b/Library/Homebrew/test/resources/source-with-broken-symlink/broken-link
@@ -1,1 +1,0 @@
-does-not-exist

--- a/Library/Homebrew/test/test_bottle.rb
+++ b/Library/Homebrew/test/test_bottle.rb
@@ -1,8 +1,0 @@
-require "testing_env"
-require "cmd/bottle"
-
-class BottleTests < Homebrew::TestCase
-  def test_most_recent_mtime_with_broken_symlink()
-    refute_nil Homebrew.most_recent_mtime(Pathname(File.join(TEST_DIRECTORY, 'resources/source-with-broken-symlink')))
-  end
-end

--- a/Library/Homebrew/test/test_download_strategies.rb
+++ b/Library/Homebrew/test/test_download_strategies.rb
@@ -11,6 +11,8 @@ class ResourceDouble
 end
 
 class AbstractDownloadStrategyTests < Homebrew::TestCase
+  include FileUtils
+
   def setup
     @name = "foo"
     @resource = ResourceDouble.new
@@ -33,6 +35,15 @@ class AbstractDownloadStrategyTests < Homebrew::TestCase
     result = @strategy.expand_safe_system_args(@args)
     assert_equal %w[foo bar baz], @args
     refute_same @args, result
+  end
+
+  def test_source_modified_time
+    mktemp "mtime" do
+      touch "foo", :mtime => Time.now - 10
+      touch "bar", :mtime => Time.now - 100
+      ln_s "not-exist", "baz"
+      assert_equal File.mtime("foo"), @strategy.source_modified_time
+    end
   end
 end
 

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -7,15 +7,16 @@ class TabTests < Homebrew::TestCase
     @used = Options.create(%w[--with-foo --without-bar])
     @unused = Options.create(%w[--with-baz --without-qux])
 
-    @tab = Tab.new("used_options"       => @used.as_flags,
-                   "unused_options"     => @unused.as_flags,
-                   "built_as_bottle"    => false,
-                   "poured_from_bottle" => true,
-                   "time"               => nil,
-                   "HEAD"               => TEST_SHA1,
-                   "compiler"           => "clang",
-                   "stdlib"             => "libcxx",
-                   "source"             => {
+    @tab = Tab.new("used_options"         => @used.as_flags,
+                   "unused_options"       => @unused.as_flags,
+                   "built_as_bottle"      => false,
+                   "poured_from_bottle"   => true,
+                   "time"                 => nil,
+                   "source_modified_time" => 0,
+                   "HEAD"                 => TEST_SHA1,
+                   "compiler"             => "clang",
+                   "stdlib"               => "libcxx",
+                   "source"               => {
                      "tap" => "Homebrew/homebrew",
                      "path" => nil,
                      "spec" => "stable"


### PR DESCRIPTION
* Avoid unnecessary stage overhead
* Support different download strategy, e.g. `git`.

cc @mikemcquaid 