### PR TITLE
knot 2.1.1

### DIFF
--- a/Library/Formula/knot.rb
+++ b/Library/Formula/knot.rb
@@ -1,9 +1,8 @@
 class Knot < Formula
   desc "High-performance authoritative-only DNS server"
   homepage "https://www.knot-dns.cz/"
-  url "https://secure.nic.cz/files/knot-dns/knot-2.0.2.tar.xz"
-  sha256 "0418a22f9e801503993b3c872f2403bf73eab5ef7266128789b0531b41ea0c7e"
-  revision 1
+  url "https://secure.nic.cz/files/knot-dns/knot-2.1.1.tar.xz"
+  sha256 "e110d11d4a4c4b5abb091b32fcb073934fb840046e975234323e0fc15f2f8f5b"
 
   head "https://gitlab.labs.nic.cz/labs/knot.git"
 


### PR DESCRIPTION
Not only is the formula outdated, but also the updated upstream fixes the following regression:
```
lib/binary.c:47:12: error: expected ';' after expression
        nettle_len dst_size = dst_max_size;
                  ^
                  ;
lib/binary.c:47:13: error: use of undeclared identifier 'dst_size'
        nettle_len dst_size = dst_max_size;
                   ^
lib/binary.c:48:50: error: use of undeclared identifier 'dst_size'; did you mean 'getbsize'?
        int result = nettle_base64_decode_update(&ctx, &dst_size, dst, src_len, src);
                                                        ^~~~~~~~
                                                        getbsize
/usr/include/stdlib.h:270:7: note: 'getbsize' declared here
char    *getbsize(int *, long *);
         ^
lib/binary.c:53:9: error: use of undeclared identifier 'dst_size'; did you mean 'getbsize'?
        return dst_size;
               ^~~~~~~~
               getbsize
/usr/include/stdlib.h:270:7: note: 'getbsize' declared here
char    *getbsize(int *, long *);
         ^
4 errors generated.
make[4]: *** [lib/libdnssec_la-binary.lo] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [all] Error 2
make: *** [all-recursive] Error 1
```