### PR TITLE
Support symlinks in brew's path.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -26,7 +26,12 @@ then
   export LC_ALL="en_US.UTF-8"
 fi
 
-BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
+# Don't expand path if it's already absolute, so as not to accidentally expand symlinks
+if [[ -n "${0%%/*}" ]]; then
+    BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
+else
+    BREW_FILE_DIRECTORY=${0%/*}
+fi
 HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"
 
 if [[ -L "$HOMEBREW_BREW_FILE" ]]
@@ -37,9 +42,9 @@ then
                          chdir "$BREW_SYMLINK_DIRECTORY" && pwd -P)"
 fi
 
-HOMEBREW_PREFIX="$(chdir "$(dirname "$(dirname "$HOMEBREW_BREW_FILE")")" && pwd -P)"
-HOMEBREW_REPOSITORY="$(chdir "$BREW_FILE_DIRECTORY"/../ && pwd -P)"
-HOMEBREW_LIBRARY="$(chdir "$BREW_FILE_DIRECTORY"/../Library && pwd -P)"
+HOMEBREW_PREFIX=${HOMEBREW_BREW_FILE%/*/*}
+HOMEBREW_REPOSITORY=${BREW_FILE_DIRECTORY%/*}
+HOMEBREW_LIBRARY=${BREW_FILE_DIRECTORY%/*}/Library
 
 # Where we store built products; /usr/local/Cellar if it exists,
 # otherwise a Cellar relative to the Repository.


### PR DESCRIPTION
Only canonicalize the path if it is relative. This way if I have a
symlink:

    ~/brew -> ~/brew-1

and my PATH is `/Users/me/brew:/usr/bin:/bin`, then my paths will be:

    HOMEBREW_PREFIX=/Users/me/brew
    HOMEBREW_REPOSITORY=/Users/me/brew
    HOMEBREW_LIBRARY=/Users/me/brew/Library

instead of

    HOMEBREW_PREFIX=/Users/me/brew-1
    HOMEBREW_REPOSITORY=/Users/me/brew-1
    HOMEBREW_LIBRARY=/Users/me/brew-1/Library

This fixes many `brew doctor` false positives and generally uses the
paths I want in installed brew packages.