### PR TITLE
Xcode 7 MACOSX_DEPLOYMENT_TARGET and SDK fixes

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -67,7 +67,7 @@ module Superenv
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
 
-    if MacOS::Xcode.without_clt?
+    if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)
       self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
       self["SDKROOT"] = MacOS.sdk_path
     end


### PR DESCRIPTION
SDK 10.10 isn't something that exists for Xcode 7, so stop looking for
it and rely on MACOSX_DEPLOYMENT_TARGET instead.

See PR #50137 Yosemite build failure