### PR TITLE
sourcekitten 0.11.0

### DIFF
--- a/Library/Formula/sourcekitten.rb
+++ b/Library/Formula/sourcekitten.rb
@@ -1,7 +1,7 @@
 class Sourcekitten < Formula
   desc "Framework and command-line tool for interacting with SourceKit"
   homepage "https://github.com/jpsim/SourceKitten"
-  url "https://github.com/jpsim/SourceKitten.git", :tag => "0.10.0", :revision => "5b86c515ef22bc81918dd94186f5fe53399ef9b8"
+  url "https://github.com/jpsim/SourceKitten.git", :tag => "0.11.0", :revision => "6415bc91fde389c9b4866e2b61e1189be4c9796c"
   head "https://github.com/jpsim/SourceKitten.git"
 
   bottle do

--- a/Library/Formula/sourcekitten.rb
+++ b/Library/Formula/sourcekitten.rb
@@ -17,6 +17,6 @@ class Sourcekitten < Formula
   end
 
   test do
-    system "#{bin}/sourcekitten", "syntax", "--text", "import Foundation // Hello World"
+    system "#{bin}/sourcekitten", "version"
   end
 end


### PR DESCRIPTION
update formula version to 0.11.0 and update the test to `sourcekitten version` to avoid creating an XPC connection to SourceKit, which would be prevented by the Homebrew sandbox.

See #50211 for details. /cc @DomT4 