### PR TITLE
git-credential-manager 1.5.0

### DIFF
--- a/Library/Formula/git-credential-manager.rb
+++ b/Library/Formula/git-credential-manager.rb
@@ -6,8 +6,11 @@ class GitCredentialManager < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+" if MacOS.version >= :el_capitan
-  depends_on :java => "1.7+" unless MacOS.version >= :el_capitan
+  if MacOS.version >= :el_capitan
+    depends_on :java => "1.8+"
+  else
+    depends_on :java => "1.7+"
+  end
 
   def install
     libexec.install "git-credential-manager-#{version}.jar"

--- a/Library/Formula/git-credential-manager.rb
+++ b/Library/Formula/git-credential-manager.rb
@@ -1,12 +1,13 @@
 class GitCredentialManager < Formula
   desc "Stores Git credentials for Visual Studio Team Services"
   homepage "https://java.visualstudio.com/Docs/tools/gitcredentialmanager"
-  url "https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-1.4.0/git-credential-manager-1.4.0.jar"
-  sha256 "9a2c405b1876753734774fc63dc01ce8751d4af1a892bea59f823d996624efec"
+  url "https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-1.5.0/git-credential-manager-1.5.0.jar"
+  sha256 "e5e685c6938e0955dabe91829d3bb4aaea9bce2bb1c6ecc6f405b74b4ce2b346"
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+" if MacOS.version >= :el_capitan
+  depends_on :java => "1.7+" unless MacOS.version >= :el_capitan
 
   def install
     libexec.install "git-credential-manager-#{version}.jar"


### PR DESCRIPTION
Notice the dependency has changed for Mac OS X 10.11+

To see the testing that was performed, refer to Microsoft/Git-Credential-Manager-for-Mac-and-Linux#32