### PR TITLE
ssh-copy-id: Added HEAD configuration

### DIFF
--- a/Library/Formula/ssh-copy-id.rb
+++ b/Library/Formula/ssh-copy-id.rb
@@ -6,6 +6,8 @@ class SshCopyId < Formula
   version "7.1p1"
   sha256 "fc0a6d2d1d063d5c66dffd952493d0cda256cad204f681de0f84ef85b2ad8428"
 
+  head "https://github.com/openssh/openssh-portable.git"
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:
(not a new formula, but...)

- [X] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

The HEAD will checkout openssh-portable and copy the contrib script just
like the binary.

HEAD currently has fixes for non-posix shells (like fish that I use)