### PR TITLE
appscale-tools: Add ssh-copy-id dependency

### DIFF
--- a/Library/Formula/appscale-tools.rb
+++ b/Library/Formula/appscale-tools.rb
@@ -14,6 +14,7 @@ class AppscaleTools < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "libyaml"
+  depends_on "ssh-copy-id"
 
   resource "termcolor" do
     url "https://pypi.python.org/packages/source/t/termcolor/termcolor-1.1.0.tar.gz"


### PR DESCRIPTION
appscale-tools runs `ssh-copy-id` during an `appscale up`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

