### PR TITLE
deparallelize perl for 10.6

### DIFF
--- a/Library/Formula/pod2man.rb
+++ b/Library/Formula/pod2man.rb
@@ -14,6 +14,7 @@ class Pod2man < Formula
   keg_only :provided_by_osx
 
   def install
+    ENV.deparalellize if MacOS.version <= :snow_leopard
     system "perl", "Makefile.PL", "PREFIX=#{prefix}",
                    "INSTALLSCRIPT=#{bin}",
                    "INSTALLMAN1DIR=#{man1}", "INSTALLMAN3DIR=#{man3}"


### PR DESCRIPTION
Otherwise nondeterministic makefile generation (sometimes)
prevents pod2man from installing correctly.