### PR TITLE
nrpe: fix nrpe.cfg paths to nagios-plugins binaries

### DIFF
--- a/Library/Formula/nrpe.rb
+++ b/Library/Formula/nrpe.rb
@@ -25,7 +25,7 @@ class Nrpe < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--libexecdir=#{sbin}",
+                          "--libexecdir=#{HOMEBREW_PREFIX}/sbin",
                           "--sysconfdir=#{etc}",
                           "--with-nrpe-user=#{user}",
                           "--with-nrpe-group=#{group}",
@@ -36,6 +36,11 @@ class Nrpe < Formula
                           "--with-ssl-lib=#{Formula["openssl"].opt_lib}",
                           "--enable-ssl",
                           "--enable-command-args"
+
+    inreplace "src/Makefile" do |s|
+      s.gsub! "$(LIBEXECDIR)", "$(SBINDIR)"
+    end
+
     system "make", "all"
     system "make", "install"
     system "make", "install-daemon-config"


### PR DESCRIPTION
The nrpe build uses `--libexecdir` for two purposes only:

* Placing its own `check_nrpe` binary (also a Nagios plugin) on installation
* Setting paths in its configuration to `check_*` from `nagios-plugins`

The current `"--libexecdir=#{sbin}"` causes an `etc/nrpe.cfg` with broken paths: the check binary names are from `nagios-plugins`, but their path is from `nrpe`. Example: `/usr/local/Cellar/nrpe/2.15_1/sbin/check_procs`.

`"--libexecdir=#{Forumla["nagios-plugins"].sbin}"` causes an `nrpe.cfg` with brittle paths hard-coded to the version of `nagios-plugins` installed at the time. It also causes `check_nrpe` to disappear into `/usr/local/Cellar/nagios-plugins/2.0.3/sbin`, from where it won't be linked into `/usr/local/sbin`. Oops.

`"--libexecdir=#{HOMEBREW_PREFIX}/sbin"` is consistent with the `nagios` formula. By itself, it would cause direct installation of `check_nrpe` to `/usr/local/sbin`, which strikes me as rude. A patch to the Makefile ensure it lands under `Cellar` where it belongs.

Checked:

* `brew audit nrpe`
* `brew tests`
* `brew test nrpe` (no tests)
* `/usr/local/etc/nrpe.cfg` command paths correct e.g. `/usr/local/sbin/check_procs` symlinked to `../Cellar/nagios-plugins/2.0.3/sbin/check_procs` as expected
* `/usr/local/sbin/check_nrpe` symlinked to `../Cellar/nrpe/2.15_1/sbin/check_nrpe` as expected