### PR TITLE
bash: Fix patch

### DIFF
--- a/Library/Formula/bash.rb
+++ b/Library/Formula/bash.rb
@@ -14,8 +14,8 @@ class Bash < Formula
     # and the more patches there are, the more unreliable they get. Upstream
     # patches can be found in: http://git.savannah.gnu.org/cgit/bash.git
     patch do
-      url "https://gist.githubusercontent.com/dunn/a8986687991b57eb3b25/raw/76dd864812e821816f4b1c18e3333c8fced3919b/bash-4.3.42.diff"
-      sha256 "2eeb9b3ed71f1e13292c2212b6b8036bc258c58ec9c82eec7a86a091b05b15d2"
+      url "https://raw.githubusercontent.com/Homebrew/patches/master/bash/bash-4.3.42.diff"
+      sha256 "a3ab0b79f63845db5bda568258b56629de25922ae52c6786d004f4f62566bf1d"
     end
   end
 


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:
(Not a new formula but this still applies)
- [X] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

A bit of context: On Linuxbrew/linuxbrew#913, we discovered that two of the files in bash's patch did not exist in the .tar.gz.  They appear to be temporary files accidentally committed to the repository.  For some reason, Linux's patch program crashes on discovering this, but it is ignored by Mac's patch program.  Even though it does not err for Homebrew, the patch file is still incorrect and could crash with other versions of patch.

I'm not sure if this should be submitted right to Homebrew or submitted upstream.  I can't figure out where this patch came from the link provided so I'm just submitting it here.