### PR TITLE
gos: kill redundant envs

### DIFF
--- a/Library/Formula/artifactory-cli-go.rb
+++ b/Library/Formula/artifactory-cli-go.rb
@@ -15,7 +15,6 @@ class ArtifactoryCliGo < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     (buildpath/"src/github.com/JFrogDev/artifactory-cli-go/").install Dir["*"]
     system "go", "build", "-o", "#{bin}/art", "-v", "github.com/JFrogDev/artifactory-cli-go/art/"
   end

--- a/Library/Formula/assh.rb
+++ b/Library/Formula/assh.rb
@@ -19,7 +19,6 @@ class Assh < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     (buildpath/"src/github.com/moul/advanced-ssh-config").install Dir["*"]
 
     system "go", "build", "-o", "#{bin}/assh", "-v", "github.com/moul/advanced-ssh-config/cmd/assh/"

--- a/Library/Formula/docker-machine-driver-xhyve.rb
+++ b/Library/Formula/docker-machine-driver-xhyve.rb
@@ -22,7 +22,6 @@ class DockerMachineDriverXhyve < Formula
     (buildpath/"gopath/src/github.com/zchee/docker-machine-driver-xhyve").install Dir["{*,.git,.gitignore}"]
 
     ENV["GOPATH"] = "#{buildpath}/gopath"
-    ENV["GO15VENDOREXPERIMENT"] = "1"
 
     cd buildpath/"gopath/src/github.com/zchee/docker-machine-driver-xhyve" do
       if build.head?

--- a/Library/Formula/keybase.rb
+++ b/Library/Formula/keybase.rb
@@ -19,7 +19,6 @@ class Keybase < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOBIN"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     (buildpath/"src/github.com/keybase/client/").install "go"
 
     system "go", "build", "-a", "-tags", "production brew", "github.com/keybase/client/go/keybase"

--- a/Library/Formula/scw.rb
+++ b/Library/Formula/scw.rb
@@ -20,7 +20,6 @@ class Scw < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOBIN"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     (buildpath/"src/github.com/scaleway/scaleway-cli").install Dir["*"]
 
     system "go", "build", "-o", "#{bin}/scw", "-v", "-ldflags", "-X  github.com/scaleway/scaleway-cli/pkg/scwversion.GITCOMMIT=homebrew", "github.com/scaleway/scaleway-cli/cmd/scw/"

--- a/Library/Formula/terraform.rb
+++ b/Library/Formula/terraform.rb
@@ -43,7 +43,6 @@ class Terraform < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     # For the gox buildtool used by terraform, which doesn't need to
     # get installed permanently
     ENV.append_path "PATH", buildpath


### PR DESCRIPTION
This ENV is set automatically by `go` from the 1.6 release as opt-out rather than opt-in, so don't need these lines.

I won't push this through CI. There's no need to do so.

Ref: https://github.com/Homebrew/homebrew/pull/49279.