### PR TITLE
Distinguish `brew info --json=v1` dependencies

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1244,6 +1244,8 @@ class Formula
       "outdated" => outdated?,
       "keg_only" => keg_only?,
       "dependencies" => deps.map(&:name).uniq,
+      "optional_dependencies" => deps.select(&:optional?).map(&:name).uniq,
+      "recommended_dependencies" => deps.select(&:recommended?).map(&:name).uniq,
       "conflicts_with" => conflicts.map(&:name),
       "caveats" => caveats
     }


### PR DESCRIPTION
Fixes #47914 by distinguishing between required, optional, and
recommended dependencies when using `brew info --json=v1`. This is done
by adding the `optional_dependencies` and `recommended_dependencies`
fields to the JSON output.

A good example of this fix is `brew info --json=v1 dtrx`.