### PR TITLE
boost: fix use of deprecated ice_not traits.

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -3,6 +3,7 @@ class Boost < Formula
   homepage "http://www.boost.org"
   url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
   sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
+  revision 1
 
   head "https://github.com/boostorg/boost.git"
 
@@ -12,6 +13,9 @@ class Boost < Formula
     sha256 "149c31c8bdb7b4f47bed445e3c5985f63dd41ba32cefc08358b873699c7d6f5d" => :yosemite
     sha256 "dae5d86bbcedd981d353e812770477fe104e349e5cfb253a735bbe1c6c32cc0a" => :mavericks
   end
+
+  # Handle compile failure with boost/graph/adjacency_matrix.hpp
+  patch :DATA
 
   env :userpaths
 
@@ -169,3 +173,17 @@ class Boost < Formula
     system "./test"
   end
 end
+
+__END__
+diff -Nur boost_1_60_0/boost/graph/adjacency_matrix.hpp boost_1_60_0-patched/boost/graph/adjacency_matrix.hpp
+--- boost_1_60_0/boost/graph/adjacency_matrix.hpp	2015-10-23 05:50:19.000000000 -0700
++++ boost_1_60_0-patched/boost/graph/adjacency_matrix.hpp	2016-01-19 14:03:29.000000000 -0800
+@@ -443,7 +443,7 @@
+     // graph type. Instead, use directedS, which also provides the
+     // functionality required for a Bidirectional Graph (in_edges,
+     // in_degree, etc.).
+-    BOOST_STATIC_ASSERT(type_traits::ice_not<(is_same<Directed, bidirectionalS>::value)>::value);
++    BOOST_STATIC_ASSERT(!(is_same<Directed, bidirectionalS>::value));
+ 
+     typedef typename mpl::if_<is_directed,
+                                     bidirectional_tag, undirected_tag>::type


### PR DESCRIPTION
The boost folks removed ice_not in 1.60 but forgot to update
boost::graph accordingly. Now any use of adjacency_matrix.hpp
fails:

    $ cat test.cpp
    #include <boost/graph/adjacency_list.hpp>
    #include <boost/graph/adjacency_matrix.hpp>

    $ clang++ -c test.cpp -I/usr/local/include
    In file included from test.cpp:2:
    /usr/local/include/boost/graph/adjacency_matrix.hpp:446:38: error: no member
          named 'ice_not' in namespace 'boost::type_traits'
        BOOST_STATIC_ASSERT(type_traits::ice_not<(is_same<Directed, bidirect...
                            ~~~~~~~~~~~~~^

This is upstream Boost bug https://svn.boost.org/trac/boost/ticket/11880.

Fix this by applying the upstream patch, boostorg/graph@1d5f43d.