### PR TITLE
openshift-cli 1.1.4

### DIFF
--- a/Library/Formula/openshift-cli.rb
+++ b/Library/Formula/openshift-cli.rb
@@ -2,8 +2,8 @@ class OpenshiftCli < Formula
   desc "OpenShift command-line interface tools"
   homepage "https://www.openshift.com/"
   url "https://github.com/openshift/origin.git",
-    :tag => "v1.1.3",
-    :revision => "cffae0523cfa80ddf917aba69f08508b91f603d5"
+    :tag => "v1.1.4",
+    :revision => "3941102b8a022b5f2d9ec2c94d1f13d519fa9c31"
 
   head "https://github.com/openshift/origin.git"
 
@@ -18,26 +18,16 @@ class OpenshiftCli < Formula
 
   def install
     # this is necessary to avoid having the version marked as dirty
-    (buildpath/".git/info/exclude").atomic_write <<-EOF.undent
-      /.brew_home
-      /src
-    EOF
+    (buildpath/".git/info/exclude").atomic_write "/.brew_home"
 
-    # this is a terrible hack that's necessary because the build script assumes
-    # that the source code was checked out via `go get` and overrides $GOPATH,
-    # and also because make will change into the target of folder symlinks
-    # rather than the folder symlinks themselves
-    real_buildpath = buildpath/"src/github.com/openshift/origin"
-    real_buildpath.install (Dir["*", ".*"] - [".", "..", "src"])
-
-    system "make", "-C", "src/github.com/openshift/origin", "all", "WHAT=cmd/openshift", "GOFLAGS=-v"
+    system "make", "all", "WHAT=cmd/openshift", "GOFLAGS=-v", "OS_OUTPUT_GOPATH=1"
 
     arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
-    bin.install real_buildpath/"_output/local/bin/darwin/#{arch}/openshift"
+    bin.install "_output/local/bin/darwin/#{arch}/openshift"
     bin.install_symlink "openshift" => "oc"
     bin.install_symlink "openshift" => "oadm"
 
-    bash_completion.install Dir[real_buildpath/"contrib/completions/bash/*"]
+    bash_completion.install Dir["contrib/completions/bash/*"]
   end
 
   test do


### PR DESCRIPTION
The terrible hacks required to make OpenShift 1.1.3 build are no longer necessary due to the addition of the `OS_OUTPUT_GOPATH=1` flag, which now instructs the build scripts to use the old behavior regarding directory layouts. Hooray!

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?