### PR TITLE
logstash: fix unlinked logstash plugin command

### DIFF
--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -24,9 +24,11 @@ class Logstash < Formula
     end
 
     inreplace %w[bin/logstash], %r{^\. "\$\(cd `dirname \$SOURCEPATH`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
+    inreplace %w[bin/plugin], %r{^\. "\$\(cd `dirname \$0`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
     inreplace %w[bin/logstash.lib.sh], /^LOGSTASH_HOME=.*$/, "LOGSTASH_HOME=#{libexec}"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/logstash"
+    bin.install_symlink libexec/"bin/plugin"
   end
 
   def caveats; <<-EOS.undent

--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -28,12 +28,13 @@ class Logstash < Formula
     inreplace %w[bin/logstash.lib.sh], /^LOGSTASH_HOME=.*$/, "LOGSTASH_HOME=#{libexec}"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/logstash"
-    bin.install_symlink libexec/"bin/plugin"
+    bin.install_symlink libexec/"bin/plugin" => "logstash-plugin"
   end
 
   def caveats; <<-EOS.undent
     Please read the getting started guide located at:
       https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html
+    The logstash `plugin` command is available as `logstash-plugin`.
     EOS
   end
 


### PR DESCRIPTION
Logstash also provides a `plugin` command/script for managing plugins.
The current recipe does not expose this command, forcing the user to
look through the Cellar to find the correct path.