### PR TITLE
translate-shell 0.9.3.1 (new formula)

### DIFF
--- a/Library/Formula/translate-shell.rb
+++ b/Library/Formula/translate-shell.rb
@@ -1,0 +1,29 @@
+class TranslateShell < Formula
+  desc "Command-line translator using Google Translate and more"
+  homepage "https://www.soimort.org/translate-shell"
+  url "https://github.com/soimort/translate-shell/archive/v0.9.3.1.tar.gz"
+  sha256 "7b5a2404ead919570cfa4d741c521ed7e124bbf27d6f5de1a6a598e7e713c2a6"
+  head "https://github.com/soimort/translate-shell.git", :branch => "develop"
+
+  depends_on "fribidi"
+  depends_on "gawk"
+  depends_on "rlwrap"
+
+  def install
+    system "make"
+    bin.install "build/trans"
+    man1.install "man/trans.1"
+  end
+
+  def caveats; <<-EOS.undent
+    By default, text-to-speech functionality is provided by OS X's builtin
+    `say' command. This functionality may be improved in certain cases by
+    installing one of mplayer, mpv, or mpg123, all of which are available
+    through `brew install'.
+    EOS
+  end
+
+  test do
+    assert_equal "Hello\n", shell_output("#{bin}/trans -b -s fr -t en bonjour")
+  end
+end


### PR DESCRIPTION
Command-line translator using Google Translate, Bing Translator, Yandex.Translate, etc.

- https://github.com/soimort/translate-shell
- https://www.soimort.org/translate-shell

I'm not sure if listing four optional dependencies — any of which enables Text-to-Speech functionality (which is optional to begin with) and none of which is required at build time — is the best idea. Please advise if you see a better approach.

---

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
