### PR TITLE
ffmpegthumbnailer: Fix build on mountain lion

### DIFF
--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,8 +1,9 @@
 class Ffmpegthumbnailer < Formula
   desc "Create thumbnails for your video files"
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
-  url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.1.1.tar.gz"
-  sha256 "e43d8aae7e80771dc700b3d960a0717d5d28156684a8ddc485572cbcbc4365e9"
+  url "https://github.com/dirkvdb/ffmpegthumbnailer/releases/download/2.1.1/ffmpegthumbnailer-2.1.1.tar.bz2"
+  sha256 "f1f1b54b7903d726a118d7b2a2992cacef561517567f3a547964ad48cb5c89bd"
+  head "https://github.com/dirkvdb/ffmpegthumbnailer.git"
 
   bottle do
     cellar :any
@@ -18,7 +19,13 @@ class Ffmpegthumbnailer < Formula
   depends_on "ffmpeg"
 
   def install
-    system "cmake", *std_cmake_args
+    ENV.cxx11 if MacOS.version < :mavericks
+
+    args = std_cmake_args
+    args << "-DENABLE_GIO=ON"
+    args << "-DENABLE_THUMBNAILER=ON"
+
+    system "cmake", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
This also uses the args the INSTALL file says to use, adds the head url,
and uses the release tarball instead of the source tarball.

Closes #49293