### PR TITLE
mapnik 3.0.9

### DIFF
--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -1,9 +1,8 @@
 class Mapnik < Formula
   desc "Toolkit for developing mapping applications"
   homepage "http://www.mapnik.org/"
-  url "https://s3.amazonaws.com/mapnik/dist/v3.0.5/mapnik-v3.0.5.tar.bz2"
-  sha256 "d8f771d45b236d987aab44819a517f4c1ed6d7ff2c42c2e51160e37d28c89cc3"
-  revision 2
+  url "https://github.com/mapnik/mapnik/archive/v3.0.9.tar.gz"
+  sha256 "f0242606096e2c4ca2cd0caac1ff0fd5f8054a38b5f288ba38b0e397b5b311b2"
 
   head "https://github.com/mapnik/mapnik.git"
 


### PR DESCRIPTION
I changed the url from s3 to github, because the github archive is significantly smaller. It does not contain any of the test data found in these repositories:

* https://github.com/mapnik/test-data
* https://github.com/mapnik/test-data-visual

which is fine, because this formula doesn't call `make test` anyway.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?