### PR TITLE
scrub: fix brew audit warning

### DIFF
--- a/Library/Formula/scrub.rb
+++ b/Library/Formula/scrub.rb
@@ -31,7 +31,7 @@ class Scrub < Formula
     path.write "foo"
 
     output = `#{bin}/scrub -r -p dod #{path}`
-    assert output.include?("scrubbing #{path}")
+    assert_match "scrubbing #{path}", output
     assert_equal 0, $?.exitstatus
     assert !File.exist?(path)
   end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

---

This change addresses the audit warning:
```* Use `assert_match` instead of `assert ...include?` ```