### PR TITLE
brew pull command can fail with encoding error

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -322,7 +322,7 @@ module Homebrew
     versions = {}
     json = Utils.popen_read(HOMEBREW_BREW_FILE, "info", "--json=v1", formula_name)
     if $?.success?
-      info = Utils::JSON.load(json)
+      info = Utils::JSON.load(json.encode(Encoding::UTF_8, undef: :replace))
       [:stable, :devel, :head].each do |vertype|
         versions[vertype] = info[0]["versions"][vertype.to_s]
       end


### PR DESCRIPTION
### All Submissions:

- [ yes ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [ yes ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [ Yes ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ N/A ] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [ N/A ] Have you successfully ran `brew tests` with your changes locally?

This change is needed to force the encoding of `brew info --json=v1` to be detected as UTF8. Running `brew info --json=v1 php70` for instance on https://github.com/Homebrew/homebrew-php/pull/2924 causes brew to error out as described in issue #49757.

Fixes #49757