### PR TITLE
ginac: formula name removed from description

### DIFF
--- a/Library/Formula/ginac.rb
+++ b/Library/Formula/ginac.rb
@@ -1,5 +1,5 @@
 class Ginac < Formula
-  desc "GiNaC is Not a Computer algebra system"
+  desc "Not a Computer algebra system"
   homepage "http://www.ginac.de/"
   url "http://www.ginac.de/ginac-1.6.7.tar.bz2"
   sha256 "cea5971b552372017ea654c025adb44d5f1b3e3ce0a739da2fe95189572b85db"


### PR DESCRIPTION
```brew audit --strict ginac``` returns:

```
ginac:
 * Description shouldn't include the formula name
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR removes the formula name from description.