### PR TITLE
use which python, rather than hardcoding /usr/bin/python

### DIFF
--- a/Library/Formula/bazaar.rb
+++ b/Library/Formula/bazaar.rb
@@ -24,7 +24,7 @@ class Bazaar < Formula
     ENV.prepend_path "PATH", "/System/Library/Frameworks/Python.framework/Versions/Current/bin"
 
     system "make"
-    inreplace "bzr", "#! /usr/bin/env python", "#!/usr/bin/python"
+    inreplace "bzr", "#! /usr/bin/env python", "#!#{which "python"}"
     libexec.install "bzr", "bzrlib"
 
     (bin/"bzr").write_env_script(libexec/"bzr", :BZR_PLUGIN_PATH => "+user:#{HOMEBREW_PREFIX}/share/bazaar/plugins")


### PR DESCRIPTION
This fixes linuxbrew, where `/System/Library/Frameworks/Python.framework/Versions/Current/bin` doesn't exist, but it's still quite valid for machomebrew.