### PR TITLE
Update v8 to v4.9.385.28

### DIFF
--- a/Library/Formula/gjstest.rb
+++ b/Library/Formula/gjstest.rb
@@ -3,7 +3,7 @@ class Gjstest < Formula
   homepage "https://github.com/google/gjstest"
   url "https://github.com/google/gjstest/archive/v1.0.2.tar.gz"
   sha256 "7bf0de1c4b880b771a733c9a5ce07c71b93f073e6acda09bec7e400c91c2057c"
-  revision 1
+  revision 2
 
   head "https://github.com/google/gjstest.git"
 

--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -42,6 +42,11 @@ class V8 < Formula
         :revision => "14288a03a92856fe1fc296d39e6a25c2d83cd6cf"
   end
 
+  resource "common" do
+    url "https://chromium.googlesource.com/chromium/src/base/trace_event/common.git",
+        :revision => "e40c41030f44cbd5b6f54081436620f43c3bb08a"
+  end
+
   resource "swarming_client" do
     url "https://chromium.googlesource.com/external/swarming.client.git",
         :revision => "df6e95e7669883c8fe9ef956c69a544154701a49"
@@ -86,6 +91,7 @@ class V8 < Formula
     (buildpath/"build/gyp").install resource("gyp")
     (buildpath/"third_party/icu").install resource("icu")
     (buildpath/"buildtools").install resource("buildtools")
+    (buildpath/"base/trace_event/common").install resource("common")
     (buildpath/"tools/swarming_client").install resource("swarming_client")
     (buildpath/"testing/gtest").install resource("gtest")
     (buildpath/"testing/gmock").install resource("gmock")

--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -29,22 +29,22 @@ class V8 < Formula
   # Note that we don't require the "test" DEPS because we don't run the tests.
   resource "gyp" do
     url "https://chromium.googlesource.com/external/gyp.git",
-        :revision => "2c1e6cced23554ce84806e570acea637f6473afc"
+        :revision => "ed163ce233f76a950dce1751ac851dbe4b1c00cc"
   end
 
   resource "icu" do
     url "https://chromium.googlesource.com/chromium/deps/icu.git",
-        :revision => "42c58d4e49f2250039f0e98d43e0b76e8f5ca024"
+        :revision => "e466f6ac8f60bb9697af4a91c6911c6fc4aec95f"
   end
 
   resource "buildtools" do
     url "https://chromium.googlesource.com/chromium/buildtools.git",
-        :revision => "4a95614772d9bcbd8bc197e1d9bd034e088fc740"
+        :revision => "14288a03a92856fe1fc296d39e6a25c2d83cd6cf"
   end
 
   resource "swarming_client" do
     url "https://chromium.googlesource.com/external/swarming.client.git",
-        :revision => "8fce79620b04bbe5415ace1103db27505bdc4c06"
+        :revision => "df6e95e7669883c8fe9ef956c69a544154701a49"
   end
 
   resource "gtest" do
@@ -59,7 +59,7 @@ class V8 < Formula
 
   resource "clang" do
     url "https://chromium.googlesource.com/chromium/src/tools/clang.git",
-        :revision => "66f5328417331216569e8beb244fd887f62e8997"
+        :revision => "3183208ae119c48012bed71645cb2ca537120811"
   end
 
   def install

--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -29,27 +29,27 @@ class V8 < Formula
   # Note that we don't require the "test" DEPS because we don't run the tests.
   resource "gyp" do
     url "https://chromium.googlesource.com/external/gyp.git",
-        :revision => "ed163ce233f76a950dce1751ac851dbe4b1c00cc"
+        :revision => "b85ad3e578da830377dbc1843aa4fbc5af17a192"
   end
 
   resource "icu" do
     url "https://chromium.googlesource.com/chromium/deps/icu.git",
-        :revision => "e466f6ac8f60bb9697af4a91c6911c6fc4aec95f"
+        :revision => "8d342a405be5ae8aacb1e16f0bc31c3a4fbf26a2"
   end
 
   resource "buildtools" do
     url "https://chromium.googlesource.com/chromium/buildtools.git",
-        :revision => "14288a03a92856fe1fc296d39e6a25c2d83cd6cf"
+        :revision => "0f8e6e4b126ee88137930a0ae4776c4741808740"
   end
 
   resource "common" do
     url "https://chromium.googlesource.com/chromium/src/base/trace_event/common.git",
-        :revision => "e40c41030f44cbd5b6f54081436620f43c3bb08a"
+        :revision => "d83d44b13d07c2fd0a40101a7deef9b93b841732"
   end
 
   resource "swarming_client" do
     url "https://chromium.googlesource.com/external/swarming.client.git",
-        :revision => "df6e95e7669883c8fe9ef956c69a544154701a49"
+        :revision => "9cdd76171e517a430a72dcd7d66ade67e109aa00"
   end
 
   resource "gtest" do
@@ -64,7 +64,7 @@ class V8 < Formula
 
   resource "clang" do
     url "https://chromium.googlesource.com/chromium/src/tools/clang.git",
-        :revision => "3183208ae119c48012bed71645cb2ca537120811"
+        :revision => "24e8c1c92fe54ef8ed7651b5850c056983354a4a"
   end
 
   def install

--- a/Library/Formula/v8.rb
+++ b/Library/Formula/v8.rb
@@ -3,8 +3,8 @@
 class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://code.google.com/p/v8/"
-  url "https://github.com/v8/v8-git-mirror/archive/4.8.271.20.tar.gz"
-  sha256 "1cc1b3c48dfaed61440181ddaf047cc67df9a36afb79f5fc1455fe5ac656977c"
+  url "https://github.com/v8/v8-git-mirror/archive/4.9.385.28.tar.gz"
+  sha256 "c77c5f9d5b6c77186485a99da459c604738d1d2d299c8224a4781cbe8227a8b9"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Tracking Chrome Stable v49.0.2623.75

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?