### PR TITLE
jcal: fixing one warning about system command

### DIFF
--- a/Library/Formula/jcal.rb
+++ b/Library/Formula/jcal.rb
@@ -16,7 +16,7 @@ class Jcal < Formula
   depends_on "libtool" => :build
 
   def install
-    system "/bin/sh autogen.sh"
+    system "/bin/sh", "autogen.sh"
     system "./configure", "--prefix=#{prefix}",
                           "--disable-debug",
                           "--disable-dependency-tracking"


### PR DESCRIPTION
```brew audit --strict  jcal``` returns:

```
jcal:
 * Use `system "/bin/sh", "autogen.sh"` instead of `system "/bin/sh autogen.sh"` 
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR fixes the warning.