### PR TITLE
Update chisel to version 1.4.0

### DIFF
--- a/Library/Formula/chisel.rb
+++ b/Library/Formula/chisel.rb
@@ -1,8 +1,8 @@
 class Chisel < Formula
   desc "Collection of LLDB commands to assist debugging iOS apps"
   homepage "https://github.com/facebook/chisel"
-  url "https://github.com/facebook/chisel/archive/1.3.0.tar.gz"
-  sha256 "6e8f64a1cb48b0937a98a7d62dc0c6de8cea5afa0040088b426d166e188a6f59"
+  url "https://github.com/facebook/chisel/archive/1.4.0.tar.gz"
+  sha256 "94d695cbc24343f8002c2b68a68bcc00601ab161ef24d16ee0718c93a2889493"
 
   bottle :unneeded
 


### PR DESCRIPTION
Here are the release notes from version 1.4.0 of chisel:

New and updated commands:

* `mwarning`: Trigger simulated memory warnings (@lianchengjiang, #131)
* `pmethods`: Print methods on an object or class (@longv2go, #113)
* `border`: Added `--depth` option (@eithanshavit, #126)

Improvements

* Fixed presponder on OS X (@kolinkrewinkel, #134)
* Fixed README (@JuIioCesar, #129)
* Fixed `pa11y` and `fa11y` for iOS 8+ (@gkassabli, #128)
* Fixed commands to work in Swift (@ultramiraculous, #121)
* Added human friendly error messages to `visualize` (@jbinney, #125)
