### PR TITLE
mysqldump-secure 0.11.3 (new formula)

### DIFF
--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -1,5 +1,5 @@
 class MysqldumpSecure < Formula
-  desc "Encrypted mysqldump with compression, logging and Nagios integration"
+  desc "Encrypted mysqldump with compression and logging"
   homepage "https://github.com/cytopia/mysqldump-secure"
   url "https://github.com/cytopia/mysqldump-secure/archive/0.11.3.tar.gz"
   sha256 "046eb5da52d17f0a22d24a53380d820ce50dcff21b55047549ac61366fbc16a1"

--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -1,0 +1,15 @@
+class MysqldumpSecure < Formula
+  desc "Encrypted mysqldump with compression, logging, blacklisting and Nagios/Icinga monitoring integration"
+  homepage "https://github.com/cytopia/mysqldump-secure"
+  url "https://github.com/cytopia/mysqldump-secure/archive/0.11.3.tar.gz"
+  version "0.11.3"
+  sha256 "046eb5da52d17f0a22d24a53380d820ce50dcff21b55047549ac61366fbc16a1"
+
+  def install
+	#ENV.deparallelize
+    system "./configure", "--prefix=#{prefix}"
+	system "make"
+    system "make", "reinstall"
+  end
+
+end

--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -1,5 +1,5 @@
 class MysqldumpSecure < Formula
-  desc "Encrypted mysqldump with compression, logging and Nagios integration."
+  desc "Encrypted mysqldump with compression, logging and Nagios integration"
   homepage "https://github.com/cytopia/mysqldump-secure"
   url "https://github.com/cytopia/mysqldump-secure/archive/0.11.3.tar.gz"
   sha256 "046eb5da52d17f0a22d24a53380d820ce50dcff21b55047549ac61366fbc16a1"
@@ -9,9 +9,8 @@ class MysqldumpSecure < Formula
     system "make"
     system "make", "reinstall"
   end
-  
+
   test do
     system bin/"mysqldump-secure 2>&1 | grep ''"
   end
-
 end

--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -1,15 +1,13 @@
 class MysqldumpSecure < Formula
-  desc "Encrypted mysqldump with compression, logging, blacklisting and Nagios/Icinga monitoring integration"
+  desc "Encrypted mysqldump with compression, logging and Nagios integration."
   homepage "https://github.com/cytopia/mysqldump-secure"
   url "https://github.com/cytopia/mysqldump-secure/archive/0.11.3.tar.gz"
   version "0.11.3"
   sha256 "046eb5da52d17f0a22d24a53380d820ce50dcff21b55047549ac61366fbc16a1"
 
   def install
-	#ENV.deparallelize
     system "./configure", "--prefix=#{prefix}"
-	system "make"
+    system "make"
     system "make", "reinstall"
   end
-
 end

--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -9,4 +9,9 @@ class MysqldumpSecure < Formula
     system "make"
     system "make", "reinstall"
   end
+  
+  test do
+    system bin/"mysqldump-secure 2>&1 | grep ''"
+  end
+
 end

--- a/Library/Formula/mysqldump-secure.rb
+++ b/Library/Formula/mysqldump-secure.rb
@@ -2,7 +2,6 @@ class MysqldumpSecure < Formula
   desc "Encrypted mysqldump with compression, logging and Nagios integration."
   homepage "https://github.com/cytopia/mysqldump-secure"
   url "https://github.com/cytopia/mysqldump-secure/archive/0.11.3.tar.gz"
-  version "0.11.3"
   sha256 "046eb5da52d17f0a22d24a53380d820ce50dcff21b55047549ac61366fbc16a1"
 
   def install


### PR DESCRIPTION
https://github.com/cytopia/mysqldump-secure

Mysqldump-secure is a POSIX compliant shell backup script for MySQL databases with strong security in mind. It will backup every available database (which is readable by the specified user) as a separate file with the possibility to opt out via blacklisting. Dumped databases can optionally be piped directly to gzip or openssl in order to compress and/or encrypt the backup. Encryption is done before the file is written to disk to avoid possible race conditions.