### PR TITLE
Promote update-bash to the default updater.

### DIFF
--- a/Library/Homebrew/cmd/update-ruby.rb
+++ b/Library/Homebrew/cmd/update-ruby.rb
@@ -6,7 +6,7 @@ require "formulary"
 require "descriptions"
 
 module Homebrew
-  def update
+  def update_ruby
     unless ARGV.named.empty?
       abort <<-EOS.undent
         This command updates brew itself, and does not take formula names.

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -250,7 +250,7 @@ pull() {
   trap - SIGINT
 }
 
-homebrew-update-bash() {
+homebrew-update() {
   local option
   local DIR
   local UPSTREAM_BRANCH

--- a/Library/Homebrew/test/test_updater.rb
+++ b/Library/Homebrew/test/test_updater.rb
@@ -1,5 +1,5 @@
 require "testing_env"
-require "cmd/update"
+require "cmd/update-ruby"
 require "formula_versions"
 require "yaml"
 

--- a/bin/brew
+++ b/bin/brew
@@ -144,7 +144,7 @@ fi
 if [[ "$(id -u)" = "0" && "$(/usr/bin/stat -f%u "$HOMEBREW_BREW_FILE")" != "0" ]]
 then
   case "$HOMEBREW_COMMAND" in
-    instal|install|reinstall|postinstall|ln|link|pin|update|update-bash|upgrade|create|migrate|tap|switch)
+    instal|install|reinstall|postinstall|ln|link|pin|update|update-ruby|upgrade|create|migrate|tap|switch)
       odie <<EOS
 Cowardly refusing to 'sudo brew $HOMEBREW_COMMAND'
 You can use brew with sudo, but only if the brew executable is owned by root.


### PR DESCRIPTION
Also, rename the existing updater to `update-ruby` to allow using as a fallback. It will eventually be removed.

CC @Homebrew/maintainers 