### PR TITLE
noti 2.0.0

### DIFF
--- a/Library/Formula/noti.rb
+++ b/Library/Formula/noti.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Noti < Formula
   desc "Displays a notification after a terminal process finishes."
   homepage "https://github.com/variadico/noti"
-  url "https://github.com/variadico/noti/archive/v1.3.0.tar.gz"
-  sha256 "78ffba8f6d8cb27df06a7c1ebe9d58cf605175c056eca1be241a5f348a117b8f"
+  url "https://github.com/variadico/noti/archive/v2.0.0.tar.gz"
+  sha256 "55c788afb4bafb63509f2b6c974e2afd7a6a97d06653ddca9ea1e92b507c5d7c"
   head "https://github.com/variadico/noti.git", :branch => "dev"
 
   bottle do
@@ -12,12 +12,6 @@ class Noti < Formula
     sha256 "7d892998f3bbed1ba19b9e6a1dfe00094d0123cecfa058e608538e05a38524e6" => :el_capitan
     sha256 "0aaa37cb4cfde091dce33a9a883f1dc2c1f27756400acdc84198c418c8cb2c4c" => :yosemite
     sha256 "2cef02d159190232c99658be80e397e6f70e78e2e80a71685c710e920afa6c40" => :mavericks
-  end
-
-  devel do
-    url "https://github.com/variadico/noti/archive/v2.0.0-rc.1.tar.gz"
-    sha256 "5ac154855f05ed60c05642030d4f66f9665e51b7032fc57e999c81160dcdf611"
-    version "2.0.0-rc.1"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Upgrade `noti` to `v2.0.0`
Temp set dev version to `v2.0.1-rc.1` (to prevent error) though this version does not actually exist.