### PR TITLE
Fixes tinyproxy plist. It should give -d option to run in foreground

### DIFF
--- a/Library/Formula/tinyproxy.rb
+++ b/Library/Formula/tinyproxy.rb
@@ -83,7 +83,8 @@ class Tinyproxy < Formula
         <false/>
         <key>ProgramArguments</key>
         <array>
-            <string>#{opt_sbin}/tinyproxy -d</string>
+            <string>#{opt_sbin}/tinyproxy</string>
+            <string>-d</string>
         </array>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>

--- a/Library/Formula/tinyproxy.rb
+++ b/Library/Formula/tinyproxy.rb
@@ -83,7 +83,7 @@ class Tinyproxy < Formula
         <false/>
         <key>ProgramArguments</key>
         <array>
-            <string>#{opt_sbin}/tinyproxy</string>
+            <string>#{opt_sbin}/tinyproxy -d</string>
         </array>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>


### PR DESCRIPTION
This patch fixes tinyproxy plist. The original was running tinyproxy as a daemon, therefore the process wasn't attaching and was not working right with `brew services restart tinyproxy`.

```bash
> tinyproxy -h
Usage: tinyproxy [options]

Options are:
  -d        Do not daemonize (run in foreground).
  -c FILE   Use an alternate configuration file.
  -h        Display this usage information.
  -l        Display the license.
  -v        Display version information.

Features compiled in:
    XTinyproxy header
    Filtering
    Upstream proxy support

For bug reporting instructions, please see:
<https://banu.com/tinyproxy/>.
```