### PR TITLE
FormulaInstaller: rescue tap unavail for reqs too

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -126,7 +126,7 @@ class FormulaInstaller
 
   def verify_deps_exist
     begin
-      formula.recursive_dependencies.map(&:to_formula)
+      compute_dependencies
     rescue TapFormulaUnavailableError => e
       if e.tap.installed?
         raise


### PR DESCRIPTION
FormulaInstaller: rescue tap unavail for reqs too

Calling `compute_dependencies` will make sure both requirements and
dependencies are expanded, so that any referenced taps can be
auto-tapped. Prior to this commit only dependencies were expanded for
the sake of auto-tapping, so dependencies of requirements would cause
installation to fail whenever a tap unavailable exception was
encountered.

Closes #50271

