### PR TITLE
ffscreencast 0.6 (new formula)

### DIFF
--- a/Library/Formula/ffscreencast.rb
+++ b/Library/Formula/ffscreencast.rb
@@ -1,0 +1,19 @@
+class Ffscreencast < Formula
+  desc "ffmpeg screencast with video overlay & multi monitor support"
+  homepage "https://github.com/cytopia/ffscreencast"
+  url "https://github.com/cytopia/ffscreencast/archive/v0.6.tar.gz"
+  sha256 "1d55d652347b26cb3b1a15398704cb4d82a3a996dcd967643ffa44347b431e81"
+
+  depends_on "ffmpeg" => [
+    "with-x265",
+    "with-faac",
+  ]
+
+  def install
+    bin.install "ffscreencast"
+  end
+
+  test do
+    system bin/"ffscreencast --test"
+  end
+end


### PR DESCRIPTION
[cytopia/ffscreencast](https://github.com/cytopia/ffscreencast)

**ffscreencast** is a shell wrapper for ffmpeg that allows fool-proof screen recording via the command line. It will auto-detect all available monitors, cameras and microphones and is able to interactively or manually choose the desired recording device(s). Additionally ffscreencast will let you overlay the camera stream on top of the desktop session.

Besides that ffscreencast can act as an ffmpeg command generator. Every available option can also just show the corresponding ffmpeg command instead of executing it. Non-ffmpeg commands, such as how the camera resolution is pulled and others can also be shown instead of being executed.