### PR TITLE
dirac: use SourceForge for download urls

### DIFF
--- a/Library/Formula/dirac.rb
+++ b/Library/Formula/dirac.rb
@@ -1,7 +1,9 @@
 class Dirac < Formula
   desc "General-purpose video codec aimed at a range of resolutions"
   homepage "http://diracvideo.org/"
-  url "http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz"
+  url "https://downloads.sourceforge.net/project/dirac/dirac-codec/Dirac-1.0.2/dirac-1.0.2.tar.gz"
+  mirror "https://launchpad.net/ubuntu/+archive/primary/+files/dirac_1.0.2.orig.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dirac/dirac_1.0.2.orig.tar.gz"
   sha256 "816b16f18d235ff8ccd40d95fc5b4fad61ae47583e86607932929d70bf1f00fd"
 
   bottle do


### PR DESCRIPTION
- use their SourceForge project for the downloads plus some mirrors,
  since their website appears to be gone or at least down
- leaving the homepage as-is in case it comes back

```
$ wget http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz
--2016-02-27 03:53:43--  http://diracvideo.org/download/dirac-research/dirac-1.0.2.tar.gz
Resolving diracvideo.org... 65.23.158.84
Connecting to diracvideo.org|65.23.158.84|:80... failed: Connection refused.
```
So it may still be alive.