### PR TITLE
kommit 1.0.0 (new formula)

### DIFF
--- a/Library/Formula/kommit.rb
+++ b/Library/Formula/kommit.rb
@@ -7,10 +7,13 @@ class Kommit < Formula
   def install
     bin.install "bin/kommit"
   end
+
   def caveats; <<-EOS.undent
     If you like to combine with git, create a symlink;
       ln -s #{bin}/kommit #{bin}/git-kommit
     EOS
+  end
+
   test do
     system "git", "init"
     system "#{bin}/kommit", "-m", "Hello"

--- a/Library/Formula/kommit.rb
+++ b/Library/Formula/kommit.rb
@@ -1,22 +1,16 @@
 class Kommit < Formula
   desc "More detailed commit messages without committing!"
   homepage "https://github.com/bilgi-webteam/kommit"
-  url "https://github.com/bilgi-webteam/kommit/archive/v0.1.4.tar.gz"
-  sha256 "ffc017790b24c238848f83e483e22874ece73af22d3261a59e465d667e9f3c13"
+  url "https://github.com/bilgi-webteam/kommit/archive/v1.0.0.tar.gz"
+  sha256 "d079ba1dcfdf31a35e3d42dbd6adf2450d305e998adb679fb9dc8ea68fa23c22"
 
   def install
-    bin.install "bin/kommit"
-  end
-
-  def caveats; <<-EOS.undent
-    If you like to combine with git, create a symlink;
-      ln -s #{bin}/kommit #{bin}/git-kommit
-    EOS
+    bin.install "bin/git-kommit"
   end
 
   test do
     system "git", "init"
-    system "#{bin}/kommit", "-m", "Hello"
-    assert_match /Hello/, shell_output("#{bin}/kommit -s /dev/null 2>&1")
+    system "#{bin}/git-kommit", "-m", "Hello"
+    assert_match /Hello/, shell_output("#{bin}/git-kommit -s /dev/null 2>&1")
   end
 end

--- a/Library/Formula/kommit.rb
+++ b/Library/Formula/kommit.rb
@@ -1,0 +1,17 @@
+class Kommit < Formula
+  desc "More detailed commit messages without committing!"
+  homepage "https://github.com/bilgi-webteam/kommit"
+  url "https://github.com/bilgi-webteam/kommit/archive/v0.1.4.tar.gz"
+  version "0.1.4"
+  sha256 "ffc017790b24c238848f83e483e22874ece73af22d3261a59e465d667e9f3c13"
+
+  def install
+    bin.install "bin/kommit"
+  end
+
+  test do
+    system "git", "init"
+    system "#{bin}/kommit", "-m", "Hello"
+    assert_match /Hello/, shell_output("#{bin}/kommit -s /dev/null 2>&1")
+  end
+end

--- a/Library/Formula/kommit.rb
+++ b/Library/Formula/kommit.rb
@@ -2,13 +2,15 @@ class Kommit < Formula
   desc "More detailed commit messages without committing!"
   homepage "https://github.com/bilgi-webteam/kommit"
   url "https://github.com/bilgi-webteam/kommit/archive/v0.1.4.tar.gz"
-  version "0.1.4"
   sha256 "ffc017790b24c238848f83e483e22874ece73af22d3261a59e465d667e9f3c13"
 
   def install
     bin.install "bin/kommit"
   end
-
+  def caveats; <<-EOS.undent
+    If you like to combine with git, create a symlink;
+      ln -s #{bin}/kommit #{bin}/git-kommit
+    EOS
   test do
     system "git", "init"
     system "#{bin}/kommit", "-m", "Hello"


### PR DESCRIPTION
    - Create more detailed commit messages without committing!
    - A mini shell tool for storing messages:
      `kommit -m "Fixes a bug in XXX function"`
    - Store your commit-extra information in to a hidden file
      `.git/kommit-message`
    - Append the `.git/kommit-message` to the original commit message in
      `prepare-commit-msg` hook and delete
      `.git/kommit-message` file after commit.

Usage:

    * `kommit -m "Message"` : Append new message.
    * `kommit -t "Message"` : Append new message with timestamp.
    * `kommit -s` : Show current messages
    * `kommit -e` : Edit messages. This uses `$EDITOR` environment variable.

Bonus:

    You can link to this file such as:
    `ln -s /usr/local/bin/kommit ~/bin/git-kommit`
    Now you can use it with in the `git` commit.
    `git kommit -m "message"`