### PR TITLE
Fix app-engine-go-64 and app-engine-go-32 to support gocode

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -18,6 +18,7 @@ class AppEngineGo32 < Formula
     ].each do |fn|
       bin.install_symlink pkgshare/fn
     end
+    (pkgshare/"goroot/pkg").install_symlink pkgshare/"goroot/pkg/darwin_386_appengine" => "darwin_386"
   end
 
   test do

--- a/Library/Formula/app-engine-go-64.rb
+++ b/Library/Formula/app-engine-go-64.rb
@@ -18,6 +18,7 @@ class AppEngineGo64 < Formula
     ].each do |fn|
       bin.install_symlink pkgshare/fn
     end
+    (pkgshare/"goroot/pkg").install_symlink pkgshare/"goroot/pkg/darwin_amd64_appengine" => "darwin_amd64"
   end
 
   test do


### PR DESCRIPTION
Currently when writing GAE web apps using app-engine-go-64 or app-engine-go-32, the IDE cannot use `gocode` to support autocomplete features because the search path is not setup correctly.  This pull request creates a symlink so that gocode searches in the correct directory to enable autocomplete.