### PR TITLE
Go upgrade to 1.6rc1

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -15,9 +15,9 @@ class Go < Formula
   end
 
   devel do
-    url "https://storage.googleapis.com/golang/go1.6beta2.src.tar.gz"
-    version "1.6beta2"
-    sha256 "8b23d15a3edf1d154ceea5e9ca6370fc60e7f57fb1c28aa8a44c40f8f3167c6d"
+    url "https://storage.googleapis.com/golang/go1.6rc1.src.tar.gz"
+    version "1.6rc1"
+    sha256 "2d1a6756f24227dcee955add4af7d194eb4a8c3656b2c4ce778994e21a533a83"
   end
 
   option "without-cgo", "Build without cgo"


### PR DESCRIPTION
Go: upgrade 1.6 rc1

https://tip.golang.org/doc/go1.6