### PR TITLE
ploticus: add prefabs to installation

### DIFF
--- a/Library/Formula/ploticus.rb
+++ b/Library/Formula/ploticus.rb
@@ -4,6 +4,7 @@ class Ploticus < Formula
   url "https://downloads.sourceforge.net/project/ploticus/ploticus/2.42/ploticus242_src.tar.gz"
   version "2.42"
   sha256 "3f29e4b9f405203a93efec900e5816d9e1b4381821881e241c08cab7dd66e0b0"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/ploticus.rb
+++ b/Library/Formula/ploticus.rb
@@ -18,10 +18,16 @@ class Ploticus < Formula
     # Use alternate name because "pl" conflicts with OS X "pl" utility
     args=["INSTALLBIN=#{bin}",
           "EXE=ploticus"]
+    inreplace "src/pl.h", /#define\s+PREFABS_DIR\s+""/, "#define PREFABS_DIR \"#{pkgshare}\""
     system "make", "-C", "src", *args
     # Required because the Makefile assumes INSTALLBIN dir exists
     bin.mkdir
     system "make", "-C", "src", "install", *args
+    pkgshare.install Dir["prefabs/*"]
+  end
+
+  def caveats
+    "Ploticus prefabs have been installed to #{pkgshare}"
   end
 
   test do


### PR DESCRIPTION
The existing formula for Ploticus 2.42 omits the installation of
the "prefabs" directory, which most users will need.

This patch ensures that the prefabs are installed into ${pkgshare},
and that ploticus knows where to find them without having to set
the PREFABS_DIR environment variable.