### PR TITLE
mpw: putting `version` before `checksum`

### DIFF
--- a/Library/Formula/mpw.rb
+++ b/Library/Formula/mpw.rb
@@ -2,8 +2,8 @@ class Mpw < Formula
   desc "Master Password for the terminal"
   homepage "http://masterpasswordapp.com"
   url "https://ssl.masterpasswordapp.com/mpw-2.1-cli4-0-gf6b2287.tar.gz"
-  sha256 "6ea76592eb8214329072d04f651af99d73de188a59ef76975d190569c7fa2b90"
   version "2.1-cli4"
+  sha256 "6ea76592eb8214329072d04f651af99d73de188a59ef76975d190569c7fa2b90"
 
   bottle do
     cellar :any


### PR DESCRIPTION
```brew audit --strict  mpw``` returns:

```
mpw:
 * `version` (line 6) should be put before `checksum` (line 5)
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR fixes this warning.