### PR TITLE
Audit: Regexp.escape formula names

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -879,11 +879,11 @@ class FormulaAuditor
         problem "`#{$1}` is now unnecessary"
       end
 
-      if line =~ %r{#\{share\}/#{formula.name}[/'"]}
+      if line =~ %r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]}
         problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
       end
 
-      if line =~ %r{share/"#{formula.name}[/'"]}
+      if line =~ %r{share/"#{Regexp.escape(formula.name)}[/'"]}
         problem "Use pkgshare instead of (share/\"#{formula.name}\")"
       end
     end

--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -301,10 +301,9 @@ class FormulaAuditorTests < Homebrew::TestCase
   end
 
   # Regression test for https://github.com/Homebrew/homebrew/pull/48744
-  # Formulae with "++" in their name would break the name check because of a
-  # regexp error:
+  # Formulae with "++" in their name would break various audit regexps:
   #   Error: nested *?+ in regexp: /^libxml++3\s/
-  def test_audit_desc_plus_plus_name
+  def test_audit_plus_plus_name
     fa = formula_auditor "foolibc++", <<-EOS.undent, :strict => true
       class Foolibcxx < Formula
         desc "foolibc++ is a test"
@@ -315,5 +314,11 @@ class FormulaAuditorTests < Homebrew::TestCase
     fa.audit_desc
     assert_equal "Description shouldn't include the formula name",
       fa.problems.shift
+
+    fa.audit_line 'ohai "#{share}/foolibc++"', 3
+    assert_equal "Use \#{pkgshare} instead of \#{share}/foolibc++", fa.problems.shift
+
+    fa.audit_line 'ohai share/"foolibc++"', 3
+    assert_equal 'Use pkgshare instead of (share/"foolibc++")', fa.problems.shift
   end
 end


### PR DESCRIPTION
We allow certain special regex characters in formula names, and if those aren't escaped when interpolating them into a regex, they'll be interpreted as special regex characters.

This can cause regex compile errors on Ruby 1.8 (for example, with "libxml++3", which has nested match characters), and more subtle matching bugs in general.

Refs an issue surfaced in #48744.