### PR TITLE
activemq 5.13.0

### DIFF
--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -12,10 +12,9 @@ class Activemq < Formula
     rm_rf Dir["bin/linux-x86-*"]
     libexec.install Dir["*"]
     (bin/"activemq").write_env_script libexec/"bin/activemq", Language::Java.java_home_env("1.6+")
-    (bin/"activemq-admin").write_env_script libexec/"bin/activemq-admin", Language::Java.java_home_env("1.6+")
   end
 
   test do
-    system "#{bin}/activemq-admin", "browse", "-h"
+    system "#{bin}/activemq", "browse", "-h"
   end
 end

--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -1,8 +1,8 @@
 class Activemq < Formula
   desc "Apache ActiveMQ: powerful open source messaging server"
   homepage "https://activemq.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/activemq/5.11.2/apache-activemq-5.11.2-bin.tar.gz"
-  sha256 "db475dffe3004a619f437347258ff07a60bce60c38dc05edca8d03ede5a64418"
+  url "https://www.apache.org/dyn/closer.cgi?path=/activemq/5.13.0/apache-activemq-5.13.0-bin.tar.gz"
+  sha256 "6b460256a56c6e2c9e2575e90f6514c5239ec06e89ac9e8694b30bb5abbc7a8c"
 
   bottle :unneeded
 


### PR DESCRIPTION
Updating from ActiveMQ 5.11.2 to 5.13.0. Tested and working fine in OSX El Capitan.