### PR TITLE
libusrsctp: upstream moved

### DIFF
--- a/Library/Formula/libusrsctp.rb
+++ b/Library/Formula/libusrsctp.rb
@@ -1,7 +1,9 @@
 class Libusrsctp < Formula
-  desc "User-land SCTP stack"
-  homepage "http://sctp.fh-muenster.de/sctp-user-land-stack.html"
-  url "http://sctp.fh-muenster.de/download/libusrsctp-0.9.1.tar.gz"
+  desc "A portable SCTP userland stack"
+  homepage "https://github.com/sctplab/usrsctp"
+  url "https://mirrorservice.org/sites/distfiles.macports.org/libusrsctp/libusrsctp-0.9.1.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/MacPorts/mpdistfiles/libusrsctp/libusrsctp-0.9.1.tar.gz"
+  mirror "https://ftp.fau.de/macports/distfiles/libusrsctp/libusrsctp-0.9.1.tar.gz"
   sha256 "63a3abe5f1cb7ddde36cba09d32579b05a98badb06ff88fca87d024925c3ff16"
 
   bottle do
@@ -13,7 +15,7 @@ class Libusrsctp < Formula
   end
 
   head do
-    url "http://sctp-refimpl.googlecode.com/svn/trunk/KERN/usrsctp"
+    url "https://github.com/sctplab/usrsctp.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- Update homepage
- Update head url
- No update available as a tag, so I created https://github.com/sctplab/usrsctp/issues/59
- Replaced the original url with mirrors for the time being
