### PR TITLE
gf-complete 2.0 - remove redundant version statement

### DIFF
--- a/Library/Formula/gf-complete.rb
+++ b/Library/Formula/gf-complete.rb
@@ -2,7 +2,6 @@ class GfComplete < Formula
   desc "Comprehensive Library for Galois Field Arithmetic"
   homepage "http://jerasure.org/"
   url "http://lab.jerasure.org/jerasure/gf-complete/repository/archive.tar.gz?ref=v2.0"
-  version "2.0"
   sha256 "0654202fe3b0d3f8a220158699bdea722e47e7f9cbc0fd52e4857aba6a069ea9"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

---

`brew audit gf-complete` returns:
`* Stable: version 2.0 is redundant with version scanned from URL`

This change removes the redundancy.