### PR TITLE
dropbox_uploader 0.16 (new formula)

### DIFF
--- a/Library/Formula/dropbox-uploader.rb
+++ b/Library/Formula/dropbox-uploader.rb
@@ -4,13 +4,12 @@ class DropboxUploader < Formula
   url "https://github.com/andreafabrizi/Dropbox-Uploader/archive/0.16.tar.gz"
   sha256 "738aebdb57f75e9033cb9bb319b14fe1c3b471f951180acb48631e9810ebf1c3"
 
-  depends_on "curl"
-
   def install
     bin.install "dropbox_uploader.sh"
   end
 
   test do
-    system "true"
+    (testpath/".dropbox_uploader").write("APPKEY=a\nAPPSECRET=b\nACCESS_LEVEL=sandbox\nOAUTH_ACCESS_TOKEN=c\nOAUTH_ACCESS_TOKEN_SECRET=d")
+    system("yes | dropbox_uploader.sh unlink")
   end
 end

--- a/Library/Formula/dropbox-uploader.rb
+++ b/Library/Formula/dropbox-uploader.rb
@@ -1,0 +1,16 @@
+class DropboxUploader < Formula
+  desc "Bash script for interacting with Dropbox"
+  homepage "http://www.andreafabrizi.it/?dropbox_uploader"
+  url "https://github.com/andreafabrizi/Dropbox-Uploader/archive/0.16.tar.gz"
+  sha256 "738aebdb57f75e9033cb9bb319b14fe1c3b471f951180acb48631e9810ebf1c3"
+
+  depends_on "curl"
+
+  def install
+    bin.install "dropbox_uploader.sh"
+  end
+
+  test do
+    system "true"
+  end
+end

--- a/Library/Formula/dropbox-uploader.rb
+++ b/Library/Formula/dropbox-uploader.rb
@@ -9,7 +9,13 @@ class DropboxUploader < Formula
   end
 
   test do
-    (testpath/".dropbox_uploader").write("APPKEY=a\nAPPSECRET=b\nACCESS_LEVEL=sandbox\nOAUTH_ACCESS_TOKEN=c\nOAUTH_ACCESS_TOKEN_SECRET=d")
-    system("yes | dropbox_uploader.sh unlink")
+    (testpath/".dropbox_uploader").write <<-EOS.undent
+      APPKEY=a
+      APPSECRET=b
+      ACCESS_LEVEL=sandbox
+      OAUTH_ACCESS_TOKEN=c
+      OAUTH_ACCESS_TOKEN_SECRET=d
+    EOS
+    pipe_output("#{bin}/dropbox_uploader.sh unlink", "y\n")
   end
 end


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

dropbox_uploader is a bash script for interacting with Dropbox.
the `test do` portion is just `true` because the script requires API keys from dropbox (obtainable by user) for first run, which is interative