### PR TITLE
dummy downgrade acme remove stable

### DIFF
--- a/Library/Formula/acme.rb
+++ b/Library/Formula/acme.rb
@@ -1,10 +1,6 @@
 class Acme < Formula
   desc "Crossassembler for multiple environments"
   homepage "https://web.archive.org/web/20150520143433/https://www.esw-heim.tu-clausthal.de/~marco/smorbrod/acme/"
-  url "https://www.mirrorservice.org/sites/ftp.cs.vu.nl/pub/minix/distfiles/backup/acme091src.tar.gz"
-  mirror "http://ftp.lip6.fr/pub/minix/distfiles/backup/acme091src.tar.gz"
-  version "0.91"
-  sha256 "31ed7f9be5cd27100b13d6c3e2faec35d15285542cbe168ec5e1b5236125decb"
 
   bottle do
     cellar :any


### PR DESCRIPTION
DO NOT MERGE.

Removes the acme stable release, leaving only devel.

This is a dummy version bump for testing brew pull --bump changes against.