### PR TITLE
mitmproxy 0.15

### DIFF
--- a/Library/Formula/mitmproxy.rb
+++ b/Library/Formula/mitmproxy.rb
@@ -190,7 +190,11 @@ class Mitmproxy < Formula
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
+
+    unless MacOS::CLT.installed?
+      ENV.append "CPPFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+      ENV.append "CPPFLAGS", "-I#{MacOS.sdk_path}/usr/include/ffi" # libffi
+    end
 
     resource("Pillow").stage do
       inreplace "setup.py", "'brew', '--prefix'", "'#{HOMEBREW_PREFIX}/bin/brew', '--prefix'"

--- a/Library/Formula/mitmproxy.rb
+++ b/Library/Formula/mitmproxy.rb
@@ -1,8 +1,8 @@
 class Mitmproxy < Formula
   desc "Intercept, modify, replay, save HTTP/S traffic"
   homepage "https://mitmproxy.org"
-  url "https://mitmproxy.org/download/mitmproxy-0.14.0.tar.gz"
-  sha256 "cefcdc514b46b29c73a10a9e5b967c7716cb98e2d2abbfa74ebba8d4511d6d55"
+  url "https://mitmproxy.org/download/mitmproxy-0.15.tar.gz"
+  sha256 "3565086026b5ca0b048e826498a9ed9b37489f5b5639a728d280f73783914aac"
   head "https://github.com/mitmproxy/mitmproxy.git"
 
   bottle do
@@ -17,13 +17,24 @@ class Mitmproxy < Formula
   option "with-cssutils", "Enable beautification of CSS responses"
 
   depends_on "freetype"
+  depends_on "jpeg"
   depends_on "openssl"
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "protobuf" => :optional
 
+  resource "argh" do
+    url "https://pypi.python.org/packages/source/a/argh/argh-0.26.1.tar.gz"
+    sha256 "06a7442cb9130fb8806fe336000fcf20edf1f2f8ad205e7b62cec118505510db"
+  end
+
+  resource "backports_abc" do
+    url "https://pypi.python.org/packages/source/b/backports_abc/backports_abc-0.4.tar.gz"
+    sha256 "8b3e4092ba3d541c7a2f9b7d0d9c0275b21c6a01c53a61c731eba6686939d0a5"
+  end
+
   resource "backports.ssl_match_hostname" do
-    url "https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz"
-    sha256 "07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae"
+    url "https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.5.0.1.tar.gz"
+    sha256 "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2"
   end
 
   resource "blinker" do
@@ -32,38 +43,48 @@ class Mitmproxy < Formula
   end
 
   resource "certifi" do
-    url "https://pypi.python.org/packages/source/c/certifi/certifi-2015.9.6.2.tar.gz"
-    sha256 "dc3a2b2d9d1033dbf27586366ae61b9d7c44d8c3a6f29694ffcbb0618ea7aea6"
+    url "https://pypi.python.org/packages/source/c/certifi/certifi-2015.11.20.1.tar.gz"
+    sha256 "30b0a7354a1b32caa8b4705d3f5fb2dadefac7ba4bf8af8a2176869f93e38f16"
   end
 
   resource "cffi" do
-    url "https://pypi.python.org/packages/source/c/cffi/cffi-1.2.1.tar.gz"
-    sha256 "eab571deb0a152e2f53c404c08a94870a131526896cad08cd43bf86ce3771e3d"
+    url "https://pypi.python.org/packages/source/c/cffi/cffi-1.5.0.tar.gz"
+    sha256 "44f76f6c3fc654860821785192eca29bd66531af57d09b681e6d52584604a7e7"
+  end
+
+  resource "click" do
+    url "https://pypi.python.org/packages/source/c/click/click-6.2.tar.gz"
+    sha256 "fba0ff70f5ebb4cebbf64c40a8fbc222fb7cf825237241e548354dabe3da6a82"
   end
 
   resource "ConfigArgParse" do
-    url "https://pypi.python.org/packages/source/C/ConfigArgParse/ConfigArgParse-0.9.3.tar.gz"
-    sha256 "141c57112e1f8eb7e594a9820e95af897a7fa2d186cef5cff7e08cb3f7252829"
+    url "https://pypi.python.org/packages/source/C/ConfigArgParse/ConfigArgParse-0.10.0.tar.gz"
+    sha256 "3b50a83dd58149dfcee98cb6565265d10b53e9c0a2bca7eeef7fb5f5524890a7"
+  end
+
+  resource "construct" do
+    url "https://pypi.python.org/packages/source/c/construct/construct-2.5.2.tar.gz"
+    sha256 "665b6271eeadf15219c726b180c8d7a641d026784d72ca3dad90a20aae009020"
   end
 
   resource "cryptography" do
