### PR TITLE
Pathname#version: only parse version from file basename

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -239,7 +239,7 @@ class Pathname
   # @private
   def version
     require "version"
-    Version.parse(self)
+    Version.parse(self.basename)
   end
 
   # @private


### PR DESCRIPTION
i.e. Ignoring the file's directory for version parsing.

cc @DomT4, @mikemcquaid