### PR TITLE
open-scene-graph: max OS = 10.9

### DIFF
--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -16,6 +16,8 @@ class OpenSceneGraph < Formula
   option "with-docs", "Build the documentation with Doxygen and Graphviz"
   deprecated_option "docs" => "with-docs"
 
+  depends_on MaximumMacOSRequirement => :mavericks
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "jpeg"


### PR DESCRIPTION
OpenSceneGraph no longer builds on 10.10 or later; looks like an Xcode 7 issue. See #46776 for details and ongoing work.

In the meantime, explicitly marking the limitation so it no longer causes spurious failures on changes to formulae on which `open-scene-graph` depends, like #49178.

After merging this, the old 10.10 bottle from back when it used to build will no longer be available. Acceptable loss imho, since it reflects the current state of things.