### PR TITLE
tests: accelerate and fix integration tests

### DIFF
--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -19,7 +19,7 @@ if ENV["HOMEBREW_INTEGRATION_TEST"]
   SimpleCov.at_exit do
     exit_code = $!.nil? ? 0 : $!.status
     $stdout.reopen("/dev/null")
-    SimpleCov.result.format!
+    SimpleCov.result # Just save result, but don't write formatted output.
     exit! exit_code
   end
 end

--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -14,8 +14,8 @@ SimpleCov.start do
   add_filter "Homebrew/vendor/"
 end
 
-if name = ENV["HOMEBREW_INTEGRATION_TEST"]
-  SimpleCov.command_name "brew #{name}"
+if ENV["HOMEBREW_INTEGRATION_TEST"]
+  SimpleCov.command_name ENV["HOMEBREW_INTEGRATION_TEST"]
   SimpleCov.at_exit do
     exit_code = $!.nil? ? 0 : $!.status
     $stdout.reopen("/dev/null")

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -4,6 +4,16 @@ require "core_formula_repository"
 require "fileutils"
 
 class IntegrationCommandTests < Homebrew::TestCase
+  def setup
+    @cmd_id_index = 0 # Assign unique IDs to invocations of `cmd_output`.
+  end
+
+  def cmd_id_from_args(args)
+    args_pretty = args.join(" ").gsub(TEST_TMPDIR, "@TMPDIR@")
+    test_pretty = "#{self.class.name}\##{name}.#{@cmd_id_index += 1}"
+    "[#{test_pretty}] brew #{args_pretty}"
+  end
+
   def cmd_output(*args)
     # 1.8-compatible way of writing def cmd_output(*args, **env)
     env = args.last.is_a?(Hash) ? args.pop : {}
@@ -18,7 +28,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     cmd_args += args
     Bundler.with_original_env do
       ENV["HOMEBREW_BREW_FILE"] = HOMEBREW_PREFIX/"bin/brew"
-      ENV["HOMEBREW_INTEGRATION_TEST"] = args.join " "
+      ENV["HOMEBREW_INTEGRATION_TEST"] = cmd_id_from_args(args)
       ENV["HOMEBREW_TEST_TMPDIR"] = TEST_TMPDIR
       env.each_pair { |k,v| ENV[k] = v }
 


### PR DESCRIPTION
Speed-up is achieved by avoiding to generate the coverage report in `index.html` on *every run* of a command in the integration tests (this makes those about 1/3 faster).

Fix means generate unique names for the commands in the cached result set created by SimpleCov, so that multiple commands with identical arguments don't overwrite each other's coverage results.

cc @bfontaine