### PR TITLE
suil: remove non-existent support for Qt 5

### DIFF
--- a/Library/Formula/suil.rb
+++ b/Library/Formula/suil.rb
@@ -15,7 +15,6 @@ class Suil < Formula
   depends_on "lv2"
   depends_on "gtk+" => :recommended
   depends_on "qt" => :optional
-  depends_on "qt5" => :optional
   depends_on :x11 => :optional
 
   def install


### PR DESCRIPTION
There will be support for Qt 5 in an upcoming release, but there's none in the current stable (0.8.2), thus remove optional `qt5` dependency. (Noticed this while preparing for Qt 5.6.0.)