### PR TITLE
Avoid pathological trailing slash

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -67,8 +67,8 @@ module Stdenv
     macosxsdk MacOS.version
 
     if MacOS::Xcode.without_clt?
-      append_path "PATH", "#{MacOS::Xcode.prefix}/usr/bin"
-      append_path "PATH", "#{MacOS::Xcode.toolchain_path}/usr/bin"
+      append_path "PATH", (MacOS::Xcode.prefix/"usr/bin").to_s
+      append_path "PATH", (MacOS::Xcode.toolchain_path/"usr/bin").to_s
     end
   end
 

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -119,8 +119,8 @@ module Superenv
     # On 10.9, there are shims for all tools in /usr/bin.
     # On 10.7 and 10.8 we need to add these directories ourselves.
     if MacOS::Xcode.without_clt? && MacOS.version <= "10.8"
-      paths << "#{MacOS::Xcode.prefix}/usr/bin"
-      paths << "#{MacOS::Xcode.toolchain_path}/usr/bin"
+      paths << (MacOS::Xcode.prefix/"usr/bin").to_s
+      paths << (MacOS::Xcode.toolchain_path/"usr/bin").to_s
     end
 
     paths << MacOS::X11.bin.to_s if x11?

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -33,7 +33,7 @@ module OS
       def sdk_paths
         @sdk_paths ||= begin
           # Xcode.prefix is pretty smart, so let's look inside to find the sdk
-          sdk_prefix = "#{Xcode.prefix}/Platforms/MacOSX.platform/Developer/SDKs"
+          sdk_prefix = (Xcode.prefix/"Platforms/MacOSX.platform/Developer/SDKs").to_s
           # Xcode < 4.3 style
           sdk_prefix = "/Developer/SDKs" unless File.directory? sdk_prefix
           # Finally query Xcode itself (this is slow, so check it last)

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -50,7 +50,7 @@ module OS
       end
 
       def toolchain_path
-        Pathname.new("#{prefix}/Toolchains/XcodeDefault.xctoolchain") if installed? && version >= "4.3"
+        (prefix/"Toolchains/XcodeDefault.xctoolchain") if installed? && version >= "4.3"
       end
 
       # Ask Spotlight where Xcode is. If the user didn't install the
@@ -79,8 +79,8 @@ module OS
 
         return nil if !MacOS::Xcode.installed? && !MacOS::CLT.installed?
 
-        %W[#{prefix}/usr/bin/xcodebuild #{which("xcodebuild")}].uniq.each do |path|
-          if File.file? path
+        [(prefix/"usr/bin/xcodebuild"), which("xcodebuild")].uniq.each do |path|
+          if path.file?
             Utils.popen_read(path, "-version") =~ /Xcode (\d(\.\d)*)/
             return $1 if $1
           end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -43,7 +43,8 @@ module OS
               path = bundle_path
               path.join("Contents", "Developer") if path
             else
-              Pathname.new(dir)
+              # Use cleanpath to avoid pathological trailing slash
+              Pathname.new(dir).cleanpath
             end
           end
       end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -144,7 +144,7 @@ module OS
         if version < "4.3"
           prefix.to_s.start_with? "/Developer"
         else
-          prefix.to_s.start_with? "/Applications/Xcode.app"
+          prefix.to_s == "/Applications/Xcode.app/Contents/Developer"
         end
       end
     end


### PR DESCRIPTION
Probably resolves #49731?

* The most proximal problem is that Python's sqlite module was linking to the wrong libsqlite3 because the Xcode system library path was (incorrectly) not removed by superenv.

* This is because the `cc` superenv shim does string comparisons on library paths to determine whether to reject them and [the path is constructed from `sdkroot`](https://github.com/Homebrew/homebrew/blob/master/Library/ENV/4.3/cc#L249-L251). `sdkroot` had taken the value `/Applications/Xcode.app/Contents/Developer//Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk`. Because of the double slash between Developer and Platforms, this string did not exactly match the Xcode system library path.

* `sdkroot` in the shim [takes the value of effective_sysroot](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/extend/ENV/super.rb#L57), which is [MacOS.sdk_path.to_s](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/extend/ENV/super.rb#L106) on Xcode-only systems.

* The most-likely-candidate SDK path [is constructed as](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/os/mac/sdk.rb#L36) `"#{Xcode.prefix}/Platforms/MacOSX.platform/Developer/SDKs"`.

* `Xcode.prefix` [is constructed from](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/os/mac/xcode.rb#L40) `MacOS.active_developer_dir` which [queries xcode-select](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/os/mac.rb#L86).

I suspect the root pathology is that `xcode-select -p` somehow came to print a path with a trailing slash.

`Pathname`s are totally happy to carry extra slashes around:

```
irb(main):016:0> p = Pathname.new("/usr/local/")
=> #<Pathname:/usr/local/>
irb(main):017:0> p.to_s
=> "/usr/local/"
irb(main):018:0> Pathname.new("#{p}/foo")
=> #<Pathname:/usr/local//foo>
irb(main):019:0> (p/"foo").to_s
=> "/usr/local/foo"
```

Note the difference between lines 18 and 19; constructing [pP]athnames by string interpolation instead of using path construction methods allows the double-slash to persist.

An exacerbating factor which made diagnosing this issue more difficult is that we [don't do exact string matches](https://github.com/Homebrew/homebrew/pull/50154/commits/cd9b4545d5863ddceb08e057d6175f2738a523a5) when we check for a default Xcode developer directory.

I think my takeaways are:
* use `Pathname#cleanpath` or `#realpath` on user/system-provided paths if you don't want a trailing slash on them
* use path construction methods, not string interpolation, to construct paths
* avoid using simple string equivalence to determine pathname equivalence