### PR TITLE
Uberftp 2.8

### DIFF
--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -1,15 +1,15 @@
 class Uberftp < Formula
   desc "Interactive GridFTP client"
-  homepage 'http://dims.ncsa.illinois.edu/set/uberftp/'
-  url 'https://github.com/JasonAlt/UberFTP/archive/Version_2_8.tar.gz'
-  sha256 '8a397d6ef02bb714bb0cbdb259819fc2311f5d36231783cd520d606c97759c2a'
+  homepage "http://dims.ncsa.illinois.edu/set/uberftp/"
+  url "https://github.com/JasonAlt/UberFTP/archive/Version_2_8.tar.gz"
+  sha256 "8a397d6ef02bb714bb0cbdb259819fc2311f5d36231783cd520d606c97759c2a"
 
   depends_on "globus-toolkit"
 
   def install
     globus = Formula["globus-toolkit"].opt_prefix
 
-    #patches needed since location changed with globus-toolkit versions >= 6.0, patch to upstream not yet merged https://github.com/JasonAlt/UberFTP/pull/8
+    #patches needed since location changed with globus-toolkit versions >= 6.0, patch to upstream not yet merged https://github.com/JasonAlt/UberFTP/pull/8, but solves not whole problem
     inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
     inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"
 

--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -9,7 +9,10 @@ class Uberftp < Formula
   def install
     globus = Formula["globus-toolkit"].opt_prefix
 
-    #patches needed since location changed with globus-toolkit versions >= 6.0, patch to upstream not yet merged https://github.com/JasonAlt/UberFTP/pull/8, but solves not whole problem
+   # patch needed since location changed with globus-toolkit versions>=6.0,
+   # patch to upstream is not yet merged 
+   # (located at https://github.com/JasonAlt/UberFTP/pull/8) 
+   # but solves not whole problem (needs aditional patch)
     inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
     inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"
 
@@ -23,4 +26,3 @@ class Uberftp < Formula
     system "#{bin}/uberftp", "-v"
   end
 end
-

--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -1,23 +1,19 @@
 class Uberftp < Formula
   desc "Interactive GridFTP client"
-  homepage "http://dims.ncsa.illinois.edu/set/uberftp/"
-  url "https://github.com/JasonAlt/UberFTP/archive/Version_2_7.tar.gz"
-  sha256 "29a111a86fa70dbbc529a5d3e5a6befc1681e64e32dc019a1a6a98cd43ffb204"
+  homepage 'http://dims.ncsa.illinois.edu/set/uberftp/'
+  url 'https://github.com/JasonAlt/UberFTP/archive/Version_2_8.tar.gz'
+  sha256 '8a397d6ef02bb714bb0cbdb259819fc2311f5d36231783cd520d606c97759c2a'
 
   depends_on "globus-toolkit"
 
   def install
-    # get the flavor
     globus = Formula["globus-toolkit"].opt_prefix
 
-    core = `"#{globus}/sbin/gpt-query" globus_core`
-    flavor = case core
-    when /gcc64dbg/ then "gcc64dbg"
-    when /gcc32dbg/ then "gcc32dbg"
-    end
+    #patches needed since location changed with globus-toolkit versions >= 6.0, patch to upstream not yet merged https://github.com/JasonAlt/UberFTP/pull/8
+    inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
+    inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"
 
     system "./configure", "--prefix=#{prefix}",
-                          "--with-globus-flavor=#{flavor}",
                           "--with-globus=#{globus}"
     system "make"
     system "make", "install"
@@ -27,3 +23,4 @@ class Uberftp < Formula
     system "#{bin}/uberftp", "-v"
   end
 end
+

--- a/Library/Formula/uberftp.rb
+++ b/Library/Formula/uberftp.rb
@@ -10,8 +10,8 @@ class Uberftp < Formula
     globus = Formula["globus-toolkit"].opt_prefix
 
    # patch needed since location changed with globus-toolkit versions>=6.0,
-   # patch to upstream is not yet merged 
-   # (located at https://github.com/JasonAlt/UberFTP/pull/8) 
+   # patch to upstream is not yet merged
+   # (located at https://github.com/JasonAlt/UberFTP/pull/8)
    # but solves not whole problem (needs aditional patch)
     inreplace "configure", "globus_location/include/globus/gcc64dbg", "globus_location/libexec/include"
     inreplace "configure", "globus_location/lib64", "globus_location/libexec/lib"


### PR DESCRIPTION
Update uberftp to version 2.8 based on work done by giffels (closed pull request #40848).
* Closes  #41277
* The patch provided at JasonAlt/UberFTP#8 makes the situation worse: another patch is needed to get ./configure running  and cause more obfuscation than the 2 replace commands. 
* Replaced the single quotes in formula for double quotes