### PR TITLE
Clarify case conventions in formula naming

### DIFF
--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -272,7 +272,7 @@ When importing classes, Homebrew will require the formula and then create an ins
 *   `foo-bar.rb` => `FooBar`
 *   `foobar.rb` => `Foobar`
 
-Thus, if you change the name of the class, you must also rename the file. Filenames should be all lowercase.
+Thus, if you change the name of the class, you must also rename the file. Filenames should be all lowercase, and class names should be the strict CamelCase equivalent, e.g. formulae `gnu-go` and `sdl_mixer` become classes `GnuGo` and `SdlMixer`, even if part of their name is an acronym.
 
 Add aliases by creating symlinks in `Library/Aliases`.
 


### PR DESCRIPTION
If a formula's class name contains an uppercase-spelled acronym, the
messages given by `brew install` can be pretty confusing (it recommends
a formula named exactly the same…)