### PR TITLE
kibana keep plugins alongside keg

### DIFF
--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -3,6 +3,7 @@ class Kibana < Formula
   homepage "https://www.elastic.co/products/kibana"
   url "https://github.com/elastic/kibana.git", :tag => "v4.4.0", :revision => "07cb4d6aecddbc9dea1a26f55778b32edcef49df"
   head "https://github.com/elastic/kibana.git"
+  revision 1
 
   bottle do
     sha256 "261acccf0e7bdb137e3f4cdae0b90a372dd31348fbb42bb7159af41e46cfa702" => :el_capitan
@@ -62,16 +63,16 @@ class Kibana < Formula
 
   def post_install
     ln_s etc/"kibana", prefix/"config"
-
-    (var/"lib/kibana/installedPlugins").mkpath
-    ln_s var/"lib/kibana/installedPlugins", prefix/"installedPlugins"
+    (prefix/"installedPlugins").mkdir
   end
 
   plist_options :manual => "kibana"
 
   def caveats; <<-EOS.undent
-    Plugins: #{var}/kibana/installedPlugins/
     Config: #{etc}/kibana/
+    If you wish to preserve your plugins upon upgrade, make a copy of
+    #{prefix}/installedPlugins before upgrading, and copy it into the
+    new keg location after upgrading.
     EOS
   end
 


### PR DESCRIPTION
This commit modifies the Kibana formula to keep the installedPlugins
directory alongside the Kibana keg. This is to address an issue for
plugins that are implicitly depending on node modules from Kibana.

Closes #48838