### PR TITLE
open-scene-graph: work around an SDK 10.11 issue

### DIFF
--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -15,10 +15,6 @@ class OpenSceneGraph < Formula
   option "with-docs", "Build the documentation with Doxygen and Graphviz"
   deprecated_option "docs" => "with-docs"
 
-  # Currently does not build on 10.10+, possibly due to Xcode 7 issue
-  # https://github.com/Homebrew/homebrew/pull/46776
-  depends_on MaximumMacOSRequirement => :mavericks
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "jpeg"
@@ -55,6 +51,7 @@ class OpenSceneGraph < Formula
 
     args = std_cmake_args
     args << "-DBUILD_DOCUMENTATION=" + ((build.with? "docs") ? "ON" : "OFF")
+    args << "-DCMAKE_CXX_FLAGS=-Wno-error=narrowing" # or: -Wno-c++11-narrowing
 
     if MacOS.prefer_64_bit?
       args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.arch_64_bit}"


### PR DESCRIPTION
This is not a true fix, as the actual problem is in the 10.11 SDK, that is used in a non-standard way. That way, the compiler doesn't see the headers as system headers and (rightfully) complains about them being broken in C++11 mode.

See also <https://plus.google.com/+ThiagoMacieira/posts/2SmArLfeDZt>.

Since the failure is not OSG's fault, it seems more fair to re-enable support for 10.10/10.11 and just swallow the error caused by the broken SDK header (by turning it back into a warning in C++11 mode).

CC @apjanke 