### PR TITLE
osquery 1.7.2 (devel), cpp-netlib 0.12.0-rc1

### DIFF
--- a/Library/Formula/cpp-netlib.rb
+++ b/Library/Formula/cpp-netlib.rb
@@ -1,9 +1,9 @@
 class CppNetlib < Formula
   desc "C++ libraries for high level network programming"
   homepage "http://cpp-netlib.org"
-  url "http://downloads.cpp-netlib.org/0.11.2/cpp-netlib-0.11.2-final.tar.gz"
-  version "0.11.2"
-  sha256 "71953379c5a6fab618cbda9ac6639d87b35cab0600a4450a7392bc08c930f2b1"
+  url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-rc1.tar.gz"
+  version "0.12.0-rc1"
+  sha256 "f692253c57219b52397a886af769afe207e9cf2eda8ad22ed0e9e48bb483fc03"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,15 +13,7 @@ class CppNetlib < Formula
     sha256 "093cc615abf08eeb6d698d85e9d4bb8003e536548f925246d86baa7f1ec45506" => :mountain_lion
   end
 
-  devel do
-    url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-rc1.tar.gz"
-    version "0.12.0-rc1"
-    sha256 "f692253c57219b52397a886af769afe207e9cf2eda8ad22ed0e9e48bb483fc03"
-
-    # Version 0.12.0+ moves from boost::asio to asio.
-    depends_on "asio"
-  end
-
+  depends_on "asio"
   depends_on "cmake" => :build
   depends_on "openssl"
 

--- a/Library/Formula/osquery.rb
+++ b/Library/Formula/osquery.rb
@@ -13,6 +13,12 @@ class Osquery < Formula
     sha256 "88f1f3b78643bc68258115a3b9ad329b05a7332e71ba94ae35f50ee6b773d5cb" => :mavericks
   end
 
+  devel do
+    url "https://github.com/facebook/osquery.git",
+    :tag => "1.7.2",
+    :revision => "6f034a71567ce237454943eb623e13eeafb4592a"
+  end
+
   # osquery only supports OS X 10.9 and above. Do not remove this.
   depends_on :macos => :mavericks
 
@@ -45,6 +51,12 @@ class Osquery < Formula
   end
 
   def install
+    # Fix build failure on case-sensitive file systems
+    # Upstream issue: facebook/osquery#1931
+    # Upstream merged: facebook/osquery@3e103e6
+    # Remove when 1.8.0 is released
+    inreplace "osquery/events/darwin/iokit.h", "IOKitlib", "IOKitLib" if build.stable?
+
     # Link dynamically against brew-installed libraries.
     ENV["BUILD_LINK_SHARED"] = "1"
 


### PR DESCRIPTION
Apply the upstream PR patch from facebook/osquery#1931

This fixes a case-sensitivity build failure. All instances of
"IOKitLib.h" are correctly spelled in the sources except for one.