### PR TITLE
halibut: deparallelize the build

### DIFF
--- a/Library/Formula/halibut.rb
+++ b/Library/Formula/halibut.rb
@@ -15,6 +15,9 @@ class Halibut < Formula
   end
 
   def install
+    # Reported to Simon Tatham (anakin@pobox.com) on 8th Mar 2016.
+    ENV.deparallelize
+
     bin.mkpath
     man1.mkpath
 


### PR DESCRIPTION
The parallelized build failure looks like this:
```
clang -g -Wall -W -ansi -pedantic -I../charset/ -I./ -MD -c -o cs-utf16.o ../charset/utf16.c
clang -g -Wall -W -ansi -pedantic -I../charset/ -I./ -MD -c -o cs-utf7.o ../charset/utf7.c
clang -g -Wall -W -ansi -pedantic -I../charset/ -I./ -MD -c -o cs-utf8.o ../charset/utf8.c
clang -g -Wall -W -ansi -pedantic -I../charset/ -I./ -MD -c -o cs-xenc.o ../charset/xenc.c
In file included from ../charset/slookup.c:9:
In file included from ../charset/enum.c:17:
./sbcsdat.c:8:2: error: unterminated conditional directive
#ifndef ENUM_CHARSETS
 ^
In file included from ../charset/slookup.c:15:
In file included from ../charset/enum.c:17:
./sbcsdat.c:8:2: error: unterminated conditional directive
#ifndef ENUM_CHARSETS
 ^
2 errors generated.
make[1]: *** [cs-slookup.o] Error 1
make[1]: *** Waiting for unfinished jobs....
sbcsdat.c:8:2: error: unterminated conditional directive
#ifndef ENUM_CHARSETS
 ^
sbcsdat.c:2298:14: error: expected '}'
    0x00f8, 0
             ^
sbcsdat.c:2274:5: note: to match this '{'
    {
    ^
sbcsdat.c:2298:14: error: expected '}'
    0x00f8, 0
             ^
sbcsdat.c:2273:38: note: to match this '{'
const sbcs_data sbcsdata_CS_CP1257 = {
                                     ^
sbcsdat.c:2298:14: error: expected ';' after top level declarator
    0x00f8, 0
             ^
             ;
4 errors generated.
make[1]: *** [cs-sbcsdat.o] Error 1
make: *** [all] Error 2
```