### PR TITLE
add ZFS support to rssh

### DIFF
--- a/Library/Formula/rssh.rb
+++ b/Library/Formula/rssh.rb
@@ -4,6 +4,8 @@ class Rssh < Formula
   url "https://downloads.sourceforge.net/project/rssh/rssh/2.3.4/rssh-2.3.4.tar.gz"
   sha256 "f30c6a760918a0ed39cf9e49a49a76cb309d7ef1c25a66e77a41e2b1d0b40cd9"
 
+  option "with-zfs", "Build with ZFS support"
+
   # Submitted upstream:
   # http://sourceforge.net/p/rssh/mailman/message/32251335/
   patch do
@@ -11,18 +13,29 @@ class Rssh < Formula
     sha256 "abd625a8dc24f3089b177fd0318ffc1cf4fcb08d0c149191bb45943ad55f6934"
   end
 
-  patch do
-    url "https://gist.github.com/kaazoo/1358e893033f536802f9/raw/e2bec9c1608ba18977bbea82a1ef8329dc55904d/rssh-2.3.4_zfs_support.patch"
-    sha256 "ea843389e402d79e2d62fb37da2c3bc3d16ead0cd84bc28824e2133635159603"
+  # Submitted upstream:
+  # https://sourceforge.net/p/rssh/mailman/message/34917198/
+  if build.with? "zfs"
+    patch do
+      url "https://gist.github.com/kaazoo/1358e893033f536802f9/raw/e2bec9c1608ba18977bbea82a1ef8329dc55904d/rssh-2.3.4_zfs_support.patch"
+      sha256 "ea843389e402d79e2d62fb37da2c3bc3d16ead0cd84bc28824e2133635159603"
+    end
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          # ZFS from https://openzfsonosx.org/ provides /usr/local/bin/zfs
-                          "--with-zfs=/usr/local/bin/zfs"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --mandir=#{man}
+    ]
+    if build.with? "zfs"
+      # ZFS from https://openzfsonosx.org/ provides /usr/local/bin/zfs
+      args << "--with-zfs=/usr/local/bin/zfs"
+    end
+
+    system "./configure", *args
+
     system "make"
     system "make", "install"
   end

--- a/Library/Formula/rssh.rb
+++ b/Library/Formula/rssh.rb
@@ -11,11 +11,18 @@ class Rssh < Formula
     sha256 "abd625a8dc24f3089b177fd0318ffc1cf4fcb08d0c149191bb45943ad55f6934"
   end
 
+  patch do
+    url "https://gist.github.com/kaazoo/1358e893033f536802f9/raw/e2bec9c1608ba18977bbea82a1ef8329dc55904d/rssh-2.3.4_zfs_support.patch"
+    sha256 "ea843389e402d79e2d62fb37da2c3bc3d16ead0cd84bc28824e2133635159603"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+                          "--mandir=#{man}",
+                          # ZFS from https://openzfsonosx.org/ provides /usr/local/bin/zfs
+                          "--with-zfs=/usr/local/bin/zfs"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Adds ZFS support to rssh. Useful for ZFS send / receive of snapshots via SSH, without the security problem of creating an interactive SSH login shell.

