### PR TITLE
ksh: functioning download urls

### DIFF
--- a/Library/Formula/ksh.rb
+++ b/Library/Formula/ksh.rb
@@ -2,10 +2,11 @@
 class Ksh < Formula
   desc "ksh93, the KornShell"
   homepage "http://www.kornshell.com"
-  url "http://www2.research.att.com/~astopen/download/tgz/ast-ksh.2012-08-01.tgz",
-    :using => :nounzip, :user => "I accept www.opensource.org/licenses/eclipse:."
-  sha256 "e6192cfa52a6a9fd20618cbaf3fa81f0cc9fd83525500757e83017275e962851"
+  url "https://opensource.apple.com/source/ksh/ksh-23/ast-ksh.2012-08-01.tgz",
+    :using => :nounzip
+  mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/ast-ksh.2012-08-01.tgz"
   version "93u+" # Versioning scheme: + means "+ patches", - means "beta/alpha".
+  sha256 "e6192cfa52a6a9fd20618cbaf3fa81f0cc9fd83525500757e83017275e962851"
 
   bottle do
     cellar :any
@@ -16,15 +17,14 @@ class Ksh < Formula
   end
 
   resource "init" do
-    url "http://www2.research.att.com/~astopen/download/tgz/INIT.2012-08-01.tgz",
-      :using => :nounzip, :user => "I accept www.opensource.org/licenses/eclipse:."
+    url "https://opensource.apple.com/source/ksh/ksh-23/INIT.2012-08-01.tgz"
+    mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/INIT.2012-08-01.tgz"
     sha256 "c40cf57e9b2186271a9c362a560aa4a6e25ba911a8258ab931d2bbdbce44cfe5"
   end
 
   def install
-    (buildpath/"lib/package/tgz").install resource("init"), Dir["*.tgz"]
-
-    system "tar", "xzf", "lib/package/tgz/INIT.2012-08-01.tgz"
+    resource("init").stage buildpath
+    (buildpath/"lib/package/tgz").install Dir["*.tgz"]
     system "/bin/ksh", "bin/package", "read"
 
     # Needed due to unusal build system.


### PR DESCRIPTION
Use alternate urls until the canonical url at AT&T comes back.

Apparently, the main url has been down since at 19th Jan 2016: https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=ksh&id=34f5b91260f859104bedd67cdbcd7e7f8cf18b88

Reported to admin at kornshell.com