### PR TITLE
Squid: enables all modules for disk-io, storeio, removal-policies, and delay-pools

### DIFF
--- a/Library/Formula/squid.rb
+++ b/Library/Formula/squid.rb
@@ -30,6 +30,10 @@ class Squid < Formula
       --enable-pf-transparent
       --with-included-ltdl
       --with-openssl
+      --enable-delay-pools
+      --enable-disk-io=yes
+      --enable-removal-policies=yes
+      --enable-storeio=yes
     ]
 
     system "./configure", *args


### PR DESCRIPTION
To run squid proxy for any reasonable number of clients, most of these options need to be tweaked. It would be convenient if the support for these options were available by default (so users, including myself, don't have to edit the formula manually every time there is an update).