### PR TITLE
cucumber-cpp 0.3 (new formula)

### DIFF
--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -47,8 +47,22 @@ class CucumberCpp < Formula
     EOS
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lcucumber-cpp", "-o", "test",
       "-lboost_regex", "-lboost_system"
-#    system "./test&;"
+    begin
+      pid = fork { exec "./test" }
 #    system "cucumber"
-    system "#{home}/bin/cucumber"
+      assert_match /Feature: Test
+
+  Scenario: Just for test   # features\/test.feature:2
+    Given A given statement # test.cpp:2
+    When A when statement   # test.cpp:4
+    Then A then statement   # test.cpp:6
+
+1 scenario \(1 passed\)
+3 steps \(3 passed\)/,
+        shell_output(testpath/"bin/cucumber")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
   end
 end

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -2,7 +2,6 @@ class CucumberCpp < Formula
   desc "Support for writing Cucumber step definitions in C++"
   homepage "https://cucumber.io"
   url "https://github.com/cucumber/cucumber-cpp/archive/v0.3.tar.gz"
-  version "0.3"
   sha256 "1c0f9949627e7528017bf00cbe49693ba9cbc3e11087f70aa33b21df93f341d6"
 
   depends_on "cmake" => :build
@@ -49,8 +48,7 @@ class CucumberCpp < Formula
       "-lboost_regex", "-lboost_system"
     begin
       pid = fork { exec "./test" }
-#    system "cucumber"
-      assert_match /Feature: Test
+      assert_match %r{^Feature: Test
 
   Scenario: Just for test   # features\/test.feature:2
     Given A given statement # test.cpp:2
@@ -58,7 +56,7 @@ class CucumberCpp < Formula
     Then A then statement   # test.cpp:6
 
 1 scenario \(1 passed\)
-3 steps \(3 passed\)/,
+3 steps \(3 passed\)},
         shell_output(testpath/"bin/cucumber")
     ensure
       Process.kill("SIGINT", pid)

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -29,7 +29,7 @@ class CucumberCpp < Formula
     EOS
     (testpath/"features/step_definiations/cucumber.wire").write <<-EOS.undent
       host: localhost
-      port:3902
+      port: 3902
     EOS
     (testpath/"test.cpp").write <<-EOS.undent
       #include <cucumber-cpp/defs.hpp>

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -8,8 +8,7 @@ class CucumberCpp < Formula
   depends_on "boost"
 
   def install
-    system "cmake", *std_cmake_args,
-                    "-DCUKE_DISABLE_GTEST=on",
+    system "cmake", *std_cmake_args, "-DCUKE_DISABLE_GTEST=on",
                     "-DCUKE_DISABLE_CPPSPEC=on",
                     "-DCUKE_DISABLE_FUNCTIONAL=on",
                     "-DCUKE_DISABLE_BOOST_TEST=on",

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -11,6 +11,8 @@ class CucumberCpp < Formula
   def install
     system "cmake", "-DCUKE_DISABLE_GTEST=on",
                     "-DCUKE_DISABLE_CPPSPEC=on",
+                    "-DCUKE_DISABLE_FUNCTIONAL=on",
+                    "-DCUKE_DISABLE_BOOST_TEST=on",
                     "."
     system "cmake", "--build", "."
     include.install "include/cucumber-cpp"

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -25,14 +25,14 @@ class CucumberCpp < Formula
     ENV.prepend_path "PATH", testpath/"bin"
     system "gem", "install", "cucumber"
 
-    (testpath/"features/test.features").write <<-EOS.undent
+    (testpath/"features/test.feature").write <<-EOS.undent
       Feature: Test
-      Scenario Outline: Just for test
-        Given A given statement
-        When A when statement
-        Then A then statement
+        Scenario: Just for test
+          Given A given statement
+          When A when statement
+          Then A then statement
     EOS
-    (testpath/"features/step_definiations/cucumber.wire").write <<-EOS.undent
+    (testpath/"features/step_definitions/cucumber.wire").write <<-EOS.undent
       host: localhost
       port: 3902
     EOS

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -8,11 +8,12 @@ class CucumberCpp < Formula
   depends_on "boost"
 
   def install
