### PR TITLE
Improve error message for invalid regex to search

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -93,6 +93,8 @@ module Homebrew
     when %r{^/(.*)/$} then Regexp.new($1)
     else /.*#{Regexp.escape(query)}.*/i
     end
+  rescue RegexpError
+    odie "#{query} is not a valid regex"
   end
 
   def search_taps(rx)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

Fixes Homebrew#50131

Previously if a bad regexp was passed to `brew search` it would produce
an output of:

```
$ brew search '/++[/'
Error: target of repeat operator is not specified: /++[/
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/cmd/search.rb:93:in `initialize'
/usr/local/Library/Homebrew/cmd/search.rb:93:in `new'
/usr/local/Library/Homebrew/cmd/search.rb:93:in `query_regexp'
/usr/local/Library/Homebrew/cmd/search.rb:43:in `search'
/usr/local/Library/brew.rb:83:in `<main>'
$
```

This commit makes it so that if `Regexp.new` is passed an invalid
regular expression that the error message now looks something like:

```
$ brew search '/++[/'
/++[/ is not a valid regex
$
```

I couldn't find any tests around the search command but am more than welcome to add any as needed.

I thought about whether it was worth rescuing all errors related to invalid regular expressions in this manner as you do in `brew.rb` but felt that since this was specifically related to the search command it wasn't necessary.

Let me know any feedback on it. Thanks!