### PR TITLE
polygen: "makefile" not "Makefile"

### DIFF
--- a/Library/Formula/polygen.rb
+++ b/Library/Formula/polygen.rb
@@ -10,7 +10,7 @@ class Polygen < Formula
     cd "src" do
       # BSD echo doesn't grok -e, which the makefile tries to use,
       # with weird results; see https://github.com/Homebrew/homebrew/pull/21344
-      inreplace "Makefile", '-e "open Absyn\n"', '"open Absyn"'
+      inreplace "makefile", '-e "open Absyn\n"', '"open Absyn"'
       system "make"
       bin.install "polygen"
     end


### PR DESCRIPTION
The `inreplace` in the formula attempts to operate on "Makefile" but the
file is actually named "makefile," which causes this to fail on a
case-sensitive file system.