### PR TITLE
logstash 2.2.1 kibana 4.4.1

### DIFF
--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -1,9 +1,8 @@
 class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://github.com/elastic/kibana.git", :tag => "v4.4.0", :revision => "07cb4d6aecddbc9dea1a26f55778b32edcef49df"
+  url "https://github.com/elastic/kibana.git", :tag => "v4.4.1", :revision => "57474ae1b8647bccc5057792af7ab3f962f7521f"
   head "https://github.com/elastic/kibana.git"
-  revision 1
 
   bottle do
     sha256 "f6fd5b4923cc1f8ca41ec27048c5ac4a13d379315a5920ee0e1a938d6489868d" => :el_capitan
@@ -12,8 +11,8 @@ class Kibana < Formula
   end
 
   resource "node" do
-    url "https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz"
-    sha256 "35daad301191e5f8dd7e5d2fbb711d081b82d1837d59837b8ee224c256cfe5e4"
+    url "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz"
+    sha256 "edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d"
   end
 
   def install

--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -1,8 +1,8 @@
 class Logstash < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://download.elastic.co/logstash/logstash/logstash-2.2.0.tar.gz"
-  sha256 "aee2437f45c726ec354f0bf9634b3638428d48bef32beb412f827eb2cc736f78"
+  url "https://download.elastic.co/logstash/logstash/logstash-2.2.1.tar.gz"
+  sha256 "a7c55428aabdf2a2143f5907f3e5bb4bfba897f17359142e4dae70d7b446591e"
 
   bottle :unneeded
 


### PR DESCRIPTION
This pull request updates: 
 - the Logstash formula from version 2.2.0 to version 2.2.1, the [latest stable version of Logstash](https://www.elastic.co/blog/logstash-2-2-1-released) as of 2016-02-12
 - the Kibana formula from version 4.4.0 to version 4.4.1, the [latest stable version of Kibana](https://www.elastic.co/blog/kibana-4-4-1-and-4-3-2-and-4-1-5) as of 2016-02-12