### PR TITLE
Updating offlineimap to version 6.7.0

### DIFF
--- a/Library/Formula/offlineimap.rb
+++ b/Library/Formula/offlineimap.rb
@@ -1,8 +1,8 @@
 class Offlineimap < Formula
   desc "Synchronizes emails between two repositories"
   homepage "http://offlineimap.org/"
-  url "https://github.com/OfflineIMAP/offlineimap/archive/v6.6.1.tar.gz"
-  sha256 "af3fd47ba087180dc0e8d2b64cf358ce7f6fe49732d13b6fcce82853d0004bb0"
+  url "https://github.com/OfflineIMAP/offlineimap/archive/v6.7.0.tar.gz"
+  sha256 "c446fb31bdca90c7db4146b918ad3fa05f6df5362a4cc961df6a7727a8aac210"
   head "https://github.com/OfflineIMAP/offlineimap.git"
 
   bottle :unneeded


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [X] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

Trivial update of offlineimap to 6.7.0 (the new stable version) from 6.6.1