### PR TITLE
metar 1.0.0 (new formula)

### DIFF
--- a/Library/Formula/metar.rb
+++ b/Library/Formula/metar.rb
@@ -1,0 +1,14 @@
+class Metar < Formula
+  desc "Get METAR aviation weather reports on your command-line"
+  homepage "https://github.com/vsinha/METAR"
+  url "https://github.com/vsinha/METAR/archive/1.0.0.tar.gz"
+  sha256 "bcec28654b73bbfcb7115462b93f64b9f4eb7ec7208c63d60e92f16d4dcf7423"
+
+  def install
+    bin.install "metar"
+  end
+
+  test do
+    system "#{bin}/metar"
+  end
+end


### PR DESCRIPTION
Simple shell script to get METAR readings on your command line

cURLs weather.noaa.gov to get the forecast
defaults to KRNT (my home airport) if no arguments are specified
desgined to work with TextBar to put METAR into your osx menubar
github repo here: https://github.com/vsinha/METAR