### PR TITLE
update-bash: add connectivity check

### DIFF
--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -208,6 +208,12 @@ update-bash() {
     esac
   done
 
+  if ! curl -I --connect-timeout 2 https://github.com &> /dev/null
+  then
+    echo "Cannot connect to github.com; please ensure you have Internet connection!"
+    exit 1
+  fi
+
   if [ -n "$HOMEBREW_DEBUG" ]
   then
     set -x


### PR DESCRIPTION
Resolves half of #48193.

Offline:
```
~> brew update-bash
Cannot connect to github.com; please ensure you have Internet connection!
```
Online (You didn't merge anything in my absence :stuck_out_tongue_winking_eye:)
```
~> brew update-bash
Already up-to-date.
```

Online this test takes about 0.6 seconds to execute, offline it times out at 2 seconds as instructed. As mentioned in https://github.com/Homebrew/homebrew/issues/48193#issuecomment-172842767 we could switch to using Debian's website for the check if we're worried about the 0.6 seconds as Debian tends to take 1/2 to 3/4 of that (probably due to defining fewer headers).

CC @mikemcquaid @xu-cheng @bfontaine 