### PR TITLE
version: correctly parse codeload URLs

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -189,6 +189,10 @@ class VersionParsingTests < Homebrew::TestCase
     assert_version_detected "1.1.4", "https://github.com/sam-github/libnet/tarball/libnet-1.1.4"
   end
 
+  def test_codeload_style
+    assert_version_detected "0.7.1", "https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1"
+  end
+
   def test_gloox_beta_style
     assert_version_detected "1.0-beta7", "http://camaya.net/download/gloox-1.0-beta7.tar.bz2"
   end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -307,8 +307,10 @@ class Version
     m = /[-_]((?:\d+\.)*\d\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
     return m.captures.first unless m.nil?
 
-    # URL with no extension e.g. https://waf.io/waf-1.8.12
-    m = /-((?:\d+\.)*\d+)$/.match(spec_s)
+    # URL with no extension
+    # e.g. https://waf.io/waf-1.8.12
+    # e.g. https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1
+    m = /[-v]((?:\d+\.)*\d+)$/.match(spec_s)
     return m.captures.first unless m.nil?
 
     # e.g. lame-398-1


### PR DESCRIPTION
Needed for #49346.  Was previously parsed as `0.7`.

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?