### PR TITLE
Pathname: add write_append support

### DIFF
--- a/Library/Formula/neo4j.rb
+++ b/Library/Formula/neo4j.rb
@@ -24,11 +24,10 @@ class Neo4j < Formula
     bin.install_symlink Dir["#{libexec}/bin/neo4j{,-shell,-import}"]
 
     # Adjust UDC props
-    open("#{libexec}/conf/neo4j-wrapper.conf", "a") do |f|
-      f.puts "wrapper.java.additional.4=-Dneo4j.ext.udc.source=homebrew"
-
-      # suppress the empty, focus-stealing java gui
-      f.puts "wrapper.java.additional=-Djava.awt.headless=true"
-    end
+    # Suppress the empty, focus-stealing java gui.
+    (libexec/"conf/neo4j-wrapper.conf").append_lines <<-EOS.undent
+      wrapper.java.additional=-Djava.awt.headless=true
+      wrapper.java.additional.4=-Dneo4j.ext.udc.source=homebrew
+    EOS
   end
 end

--- a/Library/Formula/plan9port.rb
+++ b/Library/Formula/plan9port.rb
@@ -17,15 +17,10 @@ class Plan9port < Formula
   def install
     ENV["PLAN9_TARGET"] = libexec
 
-    if build.with? "x11"
-      # Make OS X system fonts available to Plan 9
-      File.open("LOCAL.config", "a") do |f|
-        f.puts "FONTSRV=fontsrv"
-      end
-    end
+    # Make OS X system fonts available to Plan 9
+    (buildpath/"LOCAL.config").write "FONTSRV=fontsrv" if build.with? "x11"
 
     system "./INSTALL"
-
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/9"
     prefix.install Dir["#{libexec}/mac/*.app"]

--- a/Library/Formula/trafficserver.rb
+++ b/Library/Formula/trafficserver.rb
@@ -78,9 +78,7 @@ class Trafficserver < Formula
     return unless File.exist?(config)
     return if File.read(config).include?("proxy.config.admin.user_id STRING #{ENV["USER"]}")
 
-    File.open("#{config}", "a") do |f|
-      f.puts "CONFIG proxy.config.admin.user_id STRING #{ENV["USER"]}"
-    end
+    config.append_lines "CONFIG proxy.config.admin.user_id STRING #{ENV["USER"]}"
   end
 
   test do

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -131,6 +131,12 @@ class Pathname
     open("w", *open_args) { |f| f.write(content) }
   end
 
+  # Only appends to a file that is already created.
+  def append_lines(content, *open_args)
+    raise "Cannot append file that doesn't exist: #{self}" unless exist?
+    open("a", *open_args) { |f| f.puts(content) }
+  end
+
   def binwrite(contents, *open_args)
     open("wb", *open_args) { |f| f.write(contents) }
   end unless method_defined?(:binwrite)

--- a/Library/Homebrew/test/test_pathname.rb
+++ b/Library/Homebrew/test/test_pathname.rb
@@ -51,6 +51,18 @@ class PathnameTests < Homebrew::TestCase
     assert_raises(RuntimeError) { @file.write("CONTENT") }
   end
 
+  def test_append_lines
+    touch @file
+    @file.append_lines("CONTENT")
+    assert_equal "CONTENT\n", File.read(@file)
+    @file.append_lines("CONTENTS")
+    assert_equal "CONTENT\nCONTENTS\n", File.read(@file)
+  end
+
+  def test_append_lines_does_not_create
+    assert_raises(RuntimeError) { @file.append_lines("CONTENT") }
+  end
+
   def test_atomic_write
     touch @file
     @file.atomic_write("CONTENT")


### PR DESCRIPTION
I don't know how popular an idea this'll be, but since it didn't take long to throw together _(I went to get food, this didn't take three hours :stuck_out_tongue_winking_eye:)_, I thought a PR would be nicer than me occupying the team chat like a persistent protest movement again.

* Blocks writing of new files via accidental typos, etc, which the normal `open("blah", "a")` doesn't.
* Where files don't exist they should _ideally_ be using the `(buildpath/"dog").write` style instead of `open("blah", "a")` already.
* It's a bit less cluttered looking if you need several writes to different files in the formula, IMO.