### PR TITLE
libxmlsec1: update revision for gnutls 3.4.x upgrade

### DIFF
--- a/Library/Formula/libxmlsec1.rb
+++ b/Library/Formula/libxmlsec1.rb
@@ -3,6 +3,7 @@ class Libxmlsec1 < Formula
   homepage "https://www.aleksey.com/xmlsec/"
   url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.20.tar.gz"
   sha256 "3221593ca50f362b546a0888a1431ad24be1470f96b2469c0e0df5e1c55e7305"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
`libxmlsec1` should have been included in #47065