### PR TITLE
portmidi: enforce commaphilia

### DIFF
--- a/Library/Formula/portmidi.rb
+++ b/Library/Formula/portmidi.rb
@@ -32,7 +32,7 @@ class Portmidi < Formula
     inreplace "pm_common/CMakeLists.txt", "set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.5.sdk CACHE", "set(CMAKE_OSX_SYSROOT /#{MacOS.sdk_path} CACHE"
 
     system "make", "-f", "pm_mac/Makefile.osx"
-    system "make", "-f", "pm_mac/Makefile.osx install"
+    system "make", "-f", "pm_mac/Makefile.osx", "install"
 
     if build.with? "python"
       cd "pm_python" do


### PR DESCRIPTION
This fixes the following build failure:
  make: pm_mac/Makefile.osx install: No such file or directory