### PR TITLE
sdf2-bundle 2.4 (new formula)

### DIFF
--- a/Library/Formula/sdf2-bundle.rb
+++ b/Library/Formula/sdf2-bundle.rb
@@ -1,0 +1,37 @@
+class Sdf2Bundle < Formula
+  desc "parser and parser generator for syntax definition formalism (SDF2)"
+  homepage "http://www.program-transformation.org/Sdf/SdfBundle"
+  url "http://releases.strategoxt.org/strategoxt-0.17/sdf2-bundle/sdf2-bundle-2.4pre212034-37nm9z7p/sdf2-bundle-2.4.tar.gz"
+  sha256 "2ec83151173378f48a3326e905d11049d094bf9f0c7cff781bc2fce0f3afbc11"
+
+  depends_on "aterm"
+  depends_on "pkg-config" => :build
+
+  conflicts_with "sdf", :because => "Both install multiple common libraries and includes"
+
+  fails_with :clang do
+    build 700
+    cause <<-EOS.undent
+      `clang -dynamiclib  -o .libs/libErrorAPI.dylib ...` fails with error message:
+      libErrorAPI.dylib
+      Undefined symbols for architecture x86_64:
+        "_ERR_isErrorError", referenced from:
+            _ERR_fdisplayError in libErrorAPI_la-display.o
+            _ERR_liftError in libErrorAPI_la-lift.o
+
+      and more undefined symbols in other object files.
+      EOS
+  end
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "true"
+  end
+end


### PR DESCRIPTION
`sdf2-bundle` from the "strategoxt" project contains additional tools,
not present in the `sdf` package from "meta-environment.org". As such,
I would like to add the `sdf2-bundle` package to Homebrew, so that these
tools may be easily installed.

This pull request is still missing a proper `test do` block, but I
wanted to open it to get some feedback on the likely hood of the formula
being accepted before I went through the work of figuring out a decent
`test do` block.

Additionally, this formula fails to build properly with clang and
possibly modern GCCs. I think you can work around this by forcing a
32-bit build, however, it compiles fine with the old 4.2 GCC that
Homebrew defaults to when disabling Clang. I'm not sure what, if any,
additional testing needs to be done to add further `fails_with`
directives. Also, `fails_with :clang` seemed cleaner to me than adding
custom compiler flags to force 32 bit builds.

Finally, I wasn't 100% sure how to treat any conflicts with `sdf`. Right
now I specify `sdf` as a conflict, because both packages provide
libraries and includes of the same name. However, `brew link`  doesn't
complain because one package puts things in `libexec` whereas the other
(`sdfc2-bundle`) puts them in more "normal" locations. I thought it
safer to specify a conflict with `sdf` than to take chances that users
intend to link with one, but accidentally link with the other. In this
vein, I have also added a `revision` and `conflicts_with` to `sdf`s
formula. However, this formula fails `brew audit --strict` due to a
missing `test do` block, and I haven't the faintest idea where to start
with adding one. As such, I thought I would first push this commit to my
PR branch, wait for the CI tests to finish, then push the updated `sdf`
which will fail due to missing `test do`.

I would greatly appreciate some feedback from the Homebrew maintainers
advising me on how to proceed, regarding specification of conflicts,
`fails_with` and whether or not I should invest the effort in writing a
`test do` block for `sdf2-bundle`.

Many thanks,
Cheers :beers: @zbeekman