### PR TITLE
Linuxbrew fixes for terraform and packer.

### DIFF
--- a/Library/Formula/mercurial.rb
+++ b/Library/Formula/mercurial.rb
@@ -6,6 +6,10 @@ class Mercurial < Formula
   url "https://mercurial-scm.org/release/mercurial-3.7.1.tar.gz"
   sha256 "96d37d1f444a032295e190318b3166e9d05abb55916d2b3adb618a8f16c5cfed"
 
+  if OS.linux? then
+    depends_on "python" => :build
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f9bf70e4cf144fd9f3a69f8598cec3947e7312d04ba0b5a08b8dc6ecc88ba4fc" => :el_capitan

--- a/Library/Formula/packer.rb
+++ b/Library/Formula/packer.rb
@@ -307,8 +307,14 @@ class Packer < Formula
   end
 
   def install
-    ENV["XC_OS"] = "darwin"
-    ENV["XC_ARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+    if OS.mac? then
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+    else
+      ENV["XC_OS"] = "linux"
+      ENV["XC_ARCH"] = "amd64"
+    end
+
     ENV["GOPATH"] = buildpath
     # For the gox buildtool used by packer, which doesn't need to
     # get installed permanently

--- a/Library/Formula/terraform.rb
+++ b/Library/Formula/terraform.rb
@@ -67,10 +67,16 @@ class Terraform < Formula
       system "go", "test", *terraform_files
 
       mkdir "bin"
-      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      if OS.mac? then
+        os = "darwin"
+        arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      else
+        os = "linux"
+        arch = "amd64"
+      end
       system "gox",
         "-arch", arch,
-        "-os", "darwin",
+        "-os", os,
         "-output", "bin/terraform-{{.Dir}}", *terraform_files
       bin.install "bin/terraform-terraform" => "terraform"
       bin.install Dir["bin/*"]


### PR DESCRIPTION
Add logic for checking platform and setting arch and os values appropriately.

My test box (CentOS 7 VM on Digital Ocean, minimal rpms installed) requires that mercurial depend on python.

Tested on CentOS7 on Digital Ocean and on a Mac running 10.11.2.