### PR TITLE
hyperscan: leave -march=native to the build system

### DIFF
--- a/Library/Formula/hyperscan.rb
+++ b/Library/Formula/hyperscan.rb
@@ -17,6 +17,10 @@ class Hyperscan < Formula
   depends_on "cmake" => :build
 
   def install
+    # -march=native is actually the build system's default, but setting it
+    # directly in HOMEBREW_OPTFLAGS can cause build failure.
+    ENV.delete("HOMEBREW_OPTFLAGS") if ENV["HOMEBREW_OPTFLAGS"] == "-march=native"
+
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"


### PR DESCRIPTION
The default is -march=native but explicitly setting it can cause build failure. In particular, --build-from-source fails on iMac with :skylake.

Here's are the gist-logs showing the failure case:
https://gist.github.com/5357e306bfcc0e702730

And here's how a successful build looks with this PR in place:
https://gist.github.com/ilovezfs/1d0f2aa32c7bfff0d971

Note that -march=native is indeed used as part of the default when HOMEBREW_OPTFLAGS is deleted.