### PR TITLE
Add new command: brew needs <formula>

### DIFF
--- a/Library/Homebrew/cmd/needs.rb
+++ b/Library/Homebrew/cmd/needs.rb
@@ -5,7 +5,7 @@ module Homebrew
     if ARGV.named.empty?
       puts "Usage: brew needs <formula>"
     else
-      ARGV.named.each_with_index do |f, i|
+      ARGV.named.each do |f|
         print_needs f
       end
     end

--- a/Library/Homebrew/cmd/needs.rb
+++ b/Library/Homebrew/cmd/needs.rb
@@ -1,0 +1,40 @@
+require "formula"
+
+module Homebrew
+  def needs
+    if ARGV.named.empty?
+      puts "Usage: brew needs <formula>"
+    else
+      ARGV.named.each_with_index do |f, i|
+        print_needs f
+      end
+    end
+  end
+
+  def print_needs(f_in, indent="")
+    installed = Formula.installed
+    # For each installed formula f, check for formula f_in's dependencies
+    installed.each do |f|
+      f.deps.each do |dep|
+        begin
+          if dep.to_formula == Formula.factory(f_in)
+            # if found, print and recursion
+            if dep.optional?
+              puts indent + f.full_name + " (#{f_in} optional)"
+              print_needs(f.full_name, indent + "  ")
+            elsif dep.recommended?
+              puts indent + f.full_name + " (#{f_in} recommended)"
+              print_needs(f.full_name, indent + "  ")
+            else
+              puts indent + f.full_name
+              print_needs(f.full_name, indent + "  ")
+            end
+          end
+        rescue FormulaUnavailableError
+          # This may happen...
+        end
+      end
+    end
+
+  end
+end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -21,9 +21,7 @@ module Homebrew
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
-              if installed
-                Dependency.prune if not dep.to_formula.installed?
-              end
+              Dependency.prune if installed && !dep.to_formula.installed?
               Dependency.prune if ignores.any? { |ignore| dep.send(ignore) } && !dependent.build.with?(dep)
             end
             reqs = f.recursive_requirements do |dependent, req|

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -9,7 +9,8 @@ module Homebrew
     raise FormulaUnspecifiedError if ARGV.named.empty?
 
     used_formulae = ARGV.formulae
-    formulae = (ARGV.include? "--installed") ? Formula.installed : Formula
+    installed = ARGV.include? "--installed"
+    formulae = installed ? Formula.installed : Formula
     recursive = ARGV.flag? "--recursive"
     ignores = []
     ignores << "build?" if ARGV.include? "--skip-build"
@@ -20,6 +21,9 @@ module Homebrew
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
+              if installed
+                Dependency.prune if not dep.to_formula.installed?
+              end
               Dependency.prune if ignores.any? { |ignore| dep.send(ignore) } && !dependent.build.with?(dep)
             end
             reqs = f.recursive_requirements do |dependent, req|


### PR DESCRIPTION
All commands investigating dependencies do not seem to go backward.

This command would recursively print, for each argument passed, all the formulas that have this argument listed as a direct or indirect dependency.

Exemple of usage:
~~~sh
pr-needs $ brew needs harfbuzz
pango
  fontforge
  imagemagick (pango optional)
~~~

The purpose here is to determine whether `harfbuzz` would be a formula to remove or not, based on other formulas using it as a dependency.