### PR TITLE
FStar 0.9.2.0 (fix upstream)

### DIFF
--- a/Library/Formula/fstar.rb
+++ b/Library/Formula/fstar.rb
@@ -2,8 +2,8 @@ class Fstar < Formula
   desc "Language with a type system for program verification"
   homepage "https://www.fstar-lang.org/"
   url "https://github.com/FStarLang/FStar.git",
-    :tag => "0.9.2.0",
-    :revision => "658799a67706b635c5c42498fb42c21cf126e56e"
+    :tag => "v0.9.2.0",
+    :revision => "2a8ce0b3dfbfb9703079aace0d73f2479f0d0ce2"
   head "https://github.com/FStarLang/FStar.git"
 
   bottle do
@@ -13,7 +13,6 @@ class Fstar < Formula
     sha256 "d81ab524ccbb6d0735fa99b19c3536f02813a4b2cf87ebe138df40c44a0cb1cf" => :mavericks
   end
 
-  depends_on "mono" => :build
   depends_on "opam" => :build
   depends_on "ocaml" => :recommended
   depends_on "z3" => :recommended
@@ -43,9 +42,8 @@ class Fstar < Formula
       cp r.cached_download, archives/original_name
       modules << "#{r.name}=#{r.version}"
     end
-    system "opam", "install", *modules
 
-    system "make", "-C", "src/"
+    system "opam", "install", *modules
     system "opam", "config", "exec", "--",
     "make", "-C", "src/ocaml-output/"
 
@@ -67,9 +65,6 @@ class Fstar < Formula
   end
 
   def caveats; <<-EOS.undent
-    F* standard library is available in #{prefix}/stdlib:
-    - alias fstar='fstar.exe --include #{prefix}/stdlib --prims prims.fst'
-
     F* code can be extracted to OCaml code.
     To compile the generated OCaml code, you must install the
     package 'batteries' from the Opam package manager:
@@ -78,14 +73,13 @@ class Fstar < Formula
 
     F* code can be extracted to F# code.
     To compile the generated F# (.NET) code, you must install
-    Mono and the FSharp compilers:
+    the 'mono' package that includes the fsharp compiler:
     - brew install mono
     EOS
   end
 
   test do
     system "#{bin}/fstar.exe",
-    "--include", "#{prefix}/stdlib",
     "--include", "#{prefix}/examples/unit-tests",
     "--admit_fsi", "FStar.Set",
     "FStar.Set.fsi", "FStar.Heap.fst",


### PR DESCRIPTION
The version tag was re-pushed upstream and included fixes.
This updates the formula to use those changes =)