### PR TITLE
freetype 2.6.2

### DIFF
--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -3,6 +3,7 @@ class Atk < Formula
   homepage "https://library.gnome.org/devel/atk/"
   url "https://download.gnome.org/sources/atk/2.18/atk-2.18.0.tar.xz"
   sha256 "ce6c48d77bf951083029d5a396dd552d836fff3c1715d3a7022e917e46d0c92b"
+  revision 1
 
   bottle do
     revision 1

--- a/Library/Formula/fontconfig.rb
+++ b/Library/Formula/fontconfig.rb
@@ -3,6 +3,7 @@ class Fontconfig < Formula
   homepage "http://fontconfig.org/"
   url "http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2"
   sha256 "dc62447533bca844463a3c3fd4083b57c90f18a70506e7a9f4936b5a1e516a99"
+  revision 1
 
   # The bottle tooling is too lenient and thinks fontconfig
   # is relocatable, but it has hardcoded paths in the executables.

--- a/Library/Formula/freetype.rb
+++ b/Library/Formula/freetype.rb
@@ -1,10 +1,13 @@
 class Freetype < Formula
   desc "Software library to render fonts"
   homepage "http://www.freetype.org"
-  url "https://downloads.sf.net/project/freetype/freetype2/2.6/freetype-2.6.tar.bz2"
-  mirror "http://download.savannah.gnu.org/releases/freetype/freetype-2.6.tar.bz2"
-  sha256 "8469fb8124764f85029cc8247c31e132a2c5e51084ddce2a44ea32ee4ae8347e"
-  revision 1
+  url "https://downloads.sf.net/project/freetype/freetype2/2.6.2/freetype-2.6.2.tar.bz2"
+  mirror "http://download.savannah.gnu.org/releases/freetype/freetype-2.6.2.tar.bz2"
+  sha256 "baf6bdef7cdcc12ac270583f76ef245efe936267dbecef835f02a3409fcbb892"
+
+  # Note: when bumping freetype's version, you must also bump revisions of formula with
+  # "full path" references to freetype in their pkgconfig.
+  # See https://github.com/Homebrew/homebrew/pull/44587
 
   bottle do
     cellar :any
@@ -21,17 +24,9 @@ class Freetype < Formula
 
   depends_on "libpng"
 
-  # Don't define a TYPEOF macro in ftconfig.h
-  # https://savannah.nongnu.org/bugs/index.php?45376
-  # http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=5931268eecaeda3e05580bdc8885348fecc43fa8
-  patch do
-    url "https://gist.githubusercontent.com/anonymous/b47d77c41a6801879fd2/raw/fc21c3516b465095da7ed13f98bea491a7d18bbd/patch"
-    sha256 "5b21575d0384c9e502b51b0ba4be0ff453a34bcf9deba52b6baa38c3ffcde063"
-  end
-
   def install
     if build.with? "subpixel"
-      inreplace "include/config/ftoption.h",
+      inreplace "include/freetype/config/ftoption.h",
           "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */",
           "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
     end

--- a/Library/Formula/gd.rb
+++ b/Library/Formula/gd.rb
@@ -3,6 +3,7 @@ class Gd < Formula
   homepage "https://libgd.github.io/"
   url "https://bitbucket.org/libgd/gd-libgd/downloads/libgd-2.1.1.tar.xz"
   sha256 "9ada1ed45594abc998ebc942cef12b032fbad672e73efc22bc9ff54f5df2b285"
+  revision 1
 
   head do
     url "https://bitbucket.org/libgd/gd-libgd.git"

--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -7,6 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/ImageMagick-6.9.3-0.tar.xz"
   mirror "http://www.imagemagick.org/download/releases/ImageMagick-6.9.3-0.tar.xz"
   sha256 "2ba0656eb03d72d8a44e741ead524e8c34097418c0bb5487a5c4f4fe5eca9656"
+  revision 1
 
   head "http://git.imagemagick.org/repos/ImageMagick.git"
 

--- a/Library/Formula/libbluray.rb
+++ b/Library/Formula/libbluray.rb
@@ -3,6 +3,7 @@ class Libbluray < Formula
   homepage "https://www.videolan.org/developers/libbluray.html"
   url "https://download.videolan.org/pub/videolan/libbluray/0.9.2/libbluray-0.9.2.tar.bz2"
   sha256 "efc994f42d2bce6af2ce69d05ba89dbbd88bcec7aca065de094fb3a7880ce7ea"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/simple-tiles.rb
+++ b/Library/Formula/simple-tiles.rb
@@ -3,6 +3,7 @@ class SimpleTiles < Formula
   homepage "https://propublica.github.io/simple-tiles/"
   url "https://github.com/propublica/simple-tiles/archive/v0.6.0.tar.gz"
   sha256 "336fdc04c34b85270c377d880a0d4cc2ac1a9c9e5e4c3d53e0322d43c9495ac9"
+  revision 1
 
   head "https://github.com/propublica/simple-tiles.git"
 


### PR DESCRIPTION
Closes #44587 (pending 2.6.1 upgrade)

Also bumps revisions for: fontconfig gd imagemagick libbluray simple-tiles.
These formulae have pkgconfig references to freetype which include the full path to the versioned install location.