### PR TITLE
pinfo 0.6.10 (new formula)

### DIFF
--- a/Library/Formula/pinfo.rb
+++ b/Library/Formula/pinfo.rb
@@ -1,0 +1,26 @@
+class Pinfo < Formula
+  desc "User-friendly, console-based viewer for Info documents"
+  homepage "https://alioth.debian.org/projects/pinfo/"
+  url "https://alioth.debian.org/frs/download.php/file/3351/pinfo-0.6.10.tar.bz2"
+  sha256 "122180a0c23d11bc9eb569a4de3ff97d3052af96e32466fa62f2daf46ff61c5d"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  depends_on "gettext"
+  depends_on "readline" => :optional
+
+  def install
+    system "autoreconf", "--force", "--install"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "pinfo", "-h"
+  end
+end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

### Description:

pinfo is a user-friendly, console-based viewer for Info documents.

It is already available as port: [pinfo (MacPort)](https://www.macports.org/ports.php?by=name&substr=pinfo).
It compiled without any problems and works flawlessly.

## Caveats:
There is a non specified dependency to libncurse (provided by the system), I didn't know how to declare it.
I could not use the ./autogen.sh script and therefore ran autoreconf directly.
The test is trivial as I did not find a way to run it in non-interactive mode.