### PR TITLE
htop 2.0.0 (new formula)

### DIFF
--- a/Library/Aliases/htop
+++ b/Library/Aliases/htop
@@ -1,1 +1,0 @@
-../Formula/htop-osx.rb

--- a/Library/Formula/htop.rb
+++ b/Library/Formula/htop.rb
@@ -1,0 +1,32 @@
+class Htop < Formula
+  desc "Improved top (interactive process viewer) for OS X"
+  homepage "http://hisham.hm/htop/"
+  url "https://github.com/hishamhm/htop/archive/2.0.0.tar.gz"
+  sha256 "2522a93792dfee188bfaff23f30332d1173460c95f9869588398e9bdd3a0491b"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    htop requires root privileges to correctly display all running processes.
+    so you will need to run `sudo htop`.
+    You should be certain that you trust any software you grant root privileges.
+    EOS
+  end
+
+  test do
+    ENV["TERM"] = "xterm"
+    pipe_output("#{bin}/htop", "q")
+    assert $?.success?
+  end
+end


### PR DESCRIPTION
The current alias for htop was using [htop-osx](https://github.com/max-horvath/htop-osx) an older version of htop forked to work under OSX.

Today htop [launched today a new version](http://hisham.hm/htop/) which releases support for other systems, including Darwin/OSX 

Does not rename previous fork like #49057 just removes the alias and keeps the fork for the moment.

Fixes #45197.
Fixes #49054.