### PR TITLE
update-bash: release to non-developers.

### DIFF
--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -234,11 +234,6 @@ update-bash() {
   local DIR
   local UPSTREAM_BRANCH
 
-  if [[ -z "$HOMEBREW_DEVELOPER" ]]
-  then
-    odie "This command is currently only for Homebrew developers' use."
-  fi
-
   for option in "$@"
   do
     case "$option" in

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -6,10 +6,6 @@ require "descriptions"
 
 module Homebrew
   def update_report
-    unless ENV["HOMEBREW_DEVELOPER"]
-      odie "This command is currently only for Homebrew developers' use."
-    end
-
     # migrate to new directories based tap structure
     migrate_taps
 


### PR DESCRIPTION
Allow people to run this command (so we can ask people to test it) without having to set `HOMEBREW_DEVELOPER`.

There's been no (reported) issues with the `bin/brew` changes so I think it'd be nice to get this out to more people (e.g. on Twitter, the mailing list), get them to test it and submit issues to us. Next step after that would be making this the primary update command and renaming the old one to `update-ruby.rb`.

CC @Homebrew/maintainers for thoughts