### PR TITLE
docutils 0.12 (new formula)

### DIFF
--- a/Library/Formula/docutils.rb
+++ b/Library/Formula/docutils.rb
@@ -4,8 +4,22 @@ class Docutils < Formula
   url "https://downloads.sourceforge.net/project/docutils/docutils/0.12/docutils-0.12.tar.gz"
   sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
 
+  resource "docutils" do
+    url "https://downloads.sourceforge.net/project/docutils/docutils/0.12/docutils-0.12.tar.gz"
+    sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
+  end
+
   def install
-    system "python", *Language::Python.setup_install_args(prefix)
+    ENV["PYTHONPATH"] = libexec+"lib/python2.7/site-packages"
+
+    resources.each do |r|
+      r.stage { system "python", *Language::Python.setup_install_args(libexec) }
+    end
+
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir[libexec/"bin/rst2*.py"]
+    bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
   test do

--- a/Library/Formula/docutils.rb
+++ b/Library/Formula/docutils.rb
@@ -1,0 +1,11 @@
+class Docutils < Formula
+  desc "Text processing system for processing plaintext documentation into useful formats"
+  homepage "http://docutils.sourceforge.net"
+  url "http://downloads.sourceforge.net/project/docutils/docutils/0.12/docutils-0.12.tar.gz"
+  sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
+
+  def install
+    system "python", "setup.py", "install", "--prefix=#{prefix}"
+  end
+end
+

--- a/Library/Formula/docutils.rb
+++ b/Library/Formula/docutils.rb
@@ -5,7 +5,7 @@ class Docutils < Formula
   sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
 
   def install
-    system "python", "setup.py", "install", "--prefix=#{prefix}"
+    system "python", *Language::Python.setup_install_args(prefix)
   end
 
   test do

--- a/Library/Formula/docutils.rb
+++ b/Library/Formula/docutils.rb
@@ -9,6 +9,6 @@ class Docutils < Formula
   end
 
   test do
-    system "#{bin}/rst2man.py", "#{prefix}/HISTORY.txtx"
+    system "#{bin}/rst2man.py", "#{prefix}/HISTORY.txt"
   end
 end

--- a/Library/Formula/docutils.rb
+++ b/Library/Formula/docutils.rb
@@ -1,11 +1,14 @@
 class Docutils < Formula
-  desc "Text processing system for processing plaintext documentation into useful formats"
+  desc "Text processing system for reStructuredText"
   homepage "http://docutils.sourceforge.net"
-  url "http://downloads.sourceforge.net/project/docutils/docutils/0.12/docutils-0.12.tar.gz"
+  url "https://downloads.sourceforge.net/project/docutils/docutils/0.12/docutils-0.12.tar.gz"
   sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
 
   def install
     system "python", "setup.py", "install", "--prefix=#{prefix}"
   end
-end
 
+  test do
+    system "#{bin}/rst2man.py", "#{prefix}/HISTORY.txtx"
+  end
+end


### PR DESCRIPTION
Based on #44665

Updated to follow standard Python package convention
No longer has `#!/usr/bin/python` reference
