### PR TITLE
Fix app-engine-go-64 and app-engine-go-32 to use pkgshare instead of share

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -12,11 +12,11 @@ class AppEngineGo32 < Formula
     :because => "both install the same binaries"
 
   def install
-    share.install Dir["*"]
+    pkgshare.install Dir["*"]
     %w[
       api_server.py appcfg.py bulkloader.py bulkload_client.py dev_appserver.py download_appstats.py goapp
     ].each do |fn|
-      bin.install_symlink share/fn
+      bin.install_symlink pkgshare/fn
     end
   end
 

--- a/Library/Formula/app-engine-go-64.rb
+++ b/Library/Formula/app-engine-go-64.rb
@@ -12,11 +12,11 @@ class AppEngineGo64 < Formula
     :because => "both install the same binaries"
 
   def install
-    share.install Dir["*"]
+    pkgshare.install Dir["*"]
     %w[
       api_server.py appcfg.py bulkloader.py bulkload_client.py dev_appserver.py download_appstats.py goapp
     ].each do |fn|
-      bin.install_symlink share/fn
+      bin.install_symlink pkgshare/fn
     end
   end
 


### PR DESCRIPTION
This pull request installs app-engine-go-64 and app-engine-go-32 to `pkgshare` instead of `share`.