### PR TITLE
osxutils: updating the description of the formula.

### DIFF
--- a/Library/Formula/osxutils.rb
+++ b/Library/Formula/osxutils.rb
@@ -1,5 +1,5 @@
 class Osxutils < Formula
-  desc "Suite of Mac OS command line utilities"
+  desc "Suite of Mac OS command-line utilities"
   homepage "https://github.com/specious/osxutils"
   url "https://github.com/specious/osxutils/archive/v1.8.2.tar.gz"
   sha256 "83714582cce83faceee6d539cf962e587557236d0f9b5963bd70e3bc7fbceceb"


### PR DESCRIPTION
```brew audit --strict osxutils``` returns:

```
osxutils:
 * Description should use "command-line" instead of "command line"
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Apart from removing the warning, this update corrects the description of the formula.