### PR TITLE
ldc: dummy revision (do not merge)

### DIFF
--- a/Library/Formula/ldc.rb
+++ b/Library/Formula/ldc.rb
@@ -3,6 +3,7 @@ class Ldc < Formula
   homepage "http://wiki.dlang.org/LDC"
   url "https://github.com/ldc-developers/ldc/releases/download/v0.16.1/ldc-0.16.1-src.tar.gz"
   sha256 "e66cea99f0b1406bbd265ad5fe6aa1412bae31ac86d8a678eb6751f304b6f95b"
+  revision 1
 
   head "https://github.com/ldc-developers/ldc.git", :shallow => false
 


### PR DESCRIPTION
DO NOT MERGE.

This is just a dummy revision bump to trigger a CI build and reproduce the build error from #48086.