### PR TITLE
rakudo-star 2016.01 - symlink the stuff from `share/perl6/site/bin` too

### DIFF
--- a/Library/Formula/rakudo-star.rb
+++ b/Library/Formula/rakudo-star.rb
@@ -35,6 +35,9 @@ class RakudoStar < Formula
     system "make"
     system "make", "install"
 
+    # Panda is now in share/perl6/site/bin, so we need to symlink it too.
+    bin.install_symlink Dir[share/"perl6/site/bin/*"]
+
     # Move the man pages out of the top level into share.
     # Not all backends seem to generate man pages at this point (moar does not, parrot does),
     # so we need to check if the directory exists first.


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew/commit/2f37b5128e6c7aa8c57a97cfbc198f22b2b78975#commitcomment-15881022 , Panda (a Perl 6 module manager) is now in `share/perl6/site/bin`, so we need to symlink it too.