### PR TITLE
Tokyo Tyrant: install .pc file in right location

### DIFF
--- a/Library/Formula/tokyo-tyrant.rb
+++ b/Library/Formula/tokyo-tyrant.rb
@@ -17,7 +17,7 @@ class TokyoTyrant < Formula
   def install
     system "./configure", "--prefix=#{libexec}"
     system "make"
-    system "make", "install"
+    system "make", "install", "PCDIR=#{lib}/pkgconfig"
     bin.write_exec_script Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION
The pkgconfig file was installed in libexec/lib/pkgconfig.
pkg-config doesn't look there, move the .pc file to lib/pkgconfig
instead.

Fixes #49569