### PR TITLE
platformio 2.8.6

### DIFF
--- a/Library/Formula/platformio.rb
+++ b/Library/Formula/platformio.rb
@@ -1,8 +1,8 @@
 class Platformio < Formula
   desc "Ecosystem for IoT development (Arduino and MBED compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/source/p/platformio/platformio-2.8.5.tar.gz"
-  sha256 "e6cd25d43d9ea151cd9ec0ff404d3f91221d310378d7d85a2f8c782cf3627a07"
+  url "https://pypi.python.org/packages/source/p/platformio/platformio-2.8.6.tar.gz"
+  sha256 "34b683055127b7cd132baf0e784c96df22aa90afc2d3ad5947bd52871c6712d1"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
-   Launched [PlatformIO Community Forums](http://community.platformio.org) ([issue \#530])
-   Added support for ARM mbed-enabled board Seed Arch Max (STM32F407VET6) ([issue \#572])
-   Improved DNS lookup for PlatformIO API
-   Updated Arduino Wiring-based framework to the latest version for Atmel AVR/SAM development platforms
-   Updated “Teensy Loader CLI” and fixed uploading of large .hex files ([issue \#568])
-   Updated the support for Sanguino Boards ([issue \#586])
-   Better handling of used boards when re-initialize/update project
-   Improved support for non-Unicode user profiles for Windows OS
-   Disabled progress bar for download operations when prompts are disabled
-   Fixed multiple definition errors for ST STM32 development platform and ARM mbed framework ([issue \#571])
-   Fixed invalid board parameters (reset method and baudrate) for a few ESP8266 based boards
-   Fixed “KeyError: ‘content-length’” in PlatformIO Download Manager ([issue \#591])

  [issue \#530]: https://github.com/platformio/platformio/issues/530
  [issue \#572]: https://github.com/platformio/platformio/issues/572
  [issue \#568]: https://github.com/platformio/platformio/issues/568
  [issue \#586]: https://github.com/platformio/platformio/issues/586
  [issue \#571]: https://github.com/platformio/platformio/issues/571
  [issue \#591]: https://github.com/platformio/platformio/issues/591