-    url "https://pypi.python.org/packages/source/c/cryptography/cryptography-1.0.2.tar.gz"
-    sha256 "d64cd491e91ddf642c643bea16532c2a2da2da054cca6df756edadd55a8bacca"
+    url "https://pypi.python.org/packages/source/c/cryptography/cryptography-1.1.2.tar.gz"
+    sha256 "7f51459f84d670444275e615839f4542c93547a12e938a0a4906dafe5f7de153"
   end
 
   resource "enum34" do
-    url "https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz"
-    sha256 "d3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447"
+    url "https://pypi.python.org/packages/source/e/enum34/enum34-1.1.2.tar.gz"
+    sha256 "2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7"
   end
 
   resource "hpack" do
-    url "https://pypi.python.org/packages/source/h/hpack/hpack-1.1.0.tar.gz"
-    sha256 "1a4832961ac0acb0d124d9db0bcb5ab44d61c8d8466c9a3b59d49aceeca91d11"
+    url "https://pypi.python.org/packages/source/h/hpack/hpack-2.0.1.tar.gz"
+    sha256 "0d7eaafeecfb60c18cbfd1c8ffb032bca4524862d0d89540e8a62d5118529ccc"
   end
 
   resource "html2text" do
-    url "https://pypi.python.org/packages/source/h/html2text/html2text-2015.6.21.tar.gz"
-    sha256 "5026fe0ca9600709b68ae70e086a1ca000c0af02e88ac8cb108030c6b5be8c6d"
+    url "https://pypi.python.org/packages/source/h/html2text/html2text-2015.11.4.tar.gz"
+    sha256 "44531c00fd125d0d987adf4e5ab6b4a8a2b44bfa5c4dc8896f50aa0e35c33708"
   end
 
   resource "idna" do
@@ -72,8 +93,8 @@ class Mitmproxy < Formula
   end
 
   resource "ipaddress" do
-    url "https://pypi.python.org/packages/source/i/ipaddress/ipaddress-1.0.14.tar.gz"
-    sha256 "226f4be44c6cb64055e23060848266f51f329813baae28b53dc50e93488b3b3e"
+    url "https://pypi.python.org/packages/source/i/ipaddress/ipaddress-1.0.16.tar.gz"
+    sha256 "5a3182b322a706525c46282ca6f064d27a02cffbd449f9f47416f1dc96aa71b0"
   end
 
   resource "lxml" do
@@ -82,8 +103,8 @@ class Mitmproxy < Formula
   end
 
   resource "netlib" do
-    url "https://pypi.python.org/packages/source/n/netlib/netlib-0.14.0.tar.gz"
-    sha256 "cf12b0a71a493eee46fb2da284122ac363179fe0a0bc71c5c8920374aa978e75"
+    url "https://pypi.python.org/packages/source/n/netlib/netlib-0.15.1.tar.gz"
+    sha256 "f55ad129b770fcf82786fb59d3e4f4291ea4c6dca4e4850bce1977bd9e99492e"
   end
 
   resource "passlib" do
@@ -91,14 +112,19 @@ class Mitmproxy < Formula
     sha256 "a83d34f53dc9b17aa42c9a35c3fbcc5120f3fcb07f7f8721ec45e6a27be347fc"
   end
 
-  resource "pillow" do
-    url "https://pypi.python.org/packages/source/P/Pillow/Pillow-2.9.0.tar.gz"
-    sha256 "0f179d7e75e7c83b6341b9595ca1f394de7081484a9e352ad66d553a1c3daa29"
+  resource "pathtools" do
+    url "https://pypi.python.org/packages/source/p/pathtools/pathtools-0.1.2.tar.gz"
+    sha256 "7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
+  end
+
+  resource "Pillow" do
+    url "https://pypi.python.org/packages/source/P/Pillow/Pillow-3.0.0.tar.gz"
+    sha256 "ad50bef540fe5518a4653c3820452a881b6a042cb0f8bb7657c491c6bd3654bb"
   end
 
   resource "pyasn1" do
-    url "https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.8.tar.gz"
-    sha256 "5d33be7ca0ec5997d76d29ea4c33b65c00c0231407fff975199d7f40530b8347"
+    url "https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.9.tar.gz"
+    sha256 "853cacd96d1f701ddd67aa03ecc05f51890135b7262e922710112f12a2ed2a7f"
   end
 
   resource "pycparser" do
