### PR TITLE
elasticsearch 2.2.0 logstash 2.2.0 kibana 4.4.0

### DIFF
--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -116,7 +116,8 @@ class Elasticsearch < Formula
     system "#{libexec}/bin/plugin", "list"
     pid = "#{testpath}/pid"
     begin
-      system "#{bin}/elasticsearch", "-d", "-p", pid, "--path.data", testpath
+      mkdir testpath/"config"
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "--path.home", testpath
       sleep 10
       system "curl", "-XGET", "localhost:9200/"
     ensure

--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.1.1/elasticsearch-2.1.1.tar.gz"
-  sha256 "ebd69c0483f20ba7e51caa9606d4e3ce5fe2667e1216c799f0cdbb815c317ce6"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.0/elasticsearch-2.2.0.tar.gz"
+  sha256 "ed70cc81e1f55cd5f0032beea2907227b6ad8e7457dcb75ddc97a2cc6e054d30"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"

--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -1,7 +1,7 @@
 class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://github.com/elastic/kibana.git", :tag => "v4.3.1", :revision => "d6e412dc2fa54666bf6ceb54a197508a4bc70baf"
+  url "https://github.com/elastic/kibana.git", :tag => "v4.4.0", :revision => "07cb4d6aecddbc9dea1a26f55778b32edcef49df"
   head "https://github.com/elastic/kibana.git"
 
   bottle do

--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -1,8 +1,8 @@
 class Logstash < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://download.elastic.co/logstash/logstash/logstash-2.1.1.tar.gz"
-  sha256 "2ea975e16a02b416a5bd9eed5ab280224820f278d54f6e0ec4cccf0d8f5ca610"
+  url "https://download.elastic.co/logstash/logstash/logstash-2.2.0.tar.gz"
+  sha256 "aee2437f45c726ec354f0bf9634b3638428d48bef32beb412f827eb2cc736f78"
 
   bottle :unneeded
 


### PR DESCRIPTION
This pull request updates: 
 - the Elasticsearch formula from version 2.1.1 to version 2.2.0, the [latest stable version of Elasticsearch](https://www.elastic.co/blog/elasticsearch-2-2-0-and-2-1-2-and-1-7-5-released) as of 2016-02-02
 - the Logstash formula from version 2.1.1 to version 2.2.0, the [latest stable version of Logstash](https://www.elastic.co/blog/logstash-2-2-0-and-2-1-2-released) as of 2016-02-02
 - the Kibana formula from version 4.3.1 to version 4.4.0, the [latest stable version of Kibana](https://www.elastic.co/blog/kibana-4-4-0) as of 2016-02-02