### PR TITLE
ARGV remove -i switch for interactive mode

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -108,10 +108,6 @@ module HomebrewArgvExtension
     flag? "--quieter"
   end
 
-  def interactive?
-    flag? "--interactive"
-  end
-
   def one?
     flag? "--1"
   end
@@ -126,6 +122,10 @@ module HomebrewArgvExtension
 
   def homebrew_developer?
     !ENV["HOMEBREW_DEVELOPER"].nil?
+  end
+
+  def interactive?
+    include?("--interactive")
   end
 
   def sandbox?


### PR DESCRIPTION
Require "--interactive" since it can be confusing if the "-i" switch is
accidentally triggered.

Issue #49234

I also saw this bite someone on IRC recently.