### PR TITLE
zinc 0.3.9

### DIFF
--- a/Library/Formula/zinc.rb
+++ b/Library/Formula/zinc.rb
@@ -11,4 +11,8 @@ class Zinc < Formula
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/zinc"
   end
+
+  test do
+    system "#{bin}/zinc", "-version"
+  end
 end

--- a/Library/Formula/zinc.rb
+++ b/Library/Formula/zinc.rb
@@ -1,8 +1,8 @@
 class Zinc < Formula
   desc "Stand-alone version of sbt's Scala incremental compiler"
   homepage "https://github.com/typesafehub/zinc"
-  url "https://downloads.typesafe.com/zinc/0.3.7/zinc-0.3.7.tgz"
-  sha256 "8775465c624bfb2180cb03734e6ad682849663b3a70fa73bb962af496df89a3d"
+  url "https://downloads.typesafe.com/zinc/0.3.9/zinc-0.3.9.tgz"
+  sha256 "29dd3078d8b01c14231ed92f2d1abfca62cd4b63fd69505ff7abaa39f1193325"
 
   bottle :unneeded
 


### PR DESCRIPTION
Upgrading [`zinc`](https://github.com/typesafehub/zinc) to current version `0.3.9`.
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?
- [X] Have you successfully ran `brew tests` with your changes locally?