### PR TITLE
Update git-annex to 6.20160126 to fix the QuickCheck build error

### DIFF
--- a/Library/Formula/git-annex.rb
+++ b/Library/Formula/git-annex.rb
@@ -5,9 +5,8 @@ class GitAnnex < Formula
 
   desc "Manage files with git without checking in file contents"
   homepage "https://git-annex.branchable.com/"
-  url "https://hackage.haskell.org/package/git-annex-5.20151218/git-annex-5.20151218.tar.gz"
-  sha256 "d8aed73cbc1d1eefcbe6de7790c83f1d6458b4ac1e910d9a34b22782d16142ca"
-  revision 1
+  url "https://hackage.haskell.org/package/git-annex-6.20160126/git-annex-6.20160126.tar.gz"
+  sha256 "dc59f670a3d0bdb90db8fc6cadba8003708219bb0dc3d56867a9246d825c0d11"
 
   head "git://git-annex.branchable.com/"
 


### PR DESCRIPTION
The latest version of git-annex fixes the brew build error

Utility/QuickCheck.hs:27:10:
    Duplicate instance declarations:
      instance (Arbitrary v, Eq v, Ord v) => Arbitrary (S.Set v)
        -- Defined at Utility/QuickCheck.hs:27:10
      instance [safe] (Ord a, Arbitrary a) => Arbitrary (S.Set a)
        -- Defined in ‘Test.QuickCheck.Arbitrary’

which was caused by the Hackage version bump of QuickCheck to 2.8.2.

Upstream fix is here: joeyh/git-annex@bf7e928