### PR TITLE
nesc 1.3.6

### DIFF
--- a/Library/Formula/nesc.rb
+++ b/Library/Formula/nesc.rb
@@ -1,8 +1,13 @@
 class Nesc < Formula
   desc "Programming language for deeply networked systems"
-  homepage "http://nescc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/nescc/nescc/v1.3.5/nesc-1.3.5.tar.gz"
-  sha256 "c22be276d565681a2b84ddbf2a037256d24ecbf0da35e30157589609eec63096"
+  homepage "https://github.com/tinyos/nesc"
+  url "https://github.com/tinyos/nesc/archive/v1.3.6.tar.gz"
+  sha256 "80a979aacda950c227542f2ddd0604c28f66fe31223c608b4f717e5f08fb0cbf"
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on :java => :build
+  depends_on :emacs => :build
 
   bottle do
     cellar :any_skip_relocation
@@ -12,6 +17,11 @@ class Nesc < Formula
   end
 
   def install
+    # nesc is unable to build in parallel because multiple emacs instances
+    # lead to locking on the same file
+    ENV.deparallelize
+
+    system "./Bootstrap"
     system "./configure", "--disable-debug", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
### nesc 1.3.6

New homepage and package source: the old homepage at sourceforge
is apparently abandoned and there does not seem to be a
replacement. Github seems to be the closest to a homepage that
exists.It hosts the current repository for nesc and tinyos now.

Another change affects the way we build nesc. Up to 1.3.5 the
maintainers released tarballs with some preprocessing already
done, this is not the case for 1.3.6. The result is that we depend
on autoconf and automake and need to call ./Bootstrap.

### Open questions: dependencies

* The compilation step of nesc requieres Java, but there is no Formula for it. AFAIK it does not get distributed with OS X anymore, what is the standard way to deal with this?
* The build process depends on flex, bison, emacs and gperf. These come with El Capitan, but I don't know about older versions. Shouldn't there be a way to specify this?