### PR TITLE
libotr 4.1.1 --- Security Update

### DIFF
--- a/Library/Formula/libotr.rb
+++ b/Library/Formula/libotr.rb
@@ -1,8 +1,8 @@
 class Libotr < Formula
   desc "Off-The-Record (OTR) messaging library"
   homepage "https://otr.cypherpunks.ca/"
-  url "https://otr.cypherpunks.ca/libotr-4.1.0.tar.gz"
-  sha256 "4fdb891940ec89d300190a98f69a9138248dcb8c8d337633fb981b8d0a9cd930"
+  url "https://otr.cypherpunks.ca/libotr-4.1.1.tar.gz"
+  sha256 "8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5"
 
   bottle do
     cellar :any

--- a/Library/Formula/libotr.rb
+++ b/Library/Formula/libotr.rb
@@ -20,4 +20,8 @@ class Libotr < Formula
                           "--mandir=#{man}"
     system "make", "install"
   end
+  
+  test do     
+    test_from_url
+  end
 end


### PR DESCRIPTION
Updating to the libotr version 4.1.1 --- this version fixes a memory corruption vulnerability that affects 4.1.0 and below.

Security Update: https://otr.cypherpunks.ca/index.php#news
Vulnerability Details: http://www.x41-dsec.de/lab/advisories/x41-2016-001-libotr/