### PR TITLE
htop: add "ncurses" dependency

### DIFF
--- a/Library/Formula/htop.rb
+++ b/Library/Formula/htop.rb
@@ -14,6 +14,9 @@ class Htop < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
+  option "with-ncurses", "Build using homebrew ncurses (enables mouse scroll)"
+  depends_on "homebrew/dupes/ncurses" => :optional
+
   conflicts_with "htop-osx", :because => "both install an `htop` binary"
 
   def install


### PR DESCRIPTION
`htop` supports mouse scrolling, but needs to be built with `ncurses` >= 6

See https://github.com/hishamhm/htop/issues/322