### PR TITLE
formula: sort outdated versions naturally.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -975,7 +975,7 @@ class Formula
       end
 
       if older_or_same_tap_versions.all? { |v| pkg_version > v }
-        all_versions
+        all_versions.sort!
       else
         []
       end


### PR DESCRIPTION
Because the versions are read from filesystem directory listings, today we get alphabetical sorts of version numbers in `brew outdated` output:

    some-package (10.1.10, 10.1.11, 10.1.9 < 10.1.12)

Yuck! I've updated it to give a naturally-sorted output, which is much nicer:

    some-package (10.1.9, 10.1.10, 10.1.11 < 10.1.12)

Implications of this change may include a very negligible performance impact for `brew outdated` and related commands, or possibly other parts of the Homebrew system with which I'm not familiar. I'll let the maintainers be the judge of that. :grin:

All that said, this small modification :sparkles: *passes all existing tests.* :sparkles:

---

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? ***I don't think new tests are required in this case, but please correct me if I'm wrong.***
- [x] Have you successfully ran `brew tests` with your changes locally?
