### PR TITLE
golo 3.1.0-incubation-M1 (devel)

### DIFF
--- a/Library/Formula/golo.rb
+++ b/Library/Formula/golo.rb
@@ -1,7 +1,7 @@
 class Golo < Formula
   desc "Lightweight dynamic language for the JVM"
   homepage "http://golo-lang.org"
-  url "https://www.eclipse.org/downloads/download.php?file=/golo/golo-3.0.0-incubation.zip"
+  url "https://bintray.com/artifact/download/golo-lang/downloads/golo-3.0.0-incubation.zip"
   sha256 "e7d350148a3a7492348f0214679b282858ced58e4063a17bbf53f9ec2ae5f288"
 
   devel do

--- a/Library/Formula/golo.rb
+++ b/Library/Formula/golo.rb
@@ -4,6 +4,12 @@ class Golo < Formula
   url "https://www.eclipse.org/downloads/download.php?file=/golo/golo-3.0.0-incubation.zip"
   sha256 "e7d350148a3a7492348f0214679b282858ced58e4063a17bbf53f9ec2ae5f288"
 
+  devel do
+    url "https://bintray.com/artifact/download/golo-lang/downloads/golo-3.1.0-incubation-M1.zip"
+    sha256 "f0a58d4602c417c0351759eaa8787e757c5dc095604a07887c1179c007c8304a"
+    version "3.1.0-incubation-M1"
+  end
+
   head do
     url "https://github.com/eclipse/golo-lang.git"
   end


### PR DESCRIPTION
http://golo-lang.org/news/2016/01/14/golo-3.1.0-milestone1/

contains
* the `devel` for `golo-3.1.0-incubation-M1`
* the updated url for `golo-3.0.0-incubation` (use the bintray url)