### PR TITLE
make docker-machine a recommended dependency for docker-machine-driver-xhyve

### DIFF
--- a/Library/Formula/docker-machine-driver-xhyve.rb
+++ b/Library/Formula/docker-machine-driver-xhyve.rb
@@ -16,9 +16,13 @@ class DockerMachineDriverXhyve < Formula
 
   depends_on :macos => :yosemite
   depends_on "go" => :build
-  depends_on "docker-machine"
+  depends_on "docker-machine" => :recommended
 
   def install
+    unless build.with?("docker-machine")
+      opoo "You have disabled automatic installation of docker-machine; you are responsible for installing Machine yourself (e.g. via Docker Toolbox)."
+    end
+
     (buildpath/"gopath/src/github.com/zchee/docker-machine-driver-xhyve").install Dir["{*,.git,.gitignore}"]
 
     ENV["GOPATH"] = "#{buildpath}/gopath"


### PR DESCRIPTION
If you have installed Docker components via Docker Toolbox (https://www.docker.com/products/docker-toolbox), whether manually or from Cask, this formula's dependency on docker-machine will cause a conflict.  This PR adds a `--without-docker-machine` option, which disables the dependency and prints a warning message; the default behavior of the formula is unchanged.