### PR TITLE
Mplayer menu mod

### DIFF
--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -52,7 +52,8 @@ class Mplayer < Formula
 
     args << "--enable-caca" if build.with? "libcaca"
 
-    # to get OSD to work on El Capitan we seen to need x11
+    # to get OSD to work on El Capitan we seem to need x11.
+    # if you don't enable x11, explicitly disable it.
     if build.with? "x11"
       args << "--enable-x11"
       args << "--extra-libs=-lX11"

--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -54,10 +54,12 @@ class Mplayer < Formula
 
     # to get OSD to work on El Capitan we seen to need x11
     if build.with? "x11"
-      args << "--enable-x11" 
+      args << "--enable-x11"
       args << "--extra-libs=-lX11"
       args << "--extra-libs-mplayer=-lXext"
       args << "--enable-menu"
+    else
+      args << "--disable-x11"
     end
 
     system "./configure", *args

--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -19,6 +19,9 @@ class Mplayer < Formula
     patch :DATA
   end
 
+  option "with-x11OSD", "Enable x11 for freefont/freetype menu support"
+
+  depends_on :x11 => :optional
   depends_on "yasm" => :build
   depends_on "libcaca" => :optional
 
@@ -45,10 +48,14 @@ class Mplayer < Formula
       --host-cc=#{ENV.cc}
       --disable-cdparanoia
       --prefix=#{prefix}
-      --disable-x11
     ]
 
     args << "--enable-caca" if build.with? "libcaca"
+
+    args << "--enable-x11" if build.with? "x11OSD"
+    args << "--extra-libs=-lX11" if build.with? "x11OSD"
+    args << "--extra-libs-mplayer=-lXext" if build.with? "x11OSD"
+    args << "--enable-menu" if build.with? "x11OSD"
 
     system "./configure", *args
     system "make"

--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -19,7 +19,7 @@ class Mplayer < Formula
     patch :DATA
   end
 
-  option "with-x11OSD", "Enable x11 for freefont/freetype menu support"
+  option "with-x11", "Enable x11 for freefont/freetype menu support (OSD)"
 
   depends_on :x11 => :optional
   depends_on "yasm" => :build
@@ -52,10 +52,13 @@ class Mplayer < Formula
 
     args << "--enable-caca" if build.with? "libcaca"
 
-    args << "--enable-x11" if build.with? "x11OSD"
-    args << "--extra-libs=-lX11" if build.with? "x11OSD"
-    args << "--extra-libs-mplayer=-lXext" if build.with? "x11OSD"
-    args << "--enable-menu" if build.with? "x11OSD"
+    # to get OSD to work on El Capitan we seen to need x11
+    if build.with? "x11"
+      args << "--enable-x11" 
+      args << "--extra-libs=-lX11"
+      args << "--extra-libs-mplayer=-lXext"
+      args << "--enable-menu"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
### All Submissions:

- [*] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [*] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

I've modifed the .rb file, to explicitly include the requested else --disable-x11 behaviour, so that the default and normal build has no x11 dependencies. But, if you enable the menu feature, you get x11.

This means you can have an OSD with x11, or the default no OSD no x11

