### PR TITLE
capstone: Fix GNU/Linux install

### DIFF
--- a/Library/Formula/capstone.rb
+++ b/Library/Formula/capstone.rb
@@ -20,7 +20,8 @@ class Capstone < Formula
 
     ENV["HOMEBREW_CAPSTONE"] = "1"
     system "./make.sh"
-    system "./make.sh", "install"
+    system "./make.sh", "install" if OS.mac?
+    system "make", "install", "PREFIX=#{prefix}" if OS.linux?
 
     # As per the above inreplace, the pkgconfig file needs fixing as well.
     inreplace lib/"pkgconfig/capstone.pc" do |s|


### PR DESCRIPTION
On GNU/Linux the install function in make.sh will attempt to install capstone into /usr but by calling make with an explicit PREFIX it will be installed into the Cellar.