### PR TITLE
remctl 3.10

### DIFF
--- a/Library/Formula/remctl.rb
+++ b/Library/Formula/remctl.rb
@@ -1,13 +1,15 @@
 class Remctl < Formula
   desc "Client/server application for remote execution of tasks"
   homepage "http://www.eyrie.org/~eagle/software/remctl/"
-  url "http://archives.eyrie.org/software/kerberos/remctl-3.9.tar.gz"
-  sha256 "7652a38008386a2cab4ba6f596ab0620a83a2b076dd56e74d01bbb9cddaed20e"
+  url "http://archives.eyrie.org/software/kerberos/remctl-3.10.tar.xz"
+  sha256 "6a206dc3d5149fe4a40fb47850fd55619de03c165c843caf61f84b840c623a93"
 
   depends_on "pcre"
   depends_on "libevent"
 
   def install
+    # needed for gss_oid_equal()
+    ENV.append "LDFLAGS", "-framework GSS"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-pcre=#{HOMEBREW_PREFIX}"


### PR DESCRIPTION
Fixes
```
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "remctl"
```