### PR TITLE
Note git-extras and git-town conflict

### DIFF
--- a/Library/Formula/git-extras.rb
+++ b/Library/Formula/git-extras.rb
@@ -19,6 +19,8 @@ class GitExtras < Formula
     sha256 "1b0d3064c639782265ed8180c3136e86cfc65e8fa607a3b347113320888e85fe" => :mavericks
   end
 
+  conflicts_with "git-town", :because => "git-extras also ships a git-sync binary"
+
   def install
     system "make", "PREFIX=#{prefix}", "install"
   end

--- a/Library/Formula/git-town.rb
+++ b/Library/Formula/git-town.rb
@@ -6,6 +6,8 @@ class GitTown < Formula
 
   bottle :unneeded
 
+  conflicts_with "git-extras", :because => "git-town also ships a git-sync binary"
+
   def install
     libexec.install Dir["src/*"]
     bin.write_exec_script Dir["#{libexec}/git-*"]


### PR DESCRIPTION
Add `conflicts_with` statement because both install a `git-sync`