### PR TITLE
superenv: fix make_jobs regular expression

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -263,7 +263,7 @@ module Superenv
   alias_method :j1, :deparallelize
 
   def make_jobs
-    self["MAKEFLAGS"] =~ /-\w*j(\d)+/
+    self["MAKEFLAGS"] =~ /-\w*j(\d+)/
     [$1.to_i, 1].max
   end
 


### PR DESCRIPTION
HOMEBREW_MAKE_JOBS can be a multidigit number. The regex should match
the entire number not just the last digit.