### PR TITLE
brew: print help when no commands given

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -120,6 +120,7 @@ fi
 HOMEBREW_COMMAND="$1"
 shift
 case "$HOMEBREW_COMMAND" in
+  '')          HOMEBREW_COMMAND="help";;
   ls)          HOMEBREW_COMMAND="list";;
   homepage)    HOMEBREW_COMMAND="home";;
   -S)          HOMEBREW_COMMAND="search";;


### PR DESCRIPTION
Fixes #49325.

This was meant to be the same as `brew help`, right?