### PR TITLE
mutt: Use secure urls where available

### DIFF
--- a/Library/Formula/mutt.rb
+++ b/Library/Formula/mutt.rb
@@ -23,10 +23,10 @@ class Mutt < Formula
   end
 
   head do
-    url "http://dev.mutt.org/hg/mutt#default", :using => :hg
+    url "https://dev.mutt.org/hg/mutt#default", :using => :hg
 
     resource "html" do
-      url "http://dev.mutt.org/doc/manual.html", :using => :nounzip
+      url "https://dev.mutt.org/doc/manual.html", :using => :nounzip
     end
   end
 


### PR DESCRIPTION
Just moments ago, `dev.mutt.org` was made accessible by `https`.  (Saw the announcement on the mutt mailing list.)

The main homepage, however (`www.mutt.org`), is still `http`. 