### PR TITLE
influxdb: fix add binary influx_tsm that is part of 0.10

### DIFF
--- a/Library/Formula/influxdb.rb
+++ b/Library/Formula/influxdb.rb
@@ -157,6 +157,7 @@ class Influxdb < Formula
 
     bin.install "bin/influxd"
     bin.install "bin/influx"
+    bin.install "bin/influx_tsm"
     etc.install influxdb_path/"etc/config.sample.toml" => "influxdb.conf"
 
     (var/"influxdb/data").mkpath


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Influxdb 0.10 got a new database engine and the tool to convert
databases from older engines to newer. This tool was not installed
by Homebrew.