### PR TITLE
Dependency.expand: ensure pop stack

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -95,8 +95,9 @@ class Dependency
         end
       end
 
-      @expand_stack.pop
       merge_repeats(expanded_deps)
+    ensure
+      @expand_stack.pop
     end
 
     def action(dependent, dep, &_block)

--- a/Library/Homebrew/test/test_dependency_expansion.rb
+++ b/Library/Homebrew/test/test_dependency_expansion.rb
@@ -115,4 +115,20 @@ class DependencyExpansionTests < Homebrew::TestCase
     assert_equal [@foo, @bar, @baz, @qux], @f.deps
     assert_equal [@bar, @baz], Dependency.expand(@f, [@bar, @baz])
   end
+
+  def test_cyclic_dependency
+    foo = build_dep(:foo)
+    bar = build_dep(:bar, [], [foo])
+    foo.stubs(:to_formula).returns(stub(:deps => [bar], :name => "foo"))
+    f = stub(:name => "f", :deps => [foo, bar])
+    assert_nothing_raised { Dependency.expand(f) }
+  end
+
+  def test_clean_expand_stack
+    foo = build_dep(:foo)
+    foo.stubs(:to_formula).raises(FormulaUnavailableError, "foo")
+    f = stub(:name => "f", :deps => [foo])
+    assert_raises(FormulaUnavailableError) { Dependency.expand(f) }
+    assert_empty Dependency.instance_variable_get(:@expand_stack)
+  end
 end


### PR DESCRIPTION
During the dependencies expansion, there may be errors (e.g. FormulaUnavaiableError).
As result, some deps will be left behind in the stack and interfere afterwards
dependencies expansion.

So let's ensure stack clean for each expansions.

Fixes #48834.

cc @sjackman