### PR TITLE
googler 2.1 (new formula)

### DIFF
--- a/Library/Formula/googler.rb
+++ b/Library/Formula/googler.rb
@@ -1,0 +1,22 @@
+class Googler < Formula
+  desc "Google Search and News from the command-line"
+  homepage "https://github.com/jarun/googler"
+  url "https://github.com/jarun/googler/archive/v2.1.tar.gz"
+  sha256 "4f42325b3961efa19c475138507f156891c27db7882ed6f75dfa256aef63016c"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  def install
+    # googler requires Python 2.7+, but its shebang is hard-coded as
+    # #!/usr/bin/python, so there might be problems on Snow Leopard. As
+    # a work around we replace /usr/bin/python with brewed Python on
+    # Snow Leopard. This workaround won't be needed when
+    # https://github.com/jarun/googler/issues/23 is resolved.
+    inreplace "googler", "#!/usr/bin/python", "#!#{HOMEBREW_PREFIX}/bin/python" if MacOS.version <= :snow_leopard
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    assert_match /Usage: googler/, `#{bin}/googler`
+  end
+end


### PR DESCRIPTION
`googler` is a nice and actively developed/maintained CLI client for Google Search and News that I discovered earlier today. 109 stars, not bad.

There's actually another nice Google Search CLI I've been using so far — [Kerrick/google](https://github.com/Kerrick/google) (just want to share it here, who knows if this is going to help someone another day). Unfortunately it has seen no activity since 2012 (still live and kicking though at least for now, so maybe no activity is needed), plus it is hosted on RubyGems, and `brew search google` is a much more natural move when you want to find a command line tool than go hunting on gems.

P.S. For future reference, do I need to keep the template checklist around, or do I just delete it after ticking them off?