### PR TITLE
add mirror for glib

### DIFF
--- a/Library/Formula/glib.rb
+++ b/Library/Formula/glib.rb
@@ -2,6 +2,7 @@ class Glib < Formula
   desc "Core application library for C"
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz"
+  mirror "http://ftp.tuwien.ac.at/hci/gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz"
   sha256 "5031722e37036719c1a09163cc6cf7c326e4c4f1f1e074b433c156862bd733db"
 
   bottle do


### PR DESCRIPTION
For some reason downloading form `https://download.gnome.org` fails on Snow Leopard:

```
==> Downloading https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz
Error: Failed to download resource "glib"
Download failed: https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz
```
Seems to be some SSL issue:
```
curl -O https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz
curl: (35) error:14077458:SSL routines:SSL23_GET_SERVER_HELLO:reason(1112)
```

A mirror would be nice. 