### PR TITLE
haskell: fix empty flags build failures

### DIFF
--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -81,7 +81,7 @@ module Language
           end
 
           args_and_flags = args
-          args_and_flags << flags
+          args_and_flags << flags unless flags.empty?
 
           # install dependencies in the sandbox
           cabal_install "--only-dependencies", *args_and_flags


### PR DESCRIPTION
Fixes a regression introduced by #47950 in 9e3ee3e causing build
failures with the error

  cabal: The file does not exist ''.

This will occur whenever the optional :flags key isn't in the options
hash passed to install_cabal_package.