### PR TITLE
adding JSON support to kafkacat formula

### DIFF
--- a/Library/Formula/kafkacat.rb
+++ b/Library/Formula/kafkacat.rb
@@ -11,11 +11,22 @@ class Kafkacat < Formula
     sha256 "a66d6d312498e117d485d7eea58e412da287be1dc08a1be0cd621d6a77763c7f" => :mavericks
   end
 
+  option "with-json", "Adds JSON support to kafkacat"
+
   depends_on "librdkafka"
+  depends_on "yajl" if build.with?("json")
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+    ]
+
+    if build.with?("json")
+      args << "--enable-json"
+    end
+
+    system "./configure", *args
     system "make"
     system "make", "install"
   end

--- a/Library/Formula/kafkacat.rb
+++ b/Library/Formula/kafkacat.rb
@@ -11,10 +11,10 @@ class Kafkacat < Formula
     sha256 "a66d6d312498e117d485d7eea58e412da287be1dc08a1be0cd621d6a77763c7f" => :mavericks
   end
 
-  option "with-json", "Adds JSON support to kafkacat"
+  option "with-yajl", "Adds JSON support"
 
   depends_on "librdkafka"
-  depends_on "yajl" if build.with?("json")
+  depends_on "yajl" => :optional
 
   def install
     args = %W[
@@ -22,9 +22,7 @@ class Kafkacat < Formula
       --prefix=#{prefix}
     ]
 
-    if build.with?("json")
-      args << "--enable-json"
-    end
+    args << "--enable-json" if build.with?("yajl")
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
The existing formula offers no way to enable JSON support. This PR changes that to allow those who want to use this feature of kafkacat.