### PR TITLE
list: exclude .github from unbrewed

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -42,6 +42,7 @@ module Homebrew
 
   UNBREWED_EXCLUDE_FILES = %w[.DS_Store]
   UNBREWED_EXCLUDE_PATHS = %w[
+    .github/*
     bin/brew
     lib/gdk-pixbuf-2.0/*
     lib/gio/*


### PR DESCRIPTION
Recently added files polluting brew ls --unbrewed results.