### PR TITLE
mu: Remove ENV.O0 compile hack, unneeded now

### DIFF
--- a/Library/Formula/mu.rb
+++ b/Library/Formula/mu.rb
@@ -29,10 +29,6 @@ class Mu < Formula
     # shipped by default with Mac OS X is too old.
     ENV["EMACS"] = "no" if build.without? "emacs"
 
-    # https://github.com/djcb/mu/issues/380
-    # https://github.com/djcb/mu/issues/332
-    ENV.O0 if MacOS.version >= :mavericks && ENV.compiler == :clang
-
     system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -48,6 +44,10 @@ class Mu < Formula
     EOS
   end
 
+  # Regression test for:
+  # https://github.com/djcb/mu/issues/397
+  # https://github.com/djcb/mu/issues/380
+  # https://github.com/djcb/mu/issues/332
   test do
     mkdir (testpath/"cur")
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

https://github.com/djcb/mu/issues/397 is fixed in 0.9.16 and compiling
with ENV.O0 is not needed anymore