### PR TITLE
libmatheval 1.1.11 (new formula)

### DIFF
--- a/Library/Formula/libmatheval.rb
+++ b/Library/Formula/libmatheval.rb
@@ -1,0 +1,18 @@
+class Libmatheval < Formula
+  desc "Symbolic math parsing and evaluation"
+  homepage "https://www.gnu.org/software/libmatheval/"
+  url "http://ftpmirror.gnu.org/gnu/libmatheval/libmatheval-1.1.11.tar.gz"
+  sha256 "474852d6715ddc3b6969e28de5e1a5fbaff9e8ece6aebb9dc1cc63e9e88e89ab"
+  depends_on "homebrew/versions/guile18"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "ls", "#{lib}/libmatheval.a"
+    system "ls", "#{lib}/libmatheval.dylib"
+  end
+end


### PR DESCRIPTION
I made a formula for libmatheval, using the latest version on the GNU
webpage. GUILE is a dependency, but libmatheval has not been updated
after changes from GUILE 1.8 -> 2.0, so it still requires version 1.8.
The added formula includes homebrew/versions/guile18 as a dependency to
address this.

The brew audit had one error I didn't know how to solve -- it wants me to shorten the URL to just the domain name.