### PR TITLE
wavpack 4.75.2

### DIFF
--- a/Library/Formula/wavpack.rb
+++ b/Library/Formula/wavpack.rb
@@ -3,30 +3,8 @@ class Wavpack < Formula
   homepage "http://www.wavpack.com/"
 
   stable do
-    url "http://www.wavpack.com/wavpack-4.75.0.tar.bz2"
-    sha256 "c63e5c2106749dc6b2fb4302f2260f4803a93dd6cadf337764920dc836e3af2e"
-
-    # All four patches can be removed with next stable release
-    # see https://github.com/dbry/WavPack/issues/3
-    patch do
-      url "https://github.com/dbry/WavPack/commit/c7a0de1e5c0a91e0c458edf72e7007c386b38491.diff"
-      sha256 "dc2456471ebc0adbd735628d8af7b9214e84c93d01242b6c4b747549642a7d40"
-    end
-
-    patch do
-      url "https://github.com/dbry/WavPack/commit/12867b33e2de3e95b88d7cb6f449ce0c5c87cdd5.diff"
-      sha256 "a6e010e3a50697811db42860ee4af1190ef4c098f65738d21890c2fb2d57f282"
-    end
-
-    patch do
-      url "https://github.com/dbry/WavPack/commit/f9014956deb132463db2195633120e87a5fcb8b9.diff"
-      sha256 "6736617744df2bada20148ec0525d3cb516022db699dcff4b39fb59ceac4bacf"
-    end
-
-    patch do
-      url "https://github.com/dbry/WavPack/commit/ccd367b71c51889c803bfcf4311e6b6d2b01eee3.diff"
-      sha256 "04ad91aac132993fd30cc68251949af0bdc4eec4657f1d46077c26b35436bc01"
-    end
+    url "http://www.wavpack.com/wavpack-4.75.2.tar.bz2"
+    sha256 "7d31b34166c33c3109b45c6e4579b472fd05e3ee8ec6d728352961c5cdd1d6b0"
   end
 
   bottle do


### PR DESCRIPTION
Thanks to @dbry, who digged https://github.com/dbry/WavPack/issues/3 and created the 4 patches against 4.75.0 (and later incorporated them to 4.75.2) we can drop the patches from the formula. All credits go to @dbry and @dunn. Chapeau!