### PR TITLE
fabio 1.0.8 (new formula)

### DIFF
--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -26,24 +26,20 @@ class Fabio < Formula
   end
 
   test do
-    # check if Consul is reachable
     CONSUL_DEFAULT_PORT=8500
     FABIO_DEFAULT_PORT=9999
     LOCALHOST_IP="127.0.0.1".freeze
 
     if Fabio.port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) && !Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
-      # Consul is there..
       fork do
         exec "#{bin}/fabio &>fabio-start.out&"
       end
       sleep 10
-      assert_equal Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT), true
+      assert_equal true, Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
       exec "killall fabio" # fabio forks off from the fork...
     else
-      # consul not running or fabio already running (or something else on that port), fallback to version test
-      puts "Falling back to version test, Consul is not running or Fabio is already running or something occupies the port #{FABIO_DEFAULT_PORT}"
-      output = shell_output("#{bin}/fabio -v")
-      assert_match version.to_s, output
+      puts "Fabio already running or Consul not available or starting fabio failed."
+      false
     end
   end
 

--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -41,6 +41,7 @@ class Fabio < Formula
       sleep 10
       assert_equal true, Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
       exec "killall fabio" # fabio forks off from the fork...
+      exec "consul leave"
     else
       puts "Fabio already running or Consul not available or starting fabio failed."
       false

--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -30,7 +30,11 @@ class Fabio < Formula
     FABIO_DEFAULT_PORT=9999
     LOCALHOST_IP="127.0.0.1".freeze
 
-    if Fabio.port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) && !Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
+    if !Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
+      if !Fabio.port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) 
+        exec "consul agent"
+        sleep 5
+      end
       fork do
         exec "#{bin}/fabio &>fabio-start.out&"
       end

--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -44,7 +44,7 @@ class Fabio < Formula
     end
 
     if !port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
-      if !port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) 
+      if !port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT)
         fork do
           exec "consul agent -dev -bind 127.0.0.1"
           puts "consul started"
@@ -66,5 +66,4 @@ class Fabio < Formula
       false
     end
   end
-
 end

--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -1,0 +1,29 @@
+require "language/go"
+
+class Fabio < Formula
+  desc "Zero-conf load balancing HTTP(S) router."
+  homepage "https://github.com/eBay/fabio"
+  url "https://github.com/eBay/fabio/archive/v1.0.8.tar.gz"
+  sha256 "32f771087cbd789293b655d7469e9a79d4f16c65956f81d54be8ff0fcf2d6e39"
+
+  head "https://github.com/eBay/fabio.git"
+
+  depends_on "go" => :build
+
+  def install
+    mkdir_p buildpath/"src/github.com/ebay"
+    ln_s buildpath, buildpath/"src/github.com/ebay/fabio"
+
+    ENV["GOPATH"] = "#{buildpath}/_third_party:#{buildpath}"
+
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    system "go", "build", "-o", "fabio"
+    bin.install "fabio"
+  end
+
+  test do
+    output = shell_output("#{bin}/fabio -v")
+    assert_match version.to_s, output
+  end
+end

--- a/Library/Formula/fabio.rb
+++ b/Library/Formula/fabio.rb
@@ -26,29 +26,29 @@ class Fabio < Formula
   end
 
   test do
-    #check if Consul is reachable
+    # check if Consul is reachable
     CONSUL_DEFAULT_PORT=8500
     FABIO_DEFAULT_PORT=9999
-    LOCALHOST_IP="127.0.0.1"
+    LOCALHOST_IP="127.0.0.1".freeze
 
-    if Fabio.port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) and !Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
-      #Consul is there..
+    if Fabio.port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT) && !Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT)
+      # Consul is there..
       fork do
         exec "#{bin}/fabio &>fabio-start.out&"
       end
       sleep 10
-      assert_equal Fabio.port_open?(LOCALHOST_IP,FABIO_DEFAULT_PORT), true
-      exec "killall fabio" #fabio forks off from the fork... 
+      assert_equal Fabio.port_open?(LOCALHOST_IP, FABIO_DEFAULT_PORT), true
+      exec "killall fabio" # fabio forks off from the fork...
     else
-      #consul not running or fabio already running (or something else on that port), fallback to version test
+      # consul not running or fabio already running (or something else on that port), fallback to version test
       puts "Falling back to version test, Consul is not running or Fabio is already running or something occupies the port #{FABIO_DEFAULT_PORT}"
       output = shell_output("#{bin}/fabio -v")
       assert_match version.to_s, output
     end
   end
 
-  def Fabio.port_open?(ip, port, seconds=1)
-    Timeout::timeout(seconds) do
+  def self.port_open?(ip, port, seconds = 1)
+    Timeout.timeout(seconds) do
       begin
         TCPSocket.new(ip, port).close
         true
@@ -60,4 +60,3 @@ class Fabio < Formula
     false
   end
 end
-


### PR DESCRIPTION
Add formula for Fabio (https://github.com/eBay/fabio), a zero-conf load balancing HTTP(S) router. Written in Go (golang), using consul to store url -> ip:port mappings.

Added an optional, but recommended Consul dependency.