### PR TITLE
teensy_loader_cli  2.1 (devel)

### DIFF
--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -2,7 +2,7 @@ class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
-  head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
+  sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,16 +11,17 @@ class TeensyLoaderCli < Formula
     sha256 "dcd10140babb4d2937ce376c89e9c24a2e8046d2cabdad2cfdbc2542afa14471" => :mavericks
   end
 
-  devel do
-    url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "0cca2087afb54173ce03109cabb1e29658703fc8"
-    version "2.1.devel"
+  head do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git"
+
+    depends_on "libusb-compat"  => :optional
   end
 
-  option "with-libusb-compat", "Uses libusb instead od OS X HID api to connect with teensy boards. Available only for --devel and upwards."
-  depends_on "libusb-compat"  => :optional
+  devel do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "a5b2c6fdc14c3a1ce9f614c767d9c758b0a1ce96"
+    version "2.1.devel"
 
-  def pour_bottle?
-      build.without? "libusb-compat"
+    depends_on "libusb-compat"  => :optional
   end
 
   def install
@@ -39,6 +40,5 @@ class TeensyLoaderCli < Formula
   test do
     output = shell_output("#{bin}/teensy_loader_cli 2>&1", 1)
     assert_match /Filename must be specified/, output
-    # system "#{bin}/teensy_loader_cli --list-mcus"
   end
 end

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -11,15 +11,15 @@ class TeensyLoaderCli < Formula
     sha256 "dcd10140babb4d2937ce376c89e9c24a2e8046d2cabdad2cfdbc2542afa14471" => :mavericks
   end
 
-  head do
-    url "https://github.com/PaulStoffregen/teensy_loader_cli.git"
+  devel do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "a5b2c6fdc14c3a1ce9f614c767d9c758b0a1ce96"
+    version "2.1.devel"
 
     depends_on "libusb-compat"  => :optional
   end
 
-  devel do
-    url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "a5b2c6fdc14c3a1ce9f614c767d9c758b0a1ce96"
-    version "2.1.devel"
+  head do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git"
 
     depends_on "libusb-compat"  => :optional
   end

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -13,7 +13,7 @@ class TeensyLoaderCli < Formula
 
   devel do
     url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "0cca2087afb54173ce03109cabb1e29658703fc8"
-    version "2.1.x"
+    version "2.1.devel"
   end
 
   option "with-libusb-compat", "Uses libusb instead od OS X HID api to connect with teensy boards. Available only for --devel and upwards."
@@ -38,6 +38,7 @@ class TeensyLoaderCli < Formula
 
   test do
     output = shell_output("#{bin}/teensy_loader_cli 2>&1", 1)
-    assert_match /<MCU> = atmega32u4 | at90usb162 | at90usb646 | at90usb1286/, output
+    assert_match /Filename must be specified/, output
+    # system "#{bin}/teensy_loader_cli --list-mcus"
   end
 end

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -2,7 +2,6 @@ class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
   url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
-  sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
   head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
 
   bottle do
@@ -12,9 +11,27 @@ class TeensyLoaderCli < Formula
     sha256 "dcd10140babb4d2937ce376c89e9c24a2e8046d2cabdad2cfdbc2542afa14471" => :mavericks
   end
 
+  devel do
+    url "https://github.com/PaulStoffregen/teensy_loader_cli.git", :revision => "0cca2087afb54173ce03109cabb1e29658703fc8"
+    version "2.1.x"
+  end
+
+  option "with-libusb-compat", "Uses libusb instead od OS X HID api to connect with teensy boards. Available only for --devel and upwards."
+  depends_on "libusb-compat"  => :optional
+
+  def pour_bottle?
+      build.without? "libusb-compat"
+  end
+
   def install
     ENV["OS"] = "MACOSX"
-    ENV["SDK"] = MacOS.sdk_path || "/"
+
+    if build.with? "libusb-compat"
+      ENV["USE_LIBUSB"] = "YES"
+    else
+      ENV["SDK"] = MacOS.sdk_path || "/"
+    end
+
     system "make"
     bin.install "teensy_loader_cli"
   end


### PR DESCRIPTION
Update to allow use of devel repository instead of outdated (2013-ish) zip source distribution and expose libusb compilation flags.