### PR TITLE
mozjpeg: Drop vendored nasm resource

### DIFF
--- a/Library/Formula/mozjpeg.rb
+++ b/Library/Formula/mozjpeg.rb
@@ -21,25 +21,12 @@ class Mozjpeg < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "nasm" => :build
   depends_on "libpng" => :optional
 
   keg_only "mozjpeg is not linked to prevent conflicts with the standard libjpeg."
 
-  # https://github.com/mozilla/mozjpeg/issues/175
-  # https://github.com/Homebrew/homebrew/issues/39939
-  resource "nasm" do
-    url "http://www.nasm.us/pub/nasm/releasebuilds/2.11.06/nasm-2.11.06.tar.xz"
-    sha256 "90f60d95a15b8a54bf34d87b9be53da89ee3d6213ea739fb2305846f4585868a"
-  end
-
   def install
-    resource("nasm").stage do
-      system "./configure", "--prefix=#{buildpath}/nasm"
-      system "make", "install"
-    end
-
-    ENV.prepend_path "PATH", buildpath/"nasm/bin"
-
     system "autoreconf", "-i" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
With the release of nasm 2.12 this workaround is no longer needed.

**Important:** PR #49616 (nasm 2.12) is a prerequisite for merging this.