### PR TITLE
yaml-cpp 0.5.3

### DIFF
--- a/Library/Formula/yaml-cpp.rb
+++ b/Library/Formula/yaml-cpp.rb
@@ -1,8 +1,8 @@
 class YamlCpp < Formula
   desc "C++ YAML parser and emitter for YAML 1.2 spec"
   homepage "https://github.com/jbeder/yaml-cpp"
-  url "https://github.com/jbeder/yaml-cpp/archive/release-0.5.2.tar.gz"
-  sha256 "6fb92f6f5925e0af918ffbb90acf19b7b88706ebcd40fc186b7caa76609b6350"
+  url "https://github.com/jbeder/yaml-cpp/archive/release-0.5.3.tar.gz"
+  sha256 "ac50a27a201d16dc69a881b80ad39a7be66c4d755eda1f76c3a68781b922af8f"
 
   bottle do
     cellar :any
@@ -18,7 +18,7 @@ class YamlCpp < Formula
 
   depends_on "cmake" => :build
 
-  if build.cxx11?
+  if build.cxx11? && MacOS.version < :mavericks
     depends_on "boost" => "c++11"
   else
     depends_on "boost"


### PR DESCRIPTION
Require boost "c++11" build option only if < :mavericks.
Fix ConditionalAssigment audit complaint.