### PR TITLE
go: Bump tools to 1.6 revision

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -20,9 +20,12 @@ class Go < Formula
   option "without-vet", "vet will not be installed for you"
   option "without-race", "Build without race detector"
 
+  go_version = version
+
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
-    :revision => "d02228d1857b9f49cd0252788516ff5584266eb6"
+    :branch => "release-branch.go#{go_version}",
+    :revision => "c887be1b2ebd11663d4bf2fbca508c449172339e"
   end
 
   resource "gobootstrap" do


### PR DESCRIPTION
Even though formula is installing go1.6, the tools are still pinned to 1.5 release branch: https://go.googlesource.com/tools.git/+/release-branch.go1.5

I re-pinned it to 1.6: https://go.googlesource.com/tools.git/+/release-branch.go1.6

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
