### PR TITLE
test-bot: use Ruby Macho.

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -832,6 +832,7 @@ module Homebrew
 
     ENV["HOMEBREW_DEVELOPER"] = "1"
     ENV["HOMEBREW_SANDBOX"] = "1"
+    ENV["HOMEBREW_RUBY_MACHO"] = "1"
     ENV["HOMEBREW_NO_EMOJI"] = "1"
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
 


### PR DESCRIPTION
The new code paths have been used for the existing `otool`/`install_name_tool` for a while now without issue so let's start testing out Ruby Macho on the bot.

CC @woodruffw @UniqMartin 