### PR TITLE
audit: check resource placement

### DIFF
--- a/Library/Formula/mpdviz.rb
+++ b/Library/Formula/mpdviz.rb
@@ -6,6 +6,10 @@ class Mpdviz < Formula
   url "https://github.com/lucy/mpdviz/archive/0.4.6.tar.gz"
   sha256 "c34243ec3f3d91adbc36d608d5ba7082ff78870f2fd76a6650d5fb3218cc2ba3"
 
+  depends_on "pkg-config" => :build
+  depends_on "go" => :build
+  depends_on "fftw"
+
   go_resource "github.com/lucy/go-fftw" do
     url "https://github.com/lucy/go-fftw.git",
       :revision => "37bfa0d3053b133f7067e9524611a7a963294124"
@@ -25,10 +29,6 @@ class Mpdviz < Formula
     url "https://github.com/mattn/go-runewidth.git",
       :revision => "36f63b8223e701c16f36010094fb6e84ffbaf8e0"
   end
-
-  depends_on "pkg-config" => :build
-  depends_on "go" => :build
-  depends_on "fftw"
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -186,6 +186,7 @@ class FormulaAuditor
       [/^  keg_only/,                      "keg_only"],
       [/^  option/,                        "option"],
       [/^  depends_on/,                    "depends_on"],
+      [/^  (go_)?resource/,                "resource"],
       [/^  def install/,                   "install method"],
       [/^  def caveats/,                   "caveats method"],
       [/^  test do/,                       "test block"],

--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -156,6 +156,23 @@ class FormulaAuditorTests < Homebrew::TestCase
       fa.problems
   end
 
+  def test_audit_file_strict_resource_placement
+    fa = formula_auditor "foo", <<-EOS.undent, :strict => true
+      class Foo < Formula
+        url "https://example.com/foo-1.0.tgz"
+
+        resource "foo2" do
+          url "https://example.com/foo-2.0.tgz"
+        end
+
+        depends_on "openssl"
+      end
+    EOS
+    fa.audit_file
+    assert_equal ["`depends_on` (line 8) should be put before `resource` (line 4)"],
+      fa.problems
+  end
+
   def test_audit_file_strict_url_outside_of_stable_block
     fa = formula_auditor "foo", <<-EOS.undent, :strict => true
       class Foo < Formula


### PR DESCRIPTION
Realised we aren't doing this after someone filed a PR a couple days back and it wasn't flagged. We more or less enforce this on contributors, so we might as well enforce it by bot rather than by human.

`mpdviz` was the only existing case in the core and Versions that uses `go_resource`s and that's fixed here. Didn't check `resource`s more broadly, but I'd be surprised if the number is massive and it'll only show up for people manually running `--strict` on things manually where it's already present.

