### PR TITLE
pull: add devel bump flag

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -133,9 +133,13 @@ module Homebrew
         if ARGV.include? "--bump"
           odie "Can only bump one changed formula" unless changed_formulae.length == 1
           formula = changed_formulae.first
-          subject = "#{formula.name} #{formula.version}"
+          if ARGV.include? "--devel"
+            subject = "#{formula.name} #{formula.devel.version} (devel)"
+          else
+            subject = "#{formula.name} #{formula.stable.version}"
+          end
           ohai "New bump commit subject: #{subject}"
-          system "/bin/echo -n #{subject} | pbcopy"
+          system "/bin/echo -n \"#{subject}\" | pbcopy"
           message = "#{subject}\n\n#{message}"
         end
 


### PR DESCRIPTION
Adds the bump functionality for devel commits as well. Currently activated with:
```
brew pull --bump --devel #hash
```

Which produces:
```
==> Applying patch
Applying: protobuf devel 3.0.0-beta-2
Warning: protobuf has a bottle: do you need to update it with --bottle?
==> Patch closes issue #48448
==> New bump commit subject: protobuf 3.0.0-beta-2 (devel)
```

CC @mikemcquaid @xu-cheng 