### PR TITLE
brew.sh: auto run sudo check command as normal user

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -100,13 +100,7 @@ begin
     end
 
     if possible_tap && !possible_tap.installed?
-      brew_uid = HOMEBREW_BREW_FILE.stat.uid
-      tap_commands = []
-      if Process.uid.zero? && !brew_uid.zero?
-        tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]
-      end
-      tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
-      safe_system *tap_commands
+      safe_system HOMEBREW_BREW_FILE, "tap", possible_tap
       exec HOMEBREW_BREW_FILE, cmd, *ARGV
     else
       onoe "Unknown command: #{cmd}"

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -147,18 +147,32 @@ elif [[ -n "$HOMEBREW_DEVELOPER" && -f "$HOMEBREW_LIBRARY/Homebrew/dev-cmd/$HOME
   HOMEBREW_BASH_COMMAND="$HOMEBREW_LIBRARY/Homebrew/dev-cmd/$HOMEBREW_COMMAND.sh"
 fi
 
-if [[ "$(id -u)" = "0" && "$(/usr/bin/stat -f%u "$HOMEBREW_BREW_FILE")" != "0" ]]
+if [[ "$(id -u)" = "0" ]]
 then
-  case "$HOMEBREW_COMMAND" in
-    install|reinstall|postinstall|link|pin|update|update-ruby|upgrade|create|migrate|tap|switch)
-      odie <<EOS
+  brew_uid="$(ls -n "$HOMEBREW_BREW_FILE" | awk '{print $3}')"
+  brew_user="$(ls -l "$HOMEBREW_BREW_FILE" | awk '{print $3}')"
+  if [[ "$brew_uid" != "0" ]]
+  then
+    case "$HOMEBREW_COMMAND" in
+      install|reinstall|postinstall|link|pin|update|upgrade|create|migrate|tap|switch)
+      # suppress the warning message if the process is invoked by brew instance
+      parent_command="$(ps -o command= $PPID)"
+      if [[ "$parent_command" != *"$HOMEBREW_BREW_FILE"* &&
+            "$parent_command" != *"$HOMEBREW_LIBRARY/brew.rb"* ]]
+      then
+        onoe <<EOS
 Cowardly refusing to 'sudo brew $HOMEBREW_COMMAND'
 You can use brew with sudo, but only if the brew executable is owned by root.
 However, this is both not recommended and completely unsupported so do so at
 your own risk.
+
+Run 'brew $HOMEBREW_COMMAND' as $brew_user for now.
 EOS
+      fi
+      exec /usr/bin/sudo -u "#$brew_uid" "$HOMEBREW_BREW_FILE" "$HOMEBREW_COMMAND" "$@"
       ;;
-  esac
+    esac
+  fi
 fi
 
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -1,4 +1,4 @@
-odie() {
+onoe() {
   if [[ -t 2 ]] # check whether stderr is a tty.
   then
     echo -ne "\033[4;31mError\033[0m: " >&2 # highlight Error with underline and red color
@@ -11,6 +11,10 @@ odie() {
   else
     echo "$*" >&2
   fi
+}
+
+odie() {
+  onoe "$@"
   exit 1
 }
 


### PR DESCRIPTION
Instead of error out, auto correct the behaviors.
This allows commands which can be run under sudo to call brew command
which cannot be run under sudo.

For example, it allows `sudo brew cask` call `brew tap` without causing
permission problem.

cc @mikemcquaid @UniqMartin 