### PR TITLE
jsoncpp 1.6.5

### DIFF
--- a/Library/Formula/jsoncpp.rb
+++ b/Library/Formula/jsoncpp.rb
@@ -1,9 +1,9 @@
 class Jsoncpp < Formula
   desc "Library for interacting with JSON"
   homepage "https://github.com/open-source-parsers/jsoncpp"
-  url "https://github.com/open-source-parsers/jsoncpp/archive/0.10.5.tar.gz"
+  url "https://github.com/open-source-parsers/jsoncpp/archive/1.6.5.tar.gz"
   head "https://github.com/open-source-parsers/jsoncpp.git"
-  sha256 "56afb14d2ef1c52e72771a221346d4b94f0d46d4e67f796bbcaedb176ca823df"
+  sha256 "a2b121eaff56ec88cfd034d17685821a908d0d87bc319329b04f91a6552c1ac2"
 
   bottle do
     cellar :any
@@ -15,11 +15,15 @@ class Jsoncpp < Formula
 
   option :universal
 
+  needs :cxx11
+
   depends_on "cmake" => :build
 
   def install
+    ENV.cxx11
+
     cmake_args = std_cmake_args
-    cmake_args << "-DBUILD_STATIC_LIBS=ON" << "-DBUILD_SHARED_LIBS=ON" << "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
+    cmake_args << "-DBUILD_STATIC_LIBS=ON" << "-DBUILD_SHARED_LIBS=ON" << "-DJSONCPP_WITH_CMAKE_PACKAGE=ON" << "-DJSONCPP_WITH_TESTS=OFF" << "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF"
     if build.universal?
       ENV.universal_binary
       cmake_args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"

--- a/Library/Formula/libjson-rpc-cpp.rb
+++ b/Library/Formula/libjson-rpc-cpp.rb
@@ -4,6 +4,7 @@ class LibjsonRpcCpp < Formula
   url "https://github.com/cinemast/libjson-rpc-cpp/archive/v0.6.0.tar.gz"
   sha256 "98baf15e51514339be54c01296f0a51820d2d4f17f8c9d586f1747be1df3290b"
   head "https://github.com/cinemast/libjson-rpc-cpp.git"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Note

The `1.x.y` version requires c++11. As long as there're no issues with downstream builds, this should be preferred. Some of the std containers in the `0.x.y` branch are deprecated and really shouldn't be used with modern runtimes.