### PR TITLE
kibana: version 4.4.2 and style fixes

### DIFF
--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -1,7 +1,7 @@
 class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://github.com/elastic/kibana.git", :tag => "v4.4.1", :revision => "57474ae1b8647bccc5057792af7ab3f962f7521f"
+  url "https://github.com/elastic/kibana.git", :tag => "v4.4.2", :revision => "b0ef773a465d0eb27d192ca77f881eba90ef93d5"
   head "https://github.com/elastic/kibana.git"
 
   bottle do
@@ -11,8 +11,8 @@ class Kibana < Formula
   end
 
   resource "node" do
-    url "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz"
-    sha256 "edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d"
+    url "https://nodejs.org/dist/v4.3.2/node-v4.3.2.tar.gz"
+    sha256 "1f92f6d31f7292ce56db57d6703efccf3e6c945948f5901610cefa69e78d3498"
   end
 
   def install

--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -23,23 +23,23 @@ class Kibana < Formula
     end
 
     # do not download binary installs of Node.js
-    inreplace buildpath/"tasks/build/index.js", %r{('_build:downloadNodeBuilds:\w+',)}, "// \\1"
+    inreplace buildpath/"tasks/build/index.js", /('_build:downloadNodeBuilds:\w+',)/, "// \\1"
 
     # do not build packages for other platforms
     platforms = Set.new(["darwin-x64", "linux-x64", "linux-x86", "windows"])
     if OS.mac? && Hardware::CPU.is_64_bit?
       platform = "darwin-x64"
     elsif OS.linux?
-      platform = if Hardware::CPU.is_64_bit? then "linux-x64" else "linux-x86" end
+      platform = Hardware::CPU.is_64_bit? ? "linux-x64" : "linux-x86"
     else
       raise "Installing Kibana via Homebrew is only supported on Darwin x86_64, Linux i386, Linux i686, and Linux x86_64"
     end
     platforms.delete(platform)
     sub = platforms.to_a.join("|")
-    inreplace buildpath/"tasks/config/platforms.js", %r{('(#{sub})',?(?!;))}, "// \\1"
+    inreplace buildpath/"tasks/config/platforms.js", /('(#{sub})',?(?!;))/, "// \\1"
 
     # do not build zip package
-    inreplace buildpath/"tasks/build/archives.js", %r{(await exec\('zip'.*)}, "// \\1"
+    inreplace buildpath/"tasks/build/archives.js", /(await exec\('zip'.*)/, "// \\1"
 
     ENV.prepend_path "PATH", prefix/"libexec/node/bin"
     system "npm", "install"
@@ -54,7 +54,7 @@ class Kibana < Formula
     inreplace "#{bin}/kibana", %r{/node/bin/node}, "/libexec/node/bin/node"
 
     cd prefix do
-      inreplace "config/kibana.yml", %{/var/run/kibana.pid}, var/"run/kibana.pid"
+      inreplace "config/kibana.yml", %(/var/run/kibana.pid), var/"run/kibana.pid"
       (etc/"kibana").install Dir["config/*"]
       rm_rf "config"
     end


### PR DESCRIPTION
This pull requests updates the Kibana formula to version 4.4.2, the [latest stable version of Kibana as of 2016-03-10](https://www.elastic.co/blog/kibana-4-4-2-and-4-3-3-and-4-1-6). This Kibana update includes important security fixes in its node dependency.

Additionally, this pull request addresses some strict style issues in the Kibana formula.