### PR TITLE
app-engine-go-32 1.9.34

### DIFF
--- a/Library/Formula/app-engine-go-32.rb
+++ b/Library/Formula/app-engine-go-32.rb
@@ -1,8 +1,8 @@
 class AppEngineGo32 < Formula
   desc "Google App Engine SDK for Go (i386)"
   homepage "https://cloud.google.com/appengine/docs/go/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.32.zip"
-  sha256 "ceb22edccff92d2982f54d0bfde5b6926a79d1f9ea3c758d6946024fef0f4d9b"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_386-1.9.34.zip"
+  sha256 "12feac0097ed797e5bc1edc4e737ebd590f1b2c848a53dc05119517735ee7178"
 
   bottle :unneeded
 


### PR DESCRIPTION
Bump [app-engine-go-32](https://cloud.google.com/appengine/docs/go/) to 1.9.34.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
- [x] Have you successfully ran `brew test <formula>` with your changes locally?