### PR TITLE
Core/Formula Separation Step 1

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -904,8 +904,8 @@ class FormulaAuditor
 
     if formula.tap.tap_migrations.key?(formula.name)
       problem <<-EOS.undent
-       #{formula.name} seems to be listed in tap_migrations.rb!
-       Please remove #{formula.name} from present tap & tap_migrations.rb
+       #{formula.name} seems to be listed in tap_migrations.json!
+       Please remove #{formula.name} from present tap & tap_migrations.json
        before submitting it to Homebrew/homebrew.
       EOS
     end

--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -1,6 +1,7 @@
 require "hardware"
 require "software_spec"
 require "rexml/document"
+require "tap"
 
 module Homebrew
   def config
@@ -55,6 +56,18 @@ module Homebrew
 
   def origin
     Homebrew.git_origin || "(none)"
+  end
+
+  def core_tap_head
+    CoreTap.instance.git_head || "(none)"
+  end
+
+  def core_tap_last_commit
+    CoreTap.instance.git_last_commit || "never"
+  end
+
+  def core_tap_origin
+    CoreTap.instance.remote || "(none)"
   end
 
   def describe_path(path)
@@ -144,6 +157,13 @@ module Homebrew
     f.puts "ORIGIN: #{origin}"
     f.puts "HEAD: #{head}"
     f.puts "Last commit: #{last_commit}"
+    if CoreTap.instance.installed?
+      f.puts "Core tap ORIGIN: #{core_tap_origin}"
+      f.puts "Core tap HEAD: #{core_tap_head}"
+      f.puts "Core tap last commit: #{core_tap_last_commit}"
+    else
+      f.puts "Core tap: N/A"
+    end
     f.puts "HOMEBREW_PREFIX: #{HOMEBREW_PREFIX}"
     f.puts "HOMEBREW_REPOSITORY: #{HOMEBREW_REPOSITORY}"
     f.puts "HOMEBREW_CELLAR: #{HOMEBREW_CELLAR}"

--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -37,8 +37,6 @@ module Homebrew
       end
     end
 
-    migrate_taps :force => true unless ARGV.dry_run?
-
     if ObserverPathnameExtension.total.zero?
       puts "Nothing pruned" if ARGV.verbose?
     else

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -35,24 +35,25 @@ module Homebrew
     do_bump = ARGV.include?("--bump") && !ARGV.include?("--clean")
 
     bintray_fetch_formulae = []
+    tap = nil
 
     ARGV.named.each do |arg|
       if arg.to_i > 0
         issue = arg
-        url = "https://github.com/Homebrew/homebrew/pull/#{arg}"
+        url = "https://github.com/Homebrew/homebrew-core/pull/#{arg}"
         tap = CoreTap.instance
       elsif (testing_match = arg.match %r{brew.sh/job/Homebrew.*Testing/(\d+)/})
         _, testing_job = *testing_match
-        url = "https://github.com/Homebrew/homebrew/compare/master...BrewTestBot:testing-#{testing_job}"
+        url = "https://github.com/Homebrew/homebrew-core/compare/master...BrewTestBot:testing-#{testing_job}"
         tap = CoreTap.instance
         odie "Testing URLs require `--bottle`!" unless ARGV.include?("--bottle")
       elsif (api_match = arg.match HOMEBREW_PULL_API_REGEX)
         _, user, repo, issue = *api_match
-        url = "https://github.com/#{user}/homebrew#{repo}/pull/#{issue}"
-        tap = Tap.fetch(user, "homebrew#{repo}")
+        url = "https://github.com/#{user}/#{repo}/pull/#{issue}"
+        tap = Tap.fetch(user, repo) if repo.start_with?("homebrew-")
       elsif (url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX)
         url, user, repo, issue = *url_match
-        tap = Tap.fetch(user, "homebrew#{repo}")
+        tap = Tap.fetch(user, repo) if repo.start_with?("homebrew-")
       else
         odie "Not a GitHub pull request or commit: #{arg}"
       end
@@ -61,8 +62,12 @@ module Homebrew
         raise "No pull request detected!"
       end
 
