### PR TITLE
moc: fix build failure against FFmpeg 3.0

### DIFF
--- a/Library/Formula/moc.rb
+++ b/Library/Formula/moc.rb
@@ -1,8 +1,20 @@
 class Moc < Formula
   desc "Terminal-based music player"
   homepage "http://moc.daper.net"
-  url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.0.tar.bz2"
-  sha256 "d29ea52240af76c4aa56fa293553da9d66675823e689249cee5f8a60657a6091"
+  revision 1
+  head "svn://daper.net/moc/trunk"
+
+  stable do
+    url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.0.tar.bz2"
+    sha256 "d29ea52240af76c4aa56fa293553da9d66675823e689249cee5f8a60657a6091"
+
+    # Backport r2779: Adapt to FFmpeg/LibAV's audioconvert.h rename (commit 5980f5dd).
+    # Necessary for building against FFmpeg 3.0. See http://moc.daper.net/node/1496.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/1282e60/moc/moc-2.5.0.diff"
+      sha256 "1a7d2d7f967c8182db01dd95d5a05aac8f2acae2eac6fcda419baaed068bc8ef"
+    end
+  end
 
   bottle do
     revision 1
@@ -11,16 +23,11 @@ class Moc < Formula
     sha256 "94cca91c117a1575aa61a10f288e95672e61bfe0c1d473b2fac70c480c0d92ab" => :mountain_lion
   end
 
-  head do
-    url "svn://daper.net/moc/trunk"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gettext" => :build
-  end
-
   option "with-ncurses", "Build with wide character support."
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "pkg-config" => :build
   depends_on "libtool" => :run
   depends_on "berkeley-db"
@@ -38,7 +45,7 @@ class Moc < Formula
   depends_on "homebrew/dupes/ncurses" => :optional
 
   def install
-    system "autoreconf", "-fvi" if build.head?
+    system "autoreconf", "-fvi"
     system "./configure", "--disable-debug", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -50,5 +57,9 @@ class Moc < Formula
         with Chinese characters, you can install using
             --with-ncurses
     EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mocp --version")
   end
 end


### PR DESCRIPTION
Upstream's next release may not be too soon (still awaiting maintainer feedback on ETA), but maintainer has confirmed that `r2779` on the 2.5 branch is the revision that fixes FFmpeg 3.0 compatibility (see http://moc.daper.net/node/1496), and backporting it to 2.5.0 (the inline patch in this commit) is a success.

The caveat is that we now need to run `autoreconf` unconditionally, because Makefiles have to be regenerated after we patch `ffmpeg.m4`.

I also added a non-substantial test (there's no way to write a substantial test, due to the nature of this tool).
