### PR TITLE
sleepwatcher: fix brew audit warning

### DIFF
--- a/Library/Formula/sleepwatcher.rb
+++ b/Library/Formula/sleepwatcher.rb
@@ -19,7 +19,7 @@ class Sleepwatcher < Formula
 
     # Build and install binary
     cd "sources" do
-      system "mv", "../sleepwatcher.8", "."
+      mv "../sleepwatcher.8", "."
       system "make", "install", "PREFIX=#{prefix}"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

---

This addresses the following audit warning:
```* Use the `mv` Ruby method instead of `system "mv"` ```

`sleepwatcher` doesn't define any tests, unfortunately, so an error is raised with `brew test sleepwatcher`. Is the audit fix OK for the time being? (i.e., until a test is defined for the formula?)