### PR TITLE
radare2: Fix bindings install paths

### DIFF
--- a/Library/Formula/radare2.rb
+++ b/Library/Formula/radare2.rb
@@ -1,22 +1,19 @@
 class Radare2 < Formula
   desc "Reverse engineering framework"
   homepage "http://radare.org"
-  revision 1
 
   stable do
-    url "http://radare.org/get/radare2-0.9.9.tar.xz"
-    sha256 "024adba5255f12e58c2c1a5e2263fada75aad6e71b082461dea4a2b94b29df32"
+    url "http://radare.org/get/radare2-0.10.0.tar.xz"
+    sha256 "f7a755e4ff2d5fb9258be6c9b7ffa708b0533e0d1efce4ced177785a9270befd"
 
     resource "bindings" do
-      url "http://radare.org/get/radare2-bindings-0.9.9.tar.xz"
-      sha256 "817939698cc4534498226c28938288b7b4a7b6216dc6d7ddde72b0f94d987b14"
+      url "http://radare.org/get/radare2-bindings-0.10.0.tar.xz"
+      sha256 "f7f10e308c7bd6edc3ddf8d2229fa9647cdee0474134ba9120ee163723e475cf"
     end
 
-    # https://github.com/radare/radare2/issues/3019
-    # Also fixes dylib naming issue with https://github.com/radare/radare2/commit/a497a6cf5b19da8bb857803e582a3afb3d4af673
-    patch do
-      url "https://gist.githubusercontent.com/sparkhom/d4584cfefb58243995e8/raw/cb62b0e45d62832efb0db037de5a63cfa895bfa0/radare2-0.9.9-homebrew.patch"
-      sha256 "9b032de6e31ffeb302384a3fed284fee8a14b7b452405789419e78a15cb83145"
+    resource "extras" do
+      url "http://radare.org/get/radare2-extras-0.10.0.tar.xz"
+      sha256 "363fef80e39dff18c4b8263f3f4eb355c7f89aba3339505b3a37acb82fea053e"
     end
   end
 
@@ -35,17 +32,27 @@ class Radare2 < Formula
   depends_on "valabind" => :build
   depends_on "swig" => :build
   depends_on "gobject-introspection" => :build
+  depends_on "gmp"
   depends_on "libewf"
   depends_on "libmagic"
-  depends_on "gmp"
   depends_on "lua51" # It seems to latch onto Lua51 rather than Lua. Enquire this upstream.
   depends_on "openssl"
+  depends_on "yara"
 
   def install
     # Build Radare2 before bindings, otherwise compile = nope.
     system "./configure", "--prefix=#{prefix}", "--with-openssl"
-    system "make"
+    system "make", "CS_PATCHES=0"
     system "make", "install"
+
+    resource("extras").stage do
+      ENV.append_path "PATH", "#{bin}"
+      ENV.append_path "PKG_CONFIG_PATH", "#{lib}/pkgconfig"
+
+      system "./configure", "--prefix=#{prefix}"
+      system "make", "all"
+      system "make", "install"
+    end
 
     resource("bindings").stage do
       ENV.append_path "PATH", "#{bin}"
@@ -63,7 +70,6 @@ class Radare2 < Formula
       # paths.
       inreplace "libr/lang/p/Makefile", "R2_PLUGIN_PATH=", "#R2_PLUGIN_PATH="
       inreplace "Makefile", "LUAPKG=", "#LUAPKG="
-      inreplace "Makefile", "$$target/r2", "$(PERLPATH)/r2"
       inreplace "Makefile", "${DESTDIR}$$_LUADIR", "#{lib}/lua/#{lua_version}"
       make_install_args = ["R2_PLUGIN_PATH=#{lib}/radare2/#{version}",
                            "LUAPKG=lua-#{lua_version}",


### PR DESCRIPTION
Some of the rules used by the radare2 build system to figure out where
to install language bindings will install files outside the radare2
Cellar.

This patch fixes the installation targets for the following language
bindings:
 - Lua
 - Perl
 - Python