### PR TITLE
fsevents-tools (new formula)

### DIFF
--- a/Library/Formula/fsevents-tools.rb
+++ b/Library/Formula/fsevents-tools.rb
@@ -1,0 +1,21 @@
+class FseventsTools < Formula
+  desc "inotify-tools for OS X's FSEvents"
+  homepage "http://geoff.greer.fm/fsevents/"
+  url "http://geoff.greer.fm/fsevents/releases/fsevents-tools-1.0.0.tar.gz"
+  sha256 "498528e1794fa2b0cf920bd96abaf7ced15df31c104d1a3650e06fa3f95ec628"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    # Make sure notifywait exits when test-file is created.
+    system "bash", "-c", "(sleep 5.0; touch test-file;) &"
+    system "#{bin}/notifywait", "."
+    rm "test-file"
+  end
+end


### PR DESCRIPTION
Add `fsevents-tools` by @ggreer (described as inotify-tools for OS X's FSEvents).

GitHub: https://github.com/ggreer/fsevents-tools
Home: http://geoff.greer.fm/fsevents/
Blog post: http://geoff.greer.fm/2015/12/25/fsevents-tools-watch-a-directory-for-changes/

Thanks! :-)