### PR TITLE
Updated mono to latest release: 4.2 SR1 (4.2.2.30)

### DIFF
--- a/Library/Formula/mono.rb
+++ b/Library/Formula/mono.rb
@@ -3,7 +3,6 @@ class Mono < Formula
   homepage "http://www.mono-project.com/"
   url "http://download.mono-project.com/sources/mono/mono-4.2.2.30.tar.bz2"
   sha256 "57858cd033be9915d7abdc5158c1faae8fa05757c3b7117cab3d703aa696c56b"
-  revision 1
 
   # xbuild requires the .exe files inside the runtime directories to
   # be executable

--- a/Library/Formula/mono.rb
+++ b/Library/Formula/mono.rb
@@ -1,8 +1,8 @@
 class Mono < Formula
   desc "Cross platform, open source .NET development framework"
   homepage "http://www.mono-project.com/"
-  url "http://download.mono-project.com/sources/mono/mono-4.2.1.102.tar.bz2"
-  sha256 "b7b461fe04375f621d88166ba8c6f1cb33c439fd3e17136460f7d087a51ed792"
+  url "http://download.mono-project.com/sources/mono/mono-4.2.2.30.tar.bz2"
+  sha256 "57858cd033be9915d7abdc5158c1faae8fa05757c3b7117cab3d703aa696c56b"
   revision 1
 
   # xbuild requires the .exe files inside the runtime directories to
@@ -46,7 +46,7 @@ class Mono < Formula
       --enable-nls=no
     ]
 
-    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin"
+    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin" if OS.mac?
 
     system "./configure", *args
     system "make"

--- a/Library/Formula/mono.rb
+++ b/Library/Formula/mono.rb
@@ -46,7 +46,7 @@ class Mono < Formula
       --enable-nls=no
     ]
 
-    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin" if OS.mac?
+    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Updating mono to the latest release.

Now that ASP CORE 1.0 is in RC2 mono needs to be as up to date.

This allows ASP CORE 1.0 on both OS/X and Linux