### PR TITLE
daemon: deparallelize

### DIFF
--- a/Library/Formula/daemon.rb
+++ b/Library/Formula/daemon.rb
@@ -13,6 +13,9 @@ class Daemon < Formula
   end
 
   def install
+    # Parallel build failure reported to raf@raf.org 27th Feb 2016
+    ENV.deparallelize
+
     system "./config"
     system "make"
     system "make", "PREFIX=#{prefix}", "install"


### PR DESCRIPTION
Deparallelize the build to fix intermittent build failures such as

  libslack/locker.h:29:10: fatal error: 'slack/hdr.h' file not found
  libslack/prog.h:29:10: fatal error: 'slack/hdr.h' file not found
  daemon.c:656:10: fatal error: 'slack/std.h' file not found