### PR TITLE
rewrite update-report

### DIFF
--- a/Library/Homebrew/core_formula_repository.rb
+++ b/Library/Homebrew/core_formula_repository.rb
@@ -69,6 +69,12 @@ class CoreFormulaRepository < Tap
   end
 
   # @private
+  def tap_migrations
+    require "tap_migrations"
+    TAP_MIGRATIONS
+  end
+
+  # @private
   def formula_file_to_name(file)
     file.basename(".rb").to_s
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -76,6 +76,7 @@ class Tap
     @alias_reverse_table = nil
     @command_files = nil
     @formula_renames = nil
+    @tap_migrations = nil
   end
 
   # The remote path to this {Tap}.
@@ -365,6 +366,17 @@ class Tap
 
     @formula_renames ||= if (rename_file = path/"formula_renames.json").file?
       Utils::JSON.load(rename_file.read)
+    else
+      {}
+    end
+  end
+
+  # Hash with tap migrations
+  def tap_migrations
+    require "utils/json"
+
+    @tap_migrations ||= if (migration_file = path/"tap_migrations.json").file?
+      Utils::JSON.load(migration_file.read)
     else
       {}
     end

--- a/Library/Homebrew/test/fixtures/updater_fixture.yaml
+++ b/Library/Homebrew/test/fixtures/updater_fixture.yaml
@@ -40,6 +40,8 @@ update_git_diff_output_with_changed_filetype: |
   D	Library/Formula/libgsasl.rb
   M	Library/Homebrew/cmd/update.rb
   M	SUPPORTERS.md
+update_git_diff_output_with_formula_rename: |
+  R100	Library/Formula/cv.rb	Library/Formula/progress.rb
 update_git_diff_output_with_restructured_tap: |
   R100	git.rb	Formula/git.rb
   R100	lua.rb	Formula/lua.rb

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -20,6 +20,9 @@ class TapTest < Homebrew::TestCase
     (@path/"formula_renames.json").write <<-EOS.undent
      { "oldname": "foo" }
     EOS
+    (@path/"tap_migrations.json").write <<-EOS.undent
+     { "removed-formula": "homebrew/foo" }
+    EOS
     @cmd_file = @path/"cmd/brew-tap-cmd.rb"
     @cmd_file.parent.mkpath
     FileUtils.touch @cmd_file
@@ -93,6 +96,7 @@ class TapTest < Homebrew::TestCase
     assert_equal @tap.alias_table, "homebrew/foo/bar" => "homebrew/foo/foo"
     assert_equal @tap.alias_reverse_table, "homebrew/foo/foo" => ["homebrew/foo/bar"]
     assert_equal @tap.formula_renames, "oldname" => "foo"
+    assert_equal @tap.tap_migrations, "removed-formula" => "homebrew/foo"
     assert_equal [@cmd_file], @tap.command_files
     assert_kind_of Hash, @tap.to_hash
     assert_equal true, @tap.formula_file?(@formula_file)

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -5,37 +5,13 @@ require "yaml"
 
 class ReportTests < Homebrew::TestCase
   class ReporterMock < ::Reporter
-    attr_accessor :diff, :expected, :called
+    attr_accessor :diff
 
-    def initialize(repository)
-      repo_var = Reporter.repository_variable(repository)
-      ENV["HOMEBREW_UPDATE_BEFORE#{repo_var}"] = "abcdef12"
-      ENV["HOMEBREW_UPDATE_AFTER#{repo_var}"] = "abcdef12"
-      super
-      @outputs = Hash.new { |h, k| h[k] = [] }
-      @expected = []
-      @called = []
-    end
-
-    def in_repo_expect(cmd, output = "")
-      @expected << cmd
-      @outputs[cmd] << output
-    end
-
-    def `(*args)
-      cmd = args.join(" ")
-      if @expected.include?(cmd) && !@outputs[cmd].empty?
-        @called << cmd
-        @outputs[cmd].shift
-      else
-        raise "#{inspect} unexpectedly called backticks: `#{cmd}`"
-      end
-    end
-    alias_method :safe_system, :`
-    alias_method :system, :`
-
-    def inspect
-      "#<#{self.class.name}>"
+    def initialize(tap, init_rev, cur_rev)
+      @tap = tap
+      ENV["HOMEBREW_UPDATE_BEFORE#{repo_var}"] = init_rev
+      ENV["HOMEBREW_UPDATE_AFTER#{repo_var}"] = cur_rev
+      super(tap)
     end
   end
 
@@ -48,8 +24,9 @@ class ReportTests < Homebrew::TestCase
   end
 
   def setup
-    @updater = ReporterMock.new(HOMEBREW_REPOSITORY)
-    @report = Report.new
+    @tap = CoreFormulaRepository.new
+    @reporter = ReporterMock.new(@tap, "12345678", "abcdef12")
+    @hub = ReporterHub.new
   end
 
   def teardown
