### PR TITLE
tests: minor tweaks and enhancements

### DIFF
--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -22,6 +22,11 @@ module Homebrew
 
       args = []
       args << "--trace" if ARGV.include? "--trace"
+      if ARGV.value("only")
+        test_name, test_method = ARGV.value("only").split("/", 2)
+        args << "TEST=test_#{test_name}.rb"
+        args << "TESTOPTS=--name=test_#{test_method}" if test_method
+      end
       args += ARGV.named.select { |v| v[/^TEST(OPTS)?=/] }
       system "bundle", "exec", "rake", "test", *args
 

--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -17,9 +17,12 @@ module Homebrew
         system "bundle", "install", "--path", "vendor/bundle"
       end
 
+      # Make it easier to reproduce test runs.
+      ENV["SEED"] = ARGV.next if ARGV.include? "--seed"
+
       args = []
       args << "--trace" if ARGV.include? "--trace"
-      args += ARGV.named
+      args += ARGV.named.select { |v| v[/^TEST(OPTS)?=/] }
       system "bundle", "exec", "rake", "test", *args
 
       Homebrew.failed = !$?.success?

--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -7,7 +7,6 @@ SimpleCov.start do
   coverage_dir File.expand_path("#{tests_path}/coverage")
   root File.expand_path("#{tests_path}/../../")
 
-  add_filter "vendor/bundle/"
   add_filter "Formula/"
   add_filter "Homebrew/compat/"
   add_filter "Homebrew/test/"


### PR DESCRIPTION
Remove a useless coverage filter and add support for two new `brew tests` flags:

- `--only=<test>[/<method>]` to only run a specific test or just one method of that test.
- `--seed <number>` to be able to easier reproduce previous test runs.