### PR TITLE
qcachegrind: prefer macx-clang over macx-g++ spec

### DIFF
--- a/Library/Formula/qcachegrind.rb
+++ b/Library/Formula/qcachegrind.rb
@@ -16,7 +16,7 @@ class Qcachegrind < Formula
 
   def install
     cd "qcachegrind"
-    system "#{Formula["qt5"].bin}/qmake", "-spec", "macx-g++", "-config", "release"
+    system "#{Formula["qt5"].bin}/qmake", "-spec", "macx-clang", "-config", "release"
     system "make"
     # Install app
     prefix.install "qcachegrind.app"


### PR DESCRIPTION
The `macx-g++` is a legacy spec that shouldn't be used nowadays. Using it will also break the build with Qt 5.6.0 because unlike the newer and preferable `macx-clang` spec it doesn't support C++11 and above (and Qt 5.6.0 defaults to the highest C++ standard supported by the compiler).

(This looks like an oversight in #49771 where the formula was switched over from `qt` to `qt5`.)