### PR TITLE
brew fetch: only include sha256 in output

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -100,7 +100,7 @@ module Homebrew
     return unless download.file?
 
     puts "Downloaded to: #{download}" unless already_fetched
-    puts Checksum::TYPES.map { |t| "#{t.to_s.upcase}: #{download.send(t)}" }
+    puts "SHA256: #{download.sha256}"
 
     f.verify_download_integrity(download)
   end


### PR DESCRIPTION
What do you think about cutting `sha1` from the `fetch` checksum output like so, now that it's mostly deprecated? Would save some lines of output, and avoid encouraging people to use SHA1 instead of SHA256.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? Nope; didn't see existing tests for the `fetch` stuff.
- [X] Have you successfully ran `brew tests` with your changes locally?

