### PR TITLE
kstart 4.2

### DIFF
--- a/Library/Formula/kstart.rb
+++ b/Library/Formula/kstart.rb
@@ -1,8 +1,8 @@
 class Kstart < Formula
   desc "Modified version of kinit that can use keytabs to authenticate"
   homepage "http://www.eyrie.org/~eagle/software/kstart/"
-  url "http://archives.eyrie.org/software/kerberos/kstart-4.1.tar.gz"
-  sha256 "ad1a71be149d56473319bf3b9bca83a60caa3af463d52c134e8f187103700224"
+  url "https://archives.eyrie.org/software/kerberos/kstart-4.2.tar.gz"
+  sha256 "2698bc1ab2fb36d49cc946b0cb864c56dd3a2f9ef596bfff59592e13d35315cd"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Fixes
```
==> Downloading from https://archives.eyrie.org/software/kerberos/kstart-4.1.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "kstart"
```