### PR TITLE
mariadb-connector-c 2.2.2 (new formula)

### DIFF
--- a/Library/Formula/mariadb-connector-c.rb
+++ b/Library/Formula/mariadb-connector-c.rb
@@ -7,6 +7,9 @@ class MariadbConnectorC < Formula
   depends_on "cmake" => :build
   depends_on "openssl"
 
+  conflicts_with "mysql", "mariadb", "percona-server",
+                 :because => "both install plugins"
+
   def install
     args = std_cmake_args
     args << "-DWITH_OPENSSL=On"

--- a/Library/Formula/mariadb-connector-c.rb
+++ b/Library/Formula/mariadb-connector-c.rb
@@ -1,0 +1,29 @@
+class MariadbConnectorC < Formula
+  desc "MariaDB database connector for C applications"
+  homepage "https://downloads.mariadb.org/connector-c/"
+  url "https://downloads.mariadb.org/f/connector-c-2.2.2/mariadb-connector-c-2.2.2-src.tar.gz"
+  sha256 "93f56ad9f08bbaf0da8ef03bc96f7093c426ae40dede60575d485e1b99e6406b"
+
+  depends_on "cmake" => :build
+  depends_on "openssl"
+
+  def install
+    args = %W[
+      .
+      -DCMAKE_INSTALL_PREFIX=#{prefix}
+      -DCMAKE_VERBOSE_MAKEFILE=ON
+      -DOPENSSL_INCLUDE_DIR=#{Formula["openssl"].opt_include}
+      -DWITH_OPENSSL=On
+      -DCOMPILATION_COMMENT=Homebrew
+    ]
+
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/mariadb_config", "--cflags"
+    system "#{bin}/mariadb_config", "--include"
+    system "#{bin}/mariadb_config", "--libs"
+  end
+end

--- a/Library/Formula/mariadb-connector-c.rb
+++ b/Library/Formula/mariadb-connector-c.rb
@@ -23,7 +23,5 @@ class MariadbConnectorC < Formula
 
   test do
     system "#{bin}/mariadb_config", "--cflags"
-    system "#{bin}/mariadb_config", "--include"
-    system "#{bin}/mariadb_config", "--libs"
   end
 end

--- a/Library/Formula/mariadb-connector-c.rb
+++ b/Library/Formula/mariadb-connector-c.rb
@@ -8,16 +8,12 @@ class MariadbConnectorC < Formula
   depends_on "openssl"
 
   def install
-    args = %W[
-      .
-      -DCMAKE_INSTALL_PREFIX=#{prefix}
-      -DCMAKE_VERBOSE_MAKEFILE=ON
-      -DOPENSSL_INCLUDE_DIR=#{Formula["openssl"].opt_include}
-      -DWITH_OPENSSL=On
-      -DCOMPILATION_COMMENT=Homebrew
-    ]
+    args = std_cmake_args
+    args << "-DWITH_OPENSSL=On"
+    args << "-DOPENSSL_INCLUDE_DIR=#{Formula["openssl"].opt_include}"
+    args << "-DCOMPILATION_COMMENT=Homebrew"
 
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *args
     system "make", "install"
   end
 

--- a/Library/Formula/mariadb.rb
+++ b/Library/Formula/mariadb.rb
@@ -30,6 +30,8 @@ class Mariadb < Formula
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"
   conflicts_with "mytop", :because => "both install `mytop` binaries"
+  conflicts_with "mariadb-connector-c",
+    :because => "both install plugins"
 
   patch do
     # fix compilation error https://mariadb.atlassian.net/browse/MDEV-9322

--- a/Library/Formula/mysql.rb
+++ b/Library/Formula/mysql.rb
@@ -33,6 +33,8 @@ class Mysql < Formula
     :because => "mysql, mariadb, and percona install the same binaries."
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"
+  conflicts_with "mariadb-connector-c",
+    :because => "both install plugins"
 
   fails_with :llvm do
     build 2326

--- a/Library/Formula/percona-server.rb
+++ b/Library/Formula/percona-server.rb
@@ -42,6 +42,8 @@ class PerconaServer < Formula
     :because => "percona, mariadb, and mysql install the same binaries."
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"
+  conflicts_with "mariadb-connector-c",
+    :because => "both install plugins"
 
   fails_with :llvm do
     build 2334


### PR DESCRIPTION
I've tried to write [mariadb-connector-c](https://downloads.mariadb.org/connector-c/) formula.
Related to https://github.com/Homebrew/homebrew/issues/48543.

MariaDB Connector C is an another connector to MariaDB (and MySQL compatible server) for C/C++ applications.
This connector code base is different from mysql-connector-c.

I think it would be nice to provide this formula in Homebrew.
You mean that you want to write and PR like this formula , @jeroenooms ?