### PR TITLE
srmio: replace system chmod with Ruby chmod method

### DIFF
--- a/Library/Formula/srmio.rb
+++ b/Library/Formula/srmio.rb
@@ -15,7 +15,7 @@ class Srmio < Formula
 
   def install
     if build.head?
-      system "chmod u+x genautomake.sh"
+      chmod 0755, "genautomake.sh"
       system "./genautomake.sh"
     end
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

---

This change addresses the audit warning:
 ```* Use the `chmod` Ruby method instead of `system "chmod ````
