### PR TITLE
ffmpegthumbnailer 2.1.1

### DIFF
--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,8 +1,8 @@
 class Ffmpegthumbnailer < Formula
   desc "Create thumbnails for your video files"
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
-  url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.0.10.tar.gz"
-  sha256 "68125d98d72347a676ab2f9bc93ddd3537ff39d6a81145e2a58a6de5d3958e4e"
+  url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.1.1.tar.gz"
+  sha256 "e43d8aae7e80771dc700b3d960a0717d5d28156684a8ddc485572cbcbc4365e9"
 
   bottle do
     cellar :any
@@ -11,19 +11,15 @@ class Ffmpegthumbnailer < Formula
     sha256 "35fb2908a936f82fef0d09985648f977b35a47768d989093b5acede20e590556" => :mountain_lion
   end
 
-  # Look for upstream to replace the GNU build process with CMake in the future
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "ffmpeg"
 
   def install
-    system "./autogen.sh"
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "cmake", *std_cmake_args
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
Fixes build failure against FFmpeg 3.0, at the cost of breaking deinterlacing.

See https://github.com/dirkvdb/ffmpegthumbnailer/issues/128.