### PR TITLE
htop 2.0.0 (new formula)

### DIFF
--- a/Library/Aliases/htop
+++ b/Library/Aliases/htop
@@ -1,1 +1,0 @@
-../Formula/htop-osx.rb

--- a/Library/Formula/htop-osx.rb
+++ b/Library/Formula/htop-osx.rb
@@ -34,7 +34,6 @@ class HtopOsx < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    pipe_output("#{bin}/htop", "q")
-    assert $?.success?
+    pipe_output("#{bin}/htop", "q", 0)
   end
 end

--- a/Library/Formula/htop-osx.rb
+++ b/Library/Formula/htop-osx.rb
@@ -14,6 +14,8 @@ class HtopOsx < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
+  conflicts_with "htop", :because => "both install an `htop` binary"
+
   def install
     # Otherwise htop will segfault when resizing the terminal
     ENV.no_optimization if ENV.compiler == :clang
@@ -24,7 +26,7 @@ class HtopOsx < Formula
   end
 
   def caveats; <<-EOS.undent
-    htop-osx requires root privileges to correctly display all running processes.
+    htop-osx requires root privileges to correctly display all running processes,
     so you will need to run `sudo htop`.
     You should be certain that you trust any software you grant root privileges.
     EOS

--- a/Library/Formula/htop.rb
+++ b/Library/Formula/htop.rb
@@ -25,7 +25,6 @@ class Htop < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    pipe_output("#{bin}/htop", "q")
-    assert $?.success?
+    pipe_output("#{bin}/htop", "q", 0)
   end
 end

--- a/Library/Formula/htop.rb
+++ b/Library/Formula/htop.rb
@@ -1,0 +1,31 @@
+class Htop < Formula
+  desc "Improved top (interactive process viewer)"
+  homepage "https://github.com/hishamhm/htop"
+  url "https://github.com/hishamhm/htop/archive/2.0.0.tar.gz"
+  sha256 "2522a93792dfee188bfaff23f30332d1173460c95f9869588398e9bdd3a0491b"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  conflicts_with "htop-osx", :because => "both install an `htop` binary"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    htop requires root privileges to correctly display all running processes,
+    so you will need to run `sudo htop`.
+    You should be certain that you trust any software you grant root privileges.
+    EOS
+  end
+
+  test do
+    ENV["TERM"] = "xterm"
+    pipe_output("#{bin}/htop", "q")
+    assert $?.success?
+  end
+end


### PR DESCRIPTION
htop now supports OS X. This replaces the alias to htop-osx.

Fixes #45197.
Fixes #49054.

Closes #49062.