### PR TITLE
bottle: do not follow symlink when setting mtime

### DIFF
--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -209,11 +209,20 @@ module Homebrew
         tab.time = nil
         tab.write
 
-        keg.find {|k| File.utime(File.atime(k), tab.source_modified_time, k) }
+        keg.find do |file|
+          if file.symlink?
+            # Ruby does not support `File.lutime` yet.
+            # Shellout using `touch` to change modified time of symlink itself.
+            system "/usr/bin/touch", "-h",
+                   "-t", tab.source_modified_time.strftime("%Y%m%d%H%M.%S"), file
+          else
+            file.utime(tab.source_modified_time, tab.source_modified_time)
+          end
+        end
 
         cd cellar do
           safe_system "tar", "cf", tar_path, "#{f.name}/#{f.pkg_version}"
-          File.utime(File.atime(tar_path), tab.source_modified_time, tar_path)
+          tar_path.utime(tab.source_modified_time, tab.source_modified_time)
           relocatable_tar_path = "#{f}-bottle.tar"
           mv tar_path, relocatable_tar_path
           # Use gzip, faster to compress than bzip2, faster to uncompress than bzip2

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -152,6 +152,11 @@ class IntegrationCommandTests < Homebrew::TestCase
         url "https://example.com/testball-0.1.tar.gz"
       end
     EOS
+    # `brew bottle` should not fail with dead symlink
+    # https://github.com/Homebrew/homebrew/issues/49007
+    (HOMEBREW_CELLAR/"testball/0.1").cd do
+      FileUtils.ln_s "not-exist", "symlink"
+    end
     assert_match(/testball-0\.1.*\.bottle\.tar\.gz/,
                   cmd_output("bottle", "--no-revision", "testball"))
   ensure


### PR DESCRIPTION
Also set atime to mtime, which seems to be a more common practice.

Fixes #49007

cc @UniqMartin @chrmoritz