### PR TITLE
Update app-engine-go-64 and app-engine-go-32 to version 1.9.31

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -1,8 +1,8 @@
 class AppEngineGo32 < Formula
   desc "Google App Engine SDK for Go (i386)"
   homepage "https://cloud.google.com/appengine/docs/go/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.30.zip"
-  sha256 "15d7f5f378d6e765da22c5db7ff855dafee1c2f72c78347bc9a1e4426248f2e3"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.31.zip"
+  sha256 "4e47b4a97eae754ddf33a4ad407a594ee78b301d2bf9c239356b24f96662759f"
 
   bottle :unneeded
 

--- a/Library/Formula/app-engine-go-64.rb
+++ b/Library/Formula/app-engine-go-64.rb
@@ -1,8 +1,8 @@
 class AppEngineGo64 < Formula
   desc "Google App Engine SDK for Go (AMD64)"
   homepage "https://cloud.google.com/appengine/docs/go/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.30.zip"
-  sha256 "6e7df46f09a2ed7cb6c77ef267600959e904adbe3c37a38912249268097aa9ae"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.31.zip"
+  sha256 "b57ffa0915a54bcb60e133ec5e8b5daff7314dd5591b9b8c6d7ae7354e16ba81"
 
   bottle :unneeded
 


### PR DESCRIPTION
This pull request updates the version of app-engine-go-64 and app-engine-go-32 to the latest version 1.9.31.