### PR TITLE
nvm: use $HOME instead of tilde expansion

### DIFF
--- a/Library/Formula/nvm.rb
+++ b/Library/Formula/nvm.rb
@@ -24,8 +24,8 @@ class Nvm < Formula
     Add the following to #{shell_profile} or your desired shell
     configuration file:
 
-      export NVM_DIR=~/.nvm
-      . $(brew --prefix nvm)/nvm.sh
+      export NVM_DIR="$HOME/.nvm"
+      . "$(brew --prefix nvm)/nvm.sh"
 
     You can set $NVM_DIR to any location, but leaving it unchanged from
     #{prefix} will destroy any nvm-installed Node installations


### PR DESCRIPTION
Use `$HOME` variable instead of tilde expansion in shell configuration for portability reasons[1].

Resolved https://github.com/creationix/nvm/issues/855 when using oh-my-zsh.


[1] http://stackoverflow.com/questions/5930671/why-use-home-over-tilde-in-a-shell-script