### PR TITLE
source-highlight: revision for boost

### DIFF
--- a/Library/Formula/source-highlight.rb
+++ b/Library/Formula/source-highlight.rb
@@ -5,6 +5,7 @@ class SourceHighlight < Formula
   mirror "https://ftp.gnu.org/gnu/src-highlite/source-highlight-3.1.8.tar.gz"
   mirror "http://mirror.anl.gov/pub/gnu/src-highlite/source-highlight-3.1.8.tar.gz"
   sha256 "01336a7ea1d1ccc374201f7b81ffa94d0aecb33afc7d6903ebf9fbf33a55ada3"
+  revision 1
 
   bottle do
     sha256 "959727f418cb83cacabda416daa56db17b75f247a86edbe044805209cf629738" => :el_capitan
@@ -22,5 +23,9 @@ class SourceHighlight < Formula
     system "make", "install"
 
     bash_completion.install "completion/source-highlight"
+  end
+
+  test do
+    assert_match /GNU Source-highlight #{version}/, shell_output("#{bin}/source-highlight -V")
   end
 end


### PR DESCRIPTION
`source-highlight` stopped working since the recent update of `boost` to 1.60 (#47125).

```
$ source-highlight
dyld: Symbol not found: __ZN5boost9re_detail12perl_matcherIPKcNSt3__19allocatorINS_9sub_matchIS3_EEEENS_12regex_traitsIcNS_16cpp_regex_traitsIcEEEEE14construct_initERKNS_11basic_regexIcSC_EENS_15regex_constants12_match_flagsE
  Referenced from: /usr/local/Cellar/source-highlight/3.1.8/lib/libsource-highlight.4.dylib
  Expected in: /usr/local/lib/libboost_regex-mt.dylib
 in /usr/local/Cellar/source-highlight/3.1.8/lib/libsource-highlight.4.dylib
[1]    64213 trace trap  source-highlight
```

Rebuilding from source solved the problem. Probably we need to rebottle it and look for other formulae that could have harder dependency on boost.