### PR TITLE
Update caveats the fuck

### DIFF
--- a/Library/Formula/thefuck.rb
+++ b/Library/Formula/thefuck.rb
@@ -79,7 +79,8 @@ class Thefuck < Formula
 
   def caveats; <<-EOS.undent
     Add the following to your .bash_profile, .bashrc or .zshrc:
-
+      PYTHONIOENCODING="UTF-8"
+      export PYTHONIOENCODING
       eval "$(thefuck --alias)"
 
     For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases

--- a/Library/Formula/thefuck.rb
+++ b/Library/Formula/thefuck.rb
@@ -79,6 +79,7 @@ class Thefuck < Formula
 
   def caveats; <<-EOS.undent
     Add the following to your .bash_profile, .bashrc or .zshrc:
+
       PYTHONIOENCODING="UTF-8"
       export PYTHONIOENCODING
       eval "$(thefuck --alias)"


### PR DESCRIPTION
### Add caveats to Thefuck:

In order for the Python script Thefuck to run correctly, the UTF encoding must be set in an environment variable. See this issue in the Thefuck issue queue: https://github.com/nvbn/thefuck/issues/301
