### PR TITLE
Update folly dependencies.

### DIFF
--- a/Library/Formula/folly.rb
+++ b/Library/Formula/folly.rb
@@ -21,6 +21,10 @@ class Folly < Formula
   depends_on "gflags"
   depends_on "boost"
   depends_on "libevent"
+  depends_on "xz"
+  depends_on "snappy"
+  depends_on "lz4"
+  depends_on "jemalloc"
 
   needs :cxx11
   depends_on :macos => :mavericks


### PR DESCRIPTION
I've just run `brew tap facebook/fb && brew install fbthrift-compiler` which depends on folly.

I found folly also required these dependencies to work.