### PR TITLE
ccextractor: LDFLAGS needs -lpng to fix the build

### DIFF
--- a/Library/Formula/ccextractor.rb
+++ b/Library/Formula/ccextractor.rb
@@ -16,6 +16,7 @@ class Ccextractor < Formula
   depends_on "libpng"
 
   def install
+    ENV.append "LDFLAGS", "-lpng"
     system "cmake", "src", *std_cmake_args
     system "make"
     system "make", "install"


### PR DESCRIPTION
This fixes the following build error:
```
      _spupng_write_png in libccx.a(ccx_encoders_spupng.c.o)
  "_png_write_end", referenced from:
      _save_spupng in libccx.a(spupng_encoder.c.o)
      _spupng_write_png in libccx.a(ccx_encoders_spupng.c.o)
  "_png_write_image", referenced from:
      _save_spupng in libccx.a(spupng_encoder.c.o)
      _spupng_write_png in libccx.a(ccx_encoders_spupng.c.o)
  "_png_write_info", referenced from:
      _save_spupng in libccx.a(spupng_encoder.c.o)
      _spupng_write_png in libccx.a(ccx_encoders_spupng.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [ccextractor] Error 1
make[1]: *** [CMakeFiles/ccextractor.dir/all] Error 2
make: *** [all] Error 2
```