@@ -112,23 +138,33 @@ class Mitmproxy < Formula
   end
 
   resource "pyparsing" do
-    url "https://pypi.python.org/packages/source/p/pyparsing/pyparsing-2.0.3.tar.gz"
-    sha256 "06e729e1cbf5274703b1f47b6135ed8335999d547f9d8cf048b210fb8ebf844f"
+    url "https://pypi.python.org/packages/source/p/pyparsing/pyparsing-2.0.7.tar.gz"
+    sha256 "2ce0db3c70ec0413603d4aea389e4ece34ff93c265649b1c5c7d56e3c2cf19c4"
   end
 
   resource "pyperclip" do
-    url "https://pypi.python.org/packages/source/p/pyperclip/pyperclip-1.5.13.zip"
-    sha256 "b835b40605d5b24567176cf8686065fac523debbcc83fd643eba79c782817cee"
+    url "https://pypi.python.org/packages/source/p/pyperclip/pyperclip-1.5.26.zip"
+    sha256 "15929bdb305ca54ff090f066de985aa7b21f3d5f0b695edab880f0246559a88b"
+  end
+
+  resource "PyYAML" do
+    url "https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.11.tar.gz"
+    sha256 "c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8"
+  end
+
+  resource "singledispatch" do
+    url "https://pypi.python.org/packages/source/s/singledispatch/singledispatch-3.4.0.3.tar.gz"
+    sha256 "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"
   end
 
   resource "six" do
-    url "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz"
-    sha256 "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5"
+    url "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
   end
 
   resource "tornado" do
-    url "https://pypi.python.org/packages/source/t/tornado/tornado-4.2.1.tar.gz"
-    sha256 "a16fcdc4f76b184cb82f4f9eaeeacef6113b524b26a2cb331222e4a7fa6f2969"
+    url "https://pypi.python.org/packages/source/t/tornado/tornado-4.3.tar.gz"
+    sha256 "c9c2d32593d16eedf2cec1b6a41893626a2649b40b21ca9c4cac4243bde2efbf"
   end
 
   resource "urwid" do
@@ -136,14 +172,9 @@ class Mitmproxy < Formula
     sha256 "cfcec03e36de25a1073e2e35c2c7b0cc6969b85745715c3a025a31d9786896a1"
   end
 
-  resource "construct" do
-    url "https://pypi.python.org/packages/source/c/construct/construct-2.5.2.tar.gz"
-    sha256 "665b6271eeadf15219c726b180c8d7a641d026784d72ca3dad90a20aae009020"
-  end
-
-  resource "click" do
-    url "https://pypi.python.org/packages/source/c/click/click-5.1.tar.gz"
-    sha256 "678c98275431fad324275dec63791e4a17558b40e5a110e20a82866139a85a5a"
+  resource "watchdog" do
+    url "https://pypi.python.org/packages/source/w/watchdog/watchdog-0.8.3.tar.gz"
+    sha256 "7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162"
   end
 
   # Optional resources
@@ -161,15 +192,15 @@ class Mitmproxy < Formula
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
 
-    resource("pillow").stage do
+    resource("Pillow").stage do
       inreplace "setup.py", "'brew', '--prefix'", "'#{HOMEBREW_PREFIX}/bin/brew', '--prefix'"
       system "python", *Language::Python.setup_install_args(libexec/"vendor")
     end
 
-    res = %w[backports.ssl_match_hostname blinker certifi cffi ConfigArgParse
-             cryptography enum34 hpack html2text idna ipaddress lxml netlib passlib
-             pyasn1 pycparser pyOpenSSL pyparsing pyperclip six tornado urwid
-             construct click]
+    res = %w[argh backports_abc backports.ssl_match_hostname blinker certifi cffi
+             click ConfigArgParse construct cryptography enum34 hpack html2text idna
+             ipaddress lxml netlib passlib pathtools pyasn1 pycparser pyOpenSSL
+             pyparsing pyperclip PyYAML singledispatch six tornado urwid watchdog]
 
     res << "pyamf" if build.with? "pyamf"
     res << "cssutils" if build.with? "cssutils"


### PR DESCRIPTION
@tdsmith I've pulled in your commit from https://github.com/Homebrew/homebrew/pull/45078. Let me know if you've any objections there. I tweaked the line on `/usr/include` to be `/usr/include/ffi` because it matches the upstream pointer, but shout if I'm wrong; you're the Python expert :smiley:.