### PR TITLE
libspatialite: upstream patch for >=sqlite 3.10

### DIFF
--- a/Library/Formula/libspatialite.rb
+++ b/Library/Formula/libspatialite.rb
@@ -1,9 +1,18 @@
 class Libspatialite < Formula
   desc "Adds spatial SQL capabilities to SQLite"
   homepage "https://www.gaia-gis.it/fossil/libspatialite/index"
-  url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
-  sha256 "88900030a4762904a7880273f292e5e8ca6b15b7c6c3fb88ffa9e67ee8a5a499"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
+    mirror "https://ftp.netbsd.org/pub/pkgsrc/distfiles/libspatialite-4.3.0a.tar.gz"
+    mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/libspatialite-4.3.0a.tar.gz"
+    sha256 "88900030a4762904a7880273f292e5e8ca6b15b7c6c3fb88ffa9e67ee8a5a499"
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/27a0e51936e01829d0a6f3c75a7fbcaf92bb133f/libspatialite/sqlite310.patch"
+      sha256 "459434f5e6658d6f63d403a7795aa5b198b87fc9f55944c714180e7de662fce2"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
Upstream patch comment: "supporting LIKE in VirtualTables according to
changes introduced since sqlite-3.10"

Without this patch, `make check` fails in "check_virtualtable2" and
"check_virtualtable3," which prevents installation unless the option
`--without-test` is passed.

This was fixed in upstream HEAD on 24th Jan 2016:
https://www.gaia-gis.it/fossil/libspatialite/info/bf5bd8b1ba
https://www.gaia-gis.it/fossil/libspatialite/vpatch?from=aa408ed10d384f46&to=bf5bd8b1ba3981f0