### PR TITLE
libxml++3 3.0.0 (new formula)

### DIFF
--- a/Library/Formula/libxml++3.rb
+++ b/Library/Formula/libxml++3.rb
@@ -1,0 +1,64 @@
+class Libxmlxx3 < Formula
+  desc "C++ wrapper for libxml"
+  homepage "http://libxmlplusplus.sourceforge.net"
+  url "https://download.gnome.org/sources/libxml++/3.0/libxml++-3.0.0.tar.xz"
+  sha256 "2ff3640417729d357bada2e3049061642e0b078c323a8e0d37ae68df96547952"
+
+  depends_on "pkg-config" => :build
+  depends_on "glibmm"
+  # LibXML++ can't compile agains the version of LibXML shipped with Leopard
+  depends_on "libxml2" if MacOS.version <= :leopard
+
+  needs :cxx11
+
+  def install
+    ENV.cxx11
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <libxml++/libxml++.h>
+
+      int main(int argc, char *argv[])
+      {
+         xmlpp::Document document;
+         document.set_internal_subset("homebrew", "", "http://www.brew.sh/xml/test.dtd");
+         xmlpp::Element *rootnode = document.create_root_node("homebrew");
+         return 0;
+      }
+    EOS
+    ENV.libxml2
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    glibmm = Formula["glibmm"]
+    libsigcxx = Formula["libsigc++"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
+    flags += %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{glibmm.opt_include}/glibmm-2.4
+      -I#{glibmm.opt_lib}/glibmm-2.4/include
+      -I#{include}/libxml++-3.0
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{lib}/libxml++-3.0/include
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{glibmm.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lintl
+      -lsigc-2.0
+      -lxml++-3.0
+      -lxml2
+    ]
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
This is the first stable release of libxml++-3.0. ABI and API are
incompatible with libxml++-2.6. These two series of libxml++ can be
installed in parallel. (Taken from release notes)

I expect that the release of GNOME 3.20.0 will see the first software
packages switching to this new release series of libxml++.

Both packages will need to be kept around for the foreseeable future.