@@ -59,48 +36,80 @@ class ReportTests < Homebrew::TestCase
   def perform_update(fixture_name = "")
     Formulary.stubs(:factory).returns(stub(:pkg_version => "1.0"))
     FormulaVersions.stubs(:new).returns(stub(:formula_at_revision => "2.0"))
-    @updater.diff = fixture(fixture_name)
-    @report.update(@updater.report)
-    assert_equal @updater.expected, @updater.called
+    @reporter.diff = fixture(fixture_name)
+    @hub.add(@reporter) if @reporter.updated?
+  end
+
+  def test_update_report_without_revision_var
+    assert_raises(Reporter::ReporterRevisionUnsetError) { ReporterMock.new(@tap, nil, nil) }
   end
 
   def test_update_homebrew_without_any_changes
     perform_update
-    assert_empty @report
+    assert_empty @hub
   end
 
   def test_update_homebrew_without_formulae_changes
     perform_update("update_git_diff_output_without_formulae_changes")
-    assert_empty @report.select_formula(:M)
-    assert_empty @report.select_formula(:A)
-    assert_empty @report.select_formula(:D)
+    assert_empty @hub.select_formula(:M)
+    assert_empty @hub.select_formula(:A)
+    assert_empty @hub.select_formula(:D)
+  end
+
+  def test_update_homebrew_with_formulae_changes
+    perform_update("update_git_diff_output_with_formulae_changes")
+    assert_equal %w[xar yajl], @hub.select_formula(:M)
+    assert_equal %w[antiword bash-completion ddrescue dict lua], @hub.select_formula(:A)
+  end
+
+  def test_update_homebrew_with_removed_formulae
+    perform_update("update_git_diff_output_with_removed_formulae")
+    assert_equal %w[libgsasl], @hub.select_formula(:D)
   end
 
   def test_update_homebrew_with_changed_filetype
     perform_update("update_git_diff_output_with_changed_filetype")
+    assert_equal %w[elixir], @hub.select_formula(:M)
+    assert_equal %w[libbson], @hub.select_formula(:A)
+    assert_equal %w[libgsasl], @hub.select_formula(:D)
+  end
+
+  def test_update_homebrew_with_formula_rename
+    @tap.stubs(:formula_renames).returns("cv" => "progress")
+    perform_update("update_git_diff_output_with_formula_rename")
+    assert_empty @hub.select_formula(:A)
+    assert_empty @hub.select_formula(:D)
+    assert_equal [["cv", "progress"]], @hub.select_formula(:R)
   end
 
   def test_update_homebrew_with_restructured_tap
-    repo = HOMEBREW_LIBRARY.join("Taps", "foo", "bar")
-    @updater = ReporterMock.new(repo)
-    repo.join("Formula").mkpath
+    tap = Tap.new("foo", "bar")
+    @reporter = ReporterMock.new(tap, "12345678", "abcdef12")
+    tap.path.join("Formula").mkpath
 
     perform_update("update_git_diff_output_with_restructured_tap")
+    assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:A)
+    assert_empty @hub.select_formula(:D)
   end
 
   def test_update_homebrew_simulate_homebrew_php_restructuring
-    repo = HOMEBREW_LIBRARY.join("Taps", "foo", "bar")
-    @updater = ReporterMock.new(repo)
-    repo.join("Formula").mkpath
+    tap = Tap.new("foo", "bar")
+    @reporter = ReporterMock.new(tap, "12345678", "abcdef12")
+    tap.path.join("Formula").mkpath
 
     perform_update("update_git_diff_simulate_homebrew_php_restructuring")
+    assert_empty @hub.select_formula(:A)
+    assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:D)
   end
 
   def test_update_homebrew_with_tap_formulae_changes
-    repo = HOMEBREW_LIBRARY.join("Taps", "foo", "bar")
-    @updater = ReporterMock.new(repo)
-    repo.join("Formula").mkpath
+    tap = Tap.new("foo", "bar")
+    @reporter = ReporterMock.new(tap, "12345678", "abcdef12")
+    tap.path.join("Formula").mkpath
 
     perform_update("update_git_diff_output_with_tap_formulae_changes")
+    assert_equal %w[foo/bar/lua], @hub.select_formula(:A)
+    assert_equal %w[foo/bar/git], @hub.select_formula(:M)
+    assert_empty @hub.select_formula(:D)
   end
 end


### PR DESCRIPTION
* Better variable/class name. `update-report` isn't response to actual update.
* Avoid tons of unnecessary file path manipulation. Use abstraction
  offered by Tap class if possible.
* Avoid duplicated computation.
* Failure on one tap won't affect migration preformed by other taps.
* Remove redundant/dead code from original update script.

cc @mikemcquaid @UniqMartin 