### PR TITLE
software_spec: add ExternalPatch to dependency_collector

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -165,7 +165,9 @@ class SoftwareSpec
   end
 
   def patch(strip = :p1, src = nil, &block)
-    patches << Patch.create(strip, src, &block)
+    p = Patch.create(strip, src, &block)
+    dependency_collector.add(p.resource) if p.is_a? ExternalPatch
+    patches << p
   end
 
   def fails_with(compiler, &block)


### PR DESCRIPTION
Since we support `apply` DSL in the `patch` block, external
patch files could be any compressed archive. As result, it
could introduce dependencies like xz, 7z etc.

Add the resource of ExternalPatch to dependency_collector, so
we could track these resource dependencies.

cc @DomT4