### PR TITLE
ffmpeg 3.0

### DIFF
--- a/Library/Formula/caudec.rb
+++ b/Library/Formula/caudec.rb
@@ -3,7 +3,7 @@ class Caudec < Formula
   homepage "http://caudec.net"
   url "http://caudec.net/downloads/caudec-1.7.5.tar.gz"
   sha256 "5d1f5ab3286bb748bd29cbf45df2ad2faf5ed86070f90deccf71c60be832f3d5"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "146d7d8a5d2a9ed8b0c40bb6183fd0431c952205fdbc21fb3eb6ff6d363bc4d5" => :yosemite

--- a/Library/Formula/chromaprint.rb
+++ b/Library/Formula/chromaprint.rb
@@ -3,6 +3,7 @@ class Chromaprint < Formula
   homepage "https://acoustid.org/chromaprint"
   url "https://bitbucket.org/acoustid/chromaprint/downloads/chromaprint-1.3.tar.gz"
   sha256 "3dc3ff97abdce63abc1f52d5f5f8e72c22f9a690dd6625271aa96d3a585b695a"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/cmus.rb
+++ b/Library/Formula/cmus.rb
@@ -3,6 +3,7 @@ class Cmus < Formula
   homepage "https://cmus.github.io/"
   url "https://github.com/cmus/cmus/archive/v2.7.1.tar.gz"
   sha256 "8179a7a843d257ddb585f4c65599844bc0e516fe85e97f6f87a7ceade4eb5165"
+  revision 1
   head "https://github.com/cmus/cmus.git"
 
   bottle do

--- a/Library/Formula/echoprint-codegen.rb
+++ b/Library/Formula/echoprint-codegen.rb
@@ -3,7 +3,7 @@ class EchoprintCodegen < Formula
   homepage "http://echoprint.me"
   url "https://github.com/echonest/echoprint-codegen/archive/v4.12.tar.gz"
   sha256 "c40eb79af3abdb1e785b6a48a874ccfb0e9721d7d180626fe29c72a29acd3845"
-  revision 1
+  revision 2
   head "https://github.com/echonest/echoprint-codegen.git"
 
   bottle do

--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -1,8 +1,8 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-2.8.6.tar.bz2"
-  sha256 "40611e329bc354592c6f8f1deb033c31b91f80e91f5707ca4f9afceca78d8e62"
+  url "https://ffmpeg.org/releases/ffmpeg-3.0.tar.bz2"
+  sha256 "f19ff77a2f7f736a41dd1499eef4784bf3cb7461f07c13a268164823590113c0"
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
@@ -13,7 +13,6 @@ class Ffmpeg < Formula
 
   option "without-x264", "Disable H.264 encoder"
   option "without-lame", "Disable MP3 encoder"
-  option "without-libvo-aacenc", "Disable VisualOn AAC encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
   option "without-qtkit", "Disable deprecated QuickTime framework"
 
@@ -43,7 +42,6 @@ class Ffmpeg < Formula
 
   depends_on "x264" => :recommended
   depends_on "lame" => :recommended
-  depends_on "libvo-aacenc" => :recommended
   depends_on "xvid" => :recommended
 
   depends_on "faac" => :optional
@@ -66,7 +64,6 @@ class Ffmpeg < Formula
   depends_on "libcaca" => :optional
   depends_on "libbluray" => :optional
   depends_on "libsoxr" => :optional
-  depends_on "libquvi" => :optional
   depends_on "libvidstab" => :optional
   depends_on "x265" => :optional
   depends_on "openssl" => :optional
@@ -93,7 +90,6 @@ class Ffmpeg < Formula
 
     args << "--enable-libx264" if build.with? "x264"
     args << "--enable-libmp3lame" if build.with? "lame"
-    args << "--enable-libvo-aacenc" if build.with? "libvo-aacenc"
     args << "--enable-libxvid" if build.with? "xvid"
     args << "--enable-libsnappy" if build.with? "snappy"
 
@@ -116,7 +112,6 @@ class Ffmpeg < Formula
     args << "--enable-frei0r" if build.with? "frei0r"
     args << "--enable-libcaca" if build.with? "libcaca"
     args << "--enable-libsoxr" if build.with? "libsoxr"
