### PR TITLE
drip: depends on java

### DIFF
--- a/Library/Formula/drip.rb
+++ b/Library/Formula/drip.rb
@@ -4,6 +4,8 @@ class Drip < Formula
   url "https://github.com/flatland/drip/archive/0.2.4.tar.gz"
   sha256 "9ed25e29759a077d02ddac61785f33d1f2e015b74f1fd934890aba4a35b3551d"
 
+  depends_on :java => "1.5+"
+
   def install
     system "make"
     libexec.install %w[bin src Makefile]


### PR DESCRIPTION
This prevents the error "No Java runtime present, requesting install."