-      tap.install unless tap.installed?
-      Dir.chdir tap.path
+      if tap
+        tap.install unless tap.installed?
+        Dir.chdir tap.path
+      else
+        Dir.chdir HOMEBREW_REPOSITORY
+      end
 
       # The cache directory seems like a good place to put patches.
       HOMEBREW_CACHE.mkpath
@@ -93,16 +98,18 @@ module Homebrew
 
       changed_formulae = []
 
-      Utils.popen_read(
-        "git", "diff-tree", "-r", "--name-only",
-        "--diff-filter=AM", revision, "HEAD", "--", tap.formula_dir.to_s
-      ).each_line do |line|
-        name = "#{tap.name}/#{File.basename(line.chomp, ".rb")}"
-        begin
-          changed_formulae << Formula[name]
-        # Make sure we catch syntax errors.
-        rescue Exception
-          next
+      if tap
+        Utils.popen_read(
+          "git", "diff-tree", "-r", "--name-only",
+          "--diff-filter=AM", revision, "HEAD", "--", tap.formula_dir.to_s
+        ).each_line do |line|
+          name = "#{tap.name}/#{File.basename(line.chomp, ".rb")}"
+          begin
+            changed_formulae << Formula[name]
+          # Make sure we catch syntax errors.
+          rescue Exception
+            next
+          end
         end
       end
 
@@ -166,11 +173,7 @@ module Homebrew
           url
         else
           bottle_branch = "pull-bottle-#{issue}"
-          if tap.core_tap?
-            "https://github.com/BrewTestBot/homebrew/compare/homebrew:master...pr-#{issue}"
-          else
-            "https://github.com/BrewTestBot/homebrew-#{tap.repo}/compare/homebrew:master...pr-#{issue}"
-          end
+          "https://github.com/BrewTestBot/homebrew-#{tap.repo}/compare/homebrew:master...pr-#{issue}"
         end
         curl "--silent", "--fail", "-o", "/dev/null", "-I", bottle_commit_url
 
@@ -305,7 +308,7 @@ module Homebrew
       files << $1 if line =~ %r{^\+\+\+ b/(.*)}
     end
     files.each do |file|
-      if tap.formula_file?(file)
+      if tap && tap.formula_file?(file)
         formula_name = File.basename(file, ".rb")
         formulae << formula_name unless formulae.include?(formula_name)
       else

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -38,7 +38,6 @@ module Homebrew
     if ARGV.named.empty?
       formulae = Formula.files
       alias_dirs = Tap.map(&:alias_dir)
-      alias_dirs.unshift CoreTap.instance.alias_dir
     else
       tap = Tap.fetch(ARGV.named.first)
       raise TapUnavailableError, tap.name unless tap.installed?

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -10,8 +10,6 @@ module Homebrew
       end
     end
 
-    raise "#{tap} is not allowed" if taps.any?(&:core_tap?)
-
     if ARGV.json == "v1"
       print_tap_json(taps)
     else

--- a/Library/Homebrew/cmd/tap-pin.rb
+++ b/Library/Homebrew/cmd/tap-pin.rb
@@ -4,7 +4,7 @@ module Homebrew
   def tap_pin
     ARGV.named.each do |name|
       tap = Tap.fetch(name)
-      raise "#{tap} is not allowed" if tap.core_tap?
+      raise "pinning #{tap} is not allowed" if tap.core_tap?
       tap.pin
       ohai "Pinned #{tap}"
     end

--- a/Library/Homebrew/cmd/tap-unpin.rb
+++ b/Library/Homebrew/cmd/tap-unpin.rb
@@ -4,7 +4,7 @@ module Homebrew
   def tap_unpin
     ARGV.named.each do |name|
       tap = Tap.fetch(name)
-      raise "#{tap} is not allowed" if tap.core_tap?
+      raise "unpinning #{tap} is not allowed" if tap.core_tap?
       tap.unpin
       ohai "Unpinned #{tap}"
     end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -4,7 +4,6 @@ module Homebrew
   def tap
     if ARGV.include? "--repair"
       Tap.each(&:link_manpages)
-      migrate_taps :force => true
     elsif ARGV.include? "--list-official"
       require "official_taps"
       puts OFFICIAL_TAPS.map { |t| "homebrew/#{t}" }
@@ -35,13 +34,5 @@ module Homebrew
     else
       true
     end
