### PR TITLE
swift: Append `.git` to `apple/swift` HEAD repo URL — corrects retrieval.

### DIFF
--- a/Library/Formula/swift.rb
+++ b/Library/Formula/swift.rb
@@ -30,7 +30,7 @@ class Swift < Formula
   end
 
   head do
-    url "https://github.com/apple/swift"
+    url "https://github.com/apple/swift.git"
 
     resource "cmark" do
       url "https://github.com/apple/swift-cmark.git"


### PR DESCRIPTION
> Corrects HEAD repo for `swift` Formula.
>
> Previously, `HOMEBREW_VERBOSE='true' brew install --build-from-source --HEAD swift` would fail, outputting similar to `Failed to execute: /private/tmp/swift20160117-8491-10j0cvg/utils/build-script`.
>
> Only the HTML page GitHub serves for <https://github.com/apple/swift> would be retrieved — not the repo, and therefore not the `build-script`, which could not be found or executed.

```
🍺  /usr/local/Cellar/swift/HEAD: 165 files, 101.7M, built in 56 minutes 55 seconds
```

```shell
$ /usr/local/Cellar/swift/HEAD/bin/swift --version
Swift version 2.2-dev (Swift 4e1c4d8bf3)
Target: x86_64-apple-macosx10.11
```

`brew audit swift.rb` returns without an error code.