### PR TITLE
menhir 20151112 and re-parallelize the build

### DIFF
--- a/Library/Formula/menhir.rb
+++ b/Library/Formula/menhir.rb
@@ -1,8 +1,8 @@
 class Menhir < Formula
   desc "LR(1) parser generator for the OCaml programming language"
   homepage "http://cristal.inria.fr/~fpottier/menhir"
-  url "http://cristal.inria.fr/~fpottier/menhir/menhir-20141215.tar.gz"
-  sha256 "2592967c123a31e1b6566ab9f6034e7a0a709d57d547097f05693baf96a46fa4"
+  url "http://cristal.inria.fr/~fpottier/menhir/menhir-20151112.tar.gz"
+  sha256 "06616e300ed2e5f4f2c74c58873fcd4b5f8f033b4f375f201049dafe4cd20e3a"
 
   bottle do
     sha256 "fb633f4c9db5677f8bb2eb76d09f3ffafb9a26c9fcf6ea50b657208614e01aa5" => :yosemite
@@ -12,9 +12,13 @@ class Menhir < Formula
 
   depends_on "ocaml"
 
+  # Workaround parallelized build failure by separating all steps
+  # Submitted to menhir-list@yquem.inria.fr on 24th Feb 2016.
+  patch :DATA
+
   def install
-    ENV.deparallelize
-    system "make", "PREFIX=#{prefix}", "all", "install"
+    system "make", "PREFIX=#{prefix}", "all"
+    system "make", "PREFIX=#{prefix}", "install"
   end
 
   test do
@@ -40,3 +44,22 @@ class Menhir < Formula
     assert File.exist? "test.mli"
   end
 end
+
+__END__
+diff --git a/Makefile b/Makefile
+index f426f5d..54f397e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -116,7 +116,11 @@ all:
+ 	  echo "let ocamlfind = false" >> src/installation.ml ; \
+ 	fi
+ # Compile the library modules and the Menhir executable.
+-	@ $(MAKE) -C src library bootstrap
++	@ $(MAKE) -C src library
++	@ $(MAKE) -C src .versioncheck
++	@ $(MAKE) -C src stage1
++	@ $(MAKE) -C src stage2
++	@ $(MAKE) -C src stage3
+ # The source file menhirLib.ml is created by concatenating all of the source
+ # files that make up MenhirLib. This file is not needed to compile Menhir or
+ # MenhirLib. It is installed at the same time as MenhirLib and is copied by


### PR DESCRIPTION
- update to 20151112, which is required to build CompCert 2.6
- re-parallelize the build by isolating "stage2"