### PR TITLE
jenkins 1.647

### DIFF
--- a/Library/Formula/jenkins.rb
+++ b/Library/Formula/jenkins.rb
@@ -1,8 +1,8 @@
 class Jenkins < Formula
   desc "Extendable open source continuous integration server"
   homepage "https://jenkins-ci.org"
-  url "http://mirrors.jenkins-ci.org/war/1.646/jenkins.war"
-  sha256 "2b892d363e1ce88e4d3a37e7d5c17c0be5bce902b3b98e6e0ebfe0d2d509f2d4"
+  url "http://mirrors.jenkins-ci.org/war/1.647/jenkins.war"
+  sha256 "52778609d34cb532c934509bb2a63c77986ae8e9b7e85186bad0235f58e4200f"
 
   head do
     url "https://github.com/jenkinsci/jenkins.git"


### PR DESCRIPTION
Update Jenkins version to 1.647. I couldn't find any official SHASUM file, but here's a link to their changelog: https://jenkins-ci.org/changelog/

Thanks!