### PR TITLE
--repository: support to show tap path

### DIFF
--- a/Library/Homebrew/cmd/--repository.rb
+++ b/Library/Homebrew/cmd/--repository.rb
@@ -1,5 +1,11 @@
+require "tap"
+
 module Homebrew
   def __repository
-    puts HOMEBREW_REPOSITORY
+    if ARGV.named.empty?
+      puts HOMEBREW_REPOSITORY
+    else
+      puts ARGV.named.map { |tap| Tap.fetch(tap).path }
+    end
   end
 end

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -529,6 +529,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Display where Homebrew's `.git` directory is located. For standard installs,
     the `prefix` and `repository` are the same directory.
 
+  * `--repository` <user>`/`<repo>:
+    Display where tap <user>`/`<repo>'s directory is located.
+
   * `--version`:
     Print the version number of brew to standard error and exit.
 

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -124,6 +124,11 @@ class IntegrationCommandTests < Homebrew::TestCase
                  cmd("--repository")
   end
 
+  def test_repository
+    assert_match "#{HOMEBREW_LIBRARY}/Taps/foo/homebrew-bar",
+                 cmd("--repository", "foo/bar")
+  end
+
   def test_help
     assert_match "Example usage:",
                  cmd("help")

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -389,6 +389,7 @@ without any sort of versioned directory as the last path.</p></dd>
 <dt><code>--prefix</code> <var>formula</var></dt><dd><p>Display the location in the cellar where <var>formula</var> is or would be installed.</p></dd>
 <dt><code>--repository</code></dt><dd><p>Display where Homebrew's <code>.git</code> directory is located. For standard installs,
 the <code>prefix</code> and <code>repository</code> are the same directory.</p></dd>
+<dt><code>--repository</code> <var>user</var><code>/</code><var>repo</var></dt><dd><p>Display where tap <var>user</var><code>/</code><var>repo</var>'s directory is located.</p></dd>
 <dt><code>--version</code></dt><dd><p>Print the version number of brew to standard error and exit.</p></dd>
 </dl>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "January 2016" "Homebrew" "brew"
+.TH "BREW" "1" "March 2016" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for OS X
@@ -564,6 +564,10 @@ Display the location in the cellar where \fIformula\fR is or would be installed\
 .TP
 \fB\-\-repository\fR
 Display where Homebrew\'s \fB\.git\fR directory is located\. For standard installs, the \fBprefix\fR and \fBrepository\fR are the same directory\.
+.
+.TP
+\fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR
+Display where tap \fIuser\fR\fB/\fR\fIrepo\fR\'s directory is located\.
 .
 .TP
 \fB\-\-version\fR


### PR DESCRIPTION
This can become handy when we separate core code and formulae. For
example, we could use `cd $(brew --repo homebrew/core)` to go to core
tap path.