-    args << "--enable-libquvi" if build.with? "libquvi"
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
@@ -172,17 +167,17 @@ class Ffmpeg < Formula
 
   def caveats
     if build.without? "faac" then <<-EOS.undent
-      FFmpeg has been built without libfaac for licensing reasons;
-      libvo-aacenc is used by default.
-      To install with libfaac, you can:
-        brew reinstall ffmpeg --with-faac
+      The native FFmpeg AAC encoder has been stable since FFmpeg 3.0. If you
+      were using libvo-aacenc or libaacplus, both of which have been dropped in
+      FFmpeg 3.0, please consider switching to the native encoder (-c:a aac),
+      fdk-aac (-c:a libfdk_aac, ffmpeg needs to be installed with the
+      --with-fdk-aac option), or faac (-c:a libfaac, ffmpeg needs to be
+      installed with the --with-faac option).
 
-      You can also use the experimental FFmpeg encoder, libfdk-aac, or
-      libvo_aacenc to encode AAC audio:
-        ffmpeg -i input.wav -c:a aac -strict experimental output.m4a
-      Or:
-        brew reinstall ffmpeg --with-fdk-aac
-        ffmpeg -i input.wav -c:a libfdk_aac output.m4a
+      See the announcement
+      https://ffmpeg.org/index.html#removing_external_aac_encoders for details,
+      and https://trac.ffmpeg.org/wiki/Encode/AAC on best practices of encoding
+      AAC with FFmpeg.
       EOS
     end
   end

--- a/Library/Formula/ffmpeg2theora.rb
+++ b/Library/Formula/ffmpeg2theora.rb
@@ -1,6 +1,7 @@
 class Ffmpeg2theora < Formula
   desc "Convert video files to Ogg Theora format"
   homepage "https://v2v.cc/~j/ffmpeg2theora/"
+  revision 1
 
   stable do
     url "https://v2v.cc/~j/ffmpeg2theora/downloads/ffmpeg2theora-0.30.tar.bz2"

--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -3,6 +3,7 @@ class Ffmpegthumbnailer < Formula
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
   url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.1.1.tar.gz"
   sha256 "e43d8aae7e80771dc700b3d960a0717d5d28156684a8ddc485572cbcbc4365e9"
+  revision 1
   head "https://github.com/dirkvdb/ffmpegthumbnailer.git"
 
   bottle do

--- a/Library/Formula/ffms2.rb
+++ b/Library/Formula/ffms2.rb
@@ -4,6 +4,7 @@ class Ffms2 < Formula
   url "https://github.com/FFMS/ffms2/archive/2.22.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/f/ffms2/ffms2_2.22.orig.tar.gz"
   sha256 "7c5202fa2e49186fb3bb815e5b12ca71f05ec09cb707ffd9465852e21a06fdad"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/gifify.rb
+++ b/Library/Formula/gifify.rb
@@ -3,6 +3,7 @@ class Gifify < Formula
   homepage "https://github.com/jclem/gifify"
   url "https://github.com/jclem/gifify/archive/v3.0.tar.gz"
   sha256 "1fc7c77672b1f93b009b39b44beba44d0ea0573cf21f7c906c3ec97d663168e5"
+  revision 1
   head "https://github.com/jclem/gifify.git"
 
   bottle :unneeded

--- a/Library/Formula/gpac.rb
+++ b/Library/Formula/gpac.rb
@@ -11,6 +11,7 @@ class Gpac < Formula
   homepage "https://gpac.wp.mines-telecom.fr/"
   url "https://github.com/gpac/gpac/archive/v0.6.0.tar.gz"
   sha256 "b50a772ff55b5fa3680f50a06127262f43dcedf75143788101880e6f2c4e25b8"
+  revision 1
   head "https://github.com/gpac/gpac.git"
 
   bottle do

--- a/Library/Formula/libgroove.rb
+++ b/Library/Formula/libgroove.rb
@@ -3,6 +3,7 @@ class Libgroove < Formula
   homepage "https://github.com/andrewrk/libgroove"
   url "https://github.com/andrewrk/libgroove/archive/4.3.0.tar.gz"
   sha256 "76f68896f078a9613d420339ef887ca8293884ad2cd0fbc031d89a6af2993636"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libquicktime.rb
