### PR TITLE
fwup 0.5.2

### DIFF
--- a/Library/Formula/fwup.rb
+++ b/Library/Formula/fwup.rb
@@ -1,9 +1,8 @@
 class Fwup < Formula
   desc "Configurable embedded Linux firmware update creator and runner"
   homepage "https://github.com/fhunleth/fwup"
-  url "https://github.com/fhunleth/fwup/archive/v0.4.2.tar.gz"
-  sha256 "1c444d52dded8f69de127f71346d53ebee16fae7cfde23f6a324336b2b6940bb"
-  revision 1
+  url "https://github.com/fhunleth/fwup/archive/v0.5.2.tar.gz"
+  sha256 "e7735e503f894f19b5a3717c085aa9f6f18702696de91f17bd5405f95f8d6f98"
 
   bottle do
     cellar :any
@@ -14,6 +13,7 @@ class Fwup < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "confuse"
   depends_on "libarchive"
   depends_on "libsodium"


### PR DESCRIPTION
New features
* sudo is no longer needed on OSX to write to SDCards
* --unmount and --no-unmount commandline options to unmount (or not) all partitions on a device first
* --eject and --no-eject commandline options to eject devices when complete (OSX)
* --detect commandline option to list detected SDCards and removable media

Bug fixes
* Various installation fixes and clarifications in the README.md
* Fix rpath issue with libsodium not being in a system library directory *If unmounting is needed and fails, * fwup fails. This is different from before. Use --no-unmount to skip this step.
* Clean up progress printout that came before SDCard confirmation
* Improve error message when the read-only tab of an SDCard is on