### PR TITLE
mvnvm 1.0.8 (rerelease)

### DIFF
--- a/Library/Formula/mvnvm.rb
+++ b/Library/Formula/mvnvm.rb
@@ -1,8 +1,8 @@
 class Mvnvm < Formula
   desc "Maven version manager"
   homepage "http://mvnvm.org"
-  url "https://bitbucket.org/mjensen/mvnvm/get/mvnvm-1.0.8.zip"
-  sha256 "740d8a4605ef60c01b4ba9160bd1954adb727428092f0694a5d0d5403522dc02"
+  url "https://bitbucket.org/mjensen/mvnvm/downloads/mvnvm-1.0.8.zip"
+  sha256 "b2953ec2e4c94849f6764db3e6079f397e117c65a2e80e59af03a6bda013a80b"
   head "https://bitbucket.org/mjensen/mvnvm.git"
 
   bottle :unneeded


### PR DESCRIPTION
Bitbucket have changed how their dynamic zip files were generated which made the hash invalid.  I have moved the zip to the downloads section so its static and updated the hash.

### All Submissions:

- [/ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [/ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

