### PR TITLE
update-bash: fully resolve Git's path in hash.

### DIFF
--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -271,6 +271,7 @@ EOS
       odie "Git must be installed and in your PATH!"
     fi
   fi
+  hash -p "$(cd "$(dirname "$(which_git)")" && pwd -P)/git" git
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then


### PR DESCRIPTION
Otherwise Bash can cache a relative PATH and then get upset when it changes directory and cannot find it any more.

CC @xu-cheng @UniqMartin for review and @zerowidth and @davidcelis who ran into this.