-  end
-
-  # Migrate tapped formulae from symlink-based to directory-based structure.
-  def migrate_taps(options = {})
-    ignore = HOMEBREW_LIBRARY/"Formula/.gitignore"
-    return unless ignore.exist? || options.fetch(:force, false)
-    (HOMEBREW_LIBRARY/"Formula").children.each { |c| c.unlink if c.symlink? }
-    ignore.unlink if ignore.exist?
   end
 end

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -767,11 +767,7 @@ module Homebrew
     safe_system "brew", "update"
 
     if pr
-      pull_pr = if tap.core_tap?
-        pr
-      else
-        "https://github.com/#{tap.user}/homebrew-#{tap.repo}/pull/#{pr}"
-      end
+      pull_pr = "https://github.com/#{tap.user}/homebrew-#{tap.repo}/pull/#{pr}"
       safe_system "brew", "pull", "--clean", pull_pr
     end
 

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -6,7 +6,7 @@ module Homebrew
 
     ARGV.named.each do |tapname|
       tap = Tap.fetch(tapname)
-      raise "#{tap} is not allowed" if tap.core_tap?
+      raise "untapping #{tap} is not allowed" if tap.core_tap?
       tap.uninstall
     end
   end

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -8,19 +8,17 @@ module Homebrew
     install_core_tap_if_necessary
 
     hub = ReporterHub.new
+    updated = false
 
-    begin
-      master_reporter = Reporter.new(CoreTap.instance)
-    rescue Reporter::ReporterRevisionUnsetError => e
-      raise e if ARGV.homebrew_developer?
+    initial_revision = ENV["HOMEBREW_UPDATE_BEFORE"].to_s
+    current_revision = ENV["HOMEBREW_UPDATE_AFTER"].to_s
+    if initial_revision.empty? || current_revision.empty?
       odie "update-report should not be called directly!"
     end
 
-    if master_reporter.updated?
-      initial_short = shorten_revision(master_reporter.initial_revision)
-      current_short = shorten_revision(master_reporter.current_revision)
-      puts "Updated Homebrew from #{initial_short} to #{current_short}."
-      hub.add(master_reporter)
+    if initial_revision != current_revision
+      puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
+      updated = true
     end
 
     updated_taps = []
@@ -37,12 +35,14 @@ module Homebrew
         hub.add(reporter)
       end
     end
+
     unless updated_taps.empty?
       puts "Updated #{updated_taps.size} tap#{plural(updated_taps.size)} " \
            "(#{updated_taps.join(", ")})."
+      updated = true
     end
 
-    if hub.reporters.empty?
+    if !updated
       puts "Already up-to-date."
     elsif hub.empty?
       puts "No changes to formulae."
@@ -194,14 +194,10 @@ class Reporter
   private
 
   def repo_var
-    @repo_var ||= if tap.path == HOMEBREW_REPOSITORY
-      ""
-    else
-      tap.path.to_s.
+    @repo_var ||= tap.path.to_s.
         strip_prefix(Tap::TAP_DIRECTORY.to_s).
         tr("^A-Za-z0-9", "_").
         upcase
-    end
   end
 
   def diff

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -1,4 +1,3 @@
-require "cmd/tap"
 require "formula_versions"
 require "migrator"
 require "formulary"
@@ -6,8 +5,7 @@ require "descriptions"
 
 module Homebrew
   def update_report
-    # migrate to new directories based tap structure
-    migrate_taps
+    install_core_tap_if_necessary
 
     hub = ReporterHub.new
 
@@ -62,6 +60,15 @@ module Homebrew
 
   def shorten_revision(revision)
     Utils.popen_read("git", "-C", HOMEBREW_REPOSITORY, "rev-parse", "--short", revision).chomp
+  end
+
+  def install_core_tap_if_necessary
+    core_tap = CoreTap.instance
+    return if core_tap.installed?
+    CoreTap.ensure_installed! :quiet => false
+    revision = core_tap.git_head
+    ENV["HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CORE"] = revision
+    ENV["HOMEBREW_UPDATE_AFTER_HOMEBREW_HOMEBREW_CORE"] = revision
   end
 end
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -258,7 +258,8 @@ EOS
 
   if ! git --version >/dev/null 2>&1
   then
