### PR TITLE
Kobalt 0.633 (new formula)

### DIFF
--- a/Library/Formula/kobalt.rb
+++ b/Library/Formula/kobalt.rb
@@ -5,18 +5,10 @@ class Kobalt < Formula
   sha256 "bb468a7b8761de20c4700e18a6de55ee0712edd0e9d04748e53592c91389c94e"
 
   def install
-    prefix.install "kobaltw"
-    prefix.install "kobalt"
-
-    # kobaltw expects the jar file to be in ./kobalt/wrapper so
-    # install it to /usr/local/bin manually and correct the
-    # jar location
-    kobaltw = "/usr/local/bin/kobaltw"
-
-    rm kobaltw
-    ln_s "#{prefix}/kobaltw", kobaltw
-    chmod 0755, prefix/"kobaltw"
-    inreplace "#{prefix}/kobaltw", "$(dirname $0)", prefix
+    libexec.install %w[kobaltw kobalt]
+    kobaltw = libexec/"kobaltw"
+    kobaltw.chmod 0755
+    bin.write_exec_script kobaltw
   end
 
   test do
@@ -39,7 +31,7 @@ class Kobalt < Formula
     }
     EOS
 
-    system "kobaltw assemble"
+    system "#{bin}/kobaltw", "assemble"
     output = "kobaltBuild/libs/test-1.0.jar"
     assert File.exists?(output), "Couldn't find #{output}"
   end

--- a/Library/Formula/kobalt.rb
+++ b/Library/Formula/kobalt.rb
@@ -1,0 +1,48 @@
+
+class Kobalt < Formula
+  desc "A build system"
+  homepage "http://beust.com/kobalt"
+  url "https://github.com/cbeust/kobalt/releases/download/0.633/kobalt-0.633.zip"
+  version "0.633"
+  sha256 "bb468a7b8761de20c4700e18a6de55ee0712edd0e9d04748e53592c91389c94e"
+
+  def install
+    prefix.install "kobaltw"
+    prefix.install "kobalt"
+
+    # kobaltw expects the jar file to be in ./kobalt/wrapper so
+    # install it to /usr/local/bin manually and correct the
+    # jar location
+    kobaltw = "/usr/local/bin/kobaltw"
+
+    rm "#{kobaltw}"
+    ln_s "#{prefix}/kobaltw", kobaltw
+    chmod 0755, prefix/"kobaltw"
+    inreplace "#{prefix}/kobaltw", "$(dirname $0)", prefix
+  end
+
+  test do
+    (testpath/"src/main/kotlin/com/A.kt").write <<-EOS.undent
+      package com
+      class A
+      EOS
+
+    (testpath/"kobalt/src/Build.kt").write <<-EOS.undent
+      import com.beust.kobalt.*
+      import com.beust.kobalt.api.*
+      import com.beust.kobalt.plugin.packaging.*
+
+      val p = project {
+        name = "test"
+        version = "1.0"
+        assemble {
+        jar {}
+      }
+    }
+    EOS
+
+    system "kobaltw assemble"
+    output = "kobaltBuild/libs/test-1.0.jar"
+    assert File.exists?(output), "Couldn't find #{output}"
+  end
+end

--- a/Library/Formula/kobalt.rb
+++ b/Library/Formula/kobalt.rb
@@ -1,9 +1,7 @@
-
 class Kobalt < Formula
-  desc "A build system"
+  desc "Build system"
   homepage "http://beust.com/kobalt"
   url "https://github.com/cbeust/kobalt/releases/download/0.633/kobalt-0.633.zip"
-  version "0.633"
   sha256 "bb468a7b8761de20c4700e18a6de55ee0712edd0e9d04748e53592c91389c94e"
 
   def install
@@ -15,7 +13,7 @@ class Kobalt < Formula
     # jar location
     kobaltw = "/usr/local/bin/kobaltw"
 
-    rm "#{kobaltw}"
+    rm kobaltw
     ln_s "#{prefix}/kobaltw", kobaltw
     chmod 0755, prefix/"kobaltw"
     inreplace "#{prefix}/kobaltw", "$(dirname $0)", prefix

--- a/Library/Formula/kobalt.rb
+++ b/Library/Formula/kobalt.rb
@@ -12,6 +12,8 @@ class Kobalt < Formula
   end
 
   test do
+    ENV.java_cache
+
     (testpath/"src/main/kotlin/com/A.kt").write <<-EOS.undent
       package com
       class A
@@ -33,6 +35,6 @@ class Kobalt < Formula
 
     system "#{bin}/kobaltw", "assemble"
     output = "kobaltBuild/libs/test-1.0.jar"
-    assert File.exists?(output), "Couldn't find #{output}"
+    assert File.exist?(output), "Couldn't find #{output}"
   end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?

I'm getting:
```
 * Stable: version 0.633 is redundant with version scanned from URL
```

I tried to remove the `version` but then I get another error. Can you help me fix this warning?

- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

Kobalt is a build system. The test creates a simple source file and a build file and then it calls Kobalt on it. The test asserts a .jar file gets produced.