### PR TITLE
postgresql: Fix a flag name typo

### DIFF
--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -45,7 +45,7 @@ class Postgresql < Formula
     ENV.libxml2 if MacOS.version >= :snow_leopard
 
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
-    ENV.prepend "CPPLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
 
     args = %W[
       --disable-debug


### PR DESCRIPTION
"CPPLAGS" is a typo and no-effect.
It should be use "CPPFLAGS" instead.

But for now, `LDFLAGS` flag is correct. 
So, correct `openssl` and `readline` are linked to homebrewed postgresql.