### PR TITLE
add blackbox v1.20160122

### DIFF
--- a/Library/Formula/blackbox.rb
+++ b/Library/Formula/blackbox.rb
@@ -7,26 +7,8 @@ class Blackbox < Formula
   depends_on :gpg
 
   def install
-    bin.install "bin/_blackbox_common.sh"
-    bin.install "bin/_blackbox_common_test.sh"
-    bin.install "bin/_stack_lib.sh"
-    bin.install "bin/blackbox_addadmin"
-    bin.install "bin/blackbox_cat"
-    bin.install "bin/blackbox_decrypt_all_files"
-    bin.install "bin/blackbox_deregister_file"
-    bin.install "bin/blackbox_diff"
-    bin.install "bin/blackbox_edit"
-    bin.install "bin/blackbox_edit_end"
-    bin.install "bin/blackbox_edit_start"
-    bin.install "bin/blackbox_initialize"
-    bin.install "bin/blackbox_list_files"
-    bin.install "bin/blackbox_postdeploy"
-    bin.install "bin/blackbox_recurse"
-    bin.install "bin/blackbox_register_new_file"
-    bin.install "bin/blackbox_removeadmin"
-    bin.install "bin/blackbox_shred_all_files"
-    bin.install "bin/blackbox_update_all_files"
-    bin.install "bin/blackbox_whatsnew"
+    libexec.install Dir["bin/*"]
+    bin.write_exec_script Dir[libexec/"*"].select { |f| File.executable? f }
   end
 
   test do

--- a/Library/Formula/blackbox.rb
+++ b/Library/Formula/blackbox.rb
@@ -4,7 +4,7 @@ class Blackbox < Formula
   url "https://github.com/StackExchange/blackbox/archive/v1.20160122.tar.gz"
   sha256 "ac5de1d74fdbe88604b34949f3949e53cb72e55e148e46b8c2be98806c888a10"
 
-  depends_on "gpg"
+  depends_on :gpg
 
   def install
     bin.install "bin/_blackbox_common.sh"
@@ -30,7 +30,7 @@ class Blackbox < Formula
   end
 
   test do
-    system "/usr/local/Cellar/yourformula/version/bin/git", "init"
+    system "git", "init"
     system "#{bin}/blackbox_initialize", "yes"
   end
 end

--- a/Library/Formula/blackbox.rb
+++ b/Library/Formula/blackbox.rb
@@ -1,0 +1,36 @@
+class Blackbox < Formula
+  desc "Safely store secrets in Git/Mercurial/Subversion"
+  homepage "https://github.com/StackExchange/blackbox"
+  url "https://github.com/StackExchange/blackbox/archive/v1.20160122.tar.gz"
+  sha256 "ac5de1d74fdbe88604b34949f3949e53cb72e55e148e46b8c2be98806c888a10"
+
+  depends_on "gpg"
+
+  def install
+    bin.install "bin/_blackbox_common.sh"
+    bin.install "bin/_blackbox_common_test.sh"
+    bin.install "bin/_stack_lib.sh"
+    bin.install "bin/blackbox_addadmin"
+    bin.install "bin/blackbox_cat"
+    bin.install "bin/blackbox_decrypt_all_files"
+    bin.install "bin/blackbox_deregister_file"
+    bin.install "bin/blackbox_diff"
+    bin.install "bin/blackbox_edit"
+    bin.install "bin/blackbox_edit_end"
+    bin.install "bin/blackbox_edit_start"
+    bin.install "bin/blackbox_initialize"
+    bin.install "bin/blackbox_list_files"
+    bin.install "bin/blackbox_postdeploy"
+    bin.install "bin/blackbox_recurse"
+    bin.install "bin/blackbox_register_new_file"
+    bin.install "bin/blackbox_removeadmin"
+    bin.install "bin/blackbox_shred_all_files"
+    bin.install "bin/blackbox_update_all_files"
+    bin.install "bin/blackbox_whatsnew"
+  end
+
+  test do
+    system "/usr/local/Cellar/yourformula/version/bin/git", "init"
+    system "#{bin}/blackbox_initialize", "yes"
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -15,7 +15,6 @@ TAP_MIGRATIONS = {
   "bbcp" => "homebrew/head-only",
   "bcwipe" => "homebrew/boneyard",
   "bindfs" => "homebrew/fuse",
-  "blackbox" => "homebrew/boneyard",
   "bochs" => "homebrew/x11",
   "boost149" => "homebrew/versions",
   "cantera" => "homebrew/science",


### PR DESCRIPTION
Hi, this is a retry of https://github.com/Homebrew/homebrew/pull/45253. 

I've heard conflicting things about specifying GPG as a dependency. This works with either gnupg or gnupg2 so I was told to put the alias, e.g. 

`depends_on "gpg" `

This seems to fail the CI tests though... 