### PR TITLE
ARGV: switch? should only has one dash

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -195,7 +195,7 @@ module HomebrewArgvExtension
   # eg. `foo -ns -i --bar` has three switches, n, s and i
   def switch?(char)
     return false if char.length > 1
-    options_only.any? { |arg| arg[1, 1] != "-" && arg.include?(char) }
+    options_only.any? { |arg| arg.scan("-").size == 1 && arg.include?(char) }
   end
 
   def usage

--- a/Library/Homebrew/test/test_ARGV.rb
+++ b/Library/Homebrew/test/test_ARGV.rb
@@ -48,9 +48,9 @@ class ArgvExtensionTests < Homebrew::TestCase
   end
 
   def test_switch?
-    @argv << "-ns" << "-i" << "--bar"
+    @argv << "-ns" << "-i" << "--bar" << "-a-bad-arg"
     %w[n s i].each { |s| assert @argv.switch?(s) }
-    %w[b ns bar --bar -n].each { |s| assert !@argv.switch?(s) }
+    %w[b ns bar --bar -n a bad arg].each { |s| assert !@argv.switch?(s) }
   end
 
   def test_flag?


### PR DESCRIPTION
If user inputs argument such as `-with-flag`, we can assume it's a bad flag.

Closes #49256