### PR TITLE
Add ttygif (new formula)

### DIFF
--- a/Library/Formula/ttygif.rb
+++ b/Library/Formula/ttygif.rb
@@ -1,9 +1,10 @@
 class Ttygif < Formula
 
+  desc "Convert terminal recordings to animated gifs"
   homepage "https://github.com/icholy/ttygif.git"
-  head "https://github.com/icholy/ttygif.git", :branch => "master"
   url "https://github.com/icholy/ttygif/archive/1.0.8.tar.gz"
   sha256 "32b3394ebaac3389c66aee225ab61846fc84b02e218d0018515a6e9345a9f114"
+  head "https://github.com/icholy/ttygif.git", :branch => "master"
 
   depends_on "imagemagick"
   depends_on "ttyrec"

--- a/Library/Formula/ttygif.rb
+++ b/Library/Formula/ttygif.rb
@@ -2,8 +2,8 @@ class Ttygif < Formula
 
   homepage "https://github.com/icholy/ttygif.git"
   head "https://github.com/icholy/ttygif.git", :branch => "master"
-  url "https://github.com/icholy/ttygif/archive/1.0.8.zip"
-  sha1 "00e76af8ac11d8522ff32d5c86cba07545bf54c6"
+  url "https://github.com/icholy/ttygif/archive/1.0.8.tar.gz"
+  sha256 "32b3394ebaac3389c66aee225ab61846fc84b02e218d0018515a6e9345a9f114"
 
   depends_on "imagemagick"
   depends_on "ttyrec"

--- a/Library/Formula/ttygif.rb
+++ b/Library/Formula/ttygif.rb
@@ -1,17 +1,15 @@
 class Ttygif < Formula
-
   desc "Convert terminal recordings to animated gifs"
   homepage "https://github.com/icholy/ttygif.git"
   url "https://github.com/icholy/ttygif/archive/1.0.8.tar.gz"
   sha256 "32b3394ebaac3389c66aee225ab61846fc84b02e218d0018515a6e9345a9f114"
-  head "https://github.com/icholy/ttygif.git", :branch => "master"
+  head "https://github.com/icholy/ttygif.git"
 
   depends_on "imagemagick"
   depends_on "ttyrec"
 
   def install
     system "make"
-    bin.install("ttygif")
-    bin.install("concat_osx.sh")
+    bin.install %w[ttygif concat_osx.sh]
   end
 end

--- a/Library/Formula/ttygif.rb
+++ b/Library/Formula/ttygif.rb
@@ -1,0 +1,16 @@
+class Ttygif < Formula
+
+  homepage "https://github.com/icholy/ttygif.git"
+  head "https://github.com/icholy/ttygif.git", :branch => "master"
+  url "https://github.com/icholy/ttygif/archive/1.0.8.zip"
+  sha1 "00e76af8ac11d8522ff32d5c86cba07545bf54c6"
+
+  depends_on "imagemagick"
+  depends_on "ttyrec"
+
+  def install
+    system "make"
+    bin.install("ttygif")
+    bin.install("concat_osx.sh")
+  end
+end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
← **This is a program to create a gif from a file that has been generated by the `ttyreq`. Test is worried how to write .**


- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

### Note: The results of the current test

```sh
$ brew audit --online --strict ttygif
==> brew style ttygif
== Library/Formula/ttygif.rb ==
C:  2:  1: Extra empty line detected at class body beginning.

1 file inspected, 1 offense detected

==> audit problems
ttygif:
 * A `test do` test block should be added
 * GitHub fork (not canonical repository)

Error: 2 problems in 1 formula
```