### PR TITLE
resolve lrzsz package download

### DIFF
--- a/Library/Formula/lrzsz.rb
+++ b/Library/Formula/lrzsz.rb
@@ -2,6 +2,7 @@ class Lrzsz < Formula
   desc "Tools for zmodem/xmodem/ymodem file transfer"
   homepage "http://www.ohse.de/uwe/software/lrzsz.html"
   url "http://www.ohse.de/uwe/releases/lrzsz-0.12.20.tar.gz"
+  mirror "http://pkgs.fedoraproject.org/repo/pkgs/lrzsz/lrzsz-0.12.20.tar.gz/md5/b5ce6a74abc9b9eb2af94dffdfd372a4/lrzsz-0.12.20.tar.gz"
   sha256 "c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1"
 
   def install

--- a/Library/Formula/lrzsz.rb
+++ b/Library/Formula/lrzsz.rb
@@ -1,7 +1,7 @@
 class Lrzsz < Formula
   desc "Tools for zmodem/xmodem/ymodem file transfer"
   homepage "http://www.ohse.de/uwe/software/lrzsz.html"
-  url "http://pkgs.fedoraproject.org/repo/pkgs/lrzsz/lrzsz-0.12.20.tar.gz/md5/b5ce6a74abc9b9eb2af94dffdfd372a4/lrzsz-0.12.20.tar.gz"
+  url "http://www.ohse.de/uwe/releases/lrzsz-0.12.20.tar.gz"
   sha256 "c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1"
 
   def install

--- a/Library/Formula/lrzsz.rb
+++ b/Library/Formula/lrzsz.rb
@@ -1,7 +1,7 @@
 class Lrzsz < Formula
   desc "Tools for zmodem/xmodem/ymodem file transfer"
   homepage "http://www.ohse.de/uwe/software/lrzsz.html"
-  url "http://www.ohse.de/uwe/releases/lrzsz-0.12.20.tar.gz"
+  url "http://pkgs.fedoraproject.org/repo/pkgs/lrzsz/lrzsz-0.12.20.tar.gz/md5/b5ce6a74abc9b9eb2af94dffdfd372a4/lrzsz-0.12.20.tar.gz"
   sha256 "c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1"
 
   def install


### PR DESCRIPTION
The author's https download site certificate has expired,
```
ERROR: cannot verify ohse.de's certificate, issued by 'CN=StartCom Class 1 Primary Intermediate Server CA,OU=Secure Digital Certificate Signing,O=StartCom Ltd.,C=IL': Issued certificate has expired.
```
or, from brew through curl,
```
curl: (60) SSL certificate problem: Invalid certificate chain
```

This prevents package installation. Suggest fedora project archive copy at stable url by md5 hash.

Fedora url does not redirect to https. https at the Fedora url is 'self signed', so http is used here.

The author's address when accessed by http will redirect to https.

I have emailed the author. If the author notifies me of resolution of ssl certificate issue, I will suggest another pr to revert. Thanks!