+++ b/Library/Formula/libquicktime.rb
@@ -3,7 +3,7 @@ class Libquicktime < Formula
   homepage "http://libquicktime.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz"
   sha256 "1c53359c33b31347b4d7b00d3611463fe5e942cae3ec0fefe0d2fd413fd47368"
-  revision 1
+  revision 2
 
   bottle do
     revision 2

--- a/Library/Formula/mediatomb.rb
+++ b/Library/Formula/mediatomb.rb
@@ -3,7 +3,7 @@ class Mediatomb < Formula
   homepage "http://mediatomb.cc"
   url "https://downloads.sourceforge.net/mediatomb/mediatomb-0.12.1.tar.gz"
   sha256 "31163c34a7b9d1c9735181737cb31306f29f1f2a0335fb4f53ecccf8f62f11cd"
-  revision 1
+  revision 2
 
   bottle do
     revision 2

--- a/Library/Formula/minidlna.rb
+++ b/Library/Formula/minidlna.rb
@@ -3,6 +3,7 @@ class Minidlna < Formula
   homepage "https://sourceforge.net/projects/minidlna/"
   url "https://downloads.sourceforge.net/project/minidlna/minidlna/1.1.5/minidlna-1.1.5.tar.gz"
   sha256 "8477ad0416bb2af5cd8da6dde6c07ffe1a413492b7fe40a362bc8587be15ab9b"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/mjpegtools.rb
+++ b/Library/Formula/mjpegtools.rb
@@ -3,6 +3,7 @@ class Mjpegtools < Formula
   homepage "http://mjpeg.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mjpeg/mjpegtools/2.1.0/mjpegtools-2.1.0.tar.gz"
   sha256 "864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
+  revision 1
 
   depends_on :x11 => :optional
 

--- a/Library/Formula/mkvdts2ac3.rb
+++ b/Library/Formula/mkvdts2ac3.rb
@@ -1,7 +1,8 @@
 class Mkvdts2ac3 < Formula
   desc "Convert DTS audio to AC3 within a matroska file"
   homepage "https://github.com/JakeWharton/mkvdts2ac3"
-  revision 2
+  revision 3
+  head "https://github.com/JakeWharton/mkvdts2ac3.git"
 
   stable do
     url "https://github.com/JakeWharton/mkvdts2ac3/archive/1.6.0.tar.gz"
@@ -17,8 +18,6 @@ class Mkvdts2ac3 < Formula
     sha256 "2dd48305bd115dbbb8a40319440b238540d5fe307b49c0300c7fcd64a875cb5e" => :mavericks
     sha256 "47235c60299b61c5ba6fcb5e63a5d0004d0d877b441b6a64e78d432d3e7cfbce" => :mountain_lion
   end
-
-  head "https://github.com/JakeWharton/mkvdts2ac3.git"
 
   depends_on "mkvtoolnix"
   depends_on "ffmpeg"

--- a/Library/Formula/mkvtomp4.rb
+++ b/Library/Formula/mkvtomp4.rb
@@ -3,6 +3,7 @@ class Mkvtomp4 < Formula
   homepage "https://github.com/gavinbeatty/mkvtomp4/"
   url "https://github.com/gavinbeatty/mkvtomp4/archive/mkvtomp4-v1.3.tar.gz"
   sha256 "cc644b9c0947cf948c1b0f7bbf132514c6f809074ceed9edf6277a8a1b81c87a"
+  revision 1
 
   depends_on "gpac"
   depends_on "ffmpeg" => :recommended

--- a/Library/Formula/mlt.rb
+++ b/Library/Formula/mlt.rb
@@ -3,6 +3,7 @@ class Mlt < Formula
   homepage "http://www.mltframework.org/"
   url "https://github.com/mltframework/mlt/archive/v6.0.0.tar.gz"
   sha256 "34f0cb60eb2e7400e9964de5ee439851b3e51a942206cccc2961fd41b42ee5d2"
+  revision 1
 
   bottle do
     sha256 "a680addede577230dbf5c3d342f6efef2fa15186e844f85855345a7a8687b60f" => :el_capitan

--- a/Library/Formula/moc.rb
+++ b/Library/Formula/moc.rb
@@ -1,7 +1,7 @@
 class Moc < Formula
   desc "Terminal-based music player"
   homepage "http://moc.daper.net"
-  revision 1
+  revision 2
   head "svn://daper.net/moc/trunk"
 
   stable do

