### PR TITLE
app-engine-go-64 1.9.34

### DIFF
--- a/Library/Formula/app-engine-go-64.rb
+++ b/Library/Formula/app-engine-go-64.rb
@@ -1,8 +1,8 @@
 class AppEngineGo64 < Formula
   desc "Google App Engine SDK for Go (AMD64)"
   homepage "https://cloud.google.com/appengine/docs/go/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.33.zip"
-  sha256 "f6e6edfef04181e04749d0540fa16a9bf2a8674b99cbf98e47e0e2486161f541"
+  url "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_darwin_amd64-1.9.34.zip"
+  sha256 "961ea5776abd183cef76c020eceb8fb2b015006f589922fc4f6aff16dc951138"
 
   bottle :unneeded
 


### PR DESCRIPTION
Bump [app-engine-go-64](https://cloud.google.com/appengine/docs/go/) to 1.9.34.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
- [x] Have you successfully ran `brew test <formula>` with your changes locally?