### PR TITLE
testssl: add HEAD option & pass strict online audit

### DIFF
--- a/Library/Formula/testssl.rb
+++ b/Library/Formula/testssl.rb
@@ -4,12 +4,14 @@ class Testssl < Formula
   url "https://github.com/drwetter/testssl.sh/archive/v2.6.tar.gz"
   sha256 "286b3285f096a5d249de1507eee88b14848514696bc5bbc4faceffa46b563ebd"
 
+  head "https://github.com/drwetter/testssl.sh.git"
+
   bottle :unneeded
 
   depends_on "openssl"
 
   def install
-    ENV.prepend_create_path "PATH", "#{Formula["openssl"].opt_prefix}"
+    ENV.prepend_create_path "PATH", Formula["openssl"].opt_prefix.to_s
     bin.install "testssl.sh"
     bin.env_script_all_files(libexec+"bin", :PATH => ENV["PATH"])
   end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

NB patch for HEAD submitted upstream but they seem to be a bit behind. HEAD is super useful atm with DROWN detection.