### PR TITLE
chuck 1.3.5.2: add Xcode dependency, remove patch

### DIFF
--- a/Library/Formula/chuck.rb
+++ b/Library/Formula/chuck.rb
@@ -1,8 +1,8 @@
 class Chuck < Formula
   desc "Concurrent, on-the-fly audio programming language"
   homepage "http://chuck.cs.princeton.edu/"
-  url "http://chuck.cs.princeton.edu/release/files/chuck-1.3.5.1.tgz"
-  sha256 "d141ca61547131edd2b29bdb88183835e4133ef09807674bfa33a4e6e09d1f53"
+  url "http://chuck.cs.princeton.edu/release/files/chuck-1.3.5.2.tgz"
+  sha256 "e900b8545ffcb69c6d49354b18c43a9f9b8f789d3ae822f34b408eaee8d3e70b"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,8 +13,7 @@ class Chuck < Formula
     sha256 "87d6cc4e3a3b868ee1a98f2e148060ed4a69d2cd593944ebed83fe887c7cd080" => :mountain_lion
   end
 
-  # Fixes OS X version detection to include 10.11 through (thinking ahead) 10.13
-  patch :DATA
+  depends_on :xcode => :build
 
   def install
     system "make", "-C", "src", "osx"
@@ -26,18 +25,3 @@ class Chuck < Formula
     assert_match /probe \[success\]/m, shell_output("#{bin}/chuck --probe 2>&1")
   end
 end
-
-__END__
-diff --git a/src/makefile.osx b/src/makefile.osx
-index a2c06ba..ac95278 100644
---- a/src/makefile.osx
-+++ b/src/makefile.osx
-@@ -1,7 +1,7 @@
- # uncomment the following to force 32-bit compilation
- # FORCE_M32=-m32
-
--ifneq ($(shell sw_vers -productVersion | egrep '10\.(6|7|8|9|10)(\.[0-9]+)?'),)
-+ifneq ($(shell sw_vers -productVersion | egrep '10\.(6|7|8|9|10|11|12|13)(\.[0-9]+)?'),)
- SDK=$(shell xcodebuild -sdk macosx -version | grep '^Path:' | sed 's/Path: \(.*\)/\1/')
- ISYSROOT=-isysroot $(SDK)
- LINK_EXTRAS=-F/System/Library/PrivateFrameworks \


### PR DESCRIPTION
- update chuck to 1.3.5.2

- chuck invokes xcodebuild so add Xcode as a requirement instead of
  unexpectedly failing when only the CLT is present

- remove the inlined 10.11-10.13 version-matching patch in favor of the
  corresponding upstream fix