### PR TITLE
ctorrent patch for negative integers error

### DIFF
--- a/Library/Formula/ctorrent.rb
+++ b/Library/Formula/ctorrent.rb
@@ -3,13 +3,21 @@ class Ctorrent < Formula
   homepage "http://www.rahul.net/dholmes/ctorrent/"
   url "https://downloads.sourceforge.net/project/dtorrent/dtorrent/3.3.2/ctorrent-dnh3.3.2.tar.gz"
   sha256 "c87366c91475931f75b924119580abd06a7b3cb3f00fef47346552cab1e24863"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
     sha256 "47019268b9a4da02a0e36e884c9602c9ee1b8be1982e28634710c388944b333b" => :yosemite
     sha256 "ee6156a026a912c76dcf93e24506098f25387bda9022c0bcd065d4d511601ca6" => :mavericks
     sha256 "01c353acf408ba34f5ee8c4ac6acca99ab7cdb285f2e03366d9c18d9e44f221e" => :mountain_lion
+  end
+
+  # This patch skips over negative integer values appearing before "info" section in torrent file
+  # which makes ctorrent exit with "error, initial meta info failed" message.
+  # Please see https://sourceforge.net/p/dtorrent/bugs/21/ for more details
+  patch do
+    url "https://raw.githubusercontent.com/achikin/ctorrent-patch/master/ctorrent-3.3.2-negative-ints.patch"
+    sha256 "d24d04760a3480e921c54ea1af39e7bb094a8b774ee09bb8849f9c1f76731193"
   end
 
   depends_on "openssl"


### PR DESCRIPTION
From [this issue](https://sourceforge.net/p/dtorrent/bugs/21/) on ctorrent SourceForge page:

> I noticed with a bunch of random torrents that ctorrent would simply exit with "error, initial meta info failed". Since this got to be bothersome, I dug into it. If an integer with a negative value happens to occur before the "info" dictionary, then ctorrent aborts its parsing phase and exits immediately. I wrote a patch to simply skip over the negative sign if present. the strtoll() already takes care of correctly parsing this, so there should be no need for ctorrent itself to worry about it.

Example file to reproduce the issue: [test.torrent.zip](https://github.com/Homebrew/homebrew/files/134433/test.torrent.zip)
unzip the file and run `ctorrent test.torrent` the output should be `error, initial meta info failed`