--- a/Library/Formula/mpd.rb
+++ b/Library/Formula/mpd.rb
@@ -3,6 +3,7 @@ class Mpd < Formula
   homepage "http://www.musicpd.org/"
   url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.12.tar.xz"
   sha256 "7b6fe6c7ce72f5f80a276d680072b524ecb395e546e252b8f3a0756377e1e875"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/mpv.rb
+++ b/Library/Formula/mpv.rb
@@ -3,6 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.15.0.tar.gz"
   sha256 "7d31217ba8572f364fcea2955733f821374ae6d8c6d8f22f8bc63c44c0400bdc"
+  revision 1
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do

--- a/Library/Formula/nuxeo.rb
+++ b/Library/Formula/nuxeo.rb
@@ -4,6 +4,7 @@ class Nuxeo < Formula
   url "http://cdn.nuxeo.com/nuxeo-7.10/nuxeo-cap-7.10-tomcat.zip"
   version "7.10"
   sha256 "9e95fb4e3dd0fdac49395ae8b429c6cc7db3c621ecd4d0dff74ea706a2aba723"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -3,6 +3,7 @@ class OpenSceneGraph < Formula
   homepage "http://www.openscenegraph.org/projects/osg"
   url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
   sha256 "5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e"
+  revision 1
 
   head "http://www.openscenegraph.org/svn/osg/OpenSceneGraph/trunk/"
 

--- a/Library/Formula/pianobar.rb
+++ b/Library/Formula/pianobar.rb
@@ -3,7 +3,7 @@ class Pianobar < Formula
   homepage "https://github.com/PromyLOPh/pianobar/"
   url "https://6xq.net/pianobar/pianobar-2015.11.22.tar.bz2"
   sha256 "23fbc9e6f55b3277dba7a0f68ff721bad7f1eeea504c616ba008841686de322b"
-  revision 1
+  revision 2
 
   head "https://github.com/PromyLOPh/pianobar.git"
 

--- a/Library/Formula/puddletag.rb
+++ b/Library/Formula/puddletag.rb
@@ -3,7 +3,7 @@ class Puddletag < Formula
   homepage "http://puddletag.sf.net"
   url "https://github.com/keithgg/puddletag/archive/1.1.1.tar.gz"
   sha256 "550680abf9c2cf082861dfb3b61fd308f87f9ed304065582cddadcc8bdd947cc"
-  revision 1
+  revision 2
 
   head "https://github.com/keithgg/puddletag.git"
 

--- a/Library/Formula/synfig.rb
+++ b/Library/Formula/synfig.rb
@@ -3,7 +3,7 @@ class Synfig < Formula
   homepage "http://synfig.org"
   url "https://downloads.sourceforge.net/project/synfig/releases/1.0/source/synfig-1.0.tar.gz"
   sha256 "1f2f9b209d49dff838049e9817b0458ac6987e912a56c061aa2f9c2faeb40720"
-  revision 1
+  revision 2
 
   head "git://synfig.git.sourceforge.net/gitroot/synfig/synfig"
 

--- a/Library/Formula/unpaper.rb
+++ b/Library/Formula/unpaper.rb
@@ -3,6 +3,14 @@ class Unpaper < Formula
   homepage "https://www.flameeyes.eu/projects/unpaper"
   url "https://www.flameeyes.eu/files/unpaper-6.1.tar.xz"
   sha256 "237c84f5da544b3f7709827f9f12c37c346cdf029b1128fb4633f9bafa5cb930"
+  revision 1
+
+  bottle do
+    cellar :any
+    sha256 "b0bb6934af1df4298a04c6d5520aac607184025cc2217d0e139a4a004d43410f" => :yosemite
+    sha256 "bc7e3b90cdc1b5d285788e33024afc81a5b3632485346e34fb852d2d86917899" => :mavericks
+    sha256 "a4cd97fa61392b0092b5b61e459e5e9a956193715fc6ff19a582ec6190629b38" => :mountain_lion
+  end
 
   head do
     url "https://github.com/Flameeyes/unpaper.git"
