### PR TITLE
ARGV: stop supporting --homebrew-developer option

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -475,7 +475,7 @@ _brew_style ()
     local cur="${COMP_WORDS[COMP_CWORD]}"
     case "$cur" in
     --*)
-        __brewcomp "--fix --homebrew-developer"
+        __brewcomp "--fix"
         return
         ;;
     esac

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -125,7 +125,7 @@ module HomebrewArgvExtension
   end
 
   def homebrew_developer?
-    include?("--homebrew-developer") || !ENV["HOMEBREW_DEVELOPER"].nil?
+    !ENV["HOMEBREW_DEVELOPER"].nil?
   end
 
   def sandbox?


### PR DESCRIPTION
Homebrew developers have the corresponding variable permanently set in their environment and wanting to appear like a Homebrew developer for a single invocation is exceedingly rare. Additionally, the option won't be recognized by `bin/brew`. (It is also undocumented.)

Using `HOMEBREW_DEVELOPER=1 brew <command>` is still possible, and not more inconvenient than passing the `--homebrew-developer` option.