### PR TITLE
Fix symlink for zsh completion in docs

### DIFF
--- a/share/doc/homebrew/Tips-N'-Tricks.md
+++ b/share/doc/homebrew/Tips-N'-Tricks.md
@@ -55,7 +55,7 @@ source $(brew --repository)/Library/Contributions/brew_bash_completion.sh
 Run in terminal (may require `sudo`):
 
 ```zsh
-ln -s "$(brew --prefix)/Library/Contributions/brew_zsh_completion.zsh" /usr/local/share/zsh/site-functions
+ln -s "$(brew --prefix)/Library/Contributions/brew_zsh_completion.zsh" /usr/local/share/zsh/site-functions/_brew
 ```
 
 ## Pre-downloading a file for a formula


### PR DESCRIPTION
From `Library/Contributions/brew_zsh_completion.zsh`:

````bash
# Brew ZSH completion function
# Drop this somewhere in your $fpath (like /usr/share/zsh/site-functions)
# and rename it _brew
````

Then it should give symlinked file name of `_brew` instead of being just `brew_zsh_completion.zsh`