### PR TITLE
pod2man: separate make and make install

### DIFF
--- a/Library/Formula/pod2man.rb
+++ b/Library/Formula/pod2man.rb
@@ -17,6 +17,7 @@ class Pod2man < Formula
     system "perl", "Makefile.PL", "PREFIX=#{prefix}",
                    "INSTALLSCRIPT=#{bin}",
                    "INSTALLMAN1DIR=#{man1}", "INSTALLMAN3DIR=#{man3}"
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
Otherwise parallelized make install
nondeterministically (sometimes) prevents pod2man
from installing correctly.