### PR TITLE
amazon-ecs-cli 0.2.0

### DIFF
--- a/Library/Formula/amazon-ecs-cli.rb
+++ b/Library/Formula/amazon-ecs-cli.rb
@@ -3,8 +3,8 @@ require "language/go"
 class AmazonEcsCli < Formula
   desc "CLI for Amazon ECS to manage clusters and tasks for development."
   homepage "https://aws.amazon.com/ecs"
-  url "https://github.com/aws/amazon-ecs-cli/archive/v0.1.0.tar.gz"
-  sha256 "4e86e38677da12b235b14e5b2add9cea422f17a3cd14cd7358a262cdc8794a52"
+  url "https://github.com/aws/amazon-ecs-cli/archive/v0.2.0.tar.gz"
+  sha256 "7690b835b7e394ba37c93ef48af3f9ac81834e94129e8ea64c91020d404bb6c2"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Feedback on recent PRs has asked for tests that only do version checks to be replaced with something more substantial if possible. In this case, the only other ECS CLI command that does not either create an ECS cluster or assume that one is running is "configure", which creates or modifies $HOME/.ecs/config, and thus is potentially destructive of a user's actual ECS CLI configuration. Therefore, I've left the version based test in place.
