### PR TITLE
ffmpegthumbnailer: Update URL and SHA for upstream reupload

### DIFF
--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -1,8 +1,8 @@
 class Ffmpegthumbnailer < Formula
   desc "Create thumbnails for your video files"
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
-  url "https://github.com/dirkvdb/ffmpegthumbnailer/releases/download/2.1.1/ffmpegthumbnailer-2.1.1.tar.bz2"
-  sha256 "f1f1b54b7903d726a118d7b2a2992cacef561517567f3a547964ad48cb5c89bd"
+  url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.1.1.tar.gz"
+  sha256 "e43d8aae7e80771dc700b3d960a0717d5d28156684a8ddc485572cbcbc4365e9"
   head "https://github.com/dirkvdb/ffmpegthumbnailer.git"
 
   bottle do


### PR DESCRIPTION
To be fair, upstream did not retag, seeing that the commit and the SHA-256 sum of the source code archive at the tag did not change. However, it appears that upstream reuploaded an artifact (a tarball that is minimally different from the source code archive) that this formula was using.

In this commit we switch back to the source code archive because

1. We've been using the source code archive up to the last revision to this formula in #49296;
2. I didn't see any build or test issue with that;
3. Upstream did not retag, so one should treat this archive as usable; if not, it is the upstream's responsibility to make a new release (or at least retag, however abonimable it is), not ours.

Also, since we basically switched to an old URL (as in #49267), I believe there's no need for revision.