### PR TITLE
pyqt5: replace QtWebKit with QtWebEngine in test

### DIFF
--- a/Library/Formula/pyqt5.rb
+++ b/Library/Formula/pyqt5.rb
@@ -68,7 +68,7 @@ class Pyqt5 < Formula
         Network
         Quick
         Svg
-        WebKit
+        WebEngineWidgets
         Widgets
         Xml
       ].each { |mod| system python, "-c", "import PyQt5.Qt#{mod}" }


### PR DESCRIPTION
The `QtWebKit` module has been deprecated for quite a while and was finally removed in Qt 5.6.0. Adapt test to use its successor instead.

(This is in preparation for Qt 5.6.0. There will be a separate `pyqt5` revision bump as part of the `qt5` version bump PR to eliminate the stale Python wrapper for the `QtWebKit` module from the bottle.)