### PR TITLE
commands: support .sh commands

### DIFF
--- a/Library/Homebrew/cmd/command.rb
+++ b/Library/Homebrew/cmd/command.rb
@@ -4,14 +4,25 @@ module Homebrew
     cmd = ARGV.first
     cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
 
-    if (path = HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.rb").file?
-      puts path
-    elsif ARGV.homebrew_developer? && (path = HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb").file?
+    if (path = internal_command_path cmd)
       puts path
     elsif (path = which("brew-#{cmd}") || which("brew-#{cmd}.rb"))
       puts path
     else
       odie "Unknown command: #{cmd}"
     end
+  end
+
+  private
+
+  def internal_command_path(cmd)
+    extensions = %w[rb sh]
+    paths = extensions.map { |ext| HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.#{ext}" }
+
+    if ARGV.homebrew_developer?
+      paths += extensions.map { |ext| HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.#{ext}" }
+    end
+
+    paths.find { |p| p.file? }
   end
 end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -27,18 +27,30 @@ module Homebrew
   end
 
   def internal_commands
-    (HOMEBREW_LIBRARY_PATH/"cmd").children.select(&:file?).map { |f| f.basename(".rb").to_s }
+    find_internal_commands HOMEBREW_LIBRARY_PATH/"cmd"
   end
 
   def internal_development_commands
-    (HOMEBREW_LIBRARY_PATH/"dev-cmd").children.select(&:file?).map { |f| f.basename(".rb").to_s }
+    find_internal_commands HOMEBREW_LIBRARY_PATH/"dev-cmd"
   end
 
   def external_commands
-    paths.flat_map { |p| Dir["#{p}/brew-*"] }.
-      select { |f| File.executable?(f) }.
-      map { |f| File.basename(f, ".rb")[5..-1] }.
-      reject { |f| f =~ /\./ }.
-      sort
+    paths.reduce([]) do |cmds, path|
+      Dir["#{path}/brew-*"].each do |file|
+        next unless File.executable?(file)
+        cmd = File.basename(file, ".rb")[5..-1]
+        cmds << cmd unless cmd.include?(".")
+      end
+      cmds
+    end.sort
+  end
+
+  private
+
+  def find_internal_commands(directory)
+    directory.children.reduce([]) do |cmds, f|
+      cmds << f.basename.to_s.sub(/\.(?:rb|sh)$/, "") if f.file?
+      cmds
+    end
   end
 end

--- a/Library/Homebrew/test/test_commands.rb
+++ b/Library/Homebrew/test/test_commands.rb
@@ -1,8 +1,9 @@
 require "testing_env"
+require "cmd/command"
 require "cmd/commands"
 require "fileutils"
 
-class CommandsCommandTests < Homebrew::TestCase
+class CommandsTests < Homebrew::TestCase
   def setup
     @cmds = [
       # internal commands
@@ -58,5 +59,24 @@ class CommandsCommandTests < Homebrew::TestCase
     end
   ensure
     ENV.replace(env)
+  end
+
+  def test_internal_command_path
+    assert_equal HOMEBREW_LIBRARY_PATH/"cmd/rbcmd.rb",
+                 Homebrew.send(:internal_command_path, "rbcmd")
+    assert_equal HOMEBREW_LIBRARY_PATH/"cmd/shcmd.sh",
+                 Homebrew.send(:internal_command_path, "shcmd")
+    assert_nil Homebrew.send(:internal_command_path, "idontexist1234")
+  end
+
+  def test_internal_dev_command_path
+    ARGV.stubs(:homebrew_developer?).returns false
+    assert_nil Homebrew.send(:internal_command_path, "rbdevcmd")
+
+    ARGV.stubs(:homebrew_developer?).returns true
+    assert_equal HOMEBREW_LIBRARY_PATH/"dev-cmd/rbdevcmd.rb",
+                 Homebrew.send(:internal_command_path, "rbdevcmd")
+    assert_equal HOMEBREW_LIBRARY_PATH/"dev-cmd/shdevcmd.sh",
+                 Homebrew.send(:internal_command_path, "shdevcmd")
   end
 end

--- a/Library/Homebrew/test/test_commands.rb
+++ b/Library/Homebrew/test/test_commands.rb
@@ -1,0 +1,62 @@
+require "testing_env"
+require "cmd/commands"
+require "fileutils"
+
+class CommandsCommandTests < Homebrew::TestCase
+  def setup
+    @cmds = [
+      # internal commands
+      HOMEBREW_LIBRARY_PATH/"cmd/rbcmd.rb",
+      HOMEBREW_LIBRARY_PATH/"cmd/shcmd.sh",
+
+      # internal development commands
+      HOMEBREW_LIBRARY_PATH/"dev-cmd/rbdevcmd.rb",
+      HOMEBREW_LIBRARY_PATH/"dev-cmd/shdevcmd.sh",
+    ]
+
+    @cmds.each { |f| FileUtils.touch f }
+  end
+
+  def teardown
+    @cmds.each { |f| f.unlink }
+  end
+
+  def test_internal_commands
+    cmds = Homebrew.internal_commands
+    assert cmds.include?("rbcmd"), "Ruby commands files should be recognized"
+    assert cmds.include?("shcmd"), "Shell commands files should be recognized"
+    refute cmds.include?("rbdevcmd"), "Dev commands shouldn't be included"
+  end
+
+  def test_internal_development_commands
+    cmds = Homebrew.internal_development_commands
+    assert cmds.include?("rbdevcmd"), "Ruby commands files should be recognized"
+    assert cmds.include?("shdevcmd"), "Shell commands files should be recognized"
+    refute cmds.include?("rbcmd"), "Non-dev commands shouldn't be included"
+  end
+
+  def test_external_commands
+    env = ENV.to_hash
+
+    mktmpdir do |dir|
+      %w[brew-t1 brew-t2.rb brew-t3.py].each do |file|
+        path = "#{dir}/#{file}"
+        FileUtils.touch path
+        FileUtils.chmod 0744, path
+      end
+
+      FileUtils.touch "#{dir}/t4"
+
+      ENV["PATH"] = "#{ENV["PATH"]}#{File::PATH_SEPARATOR}#{dir}"
+      cmds = Homebrew.external_commands
+
+      assert cmds.include?("t1"), "Executable files should be included"
+      assert cmds.include?("t2"), "Executable Ruby files should be included"
+      refute cmds.include?("t3"),
+        "Executable files with a non Ruby extension shoudn't be included"
+      refute cmds.include?("t4"), "Non-executable files shouldn't be included"
+    end
+  ensure
+    ENV.replace(env)
+  end
+end


### PR DESCRIPTION
I also refactored things a bit and added tests.

Without this change `update-bash.sh` appears in the `brew commands` output instead of `update-bash`.

Update: this also fixes an issue with the shell completion, right now `brew upd<tab>` gives:
```
update          update-bash.sh  update-report   update-test
```
Instead of:
```
update         update-bash    update-report  update-test
```