### PR TITLE
New D import locations

### DIFF
--- a/Library/Formula/dmd.rb
+++ b/Library/Formula/dmd.rb
@@ -1,6 +1,7 @@
 class Dmd < Formula
   desc "D programming language compiler for OS X"
   homepage "https://dlang.org/"
+  revision 1
 
   stable do
     url "https://github.com/D-Programming-Language/dmd/archive/v2.070.0.tar.gz"
@@ -59,7 +60,7 @@ class Dmd < Formula
     # linked into opt by the time this build runs:
     conf.write <<-EOS.undent
         [Environment]
-        DFLAGS=-I#{include}/d2 -L-L#{lib}
+        DFLAGS=-I#{include}/dlang/dmd -L-L#{lib}
         EOS
     etc.install conf
     install_new_dmd_conf
@@ -72,8 +73,8 @@ class Dmd < Formula
     system "make", "-C", "druntime", *make_args
     system "make", "-C", "phobos", "VERSION=#{buildpath}/VERSION", *make_args
 
-    (include/"d2").install Dir["druntime/import/*"]
-    cp_r ["phobos/std", "phobos/etc"], include/"d2"
+    (include/"dlang/dmd").install Dir["druntime/import/*"]
+    cp_r ["phobos/std", "phobos/etc"], include/"dlang/dmd"
     lib.install Dir["druntime/lib/*", "phobos/**/libphobos2.a"]
 
     resource("tools").stage do

--- a/Library/Formula/ldc.rb
+++ b/Library/Formula/ldc.rb
@@ -2,6 +2,7 @@ class Ldc < Formula
   desc "Portable D programming language compiler"
   homepage "http://wiki.dlang.org/LDC"
   head "https://github.com/ldc-developers/ldc.git", :shallow => false
+  revision 1
 
   stable do
     url "https://github.com/ldc-developers/ldc/releases/download/v0.16.1/ldc-0.16.1-src.tar.gz"
@@ -34,7 +35,7 @@ class Ldc < Formula
     ENV.cxx11
     mkdir "build"
     cd "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DINCLUDE_INSTALL_DIR=#{include}/dlang/ldc", *std_cmake_args
       system "make"
       system "make", "install"
     end
@@ -43,7 +44,6 @@ class Ldc < Formula
   test do
     (testpath/"test.d").write <<-EOS.undent
       import std.stdio;
-
       void main() {
         writeln("Hello, world!");
       }


### PR DESCRIPTION
Rationale:

* `dlang` is unlikely to conflict with anything. `d2` was OK, but ldc was using `d` implicitly.
* Using the same layout as archlinux
* paves the way for including `gdc` (formula is ready, just waiting for a new release), makes sense to have things uniform between the 3 compilers. Also, eventually there will be `sdc` as well.
* Clear and explicit, harder to get them mixed up, easier for tools (e.g. IDEs) to find correctly