### PR TITLE
libxslt: add .git suffix to git url

### DIFF
--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -18,7 +18,7 @@ class Libxslt < Formula
   depends_on "libxml2"
 
   head do
-    url "https://git.gnome.org/browse/libxslt"
+    url "https://git.gnome.org/browse/libxslt.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
To make sure it's recognised as a Git URL.