### PR TITLE
superenv: refurbish --fast-math for :clang

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -158,6 +158,9 @@ class Cmd
       "-fuse-linker-plugin"
       # clang doesn't support these flags
       args << arg unless tool =~ /^clang/
+    when "--fast-math"
+      arg = "-ffast-math" if tool =~ /^clang/
+      args << arg
     when "-Wno-deprecated-register"
       # older gccs don't support these flags
       args << arg unless tool =~ /^g..-4.[02]/


### PR DESCRIPTION
This option caused build failure with clang for
homebrew/science/delly-0.7.2
Homebrew/homebrew-science#3482