### PR TITLE
sh: flush stdout before executing the shell

### DIFF
--- a/Library/Homebrew/cmd/sh.rb
+++ b/Library/Homebrew/cmd/sh.rb
@@ -24,6 +24,7 @@ module Homebrew
          ignore our configuration.
          When done, type `exit'.
          EOS
+    $stdout.flush
     exec ENV["SHELL"]
   end
 end

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -284,6 +284,11 @@ class IntegrationCommandTests < Homebrew::TestCase
     (HOMEBREW_REPOSITORY/".git").unlink
   end
 
+  def test_sh
+    assert_match "Your shell has been configured",
+                 cmd("sh", {"SHELL" => "/usr/bin/true"})
+  end
+
   def test_custom_command
     mktmpdir do |path|
       cmd = "int-test-#{rand}"


### PR DESCRIPTION
Before:
```
$ irb
>>> `brew sh`
=> ""
```

After:
```
$ irb
>>> `brew sh`
=> "Your shell has been configured to use Homebrew's build environment:\nthis should help you build stuff. Notably though, the system versions of\ngem and pip will ignore our configuration and insist on using the\nenvironment they were built under (mostly). Sadly, scons will also\nignore our configuration.\nWhen done, type `exit'.\n"
```

This also allows us to make an integration test; without this fix `cmd("sh")` would return an empty string.