### PR TITLE
avro-cpp 1.8.0

### DIFF
--- a/Library/Formula/avro-cpp.rb
+++ b/Library/Formula/avro-cpp.rb
@@ -1,8 +1,8 @@
 class AvroCpp < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.7.7/cpp/avro-cpp-1.7.7.tar.gz"
-  sha256 "f9bdfad58f513014940fcda372840e36f4f3787a20a00bc0666d254973a1ec1d"
+  url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.8.0/cpp/avro-cpp-1.8.0.tar.gz"
+  sha256 "ec6e2ec957e95ca07f70cc25f02f5c416f47cb27bd987a6ec770dcbe72527368"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Bump [avro-cpp](https://avro.apache.org/) to 1.8.0.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?