### PR TITLE
fixed the audit warning for javarepl

### DIFF
--- a/Library/Formula/javarepl.rb
+++ b/Library/Formula/javarepl.rb
@@ -17,6 +17,6 @@ class Javarepl < Formula
   end
 
   test do
-    assert pipe_output("#{bin}/javarepl", "System.out.println(64*1024)\n:quit\n").include?("65536")
+    assert_match %r{65536}, pipe_output("#{bin}/javarepl", "System.out.println(64*1024)\n:quit\n")
   end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?


This PR contains the change:
* fixed the audit warning `Use ``assert_match`` instead of``assert ...include?`` ` for javarepl

Thanks,
phchan9