### PR TITLE
do not skip Python2 on newer OSX versions

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -15,7 +15,7 @@ module Language
     def self.each_python(build, &block)
       original_pythonpath = ENV["PYTHONPATH"]
       ["python", "python3"].each do |python|
-        next if build.without? python
+        next if ((build.without? python) && ((python == "python" && MacOS.version <= :snow_leopard) || python == "python3"))
         version = major_minor_version python
         ENV["PYTHONPATH"] = if Formulary.factory(python).installed?
           nil


### PR DESCRIPTION
Say a formula specifies
```ruby
depends_on :python if MacOS.version <= :snow_leopard
```
Then, when `MacOS.version > :snow_leopard`, `build.without? "python"` evaluates to `true`. That means that loops such as
```ruby
Language::Python.each_python(build) do |python, version|
  ...
end
```
skip system Python and are empty unless `--with-python3` is specified.

That wasn't intended, was it?