### PR TITLE
gos16

### DIFF
--- a/Library/Formula/docker-machine-parallels.rb
+++ b/Library/Formula/docker-machine-parallels.rb
@@ -38,6 +38,7 @@ class DockerMachineParallels < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO15VENDOREXPERIMENT"] = "0"
 
     mkdir_p buildpath/"src/github.com/Parallels/"
     ln_sf buildpath, buildpath/"src/github.com/Parallels/docker-machine-parallels"

--- a/Library/Formula/fugu.rb
+++ b/Library/Formula/fugu.rb
@@ -24,6 +24,7 @@ class Fugu < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO15VENDOREXPERIMENT"] = "0"
     mkdir_p buildpath/"src/github.com/mattes/"
     ln_s buildpath, buildpath/"src/github.com/mattes/fugu"
     Language::Go.stage_deps resources, buildpath/"src"

--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -1,10 +1,10 @@
 class Go < Formula
   desc "Go programming environment"
   homepage "https://golang.org"
-  url "https://storage.googleapis.com/golang/go1.5.3.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.5.3.src.tar.gz"
-  version "1.5.3"
-  sha256 "754e06dab1c31ab168fc9db9e32596734015ea9e24bc44cae7f237f417ce4efe"
+  url "https://storage.googleapis.com/golang/go1.6.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.6.src.tar.gz"
+  version "1.6"
+  sha256 "a96cce8ce43a9bf9b2a4c7d470bc7ee0cb00410da815980681c8353218dcf146"
 
   head "https://github.com/golang/go.git"
 
@@ -12,12 +12,6 @@ class Go < Formula
     sha256 "b09e84e2e63314ab38d76c366ff13afa53106ec2e53987c2e75d9e591848121e" => :el_capitan
     sha256 "9553fcf68bcd70e75ab755785f5dd6285f3608e2e71324c3ba1a4f736c84a8c9" => :yosemite
     sha256 "ccce62ff1470060646749876b79d33d3092f60de8409bb5fd02e7412aa4aff72" => :mavericks
-  end
-
-  devel do
-    url "https://storage.googleapis.com/golang/go1.6rc2.src.tar.gz"
-    version "1.6rc2"
-    sha256 "92914a23cde7e34e1d017175d785e5850fbb28f323a145028e2e26053ef1a598"
   end
 
   option "without-cgo", "Build without cgo"

--- a/Library/Formula/ipfs.rb
+++ b/Library/Formula/ipfs.rb
@@ -31,6 +31,7 @@ class Ipfs < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO15VENDOREXPERIMENT"] = "0"
     mkdir_p buildpath/"src/github.com/ipfs/"
     ln_sf buildpath, buildpath/"src/github.com/ipfs/go-ipfs"
     Language::Go.stage_deps resources, buildpath/"src"


### PR DESCRIPTION
Disable `GO15VENDOREXPERIMENT` where necessary. It's the default since Go 1.6's release and has the potential to break some compiles that don't yet handle it well.

I've merged https://github.com/Homebrew/homebrew/pull/49279 into this PR so it gets tested against the new `go`, at which point if all passes it will be merged.
