### PR TITLE
Update link to Kickstarter Supporters from README

### DIFF
--- a/share/doc/homebrew/README.md
+++ b/share/doc/homebrew/README.md
@@ -30,4 +30,4 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
 
 ## Supporters
 [A list of the awesome people who gave £5 or more to our
-Kickstarter](https://github.com/Homebrew/homebrew/blob/master/SUPPORTERS.md).
+Kickstarter](./Kickstarter-Supporters.md).


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Hi there! The link to the Kickstarter Supporters file is broken. This pull request fixes the broken link, and now points to the (presumably) correct `./Kickstarter-Supporters.md` file.