### PR TITLE
openssl: 1.0.2g regression fix for Snow Leopard

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -22,6 +22,19 @@ class Openssl < Formula
 
   depends_on "makedepend" => :build
 
+  # Replace with upstream url if they merge the more robust fix
+  # https://github.com/openssl/openssl/pull/597
+  if MacOS.version <= :snow_leopard
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/3f1dc8ea145a70543aded8101a0c725abf82fc45/openssl/tshort-asm.patch"
+      sha256 "f161e2fc1395efcb53d785004d67d4962d28aa8ce282a91020f12809c03b2afd"
+    end
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/3f1dc8ea145a70543aded8101a0c725abf82fc45/openssl/revert-pass-pure-constants-verbatim.patch"
+      sha256 "e38f84181a56e70028ade8408ad70aaffaea386b7e1b35de55728ae878d544aa"
+    end
+  end
+
   def arch_args
     {
       :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],


### PR DESCRIPTION
openssl: 1.0.2g regression fix for Snow Leopard

Fixes build errors on Snow Leopard that look like this:

  sha1-x86_64.s:1243:missing or invalid immediate expression `0b00011011' taken as 0
  sha1-x86_64.s:1243:suffix or operands invalid for `pshufd'

This replicates Clemens Lang's work for MacPorts:
https://github.com/ryandesign/macports-ports/commit/5522f4c5b202436d6f9787cce417b1c5619cea1b

Quoting him,
  Reverts openssl's upstream commit
    openssl/openssl@fd7dc20
  and applies an alternative suggested in a pull request at
    openssl/openssl#597
  that would merge
    akamai/openssl@c4af68c

Homebrew/patches#11
Closes #49814
Closes #49827

