### PR TITLE
mysql 5.7.11

### DIFF
--- a/Library/Formula/mysql.rb
+++ b/Library/Formula/mysql.rb
@@ -1,8 +1,8 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.10.tar.gz"
-  sha256 "1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-boost-5.7.11.tar.gz"
+  sha256 "ab21347ba004a5aa349b911d829a14e79b1e36e4bcd007d39d75212071414e28"
 
   bottle do
     revision 3
@@ -41,11 +41,6 @@ class Mysql < Formula
     cause "https://github.com/Homebrew/homebrew/issues/issue/144"
   end
 
-  resource "boost" do
-    url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
-    sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
-  end
-
   def datadir
     var/"mysql"
   end
@@ -80,13 +75,8 @@ class Mysql < Formula
       -DSYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
       -DWITH_EDITLINE=system
+      -DWITH_BOOST=boost
     ]
-
-    # MySQL >5.7.x mandates Boost as a requirement to build & has a strict
-    # version check in place to ensure it only builds against expected release.
-    # This is problematic when Boost releases don't align with MySQL releases.
-    (buildpath/"boost_1_59_0").install resource("boost")
-    args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
 
     # To enable unit testing at build, we need to download the unit testing suite
     if build.with? "test"


### PR DESCRIPTION
MySQL now provides a source tarball named mysql-boost-5.7.x.tar.gz that
also contains the required Boost header files.

[http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-11.html#mysqld-5-7-11-compiling](url)
