### PR TITLE
hadoop: Requires Java 1.7+

### DIFF
--- a/Library/Formula/hadoop.rb
+++ b/Library/Formula/hadoop.rb
@@ -7,7 +7,7 @@ class Hadoop < Formula
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.7+"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]


### PR DESCRIPTION
From the Hadoop 2.7.0 release notes:
This release drops support for JDK6 runtime and works with JDK 7+ only.