### PR TITLE
tmux: patch head installation exceptions

### DIFF
--- a/Library/Formula/tmux.rb
+++ b/Library/Formula/tmux.rb
@@ -43,13 +43,17 @@ class Tmux < Formula
 
     system "make", "install"
 
-    bash_completion.install "examples/bash_completion_tmux.sh" => "tmux"
-    pkgshare.install "examples"
+    if build.head?
+      pkgshare.install "example_tmux.conf"
+    else
+      bash_completion.install "examples/bash_completion_tmux.sh" => "tmux"
+      pkgshare.install "examples"
+    end
   end
 
   def caveats; <<-EOS.undent
-    Example configurations have been installed to:
-      #{opt_pkgshare}/examples
+    Example configuration has been installed to:
+      #{opt_pkgshare}
     EOS
   end
 


### PR DESCRIPTION
I was receiving the following exception when installing tmux directly from the github repo
```
❯ brew reinstall tmux --HEAD
==> Reinstalling tmux
==> Cloning https://github.com/tmux/tmux.git
Updating /Library/Caches/Homebrew/tmux--git
==> Checking out branch master
==> sh autogen.sh
==> ./configure --prefix=/usr/local/Cellar/tmux/HEAD --sysconfdir=/usr/local/etc
==> make install
Error: No such file or directory - examples/bash_completion_tmux.sh
( 16s )
```

Looks like examples was removed from the repo