### PR TITLE
brew.sh: improve empty argument handling

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -117,10 +117,10 @@ then
   set -- "$@" -v
 fi
 
+HOMEBREW_ARG_COUNT="$#"
 HOMEBREW_COMMAND="$1"
 shift
 case "$HOMEBREW_COMMAND" in
-  '')          HOMEBREW_COMMAND="help";;
   ls)          HOMEBREW_COMMAND="list";;
   homepage)    HOMEBREW_COMMAND="home";;
   -S)          HOMEBREW_COMMAND="search";;
@@ -169,5 +169,7 @@ then
   source "$HOMEBREW_BASH_COMMAND"
   { "homebrew-$HOMEBREW_COMMAND" "$@"; exit $?; }
 else
-  exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$HOMEBREW_COMMAND" "$@"
+  # Unshift command back into argument list (unless argument list was empty).
+  [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
+  exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$@"
 fi


### PR DESCRIPTION
Follow-up to #49327 that leaves empty argument handling to the Ruby code (it is a bit more sophisticated and distinguishes between `help` and an empty argument list and treats them differently) instead of hard-wiring the former to the `help` command.

----

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?