### PR TITLE
bump-formula-pr: fix typo in spec existence check

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -25,7 +25,7 @@ module Homebrew
     else
       [:stable, formula.stable]
     end
-    odie "#{formula}: no #{requested_spec} specification found!" unless formula
+    odie "#{formula}: no #{requested_spec} specification found!" unless formula_spec
 
     hash_type, old_hash = if (checksum = formula_spec.checksum)
       [checksum.hash_type.to_s, checksum.hexdigest]


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?


The existence of the `formula` was already checked [on line 20](https://github.com/chrmoritz/homebrew/blob/bump-formula-cmd/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L20).
Line 28 was most likely intended to check the existence of the `formula_spec` (e.g. using the --devel options in a formula without a devel version). This PR fixes the typo to correctly check for the existence of the `formula_spec` here.

