### PR TITLE
cntlm: fix plist start-stop by running in foreground

### DIFF
--- a/Library/Formula/cntlm.rb
+++ b/Library/Formula/cntlm.rb
@@ -29,6 +29,7 @@ class Cntlm < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/cntlm</string>
+          <string>-f</string>
         </array>
         <key>KeepAlive</key>
         <false/>


### PR DESCRIPTION
`launchctl stop ~/Library/LaunchAgents/homebrew.mxcl.cntlm.plist`
didn't stop cntlm because it is daemonized when started
To fix this the -f parameter is added to run cntlm in the foreground.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
NOT NEEDED
- [X] Have you successfully ran `brew tests` with your changes locally?
NO TESTS AVAILABLE

