### PR TITLE
ponyc: do verbose build

### DIFF
--- a/Library/Formula/ponyc.rb
+++ b/Library/Formula/ponyc.rb
@@ -17,7 +17,7 @@ class Ponyc < Formula
 
   def install
     ENV.cxx11
-    system "make", "install", "config=release", "destdir=#{prefix}"
+    system "make", "install", "config=release", "destdir=#{prefix}", "verbose=1"
   end
 
   test do


### PR DESCRIPTION
This will get the actual compiler commands in to our build logs. Should not change the resulting built binaries.