### PR TITLE
tap_constants: support lowercase caskroom in regex

### DIFF
--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -5,4 +5,4 @@ HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
 # match the default and the versions brew-cask tap e.g. Caskroom/cask or Caskroom/versions
-HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^(Caskroom)/(cask|versions)/([\w+-.]+)$}
+HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^([Cc]askroom)/(cask|versions)/([\w+-.]+)$}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

Homebrew uses this regex to determine whether to pass a `brew install` command to `brew cask install` instead. If the user spells `Caskroom` lowercase, the cask name passes the `user/tap/formula` check, the `Caskroom/cask` tap is successfully cloned, but Homebrew doesn't know how to install the resulting cask. Sample user session:

```
brew install caskroom/cask/google-chrome
==> Tapping caskroom/cask
Cloning into '/usr/local/Library/Taps/caskroom/homebrew-cask'...
remote: Counting objects: 3523, done.
remote: Compressing objects: 100% (3468/3468), done.
remote: Total 3523 (delta 55), reused 740 (delta 33), pack-reused 0
Receiving objects: 100% (3523/3523), 5.91 MiB | 1.03 MiB/s, done.
Resolving deltas: 100% (55/55), done.
Checking connectivity... done.
Tapped 1 formula (3,489 files, 13.4M)
Error: No available formula with the name "caskroom/cask/google-chrome"
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
Error: No formulae found in taps.
```

With this patch, the lowercase `caskroom` does trigger a `brew cask install`:

```
brew install caskroom/cask/google-chrome
==> Tapping caskroom/cask
Cloning into '/usr/local/Library/Taps/caskroom/homebrew-cask'...
remote: Counting objects: 3523, done.
remote: Compressing objects: 100% (3468/3468), done.
remote: Total 3523 (delta 55), reused 740 (delta 33), pack-reused 0
Receiving objects: 100% (3523/3523), 5.91 MiB | 795.00 KiB/s, done.
Resolving deltas: 100% (55/55), done.
Checking connectivity... done.
Tapped 1 formula (3,489 files, 13.4M)
==> brew cask install caskroom/cask/google-chrome
```

This came up when I happened to be watching a user, whose `brew search` had brought up a cask, try to `brew install` a cask and type in the fully-qualified name in lowercase.

We don't have any tests around the area where this happened, so I'm not adding a unit test at this time.