### PR TITLE
castxml 0.1+git20160202-1 (new formula)

### DIFF
--- a/Library/Formula/castxml.rb
+++ b/Library/Formula/castxml.rb
@@ -1,0 +1,29 @@
+class Castxml < Formula
+  desc "C-family Abstract Syntax Tree XML Output"
+  homepage "https://github.com/CastXML/CastXML"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
+  version "0.1+git20160202-1"
+  sha256 "8de10ad3e930a48a6602c3adf23ed27d3845de24c231d562ca5c23e6df8dd94a"
+
+  head "https://github.com/CastXML/castxml.git"
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => "with-clang"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      int main() {
+        return 0;
+      }
+    EOS
+    system "#{bin}/castxml", "-c", "-x", "c++", "--castxml-cc-gnu", "clang++", "--castxml-gccxml", "-o", "test.xml", "test.cpp"
+  end
+end


### PR DESCRIPTION
CastXML is the successor of GCC-XML.

CastXML is a tool based on LLVM/Clang that generates the same XML output format as GCC-XML.
It is used by multiple projects like pygccxml and ITK (and all projects using py++ to build python bindings)

The version number follows the one from the debian package (https://packages.debian.org/sid/castxml)