-    brew install git
+    # we cannot install brewed git if homebrew/core is unavailable.
+    [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
     if ! git --version >/dev/null 2>&1
     then
       odie "Git must be installed and in your PATH!"

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -33,25 +33,14 @@ class Descriptions
     self.save_cache
   end
 
-  # Return true if the cache exists, and neither Homebrew nor any of the Taps
+  # Return true if the cache exists, and none of the Taps
   # repos were updated more recently than it was.
   def self.cache_fresh?
     return false unless CACHE_FILE.exist?
-    cache_mtime = File.mtime(CACHE_FILE)
-    ref_master = ".git/refs/heads/master"
-
-    master = HOMEBREW_REPOSITORY/ref_master
-
-    # If ref_master doesn't exist, it means brew update is never run.
-    # Since cache is found, we can assume it's fresh.
-    if master.exist?
-      core_mtime = File.mtime(master)
-      return false if core_mtime > cache_mtime
-    end
 
     Tap.each do |tap|
       next unless tap.git?
-      repo_mtime = File.mtime(tap.path/ref_master)
+      repo_mtime = File.mtime(tap.path/".git/refs/heads/master")
       return false if repo_mtime > cache_mtime
     end
 

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -1,5 +1,3 @@
-require "extend/ENV"
-
 module Homebrew
   #
   # Usage:
@@ -41,8 +39,7 @@ module Homebrew
       safe_system "git", "reset", "--hard", start_sha1
 
       # update ENV["PATH"]
-      ENV.extend(Stdenv)
-      ENV.prepend_path "PATH", "#{curdir}/bin"
+      ENV["PATH"] = "#{curdir}/bin:/usr/local/bin:/usr/bin:/bin"
 
       # run brew update
       oh1 "Running brew update..."

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1073,13 +1073,13 @@ class Formula
   # an array of all tap {Formula} names
   # @private
   def self.tap_names
-    @tap_names ||= Tap.flat_map(&:formula_names).sort
+    @tap_names ||= Tap.reject(&:core_tap?).flat_map(&:formula_names).sort
   end
 
   # an array of all tap {Formula} files
   # @private
   def self.tap_files
-    @tap_files ||= Tap.flat_map(&:formula_files)
+    @tap_files ||= Tap.reject(&:core_tap?).flat_map(&:formula_files)
   end
 
   # an array of all {Formula} names
@@ -1152,7 +1152,7 @@ class Formula
   # an array of all tap aliases
   # @private
   def self.tap_aliases
-    @tap_aliases ||= Tap.flat_map(&:aliases).sort
+    @tap_aliases ||= Tap.reject(&:core_tap?).flat_map(&:aliases).sort
   end
 
   # an array of all aliases

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -344,7 +344,7 @@ class Formulary
       if core_path(ref).file?
         opoo <<-EOS.undent
           #{ref} is provided by core, but is now shadowed by #{selected_formula.full_name}.
-          To refer to the core formula, use Homebrew/homebrew/#{ref} instead.
+          To refer to the core formula, use Homebrew/core/#{ref} instead.
         EOS
       end
       selected_formula

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -40,8 +40,8 @@ module Homebrew
   alias_method :failed?, :failed
 end
 
-HOMEBREW_PULL_API_REGEX = %r{https://api\.github\.com/repos/([\w-]+)/homebrew(-[\w-]+)?/pulls/(\d+)}
-HOMEBREW_PULL_OR_COMMIT_URL_REGEX = %r[https://github\.com/([\w-]+)/homebrew(-[\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})]
+HOMEBREW_PULL_API_REGEX = %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}
+HOMEBREW_PULL_OR_COMMIT_URL_REGEX = %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})]
 
 require "compat" unless ARGV.include?("--no-compat") || ENV["HOMEBREW_NO_COMPAT"]
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -52,8 +52,9 @@ class Tab < OpenStruct
       attributes["source"]["tap"] = attributes.delete("tapped_from")
     end
 
