### PR TITLE
hashpump: fix brew audit warning " Use 'assert_match' instead of 'assert...include?' "

### DIFF
--- a/Library/Formula/hashpump.rb
+++ b/Library/Formula/hashpump.rb
@@ -40,8 +40,8 @@ class Hashpump < Formula
     output = %x(#{bin}/hashpump -s '6d5f807e23db210bc254a28be2d6759a0f5f5d99' \\
       -d 'count=10&lat=37.351&user_id=1&long=-119.827&waffle=eggo' \\
       -a '&waffle=liege' -k 14)
-    assert output.include? "0e41270260895979317fff3898ab85668953aaa2"
-    assert output.include? "&waffle=liege"
+    assert_match /0e41270260895979317fff3898ab85668953aaa2/, output
+    assert_match /&waffle=liege/, output
     assert_equal 0, $?.exitstatus
   end
 end


### PR DESCRIPTION
_This is my initial commit to get used to contribution process._

After running 'brew audit' multiple warnings about better using 'assert_match' than 'assert .. include? ..' appeared, this commit is fixing one of them.

- brew audit is ok
- brew tests passed
- brew install hashpump && brew test hashpump passed

If it is merged, can I fix the other warnings like this in the same way in one pull request?