### PR TITLE
brew pull: fix encoding of `brew info --json` output

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -321,6 +321,7 @@ module Homebrew
   def current_versions_from_info_external(formula_name)
     versions = {}
     json = Utils.popen_read(HOMEBREW_BREW_FILE, "info", "--json=v1", formula_name)
+    json.force_encoding("UTF-8") if json.respond_to?(:force_encoding)
     if $?.success?
       info = Utils::JSON.load(json)
       [:stable, :devel, :head].each do |vertype|


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change? There is - #49775 - but this one supersedes it.

### Changes to Homebrew's Core:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them? Fixes #49757
- [ ] Have you written new tests for your core changes, as applicable? 
- [X] Have you successfully ran `brew tests` with your changes locally?

Fixes #49757. `force_encoding` is more approprate than `encode` because we know what encoding the data is in, and want to preserve all characters.
Closes #49775, where `brew pull` fails for formulae which have non-ASCII characters in their definitions.

## Testing

To test, do `brew pull https://github.com/Homebrew/homebrew-php/pull/2921`. Or another pull on a formula with non-ASCII characters in it.

Before:

```
Andys-MacBook-Pro :: ~/Code/homebrew-php ‹master› » brew pull https://github.com/Homebrew/homebrew-php/pull/2921
==> Fetching patch
######################################################################## 100.0%
Error: incompatible character encodings: UTF-8 and ASCII-8BIT
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/vendor/okjson.rb:361:in `[]='
/usr/local/Library/Homebrew/vendor/okjson.rb:361:in `unquote'
...
```

After:
```
$ brew pull https://github.com/Homebrew/homebrew-php/pull/2921
==> Fetching patch
######################################################################## 100.0%
==> Applying patch
Applying: php70: bottle 7.0.4
...
```