-    if attributes["source"]["tap"] == "mxcl/master"
-      attributes["source"]["tap"] = "Homebrew/homebrew"
+    if attributes["source"]["tap"] == "mxcl/master" ||
+      attributes["source"]["tap"] == "Homebrew/homebrew"
+      attributes["source"]["tap"] = "homebrew/core"
     end
 
     if attributes["source"]["spec"].nil?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -30,7 +30,7 @@ class Tap
     user = "Homebrew" if user == "homebrew"
     repo = repo.strip_prefix "homebrew-"
 
-    if user == "Homebrew" && repo == "homebrew"
+    if user == "Homebrew" && (repo == "homebrew" || repo == "core")
       return CoreTap.instance
     end
 

--- a/Library/Homebrew/test/fixtures/receipt.json
+++ b/Library/Homebrew/test/fixtures/receipt.json
@@ -14,8 +14,8 @@
   "stdlib": "libcxx",
   "compiler": "clang",
   "source": {
-      "path": "/usr/local/Library/Formula/foo.rb",
-      "tap": "Homebrew/homebrew",
+      "path": "/usr/local/Library/Taps/hombrew/homebrew-core/Formula/foo.rb",
+      "tap": "homebrew/core",
       "spec": "stable"
   }
 }

--- a/Library/Homebrew/test/fixtures/updater_fixture.yaml
+++ b/Library/Homebrew/test/fixtures/updater_fixture.yaml
@@ -7,13 +7,13 @@ update_git_diff_output_without_formulae_changes: |
   M	bin/brew
 update_git_diff_output_with_formulae_changes: |
   M	Library/Contributions/brew_bash_completion.sh
-  A	Library/Formula/antiword.rb
-  A	Library/Formula/bash-completion.rb
-  A	Library/Formula/ddrescue.rb
-  A	Library/Formula/dict.rb
-  A	Library/Formula/lua.rb
-  M	Library/Formula/xar.rb
-  M	Library/Formula/yajl.rb
+  A	Formula/antiword.rb
+  A	Formula/bash-completion.rb
+  A	Formula/ddrescue.rb
+  A	Formula/dict.rb
+  A	Formula/lua.rb
+  M	Formula/xar.rb
+  M	Formula/yajl.rb
   M	Library/Homebrew/ARGV+yeast.rb
   M	Library/Homebrew/beer_events.rb
   M	Library/Homebrew/hardware.rb
@@ -25,23 +25,23 @@ update_git_diff_output_with_formulae_changes: |
   M	README
   M	bin/brew
 update_git_diff_output_with_removed_formulae: |
-  A	Library/Formula/flac123.rb
-  M	Library/Formula/gdal.rb
-  M	Library/Formula/grass.rb
-  M	Library/Formula/json_spirit.rb
-  A	Library/Formula/libbson.rb
-  D	Library/Formula/libgsasl.rb
+  A	Formula/flac123.rb
+  M	Formula/gdal.rb
+  M	Formula/grass.rb
+  M	Formula/json_spirit.rb
+  A	Formula/libbson.rb
+  D	Formula/libgsasl.rb
 update_git_diff_output_with_changed_filetype: |
   A	Library/ENV/4.3/ant
   T	Library/ENV/4.3/bsdmake
   M	Library/ENV/4.3/make
-  M	Library/Formula/elixir.rb
-  A	Library/Formula/libbson.rb
-  D	Library/Formula/libgsasl.rb
+  M	Formula/elixir.rb
+  A	Formula/libbson.rb
+  D	Formula/libgsasl.rb
   M	Library/Homebrew/cmd/update.rb
   M	SUPPORTERS.md
 update_git_diff_output_with_formula_rename: |
-  R100	Library/Formula/cv.rb	Library/Formula/progress.rb
+  R100	Formula/cv.rb	Formula/progress.rb
 update_git_diff_output_with_restructured_tap: |
   R100	git.rb	Formula/git.rb
   R100	lua.rb	Formula/lua.rb

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -202,7 +202,7 @@ class FormulaTests < Homebrew::TestCase
 
   def test_path
     name = "foo-bar"
-    assert_equal Pathname.new("#{HOMEBREW_LIBRARY}/Formula/#{name}.rb"), Formulary.core_path(name)
+    assert_equal Pathname.new("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/Formula/#{name}.rb"), Formulary.core_path(name)
   end
 
   def test_class_specs_are_always_initialized

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -112,7 +112,7 @@ class FormularyTapFactoryTest < Homebrew::TestCase
   end
 
   def teardown
