### PR TITLE
aws-keychain 3.0 (new formula)

### DIFF
--- a/Library/Formula/aws-keychain.rb
+++ b/Library/Formula/aws-keychain.rb
@@ -10,6 +10,6 @@ class AwsKeychain < Formula
 
   test do
     # It is not possible to create a new keychain without triggering a prompt.
-    shell_output("#{bin}/aws-keychain --help", 1)
+    assert_match /Store multiple AWS IAM access keys/, shell_output("#{bin}/aws-keychain --help", 1).strip
   end
 end

--- a/Library/Formula/aws-keychain.rb
+++ b/Library/Formula/aws-keychain.rb
@@ -9,9 +9,7 @@ class AwsKeychain < Formula
   end
 
   test do
-    # aws-keychain is a simple shell script wrapper around built-in
-    # keychain utilities. It is not possible to create a new
-    # keychain without triggering a keychain prompt.
-    shell_output("aws-keychain --help", 1)
+    # It is not possible to create a new keychain without triggering a prompt.
+    shell_output("#{bin}/aws-keychain --help", 1)
   end
 end

--- a/Library/Formula/aws-keychain.rb
+++ b/Library/Formula/aws-keychain.rb
@@ -1,0 +1,17 @@
+class AwsKeychain < Formula
+  desc "Uses OS X keychain for storage of AWS credentials."
+  homepage "https://github.com/pda/aws-keychain"
+  url "https://github.com/pda/aws-keychain/archive/v3.0.0.tar.gz"
+  sha256 "3c9882d3b516b629303ca9a045fc50f6eb75fda25cd2452f10c47eda205e051f"
+
+  def install
+    bin.install "aws-keychain"
+  end
+
+  test do
+    # aws-keychain is a simple shell script wrapper around built-in
+    # keychain utilities. It is not possible to create a new
+    # keychain without triggering a keychain prompt.
+    system "aws-keychain --help || true"
+  end
+end

--- a/Library/Formula/aws-keychain.rb
+++ b/Library/Formula/aws-keychain.rb
@@ -12,6 +12,6 @@ class AwsKeychain < Formula
     # aws-keychain is a simple shell script wrapper around built-in
     # keychain utilities. It is not possible to create a new
     # keychain without triggering a keychain prompt.
-    system "aws-keychain --help || true"
+    shell_output("aws-keychain --help", 1)
   end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

The aim of aws-keychain is to run commands that require AWS credentials
without ever storing those credentials unencrypted on disk. Mac OS X's
keychain is used for storage, and credentials are passed to commands via
the well known environment variables that all tools look for.