### PR TITLE
gnome-builder: fix build on case-sensitive volumes

### DIFF
--- a/Library/Formula/gnome-builder.rb
+++ b/Library/Formula/gnome-builder.rb
@@ -31,6 +31,14 @@ class GnomeBuilder < Formula
 
   def install
     ENV.cxx11
+
+    # Fix build failure on case-sensitive volumes for libgit2-glib without vala.
+    # Reported 7th Mar 2016 to https://bugzilla.gnome.org/show_bug.cgi?id=763208
+    unless File.exist?(Formula["libgit2-glib"].share/"vala/vapi/ggit-1.0.vapi")
+      inreplace Dir["libide/{Makefile.am,Makefile.in,libide-1.0.deps}"],
+        "ggit-1.0", "Ggit-1.0"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
libgit2-glib will contain both ggit-1.0 (share/vala/vapi/ggit-1.0.vapi)
and Ggit-1.0 (share/gir-1.0/Ggit-1.0.gir) when built with vala, but will
only contain Ggit-1.0 when built without vala. On a case-insensitive
volume, the build will succeed regardless of whether libgit2-glib was
built with or without vala, since it will fall back to using Ggit-1.0
when ggit-1.0 isn't available. However, on a case-sensitive volume, the
build will fail because it doesn't find Ggit-1.0 when searching for
ggit-1.0. We can work around the issue by replacing "ggit-1.0" with
"Ggit-1.0" in libide/Makefile.am, libide/Makefile.in, and
libide/libide-1.0.deps whenever libgit2-glib is detected to have been
built without vala.

https://bugzilla.gnome.org/show_bug.cgi?id=763208
Closes #49824