### PR TITLE
node 5.5.0

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -1,10 +1,9 @@
 class Node < Formula
   desc "Platform built on the V8 JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v5.4.1/node-v5.4.1.tar.gz"
-  sha256 "78455ef2e3dea06b7d13d393c36711009048a91e5de5892523ec4a9be5a55e0c"
+  url "https://nodejs.org/dist/v5.5.0/node-v5.5.0.tar.gz"
+  sha256 "d69b18cc20699a35434858fb853997616762280610a510ec4b4ff1a94798b432"
   head "https://github.com/nodejs/node.git"
-  revision 1
 
   bottle do
     sha256 "c8a2c1dab74278a46e07c4aa46982f75579ab9429896f593aeb7bb2413eff8e4" => :el_capitan


### PR DESCRIPTION
Bump node to v5.5.0: https://nodejs.org/en/blog/release/v5.5.0/