-    @tap.path.parent.parent.rmtree
+    @tap.path.rmtree
   end
 
   def test_factory_tap_formula
@@ -138,6 +138,8 @@ class FormularyTapFactoryTest < Homebrew::TestCase
     another_tap = Tap.new "homebrew", "bar"
     (another_tap.path/"#{@name}.rb").write @code
     assert_raises(TapFormulaAmbiguityError) { Formulary.factory(@name) }
+  ensure
+    another_tap.path.rmtree
   end
 end
 
@@ -158,7 +160,7 @@ class FormularyTapPriorityTest < Homebrew::TestCase
 
   def teardown
     @core_path.unlink
-    @tap.path.parent.parent.rmtree
+    @tap.path.rmtree
   end
 
   def test_find_with_priority_core_formula

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -217,7 +217,7 @@ class IntegrationCommandTests < Homebrew::TestCase
 
     assert_match "homebrew/foo", cmd("tap")
     assert_match "homebrew/versions", cmd("tap", "--list-official")
-    assert_match "1 tap", cmd("tap-info")
+    assert_match "2 taps", cmd("tap-info")
     assert_match "https://github.com/Homebrew/homebrew-foo", cmd("tap-info", "homebrew/foo")
     assert_match "https://github.com/Homebrew/homebrew-foo", cmd("tap-info", "--json=v1", "--installed")
     assert_match "Pinned homebrew/foo", cmd("tap-pin", "homebrew/foo")
@@ -228,7 +228,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert_equal "", cmd("tap", "homebrew/bar", path/".git", "-q", "--full")
     assert_match "Untapped", cmd("untap", "homebrew/bar")
   ensure
-    Tap::TAP_DIRECTORY.rmtree
+    path.rmtree
   end
 
   def test_missing
@@ -339,13 +339,12 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_tap_readme
-    (HOMEBREW_LIBRARY/"Taps").mkpath
     assert_match "brew install homebrew/foo/<formula>",
                  cmd("tap-readme", "foo", "--verbose")
     readme = HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/README.md"
     assert readme.exist?, "The README should be created"
   ensure
-    (HOMEBREW_LIBRARY/"Taps").rmtree
+    (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo").rmtree
   end
 
   def test_unpack

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -17,7 +17,7 @@ class TabTests < Homebrew::TestCase
                    "compiler"             => "clang",
                    "stdlib"               => "libcxx",
                    "source"               => {
-                     "tap" => "Homebrew/homebrew",
+                     "tap" => "homebrew/core",
                      "path" => nil,
                      "spec" => "stable"
                    })
@@ -60,7 +60,7 @@ class TabTests < Homebrew::TestCase
 
   def test_other_attributes
     assert_equal TEST_SHA1, @tab.HEAD
-    assert_equal "Homebrew/homebrew", @tab.tap.name
+    assert_equal "homebrew/core", @tab.tap.name
     assert_nil @tab.time
     refute_predicate @tab, :built_as_bottle
     assert_predicate @tab, :poured_from_bottle
@@ -74,7 +74,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
-    assert_equal "Homebrew/homebrew", tab.tap.name
+    assert_equal "homebrew/core", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD
@@ -90,7 +90,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
-    assert_equal "Homebrew/homebrew", tab.tap.name
+    assert_equal "homebrew/core", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time
     assert_equal TEST_SHA1, tab.HEAD

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -55,7 +55,7 @@ class TapTest < Homebrew::TestCase
   end
 
   def teardown
-    Tap::TAP_DIRECTORY.rmtree
+    @path.rmtree
   end
 
   def test_fetch
@@ -68,7 +68,7 @@ class TapTest < Homebrew::TestCase
   end
 
   def test_names
-    assert_equal ["homebrew/foo"], Tap.names
+    assert_equal ["homebrew/core", "homebrew/foo"], Tap.names
   end
 
   def test_attributes
