### PR TITLE
pyenv: fix to require readline

### DIFF
--- a/Library/Formula/pyenv.rb
+++ b/Library/Formula/pyenv.rb
@@ -10,6 +10,7 @@ class Pyenv < Formula
   depends_on "autoconf" => [:recommended, :run]
   depends_on "pkg-config" => [:recommended, :run]
   depends_on "openssl" => :recommended
+  depends_on "readline" => [:recommended, :run]
 
   def install
     inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX


### PR DESCRIPTION
Adds readline as a dependency of pyenv. If it is not present, pyenv will download and build readline. While this works, it is a bit unnecessary. If readline is present in homebrew, it seems to be able to detect it and use it instead (even if it is installed as keg-only). This cuts down on the build time of new Python environments.