### PR TITLE
Fix backticks to prevent missing rendered text

### DIFF
--- a/share/doc/homebrew/Querying-Brew.md
+++ b/share/doc/homebrew/Querying-Brew.md
@@ -15,8 +15,8 @@ To enable users to do rich queries without the problems above, Homebrew provides
 
 From the manpage:
 
-  * `info --json=<version>` (--all|--installed|<formula>):
-    Print a JSON representation of <formula>. Currently the only accepted value
+  * `info --json=<version> (--all|--installed|<formula>)`:
+    Print a JSON representation of `<formula>`. Currently the only accepted value
     for <version> is `v1`.
 
     Pass `--all` to get information on all formulae, or `--installed` to get


### PR DESCRIPTION
Just a little documentation fix :) The backticks being where they were, or not, caused text like `<formula>` to not be shown when viewing the rendered text in a browser.

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
  - I searched for "formula", "docs", and "backticks" and didn't see anything-- I did not look through all 200 open PRs, though, admittedly.