### PR TITLE
gconf: removing formula name from description

### DIFF
--- a/Library/Formula/gconf.rb
+++ b/Library/Formula/gconf.rb
@@ -1,5 +1,5 @@
 class Gconf < Formula
-  desc "GConf is a system for storing user application preferences"
+  desc "System for storing user application preferences"
   homepage "https://projects.gnome.org/gconf/"
   url "https://download.gnome.org/sources/GConf/3.2/GConf-3.2.6.tar.xz"
   sha256 "1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"


### PR DESCRIPTION
```brew audit --strict gconf``` returns:

```
gconf:
 * Description shouldn't include the formula name
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR removes the formula name from description.