### PR TITLE
gitlab-ci-multi-runner: update 1.1.0 docker binary

### DIFF
--- a/Library/Formula/gitlab-ci-multi-runner.rb
+++ b/Library/Formula/gitlab-ci-multi-runner.rb
@@ -26,9 +26,9 @@ class GitlabCiMultiRunner < Formula
   end
 
   resource "prebuilt.tar.gz" do
-    url "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v1.0.4/docker/prebuilt.tar.gz",
+    url "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v1.1.0/docker/prebuilt.tar.gz",
       :using => :nounzip
-    sha256 "43dedd023672990e27289e97bf74f493576956418148f6227917b8511e8aadfd"
+    sha256 "f6fcac012eee0fa9d6419f8d045110898dcff6f516b396b9e14bfffa2ccaceb4"
   end
 
   def install

--- a/Library/Formula/gitlab-ci-multi-runner.rb
+++ b/Library/Formula/gitlab-ci-multi-runner.rb
@@ -6,6 +6,7 @@ class GitlabCiMultiRunner < Formula
   url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git",
     :tag => "v1.1.0",
     :revision => "a23a25ab6423988d93e2382af3674f4b76cc2813"
+  revision 1
 
   head "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git"
 


### PR DESCRIPTION
The url for the prebuilt docker should be updated too.