### PR TITLE
add b2 command line tool version 0.3.12

### DIFF
--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -10,6 +10,7 @@ class B2Tools < Formula
   end
 
   test do
-    system "b2 authorize_account BOGUSACCTID BOGUSAPPKEY | grep bad_auth_token"
+    assert_match "bad_auth_token",
+      shell_output("#{bin}/b2 authorize_account BOGUSACCTID BOGUSAPPKEY", 1)
   end
 end

--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -1,11 +1,16 @@
 class B2Tools < Formula
   desc "B2 Cloud Storage Command-Line Tools"
   homepage "https://github.com/Backblaze/B2_Command_Line_Tool"
-  url "https://github.com/Backblaze/B2_Command_Line_Tool/archive/v0.3.12.tar.gz"
-  sha256 "6c382d211c5df09477d5df468e43fe5b9691e44edfb5df9694e9b747a488d362"
+  url "https://github.com/Backblaze/B2_Command_Line_Tool/archive/v0.4.0.tar.gz"
+  sha256 "0253dfc4352ae6bc23e7184c2402b713f7e6f9a0584c80693ed1fdcffcf61325"
 
   def install
-    bin.install "b2"
+    ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+
     bash_completion.install "contrib/b2" => "b2-tools-completion.bash"
   end
 

--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -6,6 +6,7 @@ class B2Tools < Formula
 
   def install
     bin.install "b2"
+    bash_completion.install "contrib/b2" => "b2-tools-completion.bash"
   end
 
   test do

--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -1,15 +1,15 @@
 class B2Tools < Formula
   desc "B2 Cloud Storage Command-Line Tools"
-  homepage "https://www.backblaze.com/b2/docs/quick_command_line.html"
-  url "https://docs.backblaze.com/public/b2_src_code_bundles/b2"
-  version "0.3.12"
-  sha256 "b50576006739c592333d13cbde9a21cbb3b7e2ba3b99bfedbd70a7adbe097aa8"
+  homepage "https://github.com/Backblaze/B2_Command_Line_Tool"
+  url "https://github.com/Backblaze/B2_Command_Line_Tool/archive/v0.3.12.tar.gz"
+  sha256 "6c382d211c5df09477d5df468e43fe5b9691e44edfb5df9694e9b747a488d362"
 
   def install
     bin.install "b2"
   end
 
   test do
-    system "b2", "version"
+    system "b2 authorize_account BOGUSACCTID BOGUSAPPKEY | grep bad_auth_token"
   end
 end
+

--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -12,4 +12,3 @@ class B2Tools < Formula
     system "b2 authorize_account BOGUSACCTID BOGUSAPPKEY | grep bad_auth_token"
   end
 end
-

--- a/Library/Formula/b2-tools.rb
+++ b/Library/Formula/b2-tools.rb
@@ -1,0 +1,15 @@
+class B2Tools < Formula
+  desc "B2 Cloud Storage Command-Line Tools"
+  homepage "https://www.backblaze.com/b2/docs/quick_command_line.html"
+  url "https://docs.backblaze.com/public/b2_src_code_bundles/b2"
+  version "0.3.12"
+  sha256 "b50576006739c592333d13cbde9a21cbb3b7e2ba3b99bfedbd70a7adbe097aa8"
+
+  def install
+    bin.install "b2"
+  end
+
+  test do
+    system "b2", "version"
+  end
+end


### PR DESCRIPTION
This is to add a new formula for the Backblaze B2 command-line tool. 