@@ -12,13 +20,6 @@ class Unpaper < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
-
-  bottle do
-    cellar :any
-    sha256 "b0bb6934af1df4298a04c6d5520aac607184025cc2217d0e139a4a004d43410f" => :yosemite
-    sha256 "bc7e3b90cdc1b5d285788e33024afc81a5b3632485346e34fb852d2d86917899" => :mavericks
-    sha256 "a4cd97fa61392b0092b5b61e459e5e9a956193715fc6ff19a582ec6190629b38" => :mountain_lion
-  end
 
   def install
     system "autoreconf", "-i" if build.head?


### PR DESCRIPTION
**Update.** A checklist of dependent failures:

- [x] `ffmpeg2theora`: update to 0.30; #49236 <del>bottling failure blocking merge</del> merged;
- [x] `ffmpegthumbnailer`: <del>even master doesn't work;</del> reported https://github.com/dirkvdb/ffmpegthumbnailer/issues/128; <del>upstream no activity lately;</del> upstream released 2.1.1; #49267;
- [x] `ffms2`: update to 2.22; #49239;
- [x] `gpac`: fixed on master, reported https://github.com/gpac/gpac/issues/417; <del>maintainer (on 02/17/2016): "We're going to tag a new version by the end of the week";</del> 0.6.0 out, see #49355;
- [x] `mlt`: fixed on master, reported https://sourceforge.net/p/mlt/bugs/239/; <del>maintainer (on 02/16/2016): "I will make a new release very soon.";</del> v6.0.0 landed, #49283;
- [x] `moc`: fixed on trunk, reported http://moc.daper.net/node/1496; not really expecting a release though; I backported `r2779` in #49359;
- [x] `open-scene-graph`: [not FFmpeg's fault](https://github.com/Homebrew/homebrew/pull/49178#issuecomment-186410750); ongoing work in #46776;
- [x] `phash`: solid boneyard candidate; #49268;
- [x] `synfig`: blocked on `mlt`;
- [x] `synfigstudio`: blocked on `synfig`.

---

https://github.com/FFmpeg/FFmpeg/releases/tag/n3.0.

FFmpeg 3.0 dropped support for several external libraries; relevant to this formula are libvo-aacenv and libquvi. See [Changelog](https://github.com/FFmpeg/FFmpeg/blob/n3.0/Changelog#L4-L71) for details.

Developments on the AAC encoding front are especially notable. To quote two official announcements:

(TL;DR:

1. The native FFmpeg AAC encoder has gone stable, and it has the advantage of being un-license-encumbered;

2. If you are currently using libvo-aacenc or libaacplus, consider switching to aac or libfdk_aac. aac is almost a drop-in replacement for libvo-aacenc; fdk-aac is better than aacplus but you need to learn profiles and options.)

* [December 5th, 2015, The native FFmpeg AAC encoder is now stable!](https://ffmpeg.org/index.html#aac_encoder_stable):

    > After seven years the native FFmpeg AAC encoder has had its experimental flag removed and declared as ready for general use. The encoder is transparent at 128kbps for most samples tested with artifacts only appearing in extreme cases. Subjective quality tests put the encoder to be of equal or greater quality than most of the other encoders available to the public.

    > Licensing has always been an issue with encoding AAC audio as most of the encoders have had a license making FFmpeg unredistributable if compiled with support for them. The fact that there now exists a fully open and truly free AAC encoder integrated directly within the project means a lot to those who wish to use accepted and widespread standards.

    > ...

* [January 30, 2016, Removing support for two external AAC encoders](https://ffmpeg.org/index.html#removing_external_aac_encoders):

    > ...

    > The circumstances for both have changed. After the work spearheaded by Rostislav Pehlivanov and Claudio Freire, the now-stable FFmpeg native AAC encoder is ready to compete with much more mature encoders. The Fraunhofer FDK AAC Codec Library for Android was added in 2012 as the fourth supported external AAC encoder, and the one with the best quality and the most features supported, including HE-AAC and HE-AACv2.

    > Therefore, we have decided that it is time to remove libvo-aacenc and libaacplus. If you are currently using libvo-aacenc, prepare to transition to the native encoder (aac) when updating to the next version of FFmpeg. In most cases it is as simple as merely swapping the encoder name. If you are currently using libaacplus, start using FDK AAC (libfdk_aac) with an appropriate profile option to select the exact AAC profile that fits your needs. In both cases, you will enjoy an audible quality improvement and as well as fewer licensing headaches.
