### PR TITLE
vault: update revision for upstream retag

### DIFF
--- a/Library/Formula/vault.rb
+++ b/Library/Formula/vault.rb
@@ -1,11 +1,15 @@
 require "language/go"
 
+# Please don't update this formula until the release is official via
+# mailing list or blog post. There's a history of GitHub tags moving around.
+# https://github.com/hashicorp/vault/issues/1051
 class Vault < Formula
   desc "Secures, stores, and tightly controls access to secrets"
   homepage "https://vaultproject.io/"
   url "https://github.com/hashicorp/vault.git",
       :tag => "v0.5.0",
-      :revision => "47309289ae8f53ff97be17a4ab21b4a5afa317ef"
+      :revision => "a7b0aadc9ea6a33875dd6bdd9d11d3146b29beb1"
+  revision 1
 
   head "https://github.com/hashicorp/vault.git"
 


### PR DESCRIPTION
The tag was moved from https://github.com/hashicorp/vault/commit/47309289ae8f53ff97be17a4ab21b4a5afa317ef to https://github.com/hashicorp/vault/commit/a7b0aadc9ea6a33875dd6bdd9d11d3146b29beb1.

It looks like 44da220638ab1955f02a61eea80978a608eda17f may have been premature on our side, going on comments in https://github.com/hashicorp/vault/issues/1051. They don't use GitHub for official release tags.

Closes #49318.