@@ -95,6 +95,8 @@ class TapTest < Homebrew::TestCase
 
     (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
     assert_nil Tap.new("someone", "no-git").issues_url
+  ensure
+    path.parent.rmtree
   end
 
   def test_files
@@ -132,6 +134,8 @@ class TapTest < Homebrew::TestCase
       end
     end
     refute_predicate version_tap, :private?
+  ensure
+    version_tap.path.rmtree
   end
 
   def test_remote_not_git_repo
@@ -213,8 +217,8 @@ class CoreTapTest < Homebrew::TestCase
 
   def test_attributes
     assert_equal "Homebrew", @repo.user
-    assert_equal "homebrew", @repo.repo
-    assert_equal "Homebrew/homebrew", @repo.name
+    assert_equal "core", @repo.repo
+    assert_equal "homebrew/core", @repo.name
     assert_equal [], @repo.command_files
     assert_predicate @repo, :installed?
     refute_predicate @repo, :pinned?

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -29,10 +29,6 @@ class ReportTests < Homebrew::TestCase
     @hub = ReporterHub.new
   end
 
-  def teardown
-    FileUtils.rm_rf HOMEBREW_LIBRARY.join("Taps")
-  end
-
   def perform_update(fixture_name = "")
     Formulary.stubs(:factory).returns(stub(:pkg_version => "1.0"))
     FormulaVersions.stubs(:new).returns(stub(:formula_at_revision => "2.0"))
@@ -91,6 +87,8 @@ class ReportTests < Homebrew::TestCase
     perform_update("update_git_diff_output_with_restructured_tap")
     assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:A)
     assert_empty @hub.select_formula(:D)
+  ensure
+    tap.path.parent.rmtree
   end
 
   def test_update_homebrew_simulate_homebrew_php_restructuring
@@ -101,6 +99,8 @@ class ReportTests < Homebrew::TestCase
     perform_update("update_git_diff_simulate_homebrew_php_restructuring")
     assert_empty @hub.select_formula(:A)
     assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:D)
+  ensure
+    tap.path.parent.rmtree
   end
 
   def test_update_homebrew_with_tap_formulae_changes
@@ -112,5 +112,7 @@ class ReportTests < Homebrew::TestCase
     assert_equal %w[foo/bar/lua], @hub.select_formula(:A)
     assert_equal %w[foo/bar/git], @hub.select_formula(:M)
     assert_empty @hub.select_formula(:D)
+  ensure
+    tap.path.parent.rmtree
   end
 end

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -6,7 +6,7 @@ require "global"
 require "formulary"
 
 # Test environment setup
-HOMEBREW_LIBRARY.join("Formula").mkpath
+(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula").mkpath
 %w[cache formula_cache cellar logs].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
 
 # Test fixtures and files can be found relative to this path

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -229,6 +229,18 @@ module Homebrew
     end
   end
 
+  def self.core_tap_version_string
+    require "tap"
+    tap = CoreTap.instance
+    return "N/A" unless tap.installed?
+    if pretty_revision = tap.git_short_head
+      last_commit = tap.git_last_commit_date
+      "(git revision #{pretty_revision}; last commit #{last_commit})"
+    else
+      "(no git repository)"
+    end
+  end
+
   def self.install_gem_setup_path!(gem, version = nil, executable = gem)
     require "rubygems"
 

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -7,6 +7,11 @@ module Utils
   def self.ensure_git_installed!
     return if git_available?
 
+    # we cannot install brewed git if homebrew/core is unavailable.
+    unless CoreTap.instance.installed?
+      raise "Git is unavailable"
+    end
+
     begin
       oh1 "Installing git"
       safe_system HOMEBREW_BREW_FILE, "install", "git"

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -7,6 +7,7 @@ require "global"
 
 if ARGV == %w[--version] || ARGV == %w[-v]
   puts "Homebrew #{Homebrew.homebrew_version_string}"
+  puts "Homebrew/homebrew-core #{Homebrew.core_tap_version_string}"
   exit 0
 end
 

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -1,4 +1,4 @@
-HOMEBREW_VERSION="0.9.5"
+HOMEBREW_VERSION="0.9.8"
 
 odie() {
   if [[ -t 2 ]] # check whether stderr is a tty.


### PR DESCRIPTION
This is step 1 for core/formula separation. i.e. moving formulae to `Homebrew/homebrew-core`. We will move core code to `Homebrew/brew` in step 2.
