### PR TITLE
nginx --with-sub

### DIFF
--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -26,6 +26,7 @@ class Nginx < Formula
   option "with-debug", "Compile with support for debug log"
   option "with-spdy", "Compile with support for either SPDY or HTTP/2 module"
   option "with-gunzip", "Compile with support for gunzip module"
+  option "with-sub", "Compile with support for ngx_http_sub_module module"
 
   depends_on "pcre"
   depends_on "passenger" => :optional
@@ -78,6 +79,7 @@ class Nginx < Formula
     args << "--with-http_dav_module" if build.with? "webdav"
     args << "--with-debug" if build.with? "debug"
     args << "--with-http_gunzip_module" if build.with? "gunzip"
+    args << "--with-http_sub_module" if build.with? "sub"
 
     # This became "with-http_v2_module" in 1.9.5
     # http://nginx.org/en/docs/http/ngx_http_spdy_module.html


### PR DESCRIPTION
Per instructions, support for module `ngx_http_sub_module` does not currently exist in https://github.com/Homebrew/homebrew-nginx/blob/master/Formula/nginx-full.rb

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Added support for nginx's native text substitution module "ngx_http_sub_module"
http://nginx.org/en/docs/http/ngx_http_sub_module.html