### PR TITLE
antlr: fix warning when executing `grun`

### DIFF
--- a/Library/Formula/antlr.rb
+++ b/Library/Formula/antlr.rb
@@ -16,7 +16,7 @@ class Antlr < Formula
 
     (bin/"grun").write <<-EOS.undent
       #!/bin/bash
-      java -classpath #{prefix}/antlr-#{version}-complete.jar:. org.antlr.v4.runtime.misc.TestRig "$@"
+      java -classpath #{prefix}/antlr-#{version}-complete.jar:. org.antlr.v4.gui.TestRig "$@"
     EOS
   end
 


### PR DESCRIPTION
Update `grun` script to use new path of `TestRig`, as indicated in warning message:
```
$ grun
Warning: TestRig moved to org.antlr.v4.gui.TestRig; calling automatically
...
```
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