-    system "cmake", *std_cmake_args, "-DCUKE_DISABLE_GTEST=on",
-                    "-DCUKE_DISABLE_CPPSPEC=on",
-                    "-DCUKE_DISABLE_FUNCTIONAL=on",
-                    "-DCUKE_DISABLE_BOOST_TEST=on",
-                    "."
+    args = std_cmake_args
+    args << "-DCUKE_DISABLE_GTEST=on"
+    args << "-DCUKE_DISABLE_CPPSPEC=on"
+    args << "-DCUKE_DISABLE_FUNCTIONAL=on"
+    args << "-DCUKE_DISABLE_BOOST_TEST=on"
+    system "cmake", ".", *std_cmake_args
     system "cmake", "--build", "."
     include.install "include/cucumber-cpp"
     lib.install Dir["src/*.a"]

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -8,7 +8,8 @@ class CucumberCpp < Formula
   depends_on "boost"
 
   def install
-    system "cmake", "-DCUKE_DISABLE_GTEST=on",
+    system "cmake", *std_cmake_args,
+                    "-DCUKE_DISABLE_GTEST=on",
                     "-DCUKE_DISABLE_CPPSPEC=on",
                     "-DCUKE_DISABLE_FUNCTIONAL=on",
                     "-DCUKE_DISABLE_BOOST_TEST=on",

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -22,7 +22,6 @@ class CucumberCpp < Formula
   test do
     ENV["GEM_HOME"] = testpath
     ENV["BUNDLE_PATH"] = testpath
-    ENV.prepend_path "PATH", testpath/"bin"
     system "gem", "install", "cucumber"
 
     (testpath/"features/test.feature").write <<-EOS.undent

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -1,9 +1,9 @@
 class CucumberCpp < Formula
   desc "Support for writing Cucumber step definitions in C++"
   homepage "https://cucumber.io"
-  url "https://github.com/cucumber/cucumber-cpp/archive/1e633c6b59c75b959b480dcc4e40123e7fc59032.tar.gz"
+  url "https://github.com/cucumber/cucumber-cpp/archive/v0.3.tar.gz"
   version "0.3"
-  sha256 "1e211db8b8c230f291c8774d1c2e2bbbcf264d92016fd6081557425e43569c19"
+  sha256 "1c0f9949627e7528017bf00cbe49693ba9cbc3e11087f70aa33b21df93f341d6"
 
   depends_on "cmake" => :build
   depends_on "ruby"

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -13,7 +13,7 @@ class CucumberCpp < Formula
     args << "-DCUKE_DISABLE_CPPSPEC=on"
     args << "-DCUKE_DISABLE_FUNCTIONAL=on"
     args << "-DCUKE_DISABLE_BOOST_TEST=on"
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *args
     system "cmake", "--build", "."
     include.install "include/cucumber-cpp"
     lib.install Dir["src/*.a"]

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -20,6 +20,12 @@ class CucumberCpp < Formula
   end
 
   test do
+    home = ENV["HOME"]
+    ENV["GEM_HOME"] = home
+    ENV["BUNDLE_PATH"] = home
+    ENV.prepend_path "PATH", "#{home}/bin"
+    system "gem", "install", "cucumber"
+
     (testpath/"features/test.features").write <<-EOS.undent
       Feature: Test
       Scenario Outline: Just for test
@@ -40,9 +46,10 @@ class CucumberCpp < Formula
       THEN("^A then statement$") {
       }
     EOS
-    system ENV.cc, "test.cpp", "-L#{lib}", "-lcucumber-cpp", "-o", "test", "-stdlib=libstdc++", "-std=c++11",
-      "-lboost_unit_test_framework", "-lboost_regex", "-lboost_system"
-    system "./test&"
-    system "cucumber"
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lcucumber-cpp", "-o", "test",
+      "-lboost_regex", "-lboost_system"
+#    system "./test&;"
+#    system "cucumber"
+    system "#{home}/bin/cucumber"
   end
 end

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -6,10 +6,8 @@ class CucumberCpp < Formula
   sha256 "1c0f9949627e7528017bf00cbe49693ba9cbc3e11087f70aa33b21df93f341d6"
 
   depends_on "cmake" => :build
-  depends_on "ruby"
 
   def install
