### PR TITLE
FileUtils::mktemp fix for OS X 10.6.7 and earlier

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -22,6 +22,8 @@ module FileUtils
     else
       Process.gid
     end
+    # Make OS X 10.6.7 (ruby-1.8.7-p174) and earlier happy.
+    group_id = group_id.to_s
     begin
       chown(nil, group_id, tmp)
     rescue Errno::EPERM


### PR DESCRIPTION
FileUtils::fu_get_gid only started doing the conversion of the group
to_s automatically from OS X 10.6.8 (ruby-1.8.7-p358) forward.

OS X 10.6.7 (ruby-1.8.7-p174) would fail in brew's FileUtils::mktemp with the
error "Error: can't convert Fixnum into String."

Fixes #49045
Fixes #49348