### PR TITLE
log: add version support

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -14,14 +14,24 @@ module Homebrew
 
   private
 
-  def git_log(path=nil)
+  def git_log(path = nil)
     if File.exist? "#{`git rev-parse --show-toplevel`.chomp}/.git/shallow"
       opoo <<-EOS.undent
         The git repository is a shallow clone therefore the filtering may be incorrect.
         Use `git fetch --unshallow` to get the full repository.
       EOS
     end
+
+    if ARGV.size > 2 then raise <<-EOS.undent
+      Usage is:
+        brew log formula
+      or:
+        brew log formula version
+    EOS
+    end
+
     args = ARGV.options_only
+    args += ["--grep", ARGV[1]] unless ARGV[1].nil?
     args += ["--", path] unless path.nil?
     exec "git", "log", *args
   end


### PR DESCRIPTION
This enables people to pass a single version to `brew log` to find commits related to it. Its primary use case is people wanting to move older versions to their own tap and having to roll through an entire `git log` to find the right commits.

This functionality is already provided by git via the `--grep` flag but we've seen a lot of people not aware that functionality is there and it's a simple enough thing to expand our command to include.

It'd be fairly easy to expand this to take multiple version arguments but in the name of simplicity I've limited it to one. As ever, my Ruby is on the side of sloppy so feel free to laugh at me.

Ref: #48859