### PR TITLE
make HOMEBREW_BREW_FILE a Pathname object

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -26,8 +26,9 @@ undef cache
 # Where brews installed via URL are cached
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"
 
-HOMEBREW_BREW_FILE = ENV["HOMEBREW_BREW_FILE"]
-unless HOMEBREW_BREW_FILE
+if ENV["HOMEBREW_BREW_FILE"]
+  HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
+else
   odie "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!"
 end
 

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -17,8 +17,8 @@ module FileUtils
     # Reference from `man 2 open`
     # > When a new file is created, it is given the group of the directory which
     # contains it.
-    group_id = if File.grpowned? HOMEBREW_BREW_FILE
-      File.stat(HOMEBREW_BREW_FILE).gid
+    group_id = if HOMEBREW_BREW_FILE.grpowned?
+      HOMEBREW_BREW_FILE.stat.gid
     else
       Process.gid
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -871,7 +871,7 @@ class Formula
   # @private
   def link_overwrite?(path)
     # Don't overwrite files not created by Homebrew.
-    return false unless path.stat.uid == File.stat(HOMEBREW_BREW_FILE).uid
+    return false unless path.stat.uid == HOMEBREW_BREW_FILE.stat.uid
     # Don't overwrite files belong to other keg except when that
     # keg's formula is deleted.
     begin

--- a/Library/Homebrew/test/lib/config.rb
+++ b/Library/Homebrew/test/lib/config.rb
@@ -1,7 +1,7 @@
 require "tmpdir"
 require "pathname"
 
-HOMEBREW_BREW_FILE = ENV["HOMEBREW_BREW_FILE"]
+HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
 HOMEBREW_TEMP = Pathname.new(ENV["HOMEBREW_TEMP"] || Dir.tmpdir)
 
 TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") { |k|

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -104,7 +104,7 @@ begin
     end
 
     if possible_tap && !possible_tap.installed?
-      brew_uid = File.stat(HOMEBREW_BREW_FILE).uid
+      brew_uid = HOMEBREW_BREW_FILE.stat.uid
       tap_commands = []
       if Process.uid.zero? && !brew_uid.zero?
         tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]


### PR DESCRIPTION
Currently HOMEBREW_BREW_FILE is a String, while other of HOMEBREW_*
variables are all Pathname. This commit unifies them all as Pathname,
so it will not cause any confusion.