### PR TITLE
transmission 2.92

### DIFF
--- a/Library/Formula/transmission.rb
+++ b/Library/Formula/transmission.rb
@@ -1,8 +1,8 @@
 class Transmission < Formula
   desc "Lightweight BitTorrent client"
   homepage "http://www.transmissionbt.com/"
-  url "https://transmission.cachefly.net/transmission-2.90.tar.xz"
-  sha256 "69ff8caf81684155926f437f46bf7df1b1fb304f52c7809f546257e8923f2fd2"
+  url "https://download.transmissionbt.com/files/transmission-2.92.tar.xz"
+  sha256 "3a8d045c306ad9acb7bf81126939b9594553a388482efa0ec1bfb67b22acd35f"
 
   bottle do
     sha256 "851b3c1e6428ffb1faf9a27254583fd74d0c562a3a4f28526fd0c87acc2cbb04" => :el_capitan


### PR DESCRIPTION
Outdates #49828.

2.92 is only two commits (one of them being a version bump) different from 2.91: https://github.com/transmission/transmission/compare/4371c6e765a9...67ef7b888c37 and doesn't affect the CLI part — it only attempts to remove the ransomware bundled in infested 2.90 OS X binary installers.

Maybe I should comment on #49828 instead... But occasionally people aren't responsive enough, so I'm taking matters into my own hands.