### PR TITLE
audit: fix crash when HOMEBREW_NO_GITHUB_API is set

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -509,6 +509,8 @@ class FormulaAuditor
       return
     end
 
+    return if metadata.nil?
+
     problem "GitHub fork (not canonical repository)" if metadata["fork"]
     if (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
        (metadata["stargazers_count"] < 50)

--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -340,4 +340,21 @@ class FormulaAuditorTests < Homebrew::TestCase
     assert_equal "Please remove default template comments",
       fa.problems.shift
   end
+
+  def test_audit_github_repository_no_api
+    fa = formula_auditor "foo", <<-EOS.undent, :strict => true, :online => true
+      class Foo < Formula
+        homepage "https://github.com/example/example"
+        url "http://example.com/foo-1.0.tgz"
+      end
+    EOS
+
+    original_value = ENV["HOMEBREW_NO_GITHUB_API"]
+    ENV["HOMEBREW_NO_GITHUB_API"] = "1"
+
+    fa.audit_github_repository
+    assert_equal [], fa.problems
+  ensure
+    ENV["HOMEBREW_NO_GITHUB_API"] = original_value
+  end
 end


### PR DESCRIPTION
Running brew audit --strict --online on a formula with a GitHub homepage/url would crash if `HOMEBREW_NO_GITHUB_API` is set because `GitHub.repository` returns `nil` and the audit code assumes it always returns a hash.