### PR TITLE
libjson-rpc-cpp: bump the revision

### DIFF
--- a/Library/Formula/libjson-rpc-cpp.rb
+++ b/Library/Formula/libjson-rpc-cpp.rb
@@ -4,6 +4,7 @@ class LibjsonRpcCpp < Formula
   url "https://github.com/cinemast/libjson-rpc-cpp/archive/v0.6.0.tar.gz"
   sha256 "98baf15e51514339be54c01296f0a51820d2d4f17f8c9d586f1747be1df3290b"
   head "https://github.com/cinemast/libjson-rpc-cpp.git"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
See #50040, the forward dependency (`libjson-rpc-cpp`) needs to be rebuilt now that `jsoncpp` is building with c++11 (version `1.x.y`).

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
