### PR TITLE
memcache-top: remove redundant version statement

### DIFF
--- a/Library/Formula/memcache-top.rb
+++ b/Library/Formula/memcache-top.rb
@@ -2,7 +2,6 @@ class MemcacheTop < Formula
   desc "Grab real-time stats from memcache"
   homepage "https://code.google.com/p/memcache-top/"
   url "https://memcache-top.googlecode.com/files/memcache-top-v0.6"
-  version "0.6"
   sha256 "d5f896a9e46a92988b782e340416312cc480261ce8a5818db45ccd0da8a0f22a"
 
   bottle :unneeded


### PR DESCRIPTION
```brew audit memcache-top``` returns:

```
memcache-top:
 * Stable: version 0.6 is redundant with version scanned from URL
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR removes the redundancy.