### PR TITLE
V8: add i18n support via system icu: Return of the Jedi

### DIFF
--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -21,6 +21,7 @@ class V8 < Formula
 
   depends_on :python => :build # gyp doesn't run under 2.6 or lower
   depends_on "readline" => :optional
+  depends_on "icu4c" => :optional
 
   needs :cxx11
 
@@ -67,6 +68,13 @@ class V8 < Formula
     # https://code.google.com/p/v8/issues/detail?id=4511#c3
     ENV.append "GYP_DEFINES", "v8_use_external_startup_data=0"
 
+    if build.with? "icu4c"
+      ENV.append "GYP_DEFINES", "use_system_icu=1"
+      i18nsupport = "i18nsupport=on"
+    else
+      i18nsupport = "i18nsupport=off"
+    end
+
     # fix up libv8.dylib install_name
     # https://github.com/Homebrew/homebrew/issues/36571
     # https://code.google.com/p/v8/issues/detail?id=3871
@@ -83,7 +91,7 @@ class V8 < Formula
     (buildpath/"tools/swarming_client").install resource("swarming_client")
 
     system "make", "native", "library=shared", "snapshot=on",
-                   "console=readline", "i18nsupport=off",
+                   "console=readline", i18nsupport,
                    "strictaliasing=off"
 
     include.install Dir["include/*"]


### PR DESCRIPTION
Adds system ICU support for v8 by default without patching and so on. Also, give me a note about -j flag using in this PR. 

TL; DR
I package latest v8 4.9 (I guess I have to stop with it) and 4.10 for Ubuntu - [ppa:pinepain/v8](https://launchpad.net/~pinepain/+archive/ubuntu/v8) and [ppa:pinepain/libv8-4.10](https://launchpad.net/~pinepain/+archive/ubuntu/libv8-4.10) correspondent, which are based on [Debian's libv8](http://anonscm.debian.org/git/collab-maint/libv8.git) and problem with using system ICU looks trivial there, so here is this PR, which, I hope, will close #46479 and #47232 saga.
