### PR TITLE
puddletag 1.1.1

### DIFF
--- a/Library/Formula/puddletag.rb
+++ b/Library/Formula/puddletag.rb
@@ -1,8 +1,8 @@
 class Puddletag < Formula
   desc "Powerful, simple, audio tag editor."
   homepage "http://puddletag.sf.net"
-  url "https://github.com/keithgg/puddletag/archive/1.1.0.tar.gz"
-  sha256 "a8e3cb93799a44a48cfedc66842c9857511c19d20cd2c40418d833b68acf1f03"
+  url "https://github.com/keithgg/puddletag/archive/1.1.1.tar.gz"
+  sha256 "550680abf9c2cf082861dfb3b61fd308f87f9ed304065582cddadcc8bdd947cc"
 
   head "https://github.com/keithgg/puddletag.git"
 
@@ -41,6 +41,7 @@ class Puddletag < Formula
     end
 
     cp_r buildpath/"source/.", buildpath
+
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
     system "python", *Language::Python.setup_install_args(libexec)
 
@@ -49,6 +50,8 @@ class Puddletag < Formula
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
+    system "sh create_macos_app_bundle.sh --name Puddletag --icon puddletag.png --script #{bin}/puddletag"
+    prefix.install Dir["Puddletag.app"]
   end
 
   test do

--- a/Library/Formula/puddletag.rb
+++ b/Library/Formula/puddletag.rb
@@ -1,9 +1,8 @@
 class Puddletag < Formula
   desc "Powerful, simple, audio tag editor."
   homepage "http://puddletag.sf.net"
-  url "https://github.com/keithgg/puddletag/archive/v1.0.5.tar.gz"
-  sha256 "f94ebcc4ed31389574c187197b99256bec1f96e1e7d4dd61730e88f79deeaba2"
-  revision 1
+  url "https://github.com/keithgg/puddletag/archive/1.1.0.tar.gz"
+  sha256 "a8e3cb93799a44a48cfedc66842c9857511c19d20cd2c40418d833b68acf1f03"
 
   head "https://github.com/keithgg/puddletag.git"
 
@@ -33,12 +32,6 @@ class Puddletag < Formula
     sha256 "766eff273f2cbb007a3ea8aa69429ee9b1553aa96fe282c6ace3769b9ac47b08"
   end
 
-  # Upstream commit to fix an issue with PyQT 4.11.4. Remove on next version.
-  patch do
-    url "https://github.com/keithgg/puddletag/commit/489acd2ee62eb5fbff95f8220dc8958c14871931.patch"
-    sha256 "fce0cfce4d4477cde4827a0a4d3ef74fbabf630ada2d0cf035cf155a17c37a68"
-  end
-
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     %w[pyparsing mutagen configobj].each do |r|
@@ -55,6 +48,7 @@ class Puddletag < Formula
 
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+
   end
 
   test do

--- a/Library/Formula/puddletag.rb
+++ b/Library/Formula/puddletag.rb
@@ -51,7 +51,7 @@ class Puddletag < Formula
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
     system "sh create_macos_app_bundle.sh --name Puddletag --icon puddletag.png --script #{bin}/puddletag"
-    prefix.install Dir["Puddletag.app"]
+    prefix.install "Puddletag.app"
   end
 
   test do

--- a/Library/Formula/puddletag.rb
+++ b/Library/Formula/puddletag.rb
@@ -50,7 +50,8 @@ class Puddletag < Formula
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
-    system "sh create_macos_app_bundle.sh --name Puddletag --icon puddletag.png --script #{bin}/puddletag"
+    system "sh", "create_macos_app_bundle.sh", "--name", "Puddletag",
+                 "--icon", "puddletag.png", "--script", "#{bin}/puddletag"
     prefix.install "Puddletag.app"
   end
 


### PR DESCRIPTION
Update to version 1.1.1
Removed patch for version 1.0.5
Added script execution line (once talked about with mikemcquaid; see https://github.com/Homebrew/homebrew/pull/43677)

Info: There were two version bumps of puddletag in the last days. The last one was mainly a stability fix.