### PR TITLE
go: warn about no-op stage_deps calls

### DIFF
--- a/Library/Homebrew/language/go.rb
+++ b/Library/Homebrew/language/go.rb
@@ -7,6 +7,7 @@ module Language
     # The resource names should be the import name of the package,
     # e.g. `resource "github.com/foo/bar"`
     def self.stage_deps(resources, target)
+      opoo "tried to stage empty resources array" if resources.empty?
       resources.grep(Resource::Go) { |resource| resource.stage(target) }
     end
   end

--- a/Library/Homebrew/test/test_language_go.rb
+++ b/Library/Homebrew/test/test_language_go.rb
@@ -1,0 +1,13 @@
+# -*- coding: UTF-8 -*-
+
+require "testing_env"
+require "language/go"
+
+class LanguageGoTests < Homebrew::TestCase
+  def test_stage_deps_empty
+    Language::Go.expects(:opoo).once
+    mktmpdir do |path|
+      shutup { Language::Go.stage_deps [], path }
+    end
+  end
+end


### PR DESCRIPTION
This is similar to what we’re doing on e.g. [`bin.install []`](https://github.com/Homebrew/homebrew/blob/4d169565ee17ab851fe30705a8495676a309e344/Library/Homebrew/extend/pathname.rb#L63).