### PR TITLE
Fix backwards compatibility issues with dbus's plist files

### DIFF
--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -4,12 +4,30 @@ class DBus < Formula
   homepage "https://wiki.freedesktop.org/www/Software/dbus"
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.6.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.6.orig.tar.gz"
+  master "git://anongit.freedesktop.org/dbus/dbus.git"
   sha256 "b5fefa08a77edd76cd64d872db949eebc02cf6f3f8be82e4bbc641742af5d35f"
 
   bottle do
     sha256 "edf31f467954d3ead8d32fe9db3ef406211fa03eba81b2ab9cad842359a76829" => :el_capitan
     sha256 "e1818ef166c0d49071bd687e83ec51367052bb8846888a482cac823a991aa092" => :yosemite
     sha256 "08094b506bf81ce24aa9c38d9414b43726b35d19461440ecfc74d47d02298d50" => :mavericks
+  end
+
+  # Patches apply the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
+  if MacOS.version >= :leopard
+    patch do
+      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
+      sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
+    end
+  else
+    patch do
+      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
+      sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
+    end
+  end
+
+  def plist_name
+    "org.freedesktop.dbus-session"
   end
 
   def install
@@ -29,8 +47,6 @@ class DBus < Formula
     system "make"
     ENV.deparallelize
     system "make", "install"
-
-    (prefix/"org.freedesktop.dbus-session.plist").chmod 0644
   end
 
   def post_install

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -4,8 +4,8 @@ class DBus < Formula
   homepage "https://wiki.freedesktop.org/www/Software/dbus"
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.6.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.6.orig.tar.gz"
-  master "git://anongit.freedesktop.org/dbus/dbus.git"
   sha256 "b5fefa08a77edd76cd64d872db949eebc02cf6f3f8be82e4bbc641742af5d35f"
+  head "git://anongit.freedesktop.org/dbus/dbus.git"
 
   bottle do
     sha256 "edf31f467954d3ead8d32fe9db3ef406211fa03eba81b2ab9cad842359a76829" => :el_capitan
@@ -58,3 +58,4 @@ class DBus < Formula
     system "#{bin}/dbus-daemon", "--version"
   end
 end
+

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -13,17 +13,11 @@ class DBus < Formula
     sha256 "08094b506bf81ce24aa9c38d9414b43726b35d19461440ecfc74d47d02298d50" => :mavericks
   end
 
-  # Patches apply the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
-  if MacOS.version >= :leopard
-    patch do
-      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
-      sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
-    end
-  else
-    patch do
-      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
-      sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
-    end
+  # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
+  # Homebrew pr/issue: 50219
+  patch do
+    url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
+    sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
   end
 
   def plist_name

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -16,7 +16,7 @@ class DBus < Formula
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
   patch do
-    url "https://github.com/homebrew/patches/blob/dbus-fixes/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
+    url "https://raw.githubusercontent.com/homebrew/patches/master/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
     sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
   end
 

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -16,12 +16,8 @@ class DBus < Formula
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
   patch do
-    url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
+    url "https://github.com/homebrew/patches/blob/dbus-fixes/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
     sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
-  end
-
-  def plist_name
-    "org.freedesktop.dbus-session"
   end
 
   def install
@@ -52,4 +48,3 @@ class DBus < Formula
     system "#{bin}/dbus-daemon", "--version"
   end
 end
-

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -5,7 +5,7 @@ class DBus < Formula
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.6.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.6.orig.tar.gz"
   sha256 "b5fefa08a77edd76cd64d872db949eebc02cf6f3f8be82e4bbc641742af5d35f"
-  head "git://anongit.freedesktop.org/dbus/dbus.git"
+  head "https://anongit.freedesktop.org/git/dbus/dbus.git"
 
   bottle do
     sha256 "edf31f467954d3ead8d32fe9db3ef406211fa03eba81b2ab9cad842359a76829" => :el_capitan
@@ -16,7 +16,7 @@ class DBus < Formula
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
   patch do
-    url "https://raw.githubusercontent.com/homebrew/patches/master/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
+    url "https://raw.githubusercontent.com/Homebrew/patches/0a8a55872e/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
     sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
   end
 


### PR DESCRIPTION
### Description

D-Bus includes a session daemon plist file. However, homebrew is not
explicitly told about this file (though it figures it out),and the file
contains the ServiceIPC key, which will emit "deprecated" warnings
in launchd on modern OSX. This commit patches the included config file
based on OSX version to ensure that files free of legacy cruft are
distributed correctly.


Other changes included:
- Removed pointless "chmod" of the distributed plist file. Unless built as root, the generated plist has appropriate permissions in standard Homebrew installs. 
- Added "master" branch info for the recommended public-pull source repo for D-Bus.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [X] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?