-    system "gem", "install", "bundler"
     system "cmake", "-DCUKE_DISABLE_GTEST=on",
                     "-DCUKE_DISABLE_CPPSPEC=on",
                     "."

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -1,0 +1,24 @@
+class CucumberCpp < Formula
+  desc "Support for writing Cucumber step definitions in C++"
+  homepage "https://cucumber.io"
+  url "https://github.com/cucumber/cucumber-cpp/archive/1e633c6b59c75b959b480dcc4e40123e7fc59032.tar.gz"
+  version "0.3"
+  sha256 "1e211db8b8c230f291c8774d1c2e2bbbcf264d92016fd6081557425e43569c19"
+
+  depends_on "cmake" => :build
+  depends_on "ruby"
+
+  def install
+    system "gem", "install", "bundler"
+    system "cmake", "-DCUKE_DISABLE_GTEST=on",
+                    "-DCUKE_DISABLE_CPPSPEC=on",
+                    "."
+    system "cmake", "--build", "."
+    include.install "include/cucumber-cpp"
+    lib.install Dir["src/*.a"]
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -6,6 +6,7 @@ class CucumberCpp < Formula
   sha256 "1c0f9949627e7528017bf00cbe49693ba9cbc3e11087f70aa33b21df93f341d6"
 
   depends_on "cmake" => :build
+  depends_on "boost"
 
   def install
     system "cmake", "-DCUKE_DISABLE_GTEST=on",
@@ -17,6 +18,29 @@ class CucumberCpp < Formula
   end
 
   test do
-    system "false"
+    (testpath/"features/test.features").write <<-EOS.undent
+      Feature: Test
+      Scenario Outline: Just for test
+        Given A given statement
+        When A when statement
+        Then A then statement
+    EOS
+    (testpath/"features/step_definiations/cucumber.wire").write <<-EOS.undent
+      host: localhost
+      port:3902
+    EOS
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <cucumber-cpp/defs.hpp>
+      GIVEN("^A given statement$") {
+      }
+      WHEN("^A when statement$") {
+      }
+      THEN("^A then statement$") {
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lcucumber-cpp", "-o", "test", "-stdlib=libstdc++", "-std=c++11",
+      "-lboost_unit_test_framework", "-lboost_regex", "-lboost_system"
+    system "./test&"
+    system "cucumber"
   end
 end

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -49,16 +49,18 @@ class CucumberCpp < Formula
       "-lboost_regex", "-lboost_system"
     begin
       pid = fork { exec "./test" }
-      assert_match %r{^Feature: Test
+      expected = <<-EOS.undent
+        Feature: Test
 
-  Scenario: Just for test   # features\/test.feature:2
-    Given A given statement # test.cpp:2
-    When A when statement   # test.cpp:4
-    Then A then statement   # test.cpp:6
+          Scenario: Just for test   # features\/test.feature:2
+            Given A given statement # test.cpp:2
+            When A when statement   # test.cpp:4
+            Then A then statement   # test.cpp:6
 
-1 scenario \(1 passed\)
-3 steps \(3 passed\)},
-        shell_output(testpath/"bin/cucumber")
+        1 scenario \(1 passed\)
+        3 steps \(3 passed\)
+      EOS
+      assert_match expected, shell_output(testpath/"bin/cucumber")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Library/Formula/cucumber-cpp.rb
+++ b/Library/Formula/cucumber-cpp.rb
@@ -20,10 +20,9 @@ class CucumberCpp < Formula
   end
 
   test do
-    home = ENV["HOME"]
-    ENV["GEM_HOME"] = home
-    ENV["BUNDLE_PATH"] = home
-    ENV.prepend_path "PATH", "#{home}/bin"
+    ENV["GEM_HOME"] = testpath
+    ENV["BUNDLE_PATH"] = testpath
+    ENV.prepend_path "PATH", testpath/"bin"
     system "gem", "install", "cucumber"
 
     (testpath/"features/test.features").write <<-EOS.undent


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

As you can see I didn't check all because `brew audit --strict --online cucumber-cpp` doesn't succeed and give me the following output:

```
$ brew audit --strict --online cucumber-cpp
==> brew style cucumber-cpp

1 file inspected, no offenses detected

==> audit problems
cucumber-cpp:
 * Don't use ruby as a dependency. We allow non-Homebrew ruby installations.

Error: 1 problem in 1 formula
```

I tried to remove `depends_on "ruby"` but then I have the following error when trying to install:

```
==> gem install bundler
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
```

I submit it hopping that someone could help solving this issue.