### PR TITLE
Mitigate npm `make install` error

### DIFF
--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -67,9 +67,10 @@ class Node < Formula
 
       # make sure npm can find node
       ENV.prepend_path "PATH", bin
-      # set log level and prefix temporarily for npm's `make install`
+      # set log level temporarily for npm's `make install`
       ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
-      ENV["NPM_CONFIG_PREFIX"] = ""
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
 
       cd buildpath/"npm_install" do
         system "./configure", "--prefix=#{libexec}/npm"

--- a/Library/Formula/node.rb
+++ b/Library/Formula/node.rb
@@ -67,8 +67,9 @@ class Node < Formula
 
       # make sure npm can find node
       ENV.prepend_path "PATH", bin
-      # set log level temporarily for npm's `make install`
+      # set log level and prefix temporarily for npm's `make install`
       ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      ENV["NPM_CONFIG_PREFIX"] = ""
 
       cd buildpath/"npm_install" do
         system "./configure", "--prefix=#{libexec}/npm"


### PR DESCRIPTION
## Summary

The `$NPM_CONFIG_PREFIX` environment variable may be set to a custom path to allow for global npm packages to be installed to a directory of choice; however, when running `make install` for `npm`, if this directory is set, an error is thrown and the entire node/npm installation is aborted.

The semi-full error is:

```shell
Error: No such file or directory - $(brew --cellar node)/5.5.0/libexec/npm/lib/node_modules/npm
```

To mitigate the error, we temporarily clear the `$NPM_CONFIG_PREFIX` value. This is equivalent to:

```shell
NPM_CONFIG_PREFIX="" brew install node
```