### PR TITLE
tippecanoe 1.8.1

### DIFF
--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -1,14 +1,14 @@
 class Tippecanoe < Formula
   desc "Build vector tilesets from collections of GeoJSON features"
   homepage "https://github.com/mapbox/tippecanoe"
-  url "https://github.com/mapbox/tippecanoe/archive/1.6.4.tar.gz"
-  sha256 "a95e7f054671b24c0a8ac61b40a1cc379f58e9a4273172671409631e136da9d3"
+  url "https://github.com/mapbox/tippecanoe/archive/v1.8.1.tar.gz"
+  sha256 "f75c48a61a0517675a52bb9b152d33c742b5df1d774734d9c216299788cb2a6f"
 
   bottle do
     cellar :any
-    sha256 "04fc2c6023b7c6341c5bdd7a344772440cff44777b3b492286264fcc365f1260" => :el_capitan
-    sha256 "d6ecad260f7cbcef6947cce4066e8c535bed613def4ad4bab57cdcb3f2dad8fd" => :yosemite
-    sha256 "58f5c5747867c58e648efaa585ef92294c8bbc18fafaa93de70ab4cf291d8e49" => :mavericks
+    sha256 "ee22cf0295f3d4bd08819f25681870821eef5c0e0f31b6f618512a1bc932d609" => :el_capitan
+    sha256 "86f88750b3f09d455a17045b88b7a4dbf49904abe37f9512065a1562f1e1b2fd" => :yosemite
+    sha256 "29f0b3edda5115bfbec0b8258810dcde8cb9826f4e7d434851c0ad7446f4caf5" => :mavericks
   end
 
   depends_on "protobuf-c"
@@ -23,8 +23,10 @@ class Tippecanoe < Formula
     path.write <<-EOS.undent
       {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}
     EOS
-    output = `#{bin}/tippecanoe -o test.mbtiles #{path}`.strip
+
+    `#{bin}/tippecanoe -o test.mbtiles #{path}`
+
     assert_equal 0, $?.exitstatus
-    assert_equal "using layer 0 name test", output
+    assert File.exist?(File.join(testpath, "test.mbtiles"))
   end
 end

--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -19,14 +19,10 @@ class Tippecanoe < Formula
   end
 
   test do
-    path = testpath/"test.json"
-    path.write <<-EOS.undent
+    (testpath/"test.json").write <<-EOS.undent
       {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}
     EOS
-
-    system("#{bin}/tippecanoe -o #{testpath}/test.mbtiles #{path}")
-
-    assert_equal 0, $?.exitstatus
-    assert File.exist?(File.join(testpath, "test.mbtiles"))
+    safe_system "#{bin}/tippecanoe", "-o", "test.mbtiles", "test.json"
+    assert File.exist?("#{testpath}/test.mbtiles"), "tippecanoe generated no output!"
   end
 end

--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -24,7 +24,7 @@ class Tippecanoe < Formula
       {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}
     EOS
 
-    `#{bin}/tippecanoe -o test.mbtiles #{path}`
+    system("#{bin}/tippecanoe -o #{testpath}/test.mbtiles #{path}")
 
     assert_equal 0, $?.exitstatus
     assert File.exist?(File.join(testpath, "test.mbtiles"))

--- a/Library/Formula/tippecanoe.rb
+++ b/Library/Formula/tippecanoe.rb
@@ -6,9 +6,9 @@ class Tippecanoe < Formula
 
   bottle do
     cellar :any
-    sha256 "ee22cf0295f3d4bd08819f25681870821eef5c0e0f31b6f618512a1bc932d609" => :el_capitan
-    sha256 "86f88750b3f09d455a17045b88b7a4dbf49904abe37f9512065a1562f1e1b2fd" => :yosemite
-    sha256 "29f0b3edda5115bfbec0b8258810dcde8cb9826f4e7d434851c0ad7446f4caf5" => :mavericks
+    sha256 "04fc2c6023b7c6341c5bdd7a344772440cff44777b3b492286264fcc365f1260" => :el_capitan
+    sha256 "d6ecad260f7cbcef6947cce4066e8c535bed613def4ad4bab57cdcb3f2dad8fd" => :yosemite
+    sha256 "58f5c5747867c58e648efaa585ef92294c8bbc18fafaa93de70ab4cf291d8e49" => :mavericks
   end
 
   depends_on "protobuf-c"


### PR DESCRIPTION
Upgrade tippecanoe to v1.8.1

Update post-install test to check for MBTiles file, as the previous stdout text output assertion was no longer working, even though the install was successful.