### PR TITLE
llvm: Disable assertions by default

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -116,10 +116,8 @@ class Llvm < Formula
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build Python bindings against Homebrew Python"
   option "with-rtti", "Build with C++ RTTI"
-  option "with-assertions", "Provides more debug information, but slows down LLVM"
 
   deprecated_option "rtti" => "with-rtti"
-  deprecated_option "disable-assertions" => "without-assertions"
 
   if MacOS.version <= :snow_leopard
     depends_on :python

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -116,7 +116,7 @@ class Llvm < Formula
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build Python bindings against Homebrew Python"
   option "with-rtti", "Build with C++ RTTI"
-  option "without-assertions", "Speeds up LLVM, but provides less debug information"
+  option "with-assertions", "Provides more debug information, but slows down LLVM"
 
   deprecated_option "rtti" => "with-rtti"
   deprecated_option "disable-assertions" => "without-assertions"


### PR DESCRIPTION
This makes the build consistent with std_cmake_args, which passes
-DNDEBUG. Before this both -DNDEBUG and -DLLVM_ENABLE_ASSERTIONS=On were
passed.

Forgot to change this when I added -DNDEBUG to std_cmake_args, I think.

Also not quite sure what to do with the deprecated options; do those need to be negated as well?