### PR TITLE
tarsnap-gui 0.8 (new formula)

### DIFF
--- a/Library/Formula/tarsnap-gui.rb
+++ b/Library/Formula/tarsnap-gui.rb
@@ -1,0 +1,20 @@
+class TarsnapGui < Formula
+  desc "Cross platform GUI for the Tarsnap command-line client"
+  homepage "https://github.com/Tarsnap/tarsnap-gui/wiki/Tarsnap"
+  url "https://github.com/Tarsnap/tarsnap-gui/archive/v0.8.tar.gz"
+  sha256 "a4b5b23b6b75aa7a4af4d124521286c80d42446571cb27a858d03e772b2ff080"
+  head "https://github.com/Tarsnap/tarsnap-gui.git"
+
+  depends_on "qt5"
+  depends_on "tarsnap"
+
+  def install
+    system "qmake"
+    system "make"
+    prefix.install "Tarsnap.app"
+  end
+
+  test do
+    system "#{opt_prefix}/Tarsnap.app/Contents/MacOS/Tarsnap", "--version"
+  end
+end


### PR DESCRIPTION
Hi,

I know that this might be a long shot according to the submission rules, but I'm going to try anyway. My hopes are based on the handful of *exceptions* like MacVim already present in the repo and the fact that the application can operate headless to some extent.

Here's Tarsnap GUI the cross platform GUI for the Tarsnap command line client. The app has been in development for over an year. The only dependencies are Qt 5 and Tarsnap CLI, both dependencies are already present in the Homebrew repository. The app also features a headless operation mode, where system backups can be queued via cron or launchd, providing for little need to open the GUI once backup jobs have been defined and set for automatic backup. There are no prebuilt packages at the moment and we have plans to change that once we get to 1.0 and move this to Homebrew casks, but until then, it'd be cool to have an easy and seamless installation for OS X users and Homebrew is obviously the first choice for this.

https://github.com/Tarsnap/tarsnap-gui/wiki/Tarsnap
https://www.tarsnap.com