### PR TITLE
mysql: vendor Boost for build

### DIFF
--- a/Library/Formula/mysql.rb
+++ b/Library/Formula/mysql.rb
@@ -26,7 +26,6 @@ class Mysql < Formula
   deprecated_option "with-tests" => "with-test"
 
   depends_on "cmake" => :build
-  depends_on "boost" => :build
   depends_on "pidof" unless MacOS.version >= :mountain_lion
   depends_on "openssl"
 
@@ -38,6 +37,11 @@ class Mysql < Formula
   fails_with :llvm do
     build 2326
     cause "https://github.com/Homebrew/homebrew/issues/issue/144"
+  end
+
+  resource "boost" do
+    url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
+    sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
   end
 
   def datadir
@@ -75,6 +79,12 @@ class Mysql < Formula
       -DCOMPILATION_COMMENT=Homebrew
       -DWITH_EDITLINE=system
     ]
+
+    # MySQL >5.7.x mandates Boost as a requirement to build & has a strict
+    # version check in place to ensure it only builds against expected release.
+    # This is problematic when Boost releases don't align with MySQL releases.
+    (buildpath/"boost_1_59_0").install resource("boost")
+    args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
 
     # To enable unit testing at build, we need to download the unit testing suite
     if build.with? "test"


### PR DESCRIPTION
We missed this one when we upgraded Boost because the Boost requirement is only build-time. MySQL's incredibly strict version check is currently killing off builds since that merge.

Closes #48082.