### PR TITLE
gdub: updating the description of the formula.

### DIFF
--- a/Library/Formula/gdub.rb
+++ b/Library/Formula/gdub.rb
@@ -1,5 +1,5 @@
 class Gdub < Formula
-  desc "Gdub is a Gradle wrapper wrapper"
+  desc "A gradlew/gradle wrapper."
   homepage "http://www.gdub.rocks"
   url "https://github.com/dougborg/gdub/archive/v0.1.0.tar.gz"
   sha256 "ddf2572cc67b8df3293b1707720c6ef09d6caf73227fa869a73b16239df959c3"


### PR DESCRIPTION
```brew audit --strict gdub``` returns:

```
gdub:
 * Description shouldn't include the formula name
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Apart from removing the warning, this update corrects the description of the formula.