### PR TITLE
Allow S3 buckets to have dots in bucket name

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -451,7 +451,7 @@ class S3DownloadStrategy < CurlDownloadStrategy
       raise
     end
 
-    if @url !~ %r{^https?://+([^.]+).s3.amazonaws.com/+(.+)$}
+    if @url !~ %r{^https?://+([^.].+).s3.amazonaws.com/+(.+)$}
       raise "Bad S3 URL: " + @url
     end
     bucket = $1


### PR DESCRIPTION
I was setting up an internal brew tap for our internal tools on Amazon S3 when I noticed an issue with the URL validation with the S3DownloadStrategy. The regular expression correctly checks to ensure the bucket name does not begin with a period, but it's written such that it doesn't allow a period in the bucket name at all. 

For example:
https://company-binaries.s3.amazonaws.com/homebrew/amazingtool.tar.gz <-- Works perfectly fine
https://binaries.company.com.s3.amazonaws.com/homebrew/amazingtool.tar.gz <-- Does not work

This PR changes the regular expression such that periods are allowed after the first character of a bucket name. This is necessary to create bucket names that follow DNS conventions (which will be a requirement in US Standard soon-ish according to [their best practices.](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html)

Thanks and have a wonderful day!