### PR TITLE
arp-scan audit

### DIFF
--- a/Library/Formula/arp-scan.rb
+++ b/Library/Formula/arp-scan.rb
@@ -1,8 +1,7 @@
 class ArpScan < Formula
   desc "ARP scanning and fingerprinting tool"
-  homepage "http://www.nta-monitor.com/tools-resources/security-tools/arp-scan"
-  url "http://www.nta-monitor.com/files/arp-scan/arp-scan-1.9.tar.gz"
-  mirror "https://github.com/royhills/arp-scan/releases/download/1.9/arp-scan-1.9.tar.gz"
+  homepage "https://github.com/royhills/arp-scan"
+  url "https://github.com/royhills/arp-scan/releases/download/1.9/arp-scan-1.9.tar.gz"
   sha256 "ce908ac71c48e85dddf6dd4fe5151d13c7528b1f49717a98b2a2535bd797d892"
 
   bottle do


### PR DESCRIPTION
It looks like http://www.nta-monitor.com removed arp-scan from their website. Both the homepage and the original tar url were returning `404`s.