### PR TITLE
diagnostic: fix autoconf check

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1044,6 +1044,7 @@ module Homebrew
       end
 
       def check_for_autoconf
+        return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.provides_autotools?
 
         autoconf = which("autoconf")

--- a/Library/Homebrew/test/test_diagnostic.rb
+++ b/Library/Homebrew/test/test_diagnostic.rb
@@ -205,6 +205,7 @@ class DiagnosticChecksTest < Homebrew::TestCase
   end
 
   def test_check_for_autoconf
+    MacOS::Xcode.stubs(:installed?).returns true
     MacOS::Xcode.stubs(:provides_autotools?).returns true
     mktmpdir do |path|
       file = "#{path}/autoconf"


### PR DESCRIPTION
Xcode can only provide autotools if it is installed, thus check that first. Skipping this check will try to compare a `nil` Xcode version to 4.3, the first version of Xcode to not provide autotools. (Fixes #48208.)

cc @DomT4