### PR TITLE
Permit cleanup to remove outdated keg-only formulae

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -162,13 +162,6 @@ _brew_bottle ()
 
 _brew_cleanup ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
-    --*)
-        __brewcomp "--force"
-        return
-        ;;
-    esac
     __brew_complete_installed
 }
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1484,7 +1484,7 @@ class Formula
     eligible_for_cleanup = []
     if installed?
       eligible_kegs = installed_kegs.select { |k| pkg_version > k.version }
-      if eligible_kegs.any? && eligible_for_cleanup?
+      if eligible_kegs.any?
         eligible_kegs.each do |keg|
           if keg.linked?
             opoo "Skipping (old) #{keg} due to it being linked"
@@ -1492,8 +1492,6 @@ class Formula
             eligible_for_cleanup << keg
           end
         end
-      else
-        eligible_kegs.each { |keg| opoo "Skipping (old) keg-only: #{keg}" }
       end
     elsif installed_prefixes.any? && !pinned?
       # If the cellar only has one version installed, don't complain
@@ -1502,25 +1500,6 @@ class Formula
       opoo "Skipping #{full_name}: most recent version #{pkg_version} not installed"
     end
     eligible_for_cleanup
-  end
-
-  # @private
-  def eligible_for_cleanup?
-    # It used to be the case that keg-only kegs could not be cleaned up, because
-    # older brews were built against the full path to the keg-only keg. Then we
-    # introduced the opt symlink, and built against that instead. So provided
-    # no brew exists that was built against an old-style keg-only keg, we can
-    # remove it.
-    if !keg_only? || ARGV.force?
-      true
-    elsif opt_prefix.directory?
-      # SHA records were added to INSTALL_RECEIPTS the same day as opt symlinks
-      Formula.installed.select do |f|
-        f.deps.any? do |d|
-          d.to_formula.full_name == full_name rescue d.name == name
-        end
-      end.all? { |f| f.installed_prefixes.all? { |keg| Tab.for_keg(keg).HEAD } }
-    end
   end
 
   private

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -55,13 +55,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `cat` <formula>:
     Display the source to <formula>.
 
-  * `cleanup` [`--force`] [`--prune=`<days>] [`--dry-run`] [`-s`] [<formulae>]:
+  * `cleanup` [`--prune=`<days>] [`--dry-run`] [`-s`] [<formulae>]:
     For all installed or specific formulae, remove any older versions from the
-    cellar. By default, does not remove out-of-date keg-only brews, as other
-    software may link directly to specific versions. In addition, old downloads from
-    the Homebrew download-cache are deleted.
-
-    If `--force` is passed, remove out-of-date keg-only brews as well.
+    cellar. In addition, old downloads from the Homebrew download-cache are deleted.
 
     If `--prune=`<days> is specified, remove all cache files older than <days>.
 

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -49,12 +49,8 @@ connection are run. This should be used when creating for new formulae.</p>
 <p><code>audit</code> exits with a non-zero status if any errors are found. This is useful,
 for instance, for implementing pre-commit hooks.</p></dd>
 <dt><code>cat</code> <var>formula</var></dt><dd><p>Display the source to <var>formula</var>.</p></dd>
-<dt><code>cleanup</code> [<code>--force</code>] [<code>--prune=</code><var>days</var>] [<code>--dry-run</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
-cellar. By default, does not remove out-of-date keg-only brews, as other
-software may link directly to specific versions. In addition, old downloads from
-the Homebrew download-cache are deleted.</p>
-
-<p>If <code>--force</code> is passed, remove out-of-date keg-only brews as well.</p>
+<dt><code>cleanup</code> [<code>--prune=</code><var>days</var>] [<code>--dry-run</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
+cellar. In addition, old downloads from the Homebrew download-cache are deleted.</p>
 
 <p>If <code>--prune=</code><var>days</var> is specified, remove all cache files older than <var>days</var>.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -64,11 +64,8 @@ If \fB\-\-online\fR is passed, additional slower checks that require a network c
 Display the source to \fIformula\fR\.
 .
 .TP
-\fBcleanup\fR [\fB\-\-force\fR] [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [\fIformulae\fR]
-For all installed or specific formulae, remove any older versions from the cellar\. By default, does not remove out\-of\-date keg\-only brews, as other software may link directly to specific versions\. In addition, old downloads from the Homebrew download\-cache are deleted\.
-.
-.IP
-If \fB\-\-force\fR is passed, remove out\-of\-date keg\-only brews as well\.
+\fBcleanup\fR [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [\fIformulae\fR]
+For all installed or specific formulae, remove any older versions from the cellar\. In addition, old downloads from the Homebrew download\-cache are deleted\.
 .
 .IP
 If \fB\-\-prune=\fR\fIdays\fR is specified, remove all cache files older than \fIdays\fR\.


### PR DESCRIPTION
This check is not really relevant anymore; old-style, pre-opt installs date from 2012 at the very latest, so it is very unlikely that any packages remain which still link against these.

The test in `eligible_for_cleanup?` which was meant to allow these to be conditionally cleaned up doesn't seem to have actually been working as intended. At this point I think we can just safely remove it.

Refs #48139.