### PR TITLE
docker: fix --with-experimental (libtool dependency and optional hardware signing)

### DIFF
--- a/Library/Formula/docker.rb
+++ b/Library/Formula/docker.rb
@@ -18,6 +18,8 @@ class Docker < Formula
   option "without-completions", "Disable bash/zsh completions"
 
   depends_on "go" => :build
+  depends_on "libtool" => :run if build.with?("experimental")
+  depends_on "yubico-piv-tool" => :recommended if build.with?("experimental")
 
   def install
     ENV["AUTO_GOPATH"] = "1"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Docker experimental supports hardware signing yubikey PKCS11 libraries.  Currently the formula is breaking if libtool is not installed:

```
$ brew install docker --with-experimental
==> Cloning https://github.com/docker/docker.git
Updating /Library/Caches/Homebrew/docker--git
==> Checking out tag v1.10.3
==> hack/make.sh dynbinary
Last 15 lines from /Users/yingli/Library/Logs/Homebrew/docker/01.make.sh:
# Try this instead: make all
#

date: illegal option -- -
usage: date [-jnu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
# WARNING! DOCKER_EXPERIMENTAL is set: building experimental features

---> Making bundle: dynbinary (in bundles/1.10.3/dynbinary)
Building: bundles/1.10.3/dynbinary/docker-1.10.3
# github.com/miekg/pkcs11
vendor/src/github.com/miekg/pkcs11/pkcs11.go:26:10: fatal error: 'ltdl.h' file not found
#include <ltdl.h>
         ^
1 error generated.

READ THIS: https://git.io/brew-troubleshooting

These open issues may also help:
Fix docker-machine-driver-xhyve HEAD https://github.com/Homebrew/homebrew/pull/49467
```

This adds the libtool dependency if experimental is enabled or yubikey is enabled (since, if it ever moves out of experimental, it will be needed if yubikey support is desired).

This also adds a recommended dependency on the yubico-piv-tool formula, which installs the necessary yubikey libraries.

```
$ brew install docker --with-experimental
==> Installing dependencies for docker: libtool, yubico-piv-tool
==> Installing docker dependency: libtool
==> Downloading https://homebrew.bintray.com/bottles/libtool-2.4.6.el_capitan.bottle.tar.gz
Already downloaded: /Library/Caches/Homebrew/libtool-2.4.6.el_capitan.bottle.tar.gz
==> Pouring libtool-2.4.6.el_capitan.bottle.tar.gz
==> Caveats
In order to prevent conflicts with Apple's own libtool we have prepended a "g"
so, you have instead: glibtool and glibtoolize.
==> Summary
🍺  /usr/local/Cellar/libtool/2.4.6: 69 files, 3.6M
==> Installing docker dependency: yubico-piv-tool
==> Downloading https://homebrew.bintray.com/bottles/yubico-piv-tool-1.2.2.el_capitan.bottle.tar.gz
Already downloaded: /Library/Caches/Homebrew/yubico-piv-tool-1.2.2.el_capitan.bottle.tar.gz
==> Pouring yubico-piv-tool-1.2.2.el_capitan.bottle.tar.gz
🍺  /usr/local/Cellar/yubico-piv-tool/1.2.2: 16 files, 368.7K
==> Installing docker
==> Cloning https://github.com/docker/docker.git
Updating /Library/Caches/Homebrew/docker--git
==> Checking out tag v1.10.3
==> hack/make.sh dynbinary
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completion has been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/docker/1.10.3: 10 files, 11.7M, built in 15 seconds
```

```
brew install docker --with-experimental --without-yubico-piv-tool
==> Installing dependencies for docker: libtool
==> Installing docker dependency: libtool
==> Downloading https://homebrew.bintray.com/bottles/libtool-2.4.6.el_capitan.bottle.tar.gz
Already downloaded: /Library/Caches/Homebrew/libtool-2.4.6.el_capitan.bottle.tar.gz
==> Pouring libtool-2.4.6.el_capitan.bottle.tar.gz
==> Caveats
In order to prevent conflicts with Apple's own libtool we have prepended a "g"
so, you have instead: glibtool and glibtoolize.
==> Summary
🍺  /usr/local/Cellar/libtool/2.4.6: 69 files, 3.6M
==> Installing docker
==> Cloning https://github.com/docker/docker.git
Updating /Library/Caches/Homebrew/docker--git
==> Checking out tag v1.10.3
==> hack/make.sh dynbinary
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completion has been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/docker/1.10.3: 10 files, 11.7M, built in 15 seconds
```