### PR TITLE
selenium-server-standalone 2.49.0

### DIFF
--- a/Library/Formula/selenium-server-standalone.rb
+++ b/Library/Formula/selenium-server-standalone.rb
@@ -1,8 +1,8 @@
 class SeleniumServerStandalone < Formula
   desc "Browser automation for testing purposes"
   homepage "http://seleniumhq.org/"
-  url "https://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar"
-  sha256 "dd68dcfcd687b732683cf56722c599a8e36e510c0906ac476c2083cb5df0bb4e"
+  url "https://selenium-release.storage.googleapis.com/2.49/selenium-server-standalone-2.49.0.jar"
+  sha256 "e085ece95c77655d8f33289e82691f9b06896032078d158a570378aeef8846f0"
 
   bottle :unneeded
 


### PR DESCRIPTION
Hi!

This PR upgrades selenium-server-standalone from 2.48.2 to 2.49.0
Changelog: https://raw.githubusercontent.com/SeleniumHQ/selenium/master/java/CHANGELOG