### PR TITLE
Fix app-engine-go-64 and app-engine-go-32 installation error

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -12,12 +12,15 @@ class AppEngineGo32 < Formula
     :because => "both install the same binaries"
 
   def install
-    cd ".."
-    share.install "go_appengine" => name
+    share.install Dir["*"]
     %w[
       api_server.py appcfg.py bulkloader.py bulkload_client.py dev_appserver.py download_appstats.py goapp
     ].each do |fn|
-      bin.install_symlink share/name/fn
+      bin.install_symlink share/fn
     end
+  end
+
+  test do
+    assert_match /^usage: goapp serve/, shell_output("#{bin}/goapp help serve").strip
   end
 end

--- a/Library/Formula/app-engine-go-64.rb
+++ b/Library/Formula/app-engine-go-64.rb
@@ -12,12 +12,15 @@ class AppEngineGo64 < Formula
     :because => "both install the same binaries"
 
   def install
-    cd ".."
-    share.install "go_appengine" => name
+    share.install Dir["*"]
     %w[
       api_server.py appcfg.py bulkloader.py bulkload_client.py dev_appserver.py download_appstats.py goapp
     ].each do |fn|
-      bin.install_symlink share/name/fn
+      bin.install_symlink share/fn
     end
+  end
+
+  test do
+    assert_match /^usage: goapp serve/, shell_output("#{bin}/goapp help serve").strip
   end
 end


### PR DESCRIPTION
When installing app-engine-go-64 or app-engine-go-32, the following error is thrown:

    Error: No such file or directory - /private/tmp/app-engine-go-6420160127-43790-1cv7w6c/go_appengine

This pull request fixes this error and adds a test to ensure that the formulae are properly installed.