### PR TITLE
Make upgrade command aware of options '--ignore-dependencies' and '--only-dependencies'

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -60,6 +60,8 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options             = tab.used_options
+    fi.ignore_deps         = ARGV.ignore_deps?
+    fi.only_deps           = ARGV.only_deps?
     fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
     fi.build_from_source   = ARGV.build_from_source?
     fi.verbose             = ARGV.verbose?


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] <del>Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.</del> _(Not applicable)_
- [x] Have you successfully ran `brew tests` with your changes locally?

***

Currently the `install` command accepts options like `--ignore-dependencies` and `--only-dependencies`; however, the `upgrade` command seems to ignore them completely, as I recently observed in Linuxbrew:

```console
$ brew upgrade --ignore-dependencies sqlite 
==> Upgrading 1 outdated package, with result:
sqlite 3.11.0
==> Upgrading sqlite
==> Installing dependencies for sqlite: pkg-config, homebrew/dupes/ncurses
==> Installing sqlite dependency: pkg-config
==> Downloading https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz
^C
```

I'm not sure whether it's an intended behavior, but it would be more convenient to make the `upgrade` command analogous to `install`, (e.g. if one chooses not to install these dependencies at all, `brew upgrade --ignore-dependencies` should just work, without having to `uninstall` and `brew install --ignore-dependencies` again.)

```console
$ brew upgrade --ignore-dependencies sqlite 
==> Upgrading 1 outdated package, with result:
sqlite 3.11.0
==> Upgrading sqlite
==> Downloading https://sqlite.org/2016/sqlite-autoconf-3110000.tar.gz
^C
```
