### PR TITLE
tesseract 3.04.01

### DIFF
--- a/Library/Formula/tesseract.rb
+++ b/Library/Formula/tesseract.rb
@@ -1,8 +1,8 @@
 class Tesseract < Formula
   desc "OCR (Optical Character Recognition) engine"
   homepage "https://github.com/tesseract-ocr/"
-  url "https://github.com/tesseract-ocr/tesseract/archive/3.04.00.tar.gz"
-  sha256 "7e6e48b625e1fba9bc825a4ef8c39f12c60aae1084939133b3c6a00f8f8dc38c"
+  url "https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz"
+  sha256 "57f63e1b14ae04c3932a2683e4be4954a2849e17edd638ffe91bc5a2156adc6a"
 
   bottle do
     revision 1


### PR DESCRIPTION
Upstream fixed the following build error when using --with-opencl:

  In file included from openclwrapper.cpp:10:
  ./openclwrapper.h:2:10: fatal error: 'allheaders.h' file not found
  #include "allheaders.h"
           ^
  1 error generated.
  make[1]: *** [openclwrapper.lo] Error 1
  make: *** [install-recursive] Error 1

Closes #49352