### PR TITLE
config: fail when HOMEBREW_BREW_FILE is unset.

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -26,8 +26,9 @@ undef cache
 # Where brews installed via URL are cached
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"
 
-unless defined? HOMEBREW_BREW_FILE
-  HOMEBREW_BREW_FILE = ENV["HOMEBREW_BREW_FILE"] || which("brew").to_s
+HOMEBREW_BREW_FILE = ENV["HOMEBREW_BREW_FILE"]
+unless HOMEBREW_BREW_FILE
+  odie "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!"
 end
 
 # Where we link under

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -2,8 +2,6 @@
 
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
-HOMEBREW_BREW_FILE = ENV["HOMEBREW_BREW_FILE"]
-
 require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent.join("Homebrew")
 $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)


### PR DESCRIPTION
Not sure why this is happening (beyond the Chef cookbook stupidly deciding to not call through `bin/brew`) but spam some scary looking warnings to hope to point people in the right direction.

CC @Homebrew/maintainers for thoughts and feel free to merge this before I do tomorrow if there's a pressing need.