### PR TITLE
os/mac/ruby_mach: allow some output for debugging

### DIFF
--- a/Library/Homebrew/os/mac/ruby_mach.rb
+++ b/Library/Homebrew/os/mac/ruby_mach.rb
@@ -41,7 +41,15 @@ module RubyMachO
       end
 
       mach_data
+    rescue MachO::NotAMachOError
+      # Silently ignore errors that indicate the file is not a Mach-O binary ...
+      []
     rescue
+      # ... but complain about other (parse) errors for further investigation.
+      if ARGV.homebrew_developer?
+        onoe "Failed to read Mach-O binary: #{self}"
+        raise
+      end
       []
     end
   end

--- a/Library/Homebrew/vendor/README.md
+++ b/Library/Homebrew/vendor/README.md
@@ -3,7 +3,7 @@ Vendored Dependencies
 
 * [okjson](https://github.com/kr/okjson), version 43.
 
-* [ruby-macho](https://github.com/woodruffw/ruby-macho), version 0.2.2.
+* [ruby-macho](https://github.com/Homebrew/ruby-macho), version 0.2.2-39-ge2fbedc9.
 
 ## Licenses:
 

--- a/Library/Homebrew/vendor/macho/macho/exceptions.rb
+++ b/Library/Homebrew/vendor/macho/macho/exceptions.rb
@@ -3,11 +3,33 @@ module MachO
   class MachOError < RuntimeError
   end
 
+  # Raised when a file is not a Mach-O.
+  class NotAMachOError < MachOError
+    # @param error [String] the error in question
+    def initialize(error)
+      super error
+    end
+  end
+
+  # Raised when a file is too short to be a valid Mach-O file.
+  class TruncatedFileError < NotAMachOError
+    def initialize
+      super "File is too short to be a valid Mach-O"
+    end
+  end
+
   # Raised when a file's magic bytes are not valid Mach-O magic.
-  class MagicError < MachOError
+  class MagicError < NotAMachOError
     # @param num [Fixnum] the unknown number
     def initialize(num)
       super "Unrecognized Mach-O magic: 0x#{"%02x" % num}"
+    end
+  end
+
+  # Raised when a file is a Java classfile instead of a fat Mach-O.
+  class JavaClassFileError < NotAMachOError
+    def initialize
+      super "File is a Java class file"
     end
   end
 
@@ -80,6 +102,14 @@ module MachO
     # @param path [String] the unknown runtime path
     def initialize(path)
       super "No such runtime path: #{path}"
+    end
+  end
+
+  # Raised whenever unfinished code is called.
+  class UnimplementedError < MachOError
+    # @param thing [String] the thing that is unimplemented
+    def initialize(thing)
+      super "Unimplemented: #{thing}"
     end
   end
 end

--- a/Library/Homebrew/vendor/macho/macho/headers.rb
+++ b/Library/Homebrew/vendor/macho/macho/headers.rb
@@ -33,14 +33,11 @@ module MachO
   # any CPU (unused?)
   CPU_TYPE_ANY = -1
 
-  # x86 compatible CPUs
-  CPU_TYPE_X86 = 0x07
-
   # i386 and later compatible CPUs
-  CPU_TYPE_I386 = CPU_TYPE_X86
+  CPU_TYPE_I386 = 0x07
 
   # x86_64 (AMD64) compatible CPUs
-  CPU_TYPE_X86_64 = (CPU_TYPE_X86 | CPU_ARCH_ABI64)
+  CPU_TYPE_X86_64 = (CPU_TYPE_I386 | CPU_ARCH_ABI64)
 
   # PowerPC compatible CPUs (7400 series?)
   CPU_TYPE_POWERPC = 0x12
@@ -51,7 +48,6 @@ module MachO
   # association of cpu types to string representations
   CPU_TYPES = {
     CPU_TYPE_ANY => "CPU_TYPE_ANY",
-    CPU_TYPE_X86 => "CPU_TYPE_X86",
     CPU_TYPE_I386 => "CPU_TYPE_I386",
     CPU_TYPE_X86_64 => "CPU_TYPE_X86_64",
     CPU_TYPE_POWERPC => "CPU_TYPE_POWERPC",
@@ -166,7 +162,7 @@ module MachO
     # @return [Fixnum] the number of fat architecture structures following the header
     attr_reader :nfat_arch
 
-    FORMAT = "VV"
+    FORMAT = "N2" # always big-endian
     SIZEOF = 8
 
     # @api private
@@ -195,7 +191,7 @@ module MachO
     # @return [Fixnum] the alignment, as a power of 2
     attr_reader :align
 
-    FORMAT = "VVVVV"
+    FORMAT = "N5" # always big-endian
     SIZEOF = 20
 
     # @api private
@@ -239,7 +235,9 @@ module MachO
         flags)
       @magic = magic
       @cputype = cputype
-      @cpusubtype = cpusubtype
+      # For now we're not interested in additional capability bits also to be
+      # found in the `cpusubtype` field. We only care about the CPU sub-type.
+      @cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
       @filetype = filetype
       @ncmds = ncmds
       @sizeofcmds = sizeofcmds

--- a/Library/Homebrew/vendor/macho/macho/load_commands.rb
+++ b/Library/Homebrew/vendor/macho/macho/load_commands.rb
@@ -830,7 +830,7 @@ module MachO
     SIZEOF = 24
 
     # @api private
-    def initialize(raw_data, offset, cmd, cmdsize, cryptoff, cryptsize, cryptid)
+    def initialize(raw_data, offset, cmd, cmdsize, cryptoff, cryptsize, cryptid, pad)
       super(raw_data, offset, cmd, cmdsize)
       @cryptoff = cryptoff
       @cryptsize = cryptsize

--- a/Library/Homebrew/vendor/macho/macho/tools.rb
+++ b/Library/Homebrew/vendor/macho/macho/tools.rb
@@ -41,7 +41,7 @@ module MachO
     # @return [void]
     # @todo unstub
     def self.change_rpath(filename, old_path, new_path)
-      raise "stub"
+      raise UnimplementedError.new("changing rpaths in a Mach-O")
     end
 
     # Add a runtime path to a Mach-O or Fat binary, overwriting the source file.
@@ -50,7 +50,7 @@ module MachO
     # @return [void]
     # @todo unstub
     def self.add_rpath(filename, new_path)
-      raise "stub"
+      raise UnimplementedError.new("adding rpaths to a Mach-O")
     end
 
     # Delete a runtime path from a Mach-O or Fat binary, overwriting the source file.
@@ -59,7 +59,7 @@ module MachO
     # @return [void]
     # @todo unstub
     def self.delete_rpath(filename, old_path)
-      raise "stub"
+      raise UnimplementedError.new("removing rpaths from a Mach-O")
     end
   end
 end


### PR DESCRIPTION
The current approach of suppressing all output regardless of what the error is makes it very hard to debug any issues and misread but valid Mach-O files will be silently interpreted as non-Mach-O files instead.

~~I'm not sure whether `ARGV.homebrew_developer?` is the right thing to check for this. Maybe `ARGV.debug?` is better? Feedback is very welcome.~~ :smile_cat:

cc @woodruffw