### PR TITLE
add Tap#formula_file?

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -305,7 +305,7 @@ module Homebrew
       files << $1 if line =~ %r{^\+\+\+ b/(.*)}
     end
     files.each do |file|
-      if (tap.path/file).dirname == tap.formula_dir
+      if tap.formula_file?(file)
         formula_name = File.basename(file, ".rb")
         formulae << formula_name unless formulae.include?(formula_name)
       else

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -247,6 +247,15 @@ class Tap
     end
   end
 
+  # return true if given path would present a {Formula} file in this {Tap}.
+  # accepts both absolute path and relative path (relative to this {Tap}'s path)
+  # @private
+  def formula_file?(file)
+    file = Pathname.new(file) unless file.is_a? Pathname
+    file = file.expand_path(path)
+    file.extname == ".rb" && file.parent == formula_dir
+  end
+
   # an array of all {Formula} names of this {Tap}.
   def formula_names
     @formula_names ||= formula_files.map { |f| formula_file_to_name(f) }

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -95,6 +95,10 @@ class TapTest < Homebrew::TestCase
     assert_equal @tap.formula_renames, "oldname" => "foo"
     assert_equal [@cmd_file], @tap.command_files
     assert_kind_of Hash, @tap.to_hash
+    assert_equal true, @tap.formula_file?(@formula_file)
+    assert_equal true, @tap.formula_file?("Formula/foo.rb")
+    assert_equal false, @tap.formula_file?("bar.rb")
+    assert_equal false, @tap.formula_file?("Formula/baz.sh")
   end
 
   def test_remote


### PR DESCRIPTION
Return true if given path is a Formula file in this Tap.
Accepts both absolute path and relative path (relative to this Tap's path)

It offer an abstraction such that caller would not need to worry about
low level file system in the tap.

It will be used in `brew pull` and `brew update`.