### PR TITLE
pandoc-citeproc: solve install failure on Lion. Copied from pandoc Fo…

### DIFF
--- a/Library/Formula/pandoc-citeproc.rb
+++ b/Library/Formula/pandoc-citeproc.rb
@@ -19,7 +19,9 @@ class PandocCiteproc < Formula
   depends_on "pandoc"
 
   def install
-    install_cabal_package
+    args = []
+    args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
+    install_cabal_package *args
   end
 
   test do


### PR DESCRIPTION
…rmula.

`brew install pandoc-citeproc` failed on Lion (10.7.5). More specifically, installing the Haskell dependency `cryptonite` failed. With this change, the install procedure and `brew test pandoc-citeproc` succeeded. I have no deep knowledge of Ruby or the Homebrew Formula syntax, so I just copied code from the pandoc Formula and got lucky, I guess.