### PR TITLE
cadubi: release download was moved to GitHub

### DIFF
--- a/Library/Formula/cadubi.rb
+++ b/Library/Formula/cadubi.rb
@@ -1,7 +1,7 @@
 class Cadubi < Formula
   desc "Creative ASCII drawing utility"
   homepage "http://langworth.com/pub/cadubi/"
-  url "http://langworth.com/pub/cadubi-1.3.tar.gz"
+  url "https://github.com/statico/cadubi/releases/download/v1.3/cadubi-1.3.tar.gz"
   sha256 "ca8b6ea305e0eccb11add7fc165beeee7ef33f9f0106e84efa1b364f082df0ab"
 
   bottle :unneeded


### PR DESCRIPTION
Release URL is now on GitHub. Checksum unchanged.