### PR TITLE
version: fix GitHub releases URLs parsing

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -316,6 +316,7 @@ class VersionParsingTests < Homebrew::TestCase
 
   def test_jenkins_version_style
     assert_version_detected "1.486", "http://mirrors.jenkins-ci.org/war/1.486/jenkins.war"
+    assert_version_detected "0.10.11", "https://github.com/hechoendrupal/DrupalConsole/releases/download/0.10.11/drupal.phar"
   end
 
   def test_apache_version_style

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -368,7 +368,8 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. http://mirrors.jenkins-ci.org/war/1.486/jenkins.war
-    m = /\/(\d\.\d+(\.\d)?)\//.match(spec_s)
+    # e.g. https://github.com/foo/bar/releases/download/0.10.11/bar.phar
+    m = /\/(\d\.\d+(\.\d+)?)\//.match(spec_s)
     return m.captures.first unless m.nil?
 
     # e.g. http://www.ijg.org/files/jpegsrc.v8d.tar.gz


### PR DESCRIPTION
The current code doesn't work with releases that have more than one digit in the third group, i.e.:

* `.../releases/download/1.2.3/...` works
* `.../releases/download/1.2.34/...` doesn't work