### PR TITLE
mktorrent: fixing one warning about system command

### DIFF
--- a/Library/Formula/mktorrent.rb
+++ b/Library/Formula/mktorrent.rb
@@ -15,7 +15,7 @@ class Mktorrent < Formula
   depends_on "openssl"
 
   def install
-    system "make USE_PTHREADS=1 USE_OPENSSL=1 USE_LONG_OPTIONS=1"
+    system "make", "USE_PTHREADS=1", "USE_OPENSSL=1", "USE_LONG_OPTIONS=1"
     bin.install "mktorrent"
   end
 end


### PR DESCRIPTION
```brew audit --strict  mktorrent``` returns:

```
mktorrent:
 * A `test do` test block should be added
 * Use `system "make", "USE_PTHREADS=1", "USE_OPENSSL=1", "USE_LONG_OPTIONS=1"` instead of `system "make USE_PTHREADS=1 USE_OPENSSL=1 USE_LONG_OPTIONS=1"` 
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR fixes the second one.