### PR TITLE
libdvbpsi 1.3.0

### DIFF
--- a/Library/Formula/libdvbpsi.rb
+++ b/Library/Formula/libdvbpsi.rb
@@ -1,8 +1,8 @@
 class Libdvbpsi < Formula
   desc "Library to decode/generate MPEG TS and DVB PSI tables"
   homepage "https://www.videolan.org/developers/libdvbpsi.html"
-  url "https://download.videolan.org/pub/libdvbpsi/0.2.2/libdvbpsi-0.2.2.tar.bz2"
-  sha256 "9aa62345c8fed04a4f59524967fb154e3f9b02625666a200861555dcb9163ed3"
+  url "https://download.videolan.org/pub/libdvbpsi/1.3.0/libdvbpsi-1.3.0.tar.bz2"
+  sha256 "a2fed1d11980662f919bbd1f29e2462719e0f6227e1a531310bd5a706db0a1fe"
 
   bottle do
     cellar :any
@@ -13,8 +13,6 @@ class Libdvbpsi < Formula
   end
 
   def install
-    # Clang doesn't recognize O6.  Just remove it.  Fixes a build error.
-    inreplace "configure", "CFLAGS=\"${CFLAGS} -O6\"", "CFLAGS=\"${CFLAGS}\""
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking", "--enable-release"
     system "make", "install"
   end


### PR DESCRIPTION
update libdvbpsi from v0.2.2 to v1.3.0

libdvbpsi has had quite a lot of development in the past few years, most notably ATSC support, the standard for digital television broadcast in the United States.

Let's start shipping a more recent build of libdvbpsi.  Unfortunately some of the API has changed.  Dependent applications will need to be updated against the latest headers in order to function properly.