### PR TITLE
update-bash: don't prompt for passwords.

### DIFF
--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -303,6 +303,9 @@ EOS
       odie "Git must be installed and in your PATH!"
     fi
   fi
+  export GIT_TERMINAL_PROMPT="0"
+  export GIT_ASKPASS="false"
+  export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then

--- a/Library/Homebrew/cmd/update-bash.sh
+++ b/Library/Homebrew/cmd/update-bash.sh
@@ -189,7 +189,7 @@ pull() {
     export HOMEBREW_UPDATE_AFTER"$TAP_VAR"="$CURRENT_REVISION"
     if ! git merge-base --is-ancestor "$INITIAL_REVISION" "$CURRENT_REVISION"
     then
-      odie "Your HEAD is not a descendant of $UPSTREAM_BRANCH!"
+      odie "Your $DIR HEAD is not a descendant of $UPSTREAM_BRANCH!"
     fi
     return
   fi
@@ -333,8 +333,11 @@ EOS
     cd "$DIR" || continue
     UPSTREAM_BRANCH="$(upstream_branch)"
     # the refspec ensures that the default upstream branch gets updated
-    git fetch "${QUIET_ARGS[@]}" origin \
-      "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH" &
+    (
+      git fetch "${QUIET_ARGS[@]}" origin \
+        "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH" || \
+          odie "Fetching $DIR failed!"
+    ) &
   done
 
   wait


### PR DESCRIPTION
We execute too many `git fetch` at once for this to be useful. Just let them fail instead and make it up to users to setup username/password caching or SSH agents.

CC @tdsmith @xu-cheng 