### PR TITLE
mysql-sandbox 3.1.05

### DIFF
--- a/Library/Formula/mysql-sandbox.rb
+++ b/Library/Formula/mysql-sandbox.rb
@@ -1,8 +1,8 @@
 class MysqlSandbox < Formula
   desc "Install one or more MySQL servers"
   homepage "http://mysqlsandbox.net"
-  url "https://github.com/datacharmer/mysql-sandbox/archive/3.1.00.tar.gz"
-  sha256 "50934d23ec40b209cc08c19a7b38ea70e1f15f00845f91da0581e7e1cba4cf29"
+  url "https://github.com/datacharmer/mysql-sandbox/releases/download/3.1.05/MySQL-Sandbox-3.1.05.tar.gz"
+  sha256 "0d0ffbe2c31574bd7e3dd8e10fa01440d34d5cc768243409e75b66971e8f9c75"
   head "https://github.com/datacharmer/mysql-sandbox.git"
 
   bottle do
@@ -13,14 +13,18 @@ class MysqlSandbox < Formula
   end
 
   def install
-    # Both variables need to be set. One is compile-time, the other run-time.
+    ENV.delete "PERL_MM_OPT"
     ENV["PERL_LIBDIR"] = libexec/"lib/perl5"
-    ENV.prepend_create_path "PERL5LIB", libexec+"lib/perl5"
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5/site_perl/"
 
-    system "perl", "Makefile.PL", "PREFIX=#{prefix}"
+    system "perl", "Makefile.PL", "PREFIX=#{libexec}"
     system "make", "test", "install"
 
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec+"bin", :PERL5LIB => ENV["PERL5LIB"])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/msandbox", 1)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew/pull/43389#issuecomment-174417647

The entire install should be in `libexec` so it can find the Perl modules but it was accidentally left as `prefix` by the prior PR.