### PR TITLE
tests: add groups and project name to coverage

### DIFF
--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -18,6 +18,19 @@ SimpleCov.start do
   unless ENV["HOMEBREW_INTEGRATION_TEST"]
     track_files "#{SimpleCov.root}/**/*.rb"
   end
+
+  # Add groups and the proper project name to the output.
+  project_name "Homebrew"
+  add_group "Commands", %w[/Homebrew/cmd/ /Homebrew/dev-cmd/]
+  add_group "Extensions", "/Homebrew/extend/"
+  add_group "OS", "/Homebrew/os/"
+  add_group "Requirements", "/Homebrew/requirements/"
+  add_group "Scripts", %w[
+    /brew.rb
+    /Homebrew/build.rb
+    /Homebrew/postinstall.rb
+    /Homebrew/test.rb
+  ]
 end
 
 if ENV["HOMEBREW_INTEGRATION_TEST"]


### PR DESCRIPTION
Groups make it easier to get an overview of the coverage without having to scan through a single very long list of files. They also display a possibly helpful per-group coverage. For local runs, this results in output that looks something like this:

<img width="1194" alt="Simplecov Groups" src="https://cloud.githubusercontent.com/assets/11892150/13145372/7fcee248-d650-11e5-81cc-21952819a330.png">

The project name is normally derived from the `root` directory which happens to be `Library` in our case, thus make it explicitly `Homebrew`.