### PR TITLE
New formula: oksh (portable OpenBSD ksh)

### DIFF
--- a/Library/Formula/oksh.rb
+++ b/Library/Formula/oksh.rb
@@ -1,0 +1,21 @@
+class Oksh < Formula
+  desc "portable OpenBSD ksh (a maintained pdksh/ksh88 clone)"
+
+  # Note that this is *not* the same project as https://connochaetos.org/oksh,
+  # (linked at: http://freecode.com/projects/oksh). Though the intent of these
+  # projects is the same, that version was intentionally relicesed as GPL3 and
+  # should be avoided. https://github.com/ibara/oksh retains BSD/ISC license.
+
+  homepage "https://github.com/ibara/oksh"
+  url "http://devio.us/~bcallah/oksh/oksh-6.tar.gz"
+  sha256 "2acbb03ac5e5322011694c3e2f21024f4940bb58e9a6a4e6d1dc19cb4789c75b"
+  head "https://github.com/ibara/oksh.git"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "MANDIR=#{man}"
+  end
+
+  test do
+    system "oksh", "-c", "echo \"PS1='\\u@\\h'\" works in oksh but not pdksh."
+  end
+end


### PR DESCRIPTION
This is a formula for [oksh](https://github.com/ibara/oksh), a portable version of the `/bin/ksh` from OpenBSD.
It is a pdksh derivative that is [actively maintained](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/bin/ksh/?sortby=log#dirlist).

I [recently added the necessary bits](https://github.com/ibara/oksh/commit/6fa683f7c4cf7db53c3f7b143bdf3a181556cc9e) to @ibara's existing portability fixes so that Darwin is now supported.

Probably not going to be your login shell, but great for testing script portability across platforms, etc.

:beers: