### PR TITLE
ENV: use HOMEBREW_RUBY_PATH in compiler/SCM shims

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
+unset RUBYLIB
+unset RUBYOPT
 exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 

--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -2,6 +2,11 @@
 # Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
 unset RUBYLIB
 unset RUBYOPT
+if [ -z "$HOMEBREW_RUBY_PATH" ]
+then
+  echo "${0##*/}: The build tool has reset ENV; --env=std required." >&2
+  exit 1
+fi
 exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 
@@ -308,7 +313,6 @@ end
 
 if __FILE__ == $PROGRAM_NAME
   ##################################################################### sanity
-  abort "The build-tool has reset ENV. --env=std required." unless ENV["HOMEBREW_BREW_FILE"]
 
   if (cc = ENV["HOMEBREW_CC"]).nil? || cc.empty? || cc == "cc"
     # those values are not allowed

--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -1,6 +1,8 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -W0
+#!/bin/sh
+# Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
+exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
+#!/usr/bin/env ruby -W0
 
-$:.unshift Dir["/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/lib/ruby/{1.8,2.0.0}"].first
 require "pathname"
 require "set"
 

--- a/Library/ENV/scm/git
+++ b/Library/ENV/scm/git
@@ -1,4 +1,8 @@
-#!/usr/bin/ruby -W0
+#!/bin/sh
+# Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
+exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
+#!/usr/bin/env ruby -W0
+
 # This script because we support $GIT, $HOMEBREW_SVN, etc. and Xcode-only
 # configurations. Order is careful to be what the user would want.
 

--- a/Library/ENV/scm/git
+++ b/Library/ENV/scm/git
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
+unset RUBYLIB
+unset RUBYOPT
 exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 

--- a/Library/ENV/scm/git
+++ b/Library/ENV/scm/git
@@ -2,6 +2,11 @@
 # Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
 unset RUBYLIB
 unset RUBYOPT
+if [ -z "$HOMEBREW_RUBY_PATH" ]
+then
+  echo "${0##*/}: The build tool has reset ENV; --env=std required." >&2
+  exit 1
+fi
 exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -1,5 +1,3 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -W0
-
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 require "pathname"


### PR DESCRIPTION
The compiler and SCM shims in `Library/ENV` until now (and somewhat inconsistently) either use `/usr/bin/ruby` or `/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby`. Make them respect `HOMEBREW_RUBY_PATH` like the rest of Homebrew.

I tested this quite extensively on my own machine, where I completely rebuilt a cellar of about 160 formulae twice (first time with a default `HOMEBREW_RUBY_PATH`, second time with Ruby 1.8.7 from `homebrew/versions`) without any issue.