### PR TITLE
Create cache dir

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -1,23 +1,25 @@
 def cache
   if ENV["HOMEBREW_CACHE"]
-    Pathname.new(ENV["HOMEBREW_CACHE"]).expand_path
+    cache_path = Pathname.new(ENV["HOMEBREW_CACHE"]).expand_path
   else
     # we do this for historic reasons, however the cache *should* be the same
     # directory whichever user is used and whatever instance of brew is executed
-    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
+    cache_path = home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
     if home_cache.directory? && home_cache.writable_real?
       home_cache
     else
-      Pathname.new("/Library/Caches/Homebrew").extend Module.new {
-        def mkpath
-          unless exist?
-            super
-            chmod 0775
-          end
-        end
-      }
+      cache_path = Pathname.new("/Library/Caches/Homebrew")
     end
   end
+  cache_path.extend Module.new {
+    def mkpath
+      unless exist?
+        super
+          chmod 0775
+      end
+    end
+  }
+  cache_path
 end
 
 HOMEBREW_CACHE = cache

--- a/Library/Homebrew/formula_lock.rb
+++ b/Library/Homebrew/formula_lock.rb
@@ -1,4 +1,5 @@
 require "fcntl"
+require "fileutils"
 
 class FormulaLock
   LOCKDIR = HOMEBREW_CACHE_FORMULA
@@ -35,6 +36,7 @@ class FormulaLock
 
   def get_or_create_lockfile
     if @lockfile.nil? || @lockfile.closed?
+      FileUtils.mkdir_p(LOCKDIR) unless File.directory?(LOCKDIR)
       @lockfile = @path.open(File::RDWR | File::CREAT)
       @lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
       @lockfile

--- a/Library/Homebrew/formula_lock.rb
+++ b/Library/Homebrew/formula_lock.rb
@@ -1,5 +1,4 @@
 require "fcntl"
-require "fileutils"
 
 class FormulaLock
   LOCKDIR = HOMEBREW_CACHE_FORMULA
@@ -36,7 +35,6 @@ class FormulaLock
 
   def get_or_create_lockfile
     if @lockfile.nil? || @lockfile.closed?
-      FileUtils.mkdir_p(LOCKDIR)
       @lockfile = @path.open(File::RDWR | File::CREAT)
       @lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
       @lockfile

--- a/Library/Homebrew/formula_lock.rb
+++ b/Library/Homebrew/formula_lock.rb
@@ -36,7 +36,7 @@ class FormulaLock
 
   def get_or_create_lockfile
     if @lockfile.nil? || @lockfile.closed?
-      FileUtils.mkdir_p(LOCKDIR) unless File.directory?(LOCKDIR)
+      FileUtils.mkdir_p(LOCKDIR)
       @lockfile = @path.open(File::RDWR | File::CREAT)
       @lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
       @lockfile

--- a/Library/Homebrew/test/test_formula_lock.rb
+++ b/Library/Homebrew/test/test_formula_lock.rb
@@ -27,8 +27,9 @@ class FormulaLockTests < Homebrew::TestCase
     @nonsuch_dir = FormulaLock.new("bar")
     assert_nothing_raised { @nonsuch_dir.lock }
     assert_nothing_raised { @nonsuch_dir.unlock }
-    FormulaLock::LOCKDIR.children.each(&:unlink)
-    FormulaLock.send(:remove_const, :LOCKDIR)
-    FormulaLock.const_set(:LOCKDIR, @tmp_lockdir)
+    ensure
+      FormulaLock::LOCKDIR.children.each(&:unlink)
+      FormulaLock.send(:remove_const, :LOCKDIR)
+      FormulaLock.const_set(:LOCKDIR, @tmp_lockdir)
   end
 end

--- a/Library/Homebrew/test/test_formula_lock.rb
+++ b/Library/Homebrew/test/test_formula_lock.rb
@@ -19,4 +19,16 @@ class FormulaLockTests < Homebrew::TestCase
   def test_locking_existing_lock_suceeds
     assert_nothing_raised { @lock.lock }
   end
+
+  def test_locking_file_in_nonexistent_cache_directory
+    @tmp_lockdir = FormulaLock::LOCKDIR
+    FormulaLock.send(:remove_const, :LOCKDIR)
+    FormulaLock.const_set(:LOCKDIR, @tmp_lockdir + "nonsuch/")
+    @nonsuch_dir = FormulaLock.new("bar")
+    assert_nothing_raised { @nonsuch_dir.lock }
+    assert_nothing_raised { @nonsuch_dir.unlock }
+    FormulaLock::LOCKDIR.children.each(&:unlink)
+    FormulaLock.send(:remove_const, :LOCKDIR)
+    FormulaLock.const_set(:LOCKDIR, @tmp_lockdir)
+  end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

### Submission

#### Change
Making Homebrew create the cache directory (FormulaLock::LOCKDIR) if it does not exist, before locking the .brewing file. This prevents a "permission denied" crash.

#### Reason
When the Caches directory does not exist, brew crashes unexpectedly. At our school, the computers are automatically configured to put the brew cache at ~/Library/Caches/Homebrew. We often change computers and thus lose our ~/Library/Caches directory. This fix is small and makes it possible to move system without having to manually re-configure brew (or more likely giving up on using it, as it just crashes suddenly).

#### Tests
Added test to check if brew locks .brewing files correctly if the cache is a nonexistent directory.
Note: Because LOCKDIR is defined as a constant, the test requires calling the private method :remove_const and then restoring LOCKDIR to its original value after the test. If there is a better way to test this, I am happy to change the code.

#### Status
Tests: Passing on local computer
