### PR TITLE
crf++: add trivial test

### DIFF
--- a/Library/Formula/crf++.rb
+++ b/Library/Formula/crf++.rb
@@ -9,4 +9,9 @@ class Crfxx < Formula
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "CXXFLAGS=#{ENV.cflags}", "install"
   end
+
+  test do
+    # Using "; true" because crf_test -v and -h exit nonzero under normal operation
+    assert_match "CRF++: Yet Another CRF Tool Kit", shell_output("crf_test --help; true")
+  end
 end


### PR DESCRIPTION
The test is just `crf_test --help`; I'm adding it primarily to get a bottle built, since `crf++` currently has no bottles, and takes half a minute to build on a fast box.