### PR TITLE
Updated TBB to 4.4-2016-01-28 release

### DIFF
--- a/Library/Formula/tbb.rb
+++ b/Library/Formula/tbb.rb
@@ -1,9 +1,9 @@
 class Tbb < Formula
   desc "Rich and complete approach to parallelism in C++"
   homepage "https://www.threadingbuildingblocks.org/"
-  url "https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20151115oss_src.tgz"
-  sha256 "3dd5c4fc85c18f49307d3cde4ce937bda230679f7fe2906112e5c8dee4cc77bb"
-  version "4.4-20151115"
+  url "https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb44_20160128oss_src_0.tgz"
+  sha256 "8d256bf13aef1b0726483af9f955918f04e3de4ebbf6908aa1b0c94cbe784ad7"
+  version "4.4-20160128"
 
   bottle do
     cellar :any


### PR DESCRIPTION
TBB installation fails due to the outdated download link and breaks CI as seen in this [example](https://travis-ci.org/nyanp/tiny-cnn/jobs/112634242).

I don't run homebrew so this PR is totally untested, but it's also just a link/hash replacement.