### PR TITLE
htmldoc: disable ssl to avoid compile error

### DIFF
--- a/Library/Formula/htmldoc.rb
+++ b/Library/Formula/htmldoc.rb
@@ -3,6 +3,7 @@ class Htmldoc < Formula
   homepage "https://www.msweet.org/projects.php?Z1"
   url "https://www.msweet.org/files/project1/htmldoc-1.8.29-source.tar.bz2"
   sha256 "e8c96ad740d19169eab8305c8e2ee1c795c4afa59ba99d18786ad191a2853f31"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/htmldoc.rb
+++ b/Library/Formula/htmldoc.rb
@@ -16,6 +16,7 @@ class Htmldoc < Formula
 
   def install
     system "./configure", "--disable-debug",
+                          "--disable-ssl",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
     system "make"


### PR DESCRIPTION
1.8.29 dropped openssl support so compiling with built-in ssl fails

http://www.msweet.org/pipermail/htmldoc/2016-January/002848.html

> - Dropped support for OpenSSL.

Confirmed that it worked on El Capitan (10.11.2) with `brew reinstall -v --build-from-source htmldoc`.

Without this fix:
```
Linking htmldoc...
Undefined symbols for architecture x86_64:
  "_CFAbsoluteTimeGetCurrent", referenced from:
      _httpCredentialsGetTrust in tls.o
  "_CFArrayAppendValue", referenced from:
      __httpCreateCredentials in tls.o
  "_CFArrayCreateMutable", referenced from:
      __httpCreateCredentials in tls.o
  "_CFDataGetBytePtr", referenced from:
      _httpCopyCredentials in tls.o
  "_CFDataGetLength", referenced from:
      _httpCopyCredentials in tls.o
  "_CFRelease", referenced from:
      _httpCopyCredentials in tls.o
      __httpCreateCredentials in tls.o
      _httpCredentialsAreValidForName in tls.o
      _httpCredentialsGetTrust in tls.o
      _httpCredentialsString in tls.o
      _httpCredentialsGetExpiration in tls.o
      __httpFreeCredentials in tls.o
      ...
  "_CFStringGetCString", referenced from:
      _httpCredentialsAreValidForName in tls.o
      _httpCredentialsString in tls.o
  "_kCFAbsoluteTimeIntervalSince1970", referenced from:
      _httpCredentialsString in tls.o
      _httpCredentialsGetExpiration in tls.o
  "_kCFAllocatorDefault", referenced from:
      __httpCreateCredentials in tls.o
      _httpCredentialsAreValidForName in tls.o
      _httpCredentialsGetTrust in tls.o
      _httpCredentialsString in tls.o
      _httpCredentialsGetExpiration in tls.o
      __httpTLSStart in tls.o
  "_kCFTypeArrayCallBacks", referenced from:
      __httpCreateCredentials in tls.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```