### PR TITLE
CMake needs to link against (`depends_on`) `bzip2`

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -3,6 +3,7 @@ class Cmake < Formula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz"
   sha256 "b73f8c1029611df7ed81796bf5ca8ba0ef41c6761132340c73ffe42704f980fa"
+  revision 1
   head "https://cmake.org/cmake.git"
 
   bottle do
@@ -16,6 +17,7 @@ class Cmake < Formula
   option "with-completion", "Install Bash completion (Has potential problems with system bash)"
 
   depends_on "sphinx-doc" => :build if build.with? "docs"
+  depends_on "bzip2"
 
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.


### PR DESCRIPTION
I think this bug has not been uncovered due to the fact that this isn't an issue on OS X, because it ships with bzip2 (speculation on my part here...) but using Linuxbrew, certainly uncovers the issue. On a brand new hashicorp/precise64 vagrant VM `brew install --build-from-source cmake` failed due to missing bzip2 and if the bottled version is installed:

```
ldd ~/.linuxbrew/cmake/3.4.3/bin/cmake
...
libbz2.so.1.0 => not found
```