### PR TITLE
git-credential-manager 1.6.0

### DIFF
--- a/Library/Formula/git-credential-manager.rb
+++ b/Library/Formula/git-credential-manager.rb
@@ -1,8 +1,8 @@
 class GitCredentialManager < Formula
   desc "Stores Git credentials for Visual Studio Team Services"
   homepage "https://java.visualstudio.com/Docs/tools/gitcredentialmanager"
-  url "https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-1.5.0/git-credential-manager-1.5.0.jar"
-  sha256 "e5e685c6938e0955dabe91829d3bb4aaea9bce2bb1c6ecc6f405b74b4ce2b346"
+  url "https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-1.6.0/git-credential-manager-1.6.0.jar"
+  sha256 "ff86d25c4d1760bdb14f69d17a7c290b34a82292aa9ea9bdf00e7c57f5ed53a1"
 
   bottle :unneeded
 


### PR DESCRIPTION
These notes are for release *1.6.0*.  Other releases and their notes can be found at the [Git-Credential-Manager-for-Mac-and-Linux GitHub Releases](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases) page.

* Major:
    * Improved the error handling and reporting.
