### PR TITLE
grib-api: add option to build static library

### DIFF
--- a/Library/Formula/grib-api.rb
+++ b/Library/Formula/grib-api.rb
@@ -19,9 +19,13 @@ class GribApi < Formula
   # https://software.ecmwf.int/wiki/plugins/viewsource/viewpagesrc.action?pageId=12648475
   patch :DATA
 
+  option "with-static", "Build static instead of shared library."
+
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      args = std_cmake_args
+      args << "-DBUILD_SHARED_LIBS=OFF" if build.with? "static"
+      system "cmake", "..", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
Adds an option to build a static library instead of a shared one. According to the [grib docs](https://software.ecmwf.int/wiki/display/OIFS/Installing+grib_api+for+OpenIFS) the library should build both by default but this does not seem to be the case :(