### PR TITLE
googler 2.2

### DIFF
--- a/Library/Formula/googler.rb
+++ b/Library/Formula/googler.rb
@@ -1,8 +1,8 @@
 class Googler < Formula
   desc "Google Search and News from the command-line"
   homepage "https://github.com/jarun/googler"
-  url "https://github.com/jarun/googler/archive/v2.1.tar.gz"
-  sha256 "4f42325b3961efa19c475138507f156891c27db7882ed6f75dfa256aef63016c"
+  url "https://github.com/jarun/googler/archive/v2.2.tar.gz"
+  sha256 "5e0948e775bdfcef1db94a209778a23844a5cef4ef3aa2c12b1dadf75311db7b"
 
   bottle do
     cellar :any_skip_relocation
@@ -14,16 +14,10 @@ class Googler < Formula
   depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    # googler requires Python 2.7+, but its shebang is hard-coded as
-    # #!/usr/bin/python, so there might be problems on Snow Leopard. As
-    # a work around we replace /usr/bin/python with brewed Python on
-    # Snow Leopard. This workaround won't be needed when
-    # https://github.com/jarun/googler/issues/23 is resolved.
-    inreplace "googler", "#!/usr/bin/python", "#!#{HOMEBREW_PREFIX}/bin/python" if MacOS.version <= :snow_leopard
     system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    assert_match /Usage: googler/, `#{bin}/googler`
+    assert_match /Homebrew/, shell_output("PYTHONIOENCODING=utf-8 #{bin}/googler Homebrew </dev/null")
   end
 end


### PR DESCRIPTION
https://github.com/jarun/googler/releases/tag/v2.2.

Removed a temporary workaround, and due to an improvement when can now write a more substantial test.