### PR TITLE
utils: API Git credential tweaks.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -511,14 +511,18 @@ module GitHub
       if ENV["HOMEBREW_GITHUB_API_TOKEN"]
         ENV["HOMEBREW_GITHUB_API_TOKEN"]
       else
-        github_credentials = IO.popen("git credential-osxkeychain get", "w+") do |io|
+        github_credentials = Utils.popen("git credential-osxkeychain get", "w+") do |io|
           io.puts "protocol=https\nhost=github.com"
           io.close_write
           io.read
         end
         github_username = github_credentials[/username=(.+)/, 1]
         github_password = github_credentials[/password=(.+)/, 1]
-        [github_password, github_username] if github_username && github_password
+        if github_username && github_password
+          [github_password, github_username]
+        else
+          []
+        end
       end
     end
   end


### PR DESCRIPTION
### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

- Use empty array when `git credential-osxkeychain` lookup fails to
  cache and avoid rerunning it when there's no valid results.
- Redirect `stderr` to avoid printing errors when there's a failure
  or no `git credential-osxkeychain` installed.

CC @xu-cheng @apjanke 