### PR TITLE
fontconfig (replace broken download url)

### DIFF
--- a/Library/Formula/fontconfig.rb
+++ b/Library/Formula/fontconfig.rb
@@ -1,7 +1,7 @@
 class Fontconfig < Formula
   desc "XML-based font configuration API for X Windows"
-  homepage "http://fontconfig.org/"
-  url "http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2"
+  homepage "https://www.freedesktop.org/wiki/"
+  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.bz2"
   sha256 "dc62447533bca844463a3c3fd4083b57c90f18a70506e7a9f4936b5a1e516a99"
   revision 1
 


### PR DESCRIPTION
The old URL is gone, not even the folder exists anymore.

I've demoted it to `mirror` and put a more stable URL from the mother project as `url`.

