### PR TITLE
HOMEBREW_LIBRARY_PATH: remove redundant /Homebrew

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -50,7 +50,7 @@ HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/")
 HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
 
 unless defined? HOMEBREW_LIBRARY_PATH
-  HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent.join("Homebrew")
+  HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 end
 
 HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH


### PR DESCRIPTION
The default HOMEBREW_LIBRARY_PATH should be
  /usr/local/Library/Homebrew
not
  /usr/local/Library/Homebrew/Homebrew