### PR TITLE
Fix hub HEAD build by specifying output path explicitly 

### DIFF
--- a/Library/Formula/hub.rb
+++ b/Library/Formula/hub.rb
@@ -17,7 +17,7 @@ class Hub < Formula
   depends_on "go" => :build
 
   def install
-    system "script/build"
+    system "script/build", "-o", "hub"
     bin.install "hub"
     man1.install Dir["man/*"]
 


### PR DESCRIPTION
This fixes the following build error, which afflicts HEAD builds:
```
==> script/build
/usr/local/Library/Homebrew/debrew.rb:11:in `raise'
Errno::ENOENT: No such file or directory - hub
1. raise
2. ignore
3. backtrace
4. irb
5. shell
Choose an action: 1
ln -s ../../Cellar/hub/HEAD/etc/bash_completion.d/hub.bash_completion.sh hub.bash_completion.sh
ln -s ../Cellar/hub/HEAD/bin/hub hub
ln -s ../../../Cellar/hub/HEAD/share/man/man1/hub.1.ronn hub.1.ronn
ln -s ../../../Cellar/hub/HEAD/share/zsh/site-functions/_hub _hub
Error: No such file or directory - hub
/usr/local/Library/Homebrew/debrew.rb:11:in `raise'
/usr/local/Library/Homebrew/extend/pathname.rb:80:in `install_p'
/usr/local/Library/Homebrew/extend/pathname.rb:74:in `block in install'
/usr/local/Library/Homebrew/extend/pathname.rb:55:in `each'
/usr/local/Library/Homebrew/extend/pathname.rb:55:in `install'
/usr/local/Library/Formula/hub.rb:21:in `install'
/usr/local/Library/Homebrew/debrew.rb:22:in `block in install'
/usr/local/Library/Homebrew/debrew.rb:97:in `debrew'
/usr/local/Library/Homebrew/debrew.rb:22:in `install'
/usr/local/Library/Homebrew/build.rb:130:in `block in install'
/usr/local/Library/Homebrew/formula.rb:926:in `block in brew'
/usr/local/Library/Homebrew/formula.rb:1546:in `block in stage'
/usr/local/Library/Homebrew/resource.rb:92:in `block in unpack'
/usr/local/Library/Homebrew/extend/fileutils.rb:35:in `mktemp'
/usr/local/Library/Homebrew/resource.rb:88:in `unpack'
/usr/local/Library/Homebrew/resource.rb:81:in `stage'
/usr/local/Library/Homebrew/formula.rb:1536:in `stage'
/usr/local/Library/Homebrew/formula.rb:922:in `brew'
/usr/local/Library/Homebrew/build.rb:108:in `install'
/usr/local/Library/Homebrew/build.rb:177:in `<main>'
```