### PR TITLE
Collect and expose all collected dependencies (core change)

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -31,13 +31,19 @@ class DependencyCollector
 
   def initialize
     @deps = Dependencies.new
+    @@collected_dependencies ||= Set.new
     @requirements = Requirements.new
+  end
+
+  def self.collected_dependencies
+    @@collected_dependencies ||= Set.new
   end
 
   def add(spec)
     case dep = fetch(spec)
     when Dependency
       @deps << dep
+      @@collected_dependencies << dep
     when Requirement
       @requirements << dep
     end

--- a/Library/Homebrew/test/test_dependency_collector.rb
+++ b/Library/Homebrew/test/test_dependency_collector.rb
@@ -154,4 +154,15 @@ class DependencyCollectorTests < Homebrew::TestCase
     resource.download_strategy = Class.new
     assert_raises(TypeError) { @d.add(resource) }
   end
+
+  def test_collected_dependencies
+    @d.add "foo"
+    @d.add "bar"
+    @d2 = DependencyCollector.new
+    @d2.add "baz"
+    assert_includes DependencyCollector.collected_dependencies, Dependency.new("foo")
+    assert_includes DependencyCollector.collected_dependencies, Dependency.new("bar")
+    assert_includes DependencyCollector.collected_dependencies, Dependency.new("baz")
+    assert !(DependencyCollector.collected_dependencies.include? Dependency.new("qux"))
+  end
 end


### PR DESCRIPTION
This adds a new class method `@@collected_dependencies` to
`DependencyCollector` and exposes them via a class method
`collected_dependencies`.

We need this change for the Homebrew PHP tap. See Homebrew/homebrew-php#2889.

The PHP tap has a `PhpMetaRequirement` that works as a "just depend on any of the php versions"-dependency.

Unfortunately it currently can only work flawlessly if one of the php versions has already been installed and linked. If no PHP version has been installed yet it will fallback to `default_package php56`.

This is a problem for packages like [phan](https://github.com/Homebrew/homebrew-php/blob/master/Formula/phan.rb) which depends on `php70`. Since no php version is installed `PhpMetaRequirement` will fallback to `php56`. And since two different php versions can't be linked at the same time the install will fail. This happens very when @BrewTestBot is testing formulas in the PHP tap.

To work around this we need to know all the dependencies collected by `DependencyCollector`.

See Homebrew/homebrew-php#2889 for the change in Homebrew-PHP that will take advantage of this feature and the discussion around it.


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?