### PR TITLE
update-bash: git related improvement

### DIFF
--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -2,22 +2,43 @@ brew() {
   "$HOMEBREW_BREW_FILE" "$@"
 }
 
+git() {
+  [[ -n "$HOMEBREW_GIT" ]] || odie "HOMEBREW_GIT is unset!"
+  "$HOMEBREW_GIT" "$@"
+}
+
 which_git() {
-  local which_git
+  local git_path
   local active_developer_dir
 
-  which_git="$(which git 2>/dev/null)"
-  if [[ -n "$which_git" && "/usr/bin/git" = "$which_git" ]]
+  if [[ -n "$HOMEBREW_GIT" ]]
+  then
+    git_path="$HOMEBREW_GIT"
+  elif [[ -n "$GIT" ]]
+  then
+    git_path="$GIT"
+  else
+    git_path="git"
+  fi
+
+  git_path="$(which "$git_path" 2>/dev/null)"
+
+  if [[ -n "$git_path" ]]
+  then
+    git_path="$(chdir "${git_path%/*}" && pwd -P)/${git_path##*/}"
+  fi
+
+  if [[ -n "$HOMEBREW_OSX" && "$git_path" = "/usr/bin/git" ]]
   then
     active_developer_dir="$('/usr/bin/xcode-select' -print-path 2>/dev/null)"
     if [[ -n "$active_developer_dir" && -x "$active_developer_dir/usr/bin/git" ]]
     then
-      which_git="$active_developer_dir/usr/bin/git"
+      git_path="$active_developer_dir/usr/bin/git"
     else
-      which_git=""
+      git_path=""
     fi
   fi
-  echo "$which_git"
+  echo "$git_path"
 }
 
 git_init_if_necessary() {
@@ -263,15 +284,16 @@ EOS
     odie "$HOMEBREW_REPOSITORY must be writable!"
   fi
 
-  if [[ -z "$(which_git)" ]]
+  HOMEBREW_GIT="$(which_git)"
+  if [[ -z "$HOMEBREW_GIT" ]]
   then
     brew install git
-    if [[ -z "$(which_git)" ]]
+    HOMEBREW_GIT="$(which_git)"
+    if [[ -z "$HOMEBREW_GIT" ]]
     then
       odie "Git must be installed and in your PATH!"
     fi
   fi
-  hash -p "$(cd "$(dirname "$(which_git)")" && pwd -P)/git" git
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then


### PR DESCRIPTION
* Use git function instead of refreshing bash cache on `git` path.
* Better `which_git`:
  * Set `HOMEBREW_GIT` as result.
  * Take user's setting of `HOMEBREW_GIT` and `GIT` env variable into
    account.

cc @mikemcquaid @UniqMartin 