### PR TITLE
replace download url for fcgi tarball

### DIFF
--- a/Library/Formula/fcgi.rb
+++ b/Library/Formula/fcgi.rb
@@ -1,7 +1,7 @@
 class Fcgi < Formula
   desc "Protocol for interfacing interactive programs with a web server"
   homepage "http://www.fastcgi.com/"
-  url "http://www.fastcgi.com/dist/fcgi-2.4.0.tar.gz"
+  url "http://ftp.gwdg.de/pub/linux/gentoo/distfiles/fcgi-2.4.0.tar.gz"
   sha256 "66fc45c6b36a21bf2fbbb68e90f780cc21a9da1fffbae75e76d2b4402d3f05b9"
 
   # Fixes "dyld: Symbol not found: _environ"


### PR DESCRIPTION
fastcgi.com seems to be gone:

<pre>
==> Installing osgeo/osgeo4mac/qgis-28 dependency: fcgi
==> Downloading http://www.fastcgi.com/dist/fcgi-2.4.0.tar.gz
Error: Failed to download resource "fcgi"
</pre>

See also https://travis-ci.org/qgis/QGIS/jobs/117480455#L2646