### PR TITLE
removed java dependency for open-mpi

### DIFF
--- a/Library/Formula/open-mpi.rb
+++ b/Library/Formula/open-mpi.rb
@@ -26,7 +26,6 @@ class OpenMpi < Formula
   conflicts_with "mpich", :because => "both install mpi__ compiler wrappers"
   conflicts_with "lcdf-typetools", :because => "both install same set of binaries."
 
-  depends_on :java => :build
   depends_on :fortran => :recommended
   depends_on "libevent"
 


### PR DESCRIPTION
open-mpi does not actually require java on os x.  Java requirement removed as per #49698.