### PR TITLE
openssl: remove patch not applicable to 1.0.2f

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -22,17 +22,6 @@ class Openssl < Formula
 
   depends_on "makedepend" => :build
 
-  # Xcode 7 Clang fix introduced regression which makes older Clang versions
-  # incorrectly declare suitable instructions.
-  # https://github.com/openssl/openssl/issues/494
-  # https://svn.macports.org/repository/macports/trunk/dports/devel/openssl/files/fix-Apple-clang-version-detection.patch
-  if MacOS.version <= :mountain_lion
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/patches/312f6228/openssl/fix-Apple-clang-version-detection.patch"
-      sha256 "a3e0e13e6c70d85d916bb88cbddc134952794d6292fbab4f2740ac9a07759606"
-    end
-  end
-
   # 1.0.2f: fix typo in macro BIO_get_conn_int_port()
   # https://github.com/openssl/openssl/issues/595
   # https://github.com/openssl/openssl/pull/596


### PR DESCRIPTION
The Clang version detection patch made for an earlier release of openssl cannot be applied to 1.0.2f sources. After removing the patch, openssl installs ok on Lion 10.7.5.