### PR TITLE
Elasticsearch 2.3.0 logstash 2.3.0 kibana 4.5.0

### DIFF
--- a/Library/Formula/elasticsearch.rb
+++ b/Library/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.1/elasticsearch-2.2.1.tar.gz"
-  sha256 "7d43d18a8ee8d715d827ed26b4ff3d939628f5a5b654c6e8de9d99bf3a9b2e03"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.0/elasticsearch-2.3.0.tar.gz"
+  sha256 "d68482c7633f2986263bc5f11f93b8a58c54c6cf5e337b615446d0a7c6fdcd8b"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"

--- a/Library/Formula/kibana.rb
+++ b/Library/Formula/kibana.rb
@@ -1,7 +1,7 @@
 class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://github.com/elastic/kibana.git", :tag => "v4.4.2", :revision => "b0ef773a465d0eb27d192ca77f881eba90ef93d5"
+  url "https://github.com/elastic/kibana.git", :tag => "v4.5.0", :revision => "ff5cfc5d05a58e53f7acaa762428fa803318d31e"
   head "https://github.com/elastic/kibana.git"
 
   bottle do

--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -1,8 +1,8 @@
 class Logstash < Formula
   desc "Tool for managing events and logs"
   homepage "https://www.elastic.co/products/logstash"
-  url "https://download.elastic.co/logstash/logstash/logstash-2.2.2.tar.gz"
-  sha256 "f0a29ec8fd327e42f3023bd6bf85a00ac20617bfc214df59c765453977398312"
+  url "https://download.elastic.co/logstash/logstash/logstash-2.3.0.tar.gz"
+  sha256 "d802803ac6dc7e9215b19764dd8fbaa74c75fa1d8bf387508fb0d0d8d36b0241"
 
   bottle :unneeded
 
@@ -24,17 +24,16 @@ class Logstash < Formula
     end
 
     inreplace %w[bin/logstash], %r{^\. "\$\(cd `dirname \$SOURCEPATH`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
-    inreplace %w[bin/plugin], %r{^\. "\$\(cd `dirname \$0`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
+    inreplace %w[bin/logstash-plugin], %r{^\. "\$\(cd `dirname \$0`\/\.\.; pwd\)\/bin\/logstash\.lib\.sh\"}, ". #{libexec}/bin/logstash.lib.sh"
     inreplace %w[bin/logstash.lib.sh], /^LOGSTASH_HOME=.*$/, "LOGSTASH_HOME=#{libexec}"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/logstash"
-    bin.install_symlink libexec/"bin/plugin" => "logstash-plugin"
+    bin.install_symlink libexec/"bin/logstash-plugin"
   end
 
   def caveats; <<-EOS.undent
     Please read the getting started guide located at:
       https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html
-    The logstash `plugin` command is available as `logstash-plugin`.
     EOS
   end
 

--- a/Library/Formula/logstash.rb
+++ b/Library/Formula/logstash.rb
@@ -4,12 +4,12 @@ class Logstash < Formula
   url "https://download.elastic.co/logstash/logstash/logstash-2.3.0.tar.gz"
   sha256 "d802803ac6dc7e9215b19764dd8fbaa74c75fa1d8bf387508fb0d0d8d36b0241"
 
-  bottle :unneeded
-
   head do
     url "https://github.com/elastic/logstash.git"
     depends_on :java => "1.8"
   end
+
+  bottle :unneeded
 
   depends_on :java => "1.7+"
 


### PR DESCRIPTION
This pull request updates the following formula:
 - Elasticsearch 2.2.1 -> 2.3.0
 - Logstash 2.2.2 -> 2.3.0
 - Kibana 4.4.2 -> 4.5.0

These are the [latest stable versions](https://www.elastic.co/blog/release-bonanza-elasticsearch-graph-shield-watcher-marvel-logstash-2-3-beats-1-2-and-kibana-4-5-are-now-available) as of 2016-03-30.