### PR TITLE
groonga 6.0.0

### DIFF
--- a/Library/Formula/groonga.rb
+++ b/Library/Formula/groonga.rb
@@ -1,8 +1,8 @@
 class Groonga < Formula
   desc "Fulltext search engine and column store"
   homepage "http://groonga.org/"
-  url "http://packages.groonga.org/source/groonga/groonga-5.1.2.tar.gz"
-  sha256 "f39553c799e05b2926f4a38eaa183347c6d27fb1c55577eed555a4dc4cd9a9c4"
+  url "http://packages.groonga.org/source/groonga/groonga-6.0.0.tar.gz"
+  sha256 "a14c93240dcf749eb583087988703b72dada4a06ab3f6f2e985a3fe3828b4f6c"
 
   bottle do
     sha256 "2666fd66030fd63670bae4f38e69ac0c12ec6bcbd1427ff6601aa3b467198b31" => :el_capitan
@@ -49,6 +49,7 @@ class Groonga < Formula
     args = %W[
       --prefix=#{prefix}
       --with-zlib
+      --with-ssl
       --enable-mruby
       --without-libstemmer
     ]


### PR DESCRIPTION
* Force to enable groonga-https ssl feature by default.