### PR TITLE
llvm: enable clang and rtti by default, simplifying deps

### DIFF
--- a/Library/Formula/creduce.rb
+++ b/Library/Formula/creduce.rb
@@ -15,7 +15,7 @@ class Creduce < Formula
 
   depends_on "astyle"
   depends_on "delta"
-  depends_on "llvm" => "with-clang"
+  depends_on "llvm"
 
   depends_on :macos => :mavericks
 

--- a/Library/Formula/doxygen.rb
+++ b/Library/Formula/doxygen.rb
@@ -22,7 +22,7 @@ class Doxygen < Formula
   depends_on "cmake" => :build
   depends_on "graphviz" => :optional
   depends_on "qt" if build.with? "doxywizard"
-  depends_on "llvm" => "with-clang" if build.with? "libclang"
+  depends_on "llvm" if build.with? "libclang"
 
   def install
     args = std_cmake_args

--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -20,6 +20,7 @@ end
 class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "http://llvm.org/"
+  revision 1
 
   stable do
     url "http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz"
@@ -108,14 +109,14 @@ class Llvm < Formula
   keg_only :provided_by_osx
 
   option :universal
-  option "with-clang", "Build the Clang compiler and support libraries"
   option "with-clang-extra-tools", "Build extra tools for Clang"
   option "with-compiler-rt", "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
   option "with-libcxx", "Build the libc++ standard library"
   option "with-lld", "Build LLD linker"
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build Python bindings against Homebrew Python"
-  option "with-rtti", "Build with C++ RTTI"
+  option "without-clang", "Do not build the Clang compiler and support libraries"
+  option "without-rtti", "Build without C++ RTTI"
 
   deprecated_option "rtti" => "with-rtti"
 

--- a/Library/Formula/ponyc.rb
+++ b/Library/Formula/ponyc.rb
@@ -12,7 +12,7 @@ class Ponyc < Formula
     sha256 "6feb5a4031bcb8a23b0cbfe036d67df3f0ef4424533a66e5f4fdef29dec7d118" => :mavericks
   end
 
-  depends_on "llvm" => "with-rtti"
+  depends_on "llvm"
   needs :cxx11
 
   def install


### PR DESCRIPTION
This allows all core dependencies on `llvm` to be on the default llvm, instead of using 'with-rtti' or 'with-clang', which cause a 1-hour+ build from source and timeouts on the CI. Follows discussion in #47269.

Affected formulae:

```
[/usr/local/Library/Formula on ⇄ master]
$ grep llvm * | grep depends_on | grep 'clang\|rtti'
creduce.rb:  depends_on "llvm" => "with-clang"
doxygen.rb:  depends_on "llvm" => "with-clang" if build.with? "libclang"
emacs-clang-complete-async.rb:  depends_on "llvm" => "with-clang"
ponyc.rb:  depends_on "llvm" => "with-rtti"
rtags.rb:  depends_on "llvm" => "with-clang"
```

I'm omitting `emacs-clang-complete-async` from this PR because it lacks a `test do` and will cause the audit checks to fail, and I'd like this to go green. I'll fix it up separately if and when this is merged.

I don't think this requires a revision bump to any of the dependent formulae, because they use `llvm` as an external command and don't require a rebuild. (Except maybe `doxygen`?)